### PR TITLE
feat: Add packing and sending DataTransfer message - (WPB-8978)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
@@ -41,6 +41,7 @@ import com.wire.kalium.protobuf.messages.Cleared
 import com.wire.kalium.protobuf.messages.ClientAction
 import com.wire.kalium.protobuf.messages.Composite
 import com.wire.kalium.protobuf.messages.Confirmation
+import com.wire.kalium.protobuf.messages.DataTransfer
 import com.wire.kalium.protobuf.messages.Ephemeral
 import com.wire.kalium.protobuf.messages.External
 import com.wire.kalium.protobuf.messages.GenericMessage
@@ -55,6 +56,7 @@ import com.wire.kalium.protobuf.messages.QualifiedConversationId
 import com.wire.kalium.protobuf.messages.Quote
 import com.wire.kalium.protobuf.messages.Reaction
 import com.wire.kalium.protobuf.messages.Text
+import com.wire.kalium.protobuf.messages.TrackingIdentifier
 import kotlinx.datetime.Instant
 import pbandk.ByteArr
 
@@ -139,7 +141,7 @@ class ProtoContentMapperImpl(
             is MessageContent.ButtonActionConfirmation -> packButtonActionConfirmation(readableContent)
             is MessageContent.Location -> packLocation(readableContent, expectsReadConfirmation, legalHoldStatus)
 
-            is MessageContent.DataTransfer -> TODO("Analytics: Not yet implemented")
+            is MessageContent.DataTransfer -> packDataTransfer(readableContent)
         }
     }
 
@@ -537,6 +539,14 @@ class ProtoContentMapperImpl(
     private fun unpackCalling(protoContent: GenericMessage.Content.Calling) = MessageContent.Calling(
         value = protoContent.value.content,
         conversationId = protoContent.value.qualifiedConversationId?.let { idMapper.fromProtoModel(it) }
+    )
+
+    private fun packDataTransfer(readableContent: MessageContent.DataTransfer) = GenericMessage.Content.DataTransfer(
+        DataTransfer(
+            readableContent.trackingIdentifier?.identifier?.let { identifier ->
+                TrackingIdentifier(identifier)
+            }
+        )
     )
 
     private fun unpackDataTransfer(protoContent: GenericMessage.Content.DataTransfer) = MessageContent.DataTransfer(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1488,6 +1488,7 @@ class UserSessionScope internal constructor(
             userId,
             clientIdProvider,
             selfConversationIdProvider,
+            syncManager,
             userScopedLogger
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/analytics/AnalyticsIdentifierManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/analytics/AnalyticsIdentifierManager.kt
@@ -30,6 +30,7 @@ import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.foldToEitherWhileRight
 import com.wire.kalium.logic.kaliumLogger
+import com.wire.kalium.logic.sync.SyncManager
 import kotlinx.datetime.Clock
 
 interface AnalyticsIdentifierManager {
@@ -57,6 +58,7 @@ internal fun AnalyticsIdentifierManager(
     selfUserId: UserId,
     selfClientIdProvider: CurrentClientIdProvider,
     selfConversationIdProvider: SelfConversationIdProvider,
+    syncManager: SyncManager,
     defaultLogger: KaliumLogger = kaliumLogger
 ) = object : AnalyticsIdentifierManager {
 
@@ -70,6 +72,8 @@ internal fun AnalyticsIdentifierManager(
     }
 
     override suspend fun propagateTrackingIdentifier(identifier: String) {
+        syncManager.waitUntilLive()
+
         val messageContent = MessageContent.DataTransfer(
             trackingIdentifier = MessageContent.DataTransfer.TrackingIdentifier(
                 identifier = identifier

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
@@ -430,6 +430,26 @@ class ProtoContentMapperTest {
         assertEquals(decoded, protoContent)
     }
 
+    @Test
+    fun givenDataTransferContent_whenMappingToProtoDataAndBack_thenTheContentsShouldMatchTheOriginal() {
+        val messageContent = MessageContent.DataTransfer(
+            MessageContent.DataTransfer.TrackingIdentifier(
+                "abcd-1234"
+            )
+        )
+        val protoContent = ProtoContent.Readable(
+            TEST_MESSAGE_UUID,
+            messageContent,
+            false,
+            legalHoldStatus = Conversation.LegalHoldStatus.UNKNOWN
+        )
+
+        val encoded = protoContentMapper.encodeToProtobuf(protoContent)
+        val decoded = protoContentMapper.decodeFromProtobuf(encoded)
+
+        assertEquals(decoded, protoContent)
+    }
+
     private companion object {
         const val TEST_MESSAGE_UUID = "testUuid"
         val TEST_CONVERSATION_ID = TestConversation.ID


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8978" title="WPB-8978" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-8978</a>  [Android] Countly analytics ID and user properties
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Packing of DataTransfer message content was not implemented.

### Causes (Optional)

Forgot to implement left TODO

### Solutions

- Implement packing of DataTransfer message content
- Add SyncManager to AnalyticsIdentifierManager (specifically to `propagateTrackingIdentifier()`) in order to wait for user current device to be available when propagating identifier message.

### Dependencies (Optional)

Needs releases with:

- [X] #2887 

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

Can be tested on this PR : https://github.com/wireapp/wire-android/pull/3226