### PR TITLE
fix: testservice not closing websocket due to wrong logout (WPB-9030)

### DIFF
--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/InstanceService.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/InstanceService.kt
@@ -30,6 +30,7 @@ import com.wire.kalium.logic.data.client.ClientType
 import com.wire.kalium.logic.data.client.DeleteClientParam
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.logout.LogoutReason
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
 import com.wire.kalium.logic.feature.auth.AuthenticationResult
@@ -281,12 +282,8 @@ class InstanceService(
                 val result = session.currentSession()
                 if (result is CurrentSessionResult.Success) {
                     instance.coreLogic.sessionScope(result.accountInfo.userId) {
-                        instance.clientId?.let {
-                            runBlocking {
-                                client.deleteClient(DeleteClientParam(instance.password, ClientId(instance.clientId)))
-                            }
-                        }
-                        log.info("Instance $id: Device ${instance.clientId} removed")
+                        log.info("Instance $id: Logout device ${instance.clientId}")
+                        logout(reason = LogoutReason.SELF_HARD_LOGOUT, waitUntilCompletes = true)
                     }
                 }
             }

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/InstanceService.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/InstanceService.kt
@@ -27,7 +27,6 @@ import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.data.auth.login.ProxyCredentials
 import com.wire.kalium.logic.data.client.ClientType
-import com.wire.kalium.logic.data.client.DeleteClientParam
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.logout.LogoutReason


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The issue is that the testservice does not allow new logins of accounts after running for a while. The login timed out and did not directly show an error but was just not logging the user in and seems to wait. The machine showed over 220 established connections to the backend even thought no instance was running.

### Causes (Optional)

It looks like the websocket was not closed when instances were destroyed because of using the wrong logout method (which usually triggers closing of the websocket). There is a limit of open websockets either on library side or on system side.

### Solutions

The solution here is to use `logout(reason = LogoutReason.SELF_HARD_LOGOUT, waitUntilCompletes = true)` which triggers a close of the websocket. Not sure if this closing always will happen even if the logout process fails but my testing shows that no connections stay established after it was fired.
