### PR TITLE
chore: use user-scoped logger for sync [WPB-8645] 

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/IncrementalSyncRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/IncrementalSyncRepository.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.logic.data.sync
 
+import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.SYNC
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository.Companion.BUFFER_SIZE
 import com.wire.kalium.logic.kaliumLogger
@@ -63,7 +64,12 @@ internal interface IncrementalSyncRepository {
     }
 }
 
-internal class InMemoryIncrementalSyncRepository : IncrementalSyncRepository {
+internal class InMemoryIncrementalSyncRepository(
+    logger: KaliumLogger = kaliumLogger,
+) : IncrementalSyncRepository {
+
+    private val logger = logger.withFeatureId(SYNC)
+
     private val _syncState = MutableSharedFlow<IncrementalSyncStatus>(
         replay = 1,
         extraBufferCapacity = BUFFER_SIZE,
@@ -90,13 +96,12 @@ internal class InMemoryIncrementalSyncRepository : IncrementalSyncRepository {
     }
 
     override suspend fun updateIncrementalSyncState(newState: IncrementalSyncStatus) {
-        kaliumLogger.withFeatureId(SYNC).i("IncrementalSyncStatus Updated FROM:${_syncState.first()}; TO: $newState")
+        logger.i("IncrementalSyncStatus Updated FROM:${_syncState.first()}; TO: $newState")
         _syncState.emit(newState)
     }
 
     override suspend fun setConnectionPolicy(connectionPolicy: ConnectionPolicy) {
-        kaliumLogger.withFeatureId(SYNC).i("IncrementalSync Connection Policy changed: $connectionPolicy")
+        logger.i("IncrementalSync Connection Policy changed: $connectionPolicy")
         _connectionPolicy.emit(connectionPolicy)
     }
-
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SlowSyncRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SlowSyncRepository.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.logic.data.sync
 
+import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.SYNC
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.persistence.dao.MetadataDAO
@@ -43,8 +44,11 @@ internal interface SlowSyncRepository {
     suspend fun getSlowSyncVersion(): Int?
 }
 
-internal class SlowSyncRepositoryImpl(private val metadataDao: MetadataDAO) : SlowSyncRepository {
-    private val logger = kaliumLogger.withFeatureId(SYNC)
+internal class SlowSyncRepositoryImpl(
+    private val metadataDao: MetadataDAO,
+    logger: KaliumLogger = kaliumLogger,
+) : SlowSyncRepository {
+    private val logger = logger.withFeatureId(SYNC)
 
     private val _slowSyncStatus = MutableStateFlow<SlowSyncStatus>(SlowSyncStatus.Pending)
     override val slowSyncStatus: StateFlow<SlowSyncStatus> get() = _slowSyncStatus.asStateFlow()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncManager.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.logic.sync
 
+import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.SYNC
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
@@ -61,9 +62,10 @@ interface SyncManager {
 internal class SyncManagerImpl(
     private val slowSyncRepository: SlowSyncRepository,
     private val incrementalSyncRepository: IncrementalSyncRepository,
+    logger: KaliumLogger = kaliumLogger,
 ) : SyncManager {
 
-    private val logger by lazy { kaliumLogger.withFeatureId(SYNC) }
+    private val logger by lazy { logger.withFeatureId(SYNC) }
 
     override suspend fun waitUntilLive() {
         incrementalSyncRepository.incrementalSyncState.first { it is IncrementalSyncStatus.Live }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.logic.sync.incremental
 
+import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.SYNC
 import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.CoreFailure
@@ -76,6 +77,7 @@ internal interface EventGatherer {
 internal class EventGathererImpl(
     private val eventRepository: EventRepository,
     private val incrementalSyncRepository: IncrementalSyncRepository,
+    logger: KaliumLogger = kaliumLogger,
 ) : EventGatherer {
 
     private val _currentSource = MutableStateFlow(EventSource.PENDING)
@@ -83,7 +85,7 @@ internal class EventGathererImpl(
     override val currentSource: StateFlow<EventSource> get() = _currentSource.asStateFlow()
 
     private val offlineEventBuffer = EventProcessingHistory()
-    private val logger = kaliumLogger.withFeatureId(SYNC)
+    private val logger = logger.withFeatureId(SYNC)
 
     override suspend fun gatherEvents(): Flow<EventEnvelope> = flow {
         offlineEventBuffer.clear()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessor.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessor.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.logic.sync.incremental
 
+import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.EVENT_RECEIVER
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.event.Event
@@ -69,11 +70,12 @@ internal class EventProcessorImpl(
     private val teamEventReceiver: TeamEventReceiver,
     private val featureConfigEventReceiver: FeatureConfigEventReceiver,
     private val userPropertiesEventReceiver: UserPropertiesEventReceiver,
-    private val federationEventReceiver: FederationEventReceiver
+    private val federationEventReceiver: FederationEventReceiver,
+    logger: KaliumLogger = kaliumLogger,
 ) : EventProcessor {
 
     private val logger by lazy {
-        kaliumLogger.withFeatureId(EVENT_RECEIVER)
+        logger.withFeatureId(EVENT_RECEIVER)
     }
 
     override var disableEventProcessing: Boolean = false

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.logic.sync.incremental
 
+import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.SYNC
 import com.wire.kalium.logic.data.sync.ConnectionPolicy
 import com.wire.kalium.logic.functional.onFailure
@@ -46,8 +47,11 @@ interface IncrementalSyncWorker {
 
 internal class IncrementalSyncWorkerImpl(
     private val eventGatherer: EventGatherer,
-    private val eventProcessor: EventProcessor
+    private val eventProcessor: EventProcessor,
+    logger: KaliumLogger = kaliumLogger,
 ) : IncrementalSyncWorker {
+
+    private val logger = logger.withFeatureId(SYNC)
 
     override suspend fun processEventsWhilePolicyAllowsFlow() = channelFlow {
         val sourceJob = launch {
@@ -62,7 +66,7 @@ internal class IncrementalSyncWorkerImpl(
             }
             // When events are all consumed, cancel the source job to complete the channelFlow
             sourceJob.cancel()
-            kaliumLogger.withFeatureId(SYNC).i("SYNC Finished gathering and processing events")
+            logger.withFeatureId(SYNC).i("SYNC Finished gathering and processing events")
         }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.logic.sync.slow
 
+import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.SYNC
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
@@ -67,13 +68,14 @@ internal class SlowSyncManager(
     private val slowSyncRecoveryHandler: SlowSyncRecoveryHandler,
     private val networkStateObserver: NetworkStateObserver,
     private val syncMigrationStepsProvider: () -> SyncMigrationStepsProvider,
+    logger: KaliumLogger = kaliumLogger,
     kaliumDispatcher: KaliumDispatcher = KaliumDispatcherImpl,
     private val exponentialDurationHelper: ExponentialDurationHelper = ExponentialDurationHelperImpl(MIN_RETRY_DELAY, MAX_RETRY_DELAY)
 ) {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private val scope = CoroutineScope(SupervisorJob() + kaliumDispatcher.default.limitedParallelism(1))
-    private val logger = kaliumLogger.withFeatureId(SYNC)
+    private val logger = logger.withFeatureId(SYNC)
 
     private val coroutineExceptionHandler = SyncExceptionHandler(
         onCancellation = {
@@ -88,7 +90,7 @@ internal class SlowSyncManager(
                     logger.i("SlowSync Triggering delay($delay) and waiting for reconnection")
                     networkStateObserver.delayUntilConnectedWithInternetAgain(delay)
                     logger.i("SlowSync Delay and waiting for connection finished - retrying")
-                    kaliumLogger.i("SlowSync Connected - retrying")
+                    logger.i("SlowSync Connected - retrying")
                     startMonitoring()
                 }
             }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManagerTest.kt
@@ -475,6 +475,5 @@ class SlowSyncManagerTest {
             block()
             this to slowSyncManager
         }
-
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8645" title="WPB-8645" target="_blank"><img alt="Epic" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10807?size=medium" />WPB-8645</a>  [Android] Infrastructure code and developer experience
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

It's hard to Sync logs when there are multiple users in the same CoreLogic instance.

### Solutions

Use `userScopedLogger` from `UserSessionScope` in Sync-related instances.

### Testing

N/A

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
