### PR TITLE
fix: Stuck on Setting up Wire after canceling E2EI during login [WPB-10046]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
@@ -121,8 +121,14 @@ class ClientScope @OptIn(DelicateKaliumApi::class) internal constructor(
     val getProteusFingerprint: GetProteusFingerprintUseCase
         get() = GetProteusFingerprintUseCaseImpl(preKeyRepository)
 
+    @OptIn(DelicateKaliumApi::class)
     private val verifyExistingClientUseCase: VerifyExistingClientUseCase
-        get() = VerifyExistingClientUseCaseImpl(clientRepository)
+        get() = VerifyExistingClientUseCaseImpl(
+            selfUserId,
+            clientRepository,
+            isAllowedToRegisterMLSClient,
+            registerMLSClientUseCase
+        )
 
     val importClient: ImportClientUseCase
         get() = ImportClientUseCaseImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/GetOrRegisterClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/GetOrRegisterClientUseCase.kt
@@ -68,6 +68,11 @@ internal class GetOrRegisterClientUseCaseImpl(
                             clearOldClientRelatedData()
                             null
                         }
+
+                        is VerifyExistingClientResult.Failure.E2EICertificateRequired -> RegisterClientResult.E2EICertificateRequired(
+                            result.client,
+                            result.userId
+                        )
                     }
                 }
             ) ?: registerClient(registerClientParam)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/VerifyExistingClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/VerifyExistingClientUseCase.kt
