### PR TITLE
feat: add useSFTForOneToOneCalls flag (WPB-7153)

### DIFF
--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigModel.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigModel.kt
@@ -90,7 +90,8 @@ data class MLSMigrationModel(
 )
 
 data class ConferenceCallingModel(
-    val status: Status
+    val status: Status,
+    val useSFTForOneOnOneCalls: Boolean
 )
 
 data class E2EIModel(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
@@ -93,6 +93,8 @@ interface UserConfigRepository {
     suspend fun getSupportedProtocols(): Either<StorageFailure, Set<SupportedProtocol>>
     fun setConferenceCallingEnabled(enabled: Boolean): Either<StorageFailure, Unit>
     fun isConferenceCallingEnabled(): Either<StorageFailure, Boolean>
+    fun setUseSFTForOneOnOneCalls(shouldUse: Boolean): Either<StorageFailure, Unit>
+    fun shouldUseSFTForOneOnOneCalls(): Either<StorageFailure, Boolean>
     fun setSecondFactorPasswordChallengeStatus(isRequired: Boolean): Either<StorageFailure, Unit>
     fun isSecondFactorPasswordChallengeRequired(): Either<StorageFailure, Boolean>
     fun isReadReceiptsEnabled(): Flow<Either<StorageFailure, Boolean>>
@@ -291,6 +293,14 @@ internal class UserConfigDataSource internal constructor(
         wrapStorageRequest {
             userConfigStorage.isConferenceCallingEnabled()
         }
+
+    override fun setUseSFTForOneOnOneCalls(shouldUse: Boolean): Either<StorageFailure, Unit> = wrapStorageRequest {
+        userConfigStorage.persistUseSftForOneOnOneCalls(shouldUse)
+    }
+
+    override fun shouldUseSFTForOneOnOneCalls(): Either<StorageFailure, Boolean> = wrapStorageRequest {
+        userConfigStorage.shouldUseSftForOneOnOneCalls()
+    }
 
     override fun setSecondFactorPasswordChallengeStatus(isRequired: Boolean): Either<StorageFailure, Unit> =
         wrapStorageRequest {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
@@ -131,7 +131,8 @@ class FeatureConfigMapperImpl : FeatureConfigMapper {
 
     override fun fromDTO(data: FeatureConfigData.ConferenceCalling): ConferenceCallingModel =
         ConferenceCallingModel(
-            status = fromDTO(data.status)
+            status = fromDTO(data.status),
+            useSFTForOneOnOneCalls = data.config.useSFTForOneToOneCalls
         )
 
     override fun fromDTO(data: FeatureConfigData.E2EI?): E2EIModel =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCase.kt
@@ -71,7 +71,7 @@ internal class SyncFeatureConfigsUseCaseImpl(
             conferenceCallingConfigHandler.handle(it.conferenceCallingModel)
             passwordChallengeConfigHandler.handle(it.secondFactorPasswordChallengeModel)
             selfDeletingMessagesConfigHandler.handle(it.selfDeletingMessagesModel)
-            it.e2EIModel?.let { e2EIModel -> e2EIConfigHandler.handle(e2EIModel) }
+            it.e2EIModel.let { e2EIModel -> e2EIConfigHandler.handle(e2EIModel) }
             appLockConfigHandler.handle(it.appLockModel)
             Either.Right(Unit)
         }.onFailure { networkFailure ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/handler/ConferenceCallingConfigHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/handler/ConferenceCallingConfigHandler.kt
@@ -22,12 +22,16 @@ import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.featureConfig.ConferenceCallingModel
 import com.wire.kalium.logic.data.featureConfig.Status
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.flatMap
 
 class ConferenceCallingConfigHandler(
     private val userConfigRepository: UserConfigRepository
 ) {
     fun handle(conferenceCallingConfig: ConferenceCallingModel): Either<CoreFailure, Unit> {
         val conferenceCallingEnabled = conferenceCallingConfig.status == Status.ENABLED
-        return userConfigRepository.setConferenceCallingEnabled(conferenceCallingEnabled)
+        val result = userConfigRepository.setConferenceCallingEnabled(conferenceCallingEnabled).flatMap {
+            userConfigRepository.setUseSFTForOneOnOneCalls(conferenceCallingConfig.useSFTForOneOnOneCalls)
+        }
+        return result
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/FeatureConfigMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/FeatureConfigMapperTest.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.logic.data.featureConfig.FeatureConfigMapperImpl
 import com.wire.kalium.logic.data.featureConfig.Status
 import com.wire.kalium.network.api.authenticated.featureConfigs.AppLockConfigDTO
 import com.wire.kalium.network.api.authenticated.featureConfigs.ClassifiedDomainsConfigDTO
+import com.wire.kalium.network.api.authenticated.featureConfigs.ConferenceCallingConfig
 import com.wire.kalium.network.api.authenticated.featureConfigs.FeatureConfigData
 import com.wire.kalium.network.api.authenticated.featureConfigs.FeatureConfigResponse
 import com.wire.kalium.network.api.authenticated.featureConfigs.FeatureFlagStatusDTO
@@ -141,7 +142,7 @@ class FeatureConfigMapperTest {
                 ClassifiedDomainsConfigDTO(listOf("wire.com")),
                 FeatureFlagStatusDTO.ENABLED
             ),
-            FeatureConfigData.ConferenceCalling(FeatureFlagStatusDTO.ENABLED),
+            FeatureConfigData.ConferenceCalling(FeatureFlagStatusDTO.ENABLED, ConferenceCallingConfig(false)),
             FeatureConfigData.ConversationGuestLinks(FeatureFlagStatusDTO.ENABLED),
             FeatureConfigData.DigitalSignatures(FeatureFlagStatusDTO.ENABLED),
             FeatureConfigData.FileSharing(FeatureFlagStatusDTO.ENABLED),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/FeatureConfigMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/FeatureConfigMapperTest.kt
@@ -23,7 +23,7 @@ import com.wire.kalium.logic.data.featureConfig.FeatureConfigMapperImpl
 import com.wire.kalium.logic.data.featureConfig.Status
 import com.wire.kalium.network.api.authenticated.featureConfigs.AppLockConfigDTO
 import com.wire.kalium.network.api.authenticated.featureConfigs.ClassifiedDomainsConfigDTO
-import com.wire.kalium.network.api.authenticated.featureConfigs.ConferenceCallingConfig
+import com.wire.kalium.network.api.authenticated.featureConfigs.ConferenceCallingConfigDTO
 import com.wire.kalium.network.api.authenticated.featureConfigs.FeatureConfigData
 import com.wire.kalium.network.api.authenticated.featureConfigs.FeatureConfigResponse
 import com.wire.kalium.network.api.authenticated.featureConfigs.FeatureFlagStatusDTO
@@ -142,7 +142,7 @@ class FeatureConfigMapperTest {
                 ClassifiedDomainsConfigDTO(listOf("wire.com")),
                 FeatureFlagStatusDTO.ENABLED
             ),
-            FeatureConfigData.ConferenceCalling(FeatureFlagStatusDTO.ENABLED, ConferenceCallingConfig(false)),
+            FeatureConfigData.ConferenceCalling(FeatureFlagStatusDTO.ENABLED, ConferenceCallingConfigDTO(false)),
             FeatureConfigData.ConversationGuestLinks(FeatureFlagStatusDTO.ENABLED),
             FeatureConfigData.DigitalSignatures(FeatureFlagStatusDTO.ENABLED),
             FeatureConfigData.FileSharing(FeatureFlagStatusDTO.ENABLED),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigRepositoryTest.kt
@@ -25,7 +25,7 @@ import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.authenticated.featureConfigs.AppLockConfigDTO
 import com.wire.kalium.network.api.authenticated.featureConfigs.ClassifiedDomainsConfigDTO
-import com.wire.kalium.network.api.authenticated.featureConfigs.ConferenceCallingConfig
+import com.wire.kalium.network.api.authenticated.featureConfigs.ConferenceCallingConfigDTO
 import com.wire.kalium.network.api.authenticated.featureConfigs.E2EIConfigDTO
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigApi
 import com.wire.kalium.network.api.authenticated.featureConfigs.FeatureConfigData
@@ -146,7 +146,7 @@ class FeatureConfigRepositoryTest {
                 AppLockConfigDTO(true, 0), FeatureFlagStatusDTO.ENABLED
             ),
             FeatureConfigData.ClassifiedDomains(ClassifiedDomainsConfigDTO(listOf()), FeatureFlagStatusDTO.ENABLED),
-            FeatureConfigData.ConferenceCalling(FeatureFlagStatusDTO.ENABLED, ConferenceCallingConfig(false)),
+            FeatureConfigData.ConferenceCalling(FeatureFlagStatusDTO.ENABLED, ConferenceCallingConfigDTO(false)),
             FeatureConfigData.ConversationGuestLinks(FeatureFlagStatusDTO.ENABLED),
             FeatureConfigData.DigitalSignatures(FeatureFlagStatusDTO.ENABLED),
             FeatureConfigData.FileSharing(FeatureFlagStatusDTO.ENABLED),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigRepositoryTest.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.authenticated.featureConfigs.AppLockConfigDTO
 import com.wire.kalium.network.api.authenticated.featureConfigs.ClassifiedDomainsConfigDTO
+import com.wire.kalium.network.api.authenticated.featureConfigs.ConferenceCallingConfig
 import com.wire.kalium.network.api.authenticated.featureConfigs.E2EIConfigDTO
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigApi
 import com.wire.kalium.network.api.authenticated.featureConfigs.FeatureConfigData
@@ -59,7 +60,7 @@ class FeatureConfigRepositoryTest {
                 ClassifiedDomainsConfigModel(listOf()),
                 Status.ENABLED
             ),
-            ConferenceCallingModel(Status.ENABLED),
+            ConferenceCallingModel(Status.ENABLED, false),
             ConfigsStatusModel(Status.ENABLED),
             ConfigsStatusModel(Status.ENABLED),
             ConfigsStatusModel(Status.ENABLED),
@@ -145,7 +146,7 @@ class FeatureConfigRepositoryTest {
                 AppLockConfigDTO(true, 0), FeatureFlagStatusDTO.ENABLED
             ),
             FeatureConfigData.ClassifiedDomains(ClassifiedDomainsConfigDTO(listOf()), FeatureFlagStatusDTO.ENABLED),
-            FeatureConfigData.ConferenceCalling(FeatureFlagStatusDTO.ENABLED),
+            FeatureConfigData.ConferenceCalling(FeatureFlagStatusDTO.ENABLED, ConferenceCallingConfig(false)),
             FeatureConfigData.ConversationGuestLinks(FeatureFlagStatusDTO.ENABLED),
             FeatureConfigData.DigitalSignatures(FeatureFlagStatusDTO.ENABLED),
             FeatureConfigData.FileSharing(FeatureFlagStatusDTO.ENABLED),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigTest.kt
@@ -29,7 +29,7 @@ object FeatureConfigTest {
             ClassifiedDomainsConfigModel(listOf()),
             Status.ENABLED
         ),
-        conferenceCallingModel: ConferenceCallingModel = ConferenceCallingModel(Status.ENABLED),
+        conferenceCallingModel: ConferenceCallingModel = ConferenceCallingModel(Status.ENABLED, false),
         conversationGuestLinksModel: ConfigsStatusModel = ConfigsStatusModel(Status.ENABLED),
         digitalSignaturesModel: ConfigsStatusModel = ConfigsStatusModel(Status.ENABLED),
         fileSharingModel: ConfigsStatusModel = ConfigsStatusModel(Status.ENABLED),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCaseTest.kt
@@ -119,7 +119,7 @@ class SyncFeatureConfigsUseCaseTest {
     fun givenConferenceCallingIsEnabled_whenSyncing_thenItShouldBeStoredAsEnabled() = runTest {
         val (arrangement, syncFeatureConfigsUseCase) = Arrangement()
             .withRemoteFeatureConfigsSucceeding(
-                FeatureConfigTest.newModel(conferenceCallingModel = ConferenceCallingModel(Status.ENABLED))
+                FeatureConfigTest.newModel(conferenceCallingModel = ConferenceCallingModel(Status.ENABLED, false))
             )
             .withGetTeamSettingsSelfDeletionStatusSuccessful()
             .withGetSupportedProtocolsReturning(null)
@@ -136,7 +136,7 @@ class SyncFeatureConfigsUseCaseTest {
     fun givenConferenceCallingIsDisasbled_whenSyncing_thenItShouldBeStoredAsDisabled() = runTest {
         val (arrangement, syncFeatureConfigsUseCase) = Arrangement()
             .withRemoteFeatureConfigsSucceeding(
-                FeatureConfigTest.newModel(conferenceCallingModel = ConferenceCallingModel(Status.DISABLED))
+                FeatureConfigTest.newModel(conferenceCallingModel = ConferenceCallingModel(Status.DISABLED, false))
             )
             .withGetTeamSettingsSelfDeletionStatusSuccessful()
             .withGetSupportedProtocolsReturning(null)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/handler/ConferenceCallingConfigHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/handler/ConferenceCallingConfigHandlerTest.kt
@@ -1,0 +1,141 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.featureConfig.handler
+
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.data.featureConfig.ConferenceCallingModel
+import com.wire.kalium.logic.data.featureConfig.Status
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.isLeft
+import com.wire.kalium.logic.functional.isRight
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.every
+import io.mockative.mock
+import io.mockative.once
+import io.mockative.verify
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class ConferenceCallingConfigHandlerTest {
+
+    @Test
+    fun givenUserConfigRepositoryFailureForConferenceCallingEnabled_whenHandlingTheEvent_ThenReturnFailure() {
+        val conferenceCallingModel = ConferenceCallingModel(Status.ENABLED, false)
+        val (arrangement, conferenceCallingConfigHandler) = Arrangement()
+            .withSetConferenceCallingEnabledFailure()
+            .arrange()
+
+        val result = conferenceCallingConfigHandler.handle(conferenceCallingModel)
+
+        verify {
+            arrangement.userConfigRepository.setConferenceCallingEnabled(conferenceCallingModel.status.toBoolean())
+        }.wasInvoked(exactly = once)
+
+        verify {
+            arrangement.userConfigRepository.setUseSFTForOneOnOneCalls(any())
+        }.wasNotInvoked()
+
+        assertTrue { result.isLeft() }
+    }
+
+    @Test
+    fun givenUserConfigRepositoryFailureForUseSFTForOneOnOneCalls_whenHandlingTheEvent_ThenReturnFailure() {
+        val conferenceCallingModel = ConferenceCallingModel(Status.ENABLED, false)
+        val (arrangement, conferenceCallingConfigHandler) = Arrangement()
+            .withSetConferenceCallingEnabledSuccess()
+            .withSetUseSFTForOneOnOneCallsFailure()
+            .arrange()
+
+        val result = conferenceCallingConfigHandler.handle(conferenceCallingModel)
+
+        verify {
+            arrangement.userConfigRepository.setConferenceCallingEnabled(conferenceCallingModel.status.toBoolean())
+        }.wasInvoked(exactly = once)
+
+        verify {
+            arrangement.userConfigRepository.setUseSFTForOneOnOneCalls(any())
+        }.wasInvoked(exactly = once)
+
+        assertTrue { result.isLeft() }
+    }
+
+    @Test
+    fun givenUserConfigRepositorySuccess_whenHandlingTheEvent_ThenReturnUnit() {
+        val conferenceCallingModel = ConferenceCallingModel(Status.ENABLED, false)
+        val (arrangement, conferenceCallingConfigHandler) = Arrangement()
+            .withSetConferenceCallingEnabledSuccess()
+            .withSetUseSFTForOneOnOneCallsSuccess()
+            .arrange()
+
+        val result = conferenceCallingConfigHandler.handle(conferenceCallingModel)
+
+        verify {
+            arrangement.userConfigRepository.setConferenceCallingEnabled(conferenceCallingModel.status.toBoolean())
+        }.wasInvoked(exactly = once)
+
+        verify {
+            arrangement.userConfigRepository.setUseSFTForOneOnOneCalls(any())
+        }.wasInvoked(exactly = once)
+
+        assertTrue { result.isRight() }
+    }
+
+    private class Arrangement {
+
+        @Mock
+        val userConfigRepository: UserConfigRepository = mock(UserConfigRepository::class)
+
+        fun arrange() = run {
+            this@Arrangement to ConferenceCallingConfigHandler(
+                userConfigRepository = userConfigRepository
+            )
+        }
+
+        init {
+            every {
+                userConfigRepository.setAppLockStatus(any(), any(), any())
+            }.returns(Either.Right(Unit))
+        }
+
+        fun withSetConferenceCallingEnabledFailure() = apply {
+            every {
+                userConfigRepository.setConferenceCallingEnabled(any())
+            }.returns(Either.Left(StorageFailure.DataNotFound))
+        }
+
+        fun withSetConferenceCallingEnabledSuccess() = apply {
+            every {
+                userConfigRepository.setConferenceCallingEnabled(any())
+            }.returns(Either.Right(Unit))
+        }
+
+        fun withSetUseSFTForOneOnOneCallsFailure() = apply {
+            every {
+                userConfigRepository.setUseSFTForOneOnOneCalls(any())
+            }.returns(Either.Left(StorageFailure.DataNotFound))
+        }
+
+        fun withSetUseSFTForOneOnOneCallsSuccess() = apply {
+            every {
+                userConfigRepository.setUseSFTForOneOnOneCalls(any())
+            }.returns(Either.Right(Unit))
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
@@ -112,8 +112,9 @@ class FeatureConfigEventReceiverTest {
     }
 
     @Test
-    fun givenConferenceCallingUpdatedEventGrantingAccess_whenProcessingEvent_ThenSetConferenceCallingEnabledToTrue() = runTest {
+    fun givenConferenceCallingEventEnabled_whenProcessingEvent_ThenSetConferenceCallingEnabledToTrueAndSetShouldUseSFTFlag() = runTest {
         val (arrangement, featureConfigEventReceiver) = Arrangement()
+            .withSetUseSFTForOneOnOneCallsSuccessful()
             .withSettingConferenceCallingEnabledSuccessful()
             .arrange()
 
@@ -125,11 +126,16 @@ class FeatureConfigEventReceiverTest {
         verify {
             arrangement.userConfigRepository.setConferenceCallingEnabled(eq(true))
         }.wasInvoked(once)
+
+        verify {
+            arrangement.userConfigRepository.setUseSFTForOneOnOneCalls(eq(false))
+        }.wasInvoked(once)
     }
 
     @Test
-    fun givenConferenceCallingUpdatedEventGrantingAccess_whenProcessingEvent_ThenSetConferenceCallingEnabledToFalse() = runTest {
+    fun givenConferenceCallingEventDisabled_whenProcessingEvent_ThenSetConferenceCallingEnabledToFalseOnly() = runTest {
         val (arrangement, featureConfigEventReceiver) = Arrangement()
+            .withSetUseSFTForOneOnOneCallsSuccessful()
             .withSettingConferenceCallingEnabledSuccessful()
             .arrange()
 
@@ -141,6 +147,10 @@ class FeatureConfigEventReceiverTest {
         verify {
             arrangement.userConfigRepository.setConferenceCallingEnabled(eq(false))
         }.wasInvoked(once)
+
+        verify {
+            arrangement.userConfigRepository.setUseSFTForOneOnOneCalls(eq(true))
+        }.wasNotInvoked()
     }
 
     @Test
@@ -336,6 +346,12 @@ class FeatureConfigEventReceiverTest {
         fun withSettingConferenceCallingEnabledSuccessful() = apply {
             every {
                 userConfigRepository.setConferenceCallingEnabled(any())
+            }.returns(Either.Right(Unit))
+        }
+
+        fun withSetUseSFTForOneOnOneCallsSuccessful() = apply {
+            every {
+                userConfigRepository.setUseSFTForOneOnOneCalls(any())
             }.returns(Either.Right(Unit))
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
@@ -118,7 +118,7 @@ class FeatureConfigEventReceiverTest {
             .arrange()
 
         featureConfigEventReceiver.onEvent(
-            arrangement.newConferenceCallingUpdatedEvent(ConferenceCallingModel(Status.ENABLED)),
+            arrangement.newConferenceCallingUpdatedEvent(ConferenceCallingModel(Status.ENABLED, false)),
             TestEvent.liveDeliveryInfo
         )
 
@@ -134,7 +134,7 @@ class FeatureConfigEventReceiverTest {
             .arrange()
 
         featureConfigEventReceiver.onEvent(
-            event = arrangement.newConferenceCallingUpdatedEvent(ConferenceCallingModel(Status.DISABLED)),
+            event = arrangement.newConferenceCallingUpdatedEvent(ConferenceCallingModel(Status.DISABLED, false)),
             deliveryInfo = TestEvent.liveDeliveryInfo
         )
 

--- a/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/FeatureConfigJson.kt
+++ b/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/FeatureConfigJson.kt
@@ -20,7 +20,7 @@ package com.wire.kalium.mocks.responses
 
 import com.wire.kalium.network.api.authenticated.featureConfigs.AppLockConfigDTO
 import com.wire.kalium.network.api.authenticated.featureConfigs.ClassifiedDomainsConfigDTO
-import com.wire.kalium.network.api.authenticated.featureConfigs.ConferenceCallingConfig
+import com.wire.kalium.network.api.authenticated.featureConfigs.ConferenceCallingConfigDTO
 import com.wire.kalium.network.api.authenticated.featureConfigs.FeatureConfigData
 import com.wire.kalium.network.api.authenticated.featureConfigs.FeatureConfigData.AppLock
 import com.wire.kalium.network.api.authenticated.featureConfigs.FeatureConfigData.ClassifiedDomains
@@ -66,8 +66,8 @@ object FeatureConfigJson {
             |  },
             |  "conferenceCalling": {
             |    "config": {
-			|      "useSFTForOneToOneCalls": false,
-		    |    },
+			|      "useSFTForOneToOneCalls": false
+            |    },
             |    "status": "enabled"
             |  },
             |  "conversationGuestLinks": {
@@ -120,7 +120,7 @@ object FeatureConfigJson {
                 AppLockConfigDTO(true, 0), FeatureFlagStatusDTO.ENABLED
             ),
             ClassifiedDomains(ClassifiedDomainsConfigDTO(listOf()), FeatureFlagStatusDTO.ENABLED),
-            ConferenceCalling(FeatureFlagStatusDTO.ENABLED, ConferenceCallingConfig(false)),
+            ConferenceCalling(FeatureFlagStatusDTO.ENABLED, ConferenceCallingConfigDTO(false)),
             ConversationGuestLinks(FeatureFlagStatusDTO.ENABLED),
             DigitalSignatures(FeatureFlagStatusDTO.ENABLED),
             FileSharing(FeatureFlagStatusDTO.ENABLED),

--- a/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/FeatureConfigJson.kt
+++ b/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/FeatureConfigJson.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.mocks.responses
 
 import com.wire.kalium.network.api.authenticated.featureConfigs.AppLockConfigDTO
 import com.wire.kalium.network.api.authenticated.featureConfigs.ClassifiedDomainsConfigDTO
+import com.wire.kalium.network.api.authenticated.featureConfigs.ConferenceCallingConfig
 import com.wire.kalium.network.api.authenticated.featureConfigs.FeatureConfigData
 import com.wire.kalium.network.api.authenticated.featureConfigs.FeatureConfigData.AppLock
 import com.wire.kalium.network.api.authenticated.featureConfigs.FeatureConfigData.ClassifiedDomains
@@ -64,6 +65,9 @@ object FeatureConfigJson {
             |    "status": "enabled"
             |  },
             |  "conferenceCalling": {
+            |    "config": {
+			|      "useSFTForOneToOneCalls": false,
+		    |    },
             |    "status": "enabled"
             |  },
             |  "conversationGuestLinks": {
@@ -116,7 +120,7 @@ object FeatureConfigJson {
                 AppLockConfigDTO(true, 0), FeatureFlagStatusDTO.ENABLED
             ),
             ClassifiedDomains(ClassifiedDomainsConfigDTO(listOf()), FeatureFlagStatusDTO.ENABLED),
-            ConferenceCalling(FeatureFlagStatusDTO.ENABLED),
+            ConferenceCalling(FeatureFlagStatusDTO.ENABLED, ConferenceCallingConfig(false)),
             ConversationGuestLinks(FeatureFlagStatusDTO.ENABLED),
             DigitalSignatures(FeatureFlagStatusDTO.ENABLED),
             FileSharing(FeatureFlagStatusDTO.ENABLED),

--- a/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/FeatureConfigResponseJson.kt
+++ b/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/FeatureConfigResponseJson.kt
@@ -19,6 +19,7 @@ package com.wire.kalium.mocks.responses
 
 import com.wire.kalium.network.api.authenticated.featureConfigs.AppLockConfigDTO
 import com.wire.kalium.network.api.authenticated.featureConfigs.ClassifiedDomainsConfigDTO
+import com.wire.kalium.network.api.authenticated.featureConfigs.ConferenceCallingConfig
 import com.wire.kalium.network.api.authenticated.featureConfigs.E2EIConfigDTO
 import com.wire.kalium.network.api.authenticated.featureConfigs.FeatureConfigData
 import com.wire.kalium.network.api.authenticated.featureConfigs.FeatureConfigResponse
@@ -46,7 +47,7 @@ object FeatureConfigResponseJson {
             ClassifiedDomainsConfigDTO(listOf("wire.com")),
             FeatureFlagStatusDTO.ENABLED
         ),
-        FeatureConfigData.ConferenceCalling(FeatureFlagStatusDTO.ENABLED),
+        FeatureConfigData.ConferenceCalling(FeatureFlagStatusDTO.ENABLED, ConferenceCallingConfig(false)),
         FeatureConfigData.ConversationGuestLinks(FeatureFlagStatusDTO.ENABLED),
         FeatureConfigData.DigitalSignatures(FeatureFlagStatusDTO.ENABLED),
         FeatureConfigData.FileSharing(FeatureFlagStatusDTO.ENABLED),

--- a/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/FeatureConfigResponseJson.kt
+++ b/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/FeatureConfigResponseJson.kt
@@ -19,7 +19,7 @@ package com.wire.kalium.mocks.responses
 
 import com.wire.kalium.network.api.authenticated.featureConfigs.AppLockConfigDTO
 import com.wire.kalium.network.api.authenticated.featureConfigs.ClassifiedDomainsConfigDTO
-import com.wire.kalium.network.api.authenticated.featureConfigs.ConferenceCallingConfig
+import com.wire.kalium.network.api.authenticated.featureConfigs.ConferenceCallingConfigDTO
 import com.wire.kalium.network.api.authenticated.featureConfigs.E2EIConfigDTO
 import com.wire.kalium.network.api.authenticated.featureConfigs.FeatureConfigData
 import com.wire.kalium.network.api.authenticated.featureConfigs.FeatureConfigResponse
@@ -47,7 +47,7 @@ object FeatureConfigResponseJson {
             ClassifiedDomainsConfigDTO(listOf("wire.com")),
             FeatureFlagStatusDTO.ENABLED
         ),
-        FeatureConfigData.ConferenceCalling(FeatureFlagStatusDTO.ENABLED, ConferenceCallingConfig(false)),
+        FeatureConfigData.ConferenceCalling(FeatureFlagStatusDTO.ENABLED, ConferenceCallingConfigDTO(false)),
         FeatureConfigData.ConversationGuestLinks(FeatureFlagStatusDTO.ENABLED),
         FeatureConfigData.DigitalSignatures(FeatureFlagStatusDTO.ENABLED),
         FeatureConfigData.FileSharing(FeatureFlagStatusDTO.ENABLED),

--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/featureConfigs/FeatureConfigResponse.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/featureConfigs/FeatureConfigResponse.kt
@@ -69,6 +69,12 @@ enum class FeatureFlagStatusDTO {
 }
 
 @Serializable
+data class ConferenceCallingConfig(
+    @SerialName("useSFTForOneToOneCalls")
+    val useSFTForOneToOneCalls: Boolean
+)
+
+@Serializable
 data class AppLockConfigDTO(
     @SerialName("enforceAppLock")
     val enforceAppLock: Boolean,
@@ -155,7 +161,9 @@ sealed class FeatureConfigData {
     @Serializable
     data class ConferenceCalling(
         @SerialName("status")
-        val status: FeatureFlagStatusDTO
+        val status: FeatureFlagStatusDTO,
+        @SerialName("config")
+        val config: ConferenceCallingConfig
     ) : FeatureConfigData()
 
     @SerialName("conversationGuestLinks")

--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/featureConfigs/FeatureConfigResponse.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/featureConfigs/FeatureConfigResponse.kt
@@ -69,7 +69,7 @@ enum class FeatureFlagStatusDTO {
 }
 
 @Serializable
-data class ConferenceCallingConfig(
+data class ConferenceCallingConfigDTO(
     @SerialName("useSFTForOneToOneCalls")
     val useSFTForOneToOneCalls: Boolean
 )
@@ -163,7 +163,7 @@ sealed class FeatureConfigData {
         @SerialName("status")
         val status: FeatureFlagStatusDTO,
         @SerialName("config")
-        val config: ConferenceCallingConfig
+        val config: ConferenceCallingConfigDTO
     ) : FeatureConfigData()
 
     @SerialName("conversationGuestLinks")

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/config/UserConfigStorage.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/config/UserConfigStorage.kt
@@ -145,6 +145,10 @@ interface UserConfigStorage {
      */
     fun isConferenceCallingEnabled(): Boolean
 
+    fun persistUseSftForOneOnOneCalls(shouldUse: Boolean)
+
+    fun shouldUseSftForOneOnOneCalls(): Boolean
+
     /**
      * Get the saved flag to know whether user's Read Receipts are currently enabled or not
      */
@@ -503,6 +507,16 @@ class UserConfigStorageImpl(
             DEFAULT_CONFERENCE_CALLING_ENABLED_VALUE
         )
 
+    override fun persistUseSftForOneOnOneCalls(shouldUse: Boolean) {
+        kaliumPreferences.putBoolean(USE_SFT_FOR_ONE_ON_ONE_CALLS, shouldUse)
+    }
+
+    override fun shouldUseSftForOneOnOneCalls(): Boolean =
+        kaliumPreferences.getBoolean(
+            USE_SFT_FOR_ONE_ON_ONE_CALLS,
+            DEFAULT_USE_SFT_FOR_ONE_ON_ONE_CALLS_VALUE
+        )
+
     override fun areReadReceiptsEnabled(): Flow<Boolean> = areReadReceiptsEnabledFlow
         .map { kaliumPreferences.getBoolean(ENABLE_READ_RECEIPTS, true) }
         .onStart { emit(kaliumPreferences.getBoolean(ENABLE_READ_RECEIPTS, true)) }
@@ -577,8 +591,10 @@ class UserConfigStorageImpl(
         const val E2EI_SETTINGS = "end_to_end_identity_settings"
         const val E2EI_NOTIFICATION_TIME = "end_to_end_identity_notification_time"
         const val ENABLE_CONFERENCE_CALLING = "enable_conference_calling"
+        const val USE_SFT_FOR_ONE_ON_ONE_CALLS = "use_sft_for_one_on_one_calls"
         const val ENABLE_READ_RECEIPTS = "enable_read_receipts"
         const val DEFAULT_CONFERENCE_CALLING_ENABLED_VALUE = false
+        const val DEFAULT_USE_SFT_FOR_ONE_ON_ONE_CALLS_VALUE = false
         const val REQUIRE_SECOND_FACTOR_PASSWORD_CHALLENGE =
             "require_second_factor_password_challenge"
         const val ENABLE_SCREENSHOT_CENSORING = "enable_screenshot_censoring"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7153" title="WPB-7153" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-7153</a>  [Android] Add flag for customer specific 1:1 calls in federated environment
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Description

For some network restrictions in federated environments, some customers need to run 1:1 calls the same as we do for conference calls, using SFT.

For that a new flag added called `useSFTForOneToOneCalls` that we use to know if we should force 1:1 calls to be running on SFTs. 

_Next PR will be to enforce running 1:1 on SFT_

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
