### PR TITLE
feat: Update isReplyAllowed in Notifications according LegalHoldStatus [WPB-7425]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/notification/LocalNotificationMessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/notification/LocalNotificationMessageMapper.kt
@@ -119,13 +119,17 @@ class LocalNotificationMessageMapperImpl : LocalNotificationMessageMapper {
     ): List<LocalNotification.Conversation> =
         list.groupBy { it.conversationId }
             .map { (conversationId, messages) ->
+                val isReplyAllowed = messages.first().run {
+                    degradedConversationNotified
+                            && (legalHoldStatus == ConversationEntity.LegalHoldStatus.ENABLED && !legalHoldStatusChangeNotified)
+                }
                 LocalNotification.Conversation(
                     // todo: needs some clean up!
                     id = conversationId.toModel(),
                     conversationName = messages.first().conversationName ?: "",
                     messages = messages.take(messageSizePerConversation).mapNotNull { mapMessage(it) },
                     isOneToOneConversation = messages.first().conversationType == ConversationEntity.Type.ONE_ON_ONE,
-                    isReplyAllowed = messages.first().degradedConversationNotified
+                    isReplyAllowed = isReplyAllowed
                 )
             }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/notification/LocalNotificationMessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/notification/LocalNotificationMessageMapper.kt
@@ -121,7 +121,7 @@ class LocalNotificationMessageMapperImpl : LocalNotificationMessageMapper {
             .map { (conversationId, messages) ->
                 val isReplyAllowed = messages.first().run {
                     degradedConversationNotified
-                            && (legalHoldStatus == ConversationEntity.LegalHoldStatus.ENABLED && !legalHoldStatusChangeNotified)
+                            && (legalHoldStatus != ConversationEntity.LegalHoldStatus.ENABLED || legalHoldStatusChangeNotified)
                 }
                 LocalNotification.Conversation(
                     // todo: needs some clean up!

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/MessageRepositoryTest.kt
@@ -898,7 +898,9 @@ class MessageRepositoryTest {
             conversationName = null,
             mutedStatus = ConversationEntity.MutedStatus.ALL_ALLOWED,
             conversationType = ConversationEntity.Type.ONE_ON_ONE,
-            degradedConversationNotified = true
+            degradedConversationNotified = true,
+            legalHoldStatus = ConversationEntity.LegalHoldStatus.ENABLED,
+            legalHoldStatusChangeNotified = true
         )
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/notification/LocalNotificationMessageMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/notification/LocalNotificationMessageMapperTest.kt
@@ -1,0 +1,156 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.notification
+
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.persistence.dao.conversation.ConversationEntity
+import com.wire.kalium.persistence.dao.message.MessageEntity
+import com.wire.kalium.persistence.dao.message.NotificationMessageEntity
+import kotlinx.datetime.Instant
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LocalNotificationMessageMapperTest {
+    private lateinit var notificationMapper: LocalNotificationMessageMapper
+
+    @BeforeTest
+    fun setup() {
+        notificationMapper = LocalNotificationMessageMapperImpl()
+    }
+
+    @Test
+    fun givenListOfNotificationMessageEntity_whenDegradedConversationNotNotified_thenReplayDisabled() {
+        val result = notificationMapper.fromEntitiesToLocalNotifications(
+            listOf(
+                NOTIFICATION_ENTITY.copy(degradedConversationNotified = false),
+            ),
+            10
+        ) { _ -> TEXT_MASSAGE_NOTIFICATION }
+
+        assertEquals(false, result[0].isReplyAllowed)
+    }
+
+    @Test
+    fun givenListOfNotificationMessageEntity_whenLegalHoldDisabled_thenReplayAllowed() {
+        val result = notificationMapper.fromEntitiesToLocalNotifications(
+            listOf(
+                NOTIFICATION_ENTITY.copy(
+                    legalHoldStatus = ConversationEntity.LegalHoldStatus.DISABLED,
+                    legalHoldStatusChangeNotified = false
+                )
+            ),
+            10
+        ) { _ -> TEXT_MASSAGE_NOTIFICATION }
+
+        assertEquals(true, result[0].isReplyAllowed)
+    }
+
+    @Test
+    fun givenListOfNotificationMessageEntity_whenLegalHoldEnabled_thenReplayDisabled() {
+        val result = notificationMapper.fromEntitiesToLocalNotifications(
+            listOf(
+                NOTIFICATION_ENTITY.copy(
+                    legalHoldStatus = ConversationEntity.LegalHoldStatus.ENABLED,
+                    legalHoldStatusChangeNotified = false
+                )
+            ),
+            10
+        ) { _ -> TEXT_MASSAGE_NOTIFICATION }
+
+        assertEquals(false, result[0].isReplyAllowed)
+    }
+
+    @Test
+    fun givenListOfNotificationMessageEntity_whenLegalHoldEnabledAndUserNotified_thenReplayAllowed() {
+        val result = notificationMapper.fromEntitiesToLocalNotifications(
+            listOf(
+                NOTIFICATION_ENTITY.copy(
+                    legalHoldStatus = ConversationEntity.LegalHoldStatus.ENABLED,
+                    legalHoldStatusChangeNotified = true
+                )
+            ),
+            10
+        ) { _ -> TEXT_MASSAGE_NOTIFICATION }
+
+        assertEquals(true, result[0].isReplyAllowed)
+    }
+
+    @Test
+    fun givenListOfNotificationMessageEntity_whenMessagePerConvSmaller_thenOlderMessagesFilteredOut() {
+        val result = notificationMapper.fromEntitiesToLocalNotifications(
+            listOf(
+                NOTIFICATION_ENTITY.copy(
+                    id = "0",
+                    legalHoldStatus = ConversationEntity.LegalHoldStatus.ENABLED,
+                    legalHoldStatusChangeNotified = true
+                ),
+                NOTIFICATION_ENTITY.copy(
+                    id = "1",
+                    legalHoldStatus = ConversationEntity.LegalHoldStatus.ENABLED,
+                    legalHoldStatusChangeNotified = true
+                ),
+                NOTIFICATION_ENTITY.copy(
+                    id = "2",
+                    legalHoldStatus = ConversationEntity.LegalHoldStatus.ENABLED,
+                    legalHoldStatusChangeNotified = true
+                ),
+                NOTIFICATION_ENTITY.copy(
+                    id = "3",
+                    legalHoldStatus = ConversationEntity.LegalHoldStatus.ENABLED,
+                    legalHoldStatusChangeNotified = true
+                )
+            ),
+            2
+        ) { _ -> TEXT_MASSAGE_NOTIFICATION }
+
+        assertEquals(2, result[0].messages.size)
+    }
+
+    companion object {
+        private val TEXT_MASSAGE_NOTIFICATION = LocalNotificationMessage.Text(
+            messageId = "messageId",
+            author = LocalNotificationMessageAuthor("authorName", null),
+            text = "text of message",
+            time = Instant.DISTANT_PAST,
+            isQuotingSelfUser = false
+        )
+
+        private val NOTIFICATION_ENTITY = NotificationMessageEntity(
+            id = "message_id",
+            contentType = MessageEntity.ContentType.TEXT,
+            isSelfDelete = false,
+            senderUserId = TestUser.ENTITY_ID,
+            senderImage = null,
+            date = Instant.DISTANT_PAST,
+            senderName = "Sender",
+            text = "Some text in message",
+            assetMimeType = null,
+            isQuotingSelf = false,
+            conversationId = TestConversation.ENTITY_ID,
+            conversationName = null,
+            mutedStatus = ConversationEntity.MutedStatus.ALL_ALLOWED,
+            conversationType = ConversationEntity.Type.ONE_ON_ONE,
+            degradedConversationNotified = true,
+            legalHoldStatus = ConversationEntity.LegalHoldStatus.ENABLED,
+            legalHoldStatusChangeNotified = true
+        )
+    }
+
+}

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Notification.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Notification.sq
@@ -14,11 +14,14 @@ SELECT
     AssetContent.asset_mime_type AS assetMimeType,
     Conversation.muted_status AS mutedStatus,
     Conversation.type AS conversationType,
-    Conversation.degraded_conversation_notified AS degradedConversationNotified
+    Conversation.degraded_conversation_notified AS degradedConversationNotified,
+    Conversation.legal_hold_status AS legalHoldStatus,
+    LegalHoldNotified.legal_hold_status_change_notified AS legalHoldStatusChangeNotified
 FROM Message
 LEFT JOIN SelfUser
 JOIN User ON Message.sender_user_id = User.qualified_id AND Message.content_type IN  ('TEXT', 'RESTRICTED_ASSET', 'ASSET', 'KNOCK', 'MISSED_CALL', 'LOCATION')
 JOIN Conversation AS Conversation ON Message.conversation_id == Conversation.qualified_id AND (Message.creation_date > IFNULL(Conversation.last_notified_date, 0))
+JOIN ConversationLegalHoldStatusChangeNotified AS LegalHoldNotified ON Message.conversation_id == LegalHoldNotified.conversation_id AND (Message.creation_date > IFNULL(Conversation.last_notified_date, 0))
 LEFT JOIN MessageAssetContent AS AssetContent ON Message.id = AssetContent.message_id AND Message.conversation_id = AssetContent.conversation_id
 LEFT JOIN MessageTextContent AS TextContent ON Message.id = TextContent.message_id AND Message.conversation_id = TextContent.conversation_id
 WHERE

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
@@ -424,7 +424,9 @@ data class NotificationMessageEntity(
     val conversationName: String?,
     val mutedStatus: ConversationEntity.MutedStatus,
     val conversationType: ConversationEntity.Type,
-    val degradedConversationNotified: Boolean
+    val degradedConversationNotified: Boolean,
+    val legalHoldStatus: ConversationEntity.LegalHoldStatus,
+    val legalHoldStatusChangeNotified: Boolean
 )
 
 sealed class MessagePreviewEntityContent {

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
@@ -291,7 +291,9 @@ object MessageMapper {
         assetMimeType: String?,
         mutedStatus: ConversationEntity.MutedStatus,
         conversationType: ConversationEntity.Type,
-        degradedConversationNotified: Boolean
+        degradedConversationNotified: Boolean,
+        legalHoldStatus: ConversationEntity.LegalHoldStatus,
+        legalHoldStatusChangeNotified: Boolean
     ): NotificationMessageEntity = NotificationMessageEntity(
         id = id,
         contentType = contentType,
@@ -307,7 +309,9 @@ object MessageMapper {
         conversationType = conversationType,
         isQuotingSelf = isQuotingSelf == true,
         isSelfDelete = isSelfDelete,
-        degradedConversationNotified = degradedConversationNotified
+        degradedConversationNotified = degradedConversationNotified,
+        legalHoldStatus = legalHoldStatus,
+        legalHoldStatusChangeNotified = legalHoldStatusChangeNotified
     )
 
     private fun createMessageEntity(

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageNotificationsTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageNotificationsTest.kt
@@ -371,6 +371,8 @@ class MessageNotificationsTest : BaseMessageTest() {
     override suspend fun insertInitialData() {
         super.insertInitialData()
         // Always insert original messages
+        conversationDAO.updateLegalHoldStatusChangeNotified(TEST_CONVERSATION_1.id, true)
+        conversationDAO.updateLegalHoldStatusChangeNotified(TEST_CONVERSATION_2.id, true)
     }
 
     private companion object {


### PR DESCRIPTION
# What's new in this PR?

### Issues

When LegalHold activated and user was not notified about it, we need to disable "Reply" feature for notifications.

### Causes (Optional)

Wasn't implemented

### Solutions

Implement it.