@@ -22,7 +22,13 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.client.Client
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.logic.functional.getOrElse
+import com.wire.kalium.logic.functional.map
+import com.wire.kalium.util.DelicateKaliumApi
 
 /**
  * Checks if the given client is still exists on the backend, otherwise returns failure.
@@ -36,18 +42,48 @@ interface VerifyExistingClientUseCase {
     suspend operator fun invoke(clientId: ClientId): VerifyExistingClientResult
 }
 
-internal class VerifyExistingClientUseCaseImpl(
-    private val clientRepository: ClientRepository
+internal class VerifyExistingClientUseCaseImpl @OptIn(DelicateKaliumApi::class) constructor(
+    private val selfUserId: UserId,
+    private val clientRepository: ClientRepository,
+    private val isAllowedToRegisterMLSClient: IsAllowedToRegisterMLSClientUseCase,
+    private val registerMLSClientUseCase: RegisterMLSClientUseCase,
 ) : VerifyExistingClientUseCase {
 
+    @OptIn(DelicateKaliumApi::class)
     override suspend fun invoke(clientId: ClientId): VerifyExistingClientResult {
         return clientRepository.selfListOfClients()
             .fold({
                 VerifyExistingClientResult.Failure.Generic(it)
             }, { listOfClients ->
                 val client = listOfClients.firstOrNull { it.id == clientId }
+                when {
+                    (client == null) -> VerifyExistingClientResult.Failure.ClientNotRegistered
+
+                    isAllowedToRegisterMLSClient() -> {
+                        registerMLSClientUseCase.invoke(clientId = client.id).map {
+                            if (it is RegisterMLSClientResult.E2EICertificateRequired)
+                                VerifyExistingClientResult.Failure.E2EICertificateRequired(client, selfUserId)
+                            else VerifyExistingClientResult.Success(client)
+                        }.getOrElse { VerifyExistingClientResult.Failure.Generic(it) }
+                    }
+
+                    else -> VerifyExistingClientResult.Success(client)
+                }
+
+
+
                 if (client != null) {
-                    VerifyExistingClientResult.Success(client)
+                    if (isAllowedToRegisterMLSClient()) {
+                        registerMLSClientUseCase.invoke(clientId = client.id).fold({
+                            VerifyExistingClientResult.Failure.Generic(it)
+                        }) {
+                            if (it is RegisterMLSClientResult.E2EICertificateRequired)
+                                VerifyExistingClientResult.Failure.E2EICertificateRequired(client, selfUserId)
+                            else VerifyExistingClientResult.Success(client)
+                        }
+                    } else {
+                        VerifyExistingClientResult.Success(client)
+                    }
                 } else {
                     VerifyExistingClientResult.Failure.ClientNotRegistered
                 }
@@ -61,5 +97,6 @@ sealed class VerifyExistingClientResult {
     sealed class Failure : VerifyExistingClientResult() {
         data object ClientNotRegistered : Failure()
         data class Generic(val genericFailure: CoreFailure) : Failure()
+        class E2EICertificateRequired(val client: Client, val userId: UserId) : Failure()
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/VerifyExistingClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/VerifyExistingClientUseCase.kt
@@ -23,8 +23,6 @@ import com.wire.kalium.logic.data.client.Client
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.functional.Either
-import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.getOrElse
 import com.wire.kalium.logic.functional.map
@@ -69,8 +67,6 @@ internal class VerifyExistingClientUseCaseImpl @OptIn(DelicateKaliumApi::class) 
 
                     else -> VerifyExistingClientResult.Success(client)
                 }
-
-
 
                 if (client != null) {
                     if (isAllowedToRegisterMLSClient()) {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/usecase/IsAllowedToRegisterMLSClientUseCaseArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/usecase/IsAllowedToRegisterMLSClientUseCaseArrangement.kt
@@ -1,0 +1,45 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.util.arrangement.usecase
+
+import com.wire.kalium.logic.feature.client.IsAllowedToRegisterMLSClientUseCase
+import com.wire.kalium.util.DelicateKaliumApi
+import io.mockative.given
+import io.mockative.mock
+
+@OptIn(DelicateKaliumApi::class)
+interface IsAllowedToRegisterMLSClientUseCaseArrangement {
+
+    val isAllowedToRegisterMLSClientUseCase: IsAllowedToRegisterMLSClientUseCase
+
+    fun withIsAllowedToRegisterMLSClient(isAllowed: Boolean)
+}
+
+@OptIn(DelicateKaliumApi::class)
+class IsAllowedToRegisterMLSClientUseCaseArrangementImpl : IsAllowedToRegisterMLSClientUseCaseArrangement {
+
+    override val isAllowedToRegisterMLSClientUseCase: IsAllowedToRegisterMLSClientUseCase = mock(IsAllowedToRegisterMLSClientUseCase::class)
+
+    override fun withIsAllowedToRegisterMLSClient(isAllowed: Boolean) {
+        given(isAllowedToRegisterMLSClientUseCase)
+            .suspendFunction(isAllowedToRegisterMLSClientUseCase::invoke)
+            .whenInvoked()
+            .thenReturn(isAllowed)
+    }
+
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/usecase/RegisterMLSClientUseCase.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/usecase/RegisterMLSClientUseCase.kt
@@ -1,0 +1,45 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.util.arrangement.usecase
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.feature.client.RegisterMLSClientResult
+import com.wire.kalium.logic.feature.client.RegisterMLSClientUseCase
+import com.wire.kalium.logic.functional.Either
+import io.mockative.any
+import io.mockative.given
+import io.mockative.mock
+
+interface RegisterMLSClientUseCaseArrangement {
+
+    val registerMLSClientUseCase: RegisterMLSClientUseCase
+
+    fun withRegisterMLSClient(result: Either<CoreFailure, RegisterMLSClientResult>)
+}
+
+class RegisterMLSClientUseCaseArrangementImpl : RegisterMLSClientUseCaseArrangement {
+    override val registerMLSClientUseCase: RegisterMLSClientUseCase = mock(RegisterMLSClientUseCase::class)
+
+    override fun withRegisterMLSClient(result: Either<CoreFailure, RegisterMLSClientResult>) {
+        given(registerMLSClientUseCase)
+            .suspendFunction(registerMLSClientUseCase::invoke)
+            .whenInvokedWith(any())
+            .thenReturn(result)
+    }
+
+}


### PR DESCRIPTION
# What's new in this PR?

### Issues

When the user wants to login with his second account, and cancels generating his certificate and then tries to login again, he’s stuck on setting up wire screen.

### Causes (Optional)

When user trying to login to the same acc as already tried, client is already exist. Checking "if E2EI is required" was missed for existed clients.

### Solutions

Add checking if E2EI is required for the case when user login into existed client (`VerifyExistingClientUseCase`). 
And update unit tests.
