### PR TITLE
refactor: simplify getting conversations by ID [WPB-10298]

### DIFF
--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -249,9 +249,11 @@ class CallManagerImpl internal constructor(
                 message.conversationId
             }
 
-            val type = conversationRepository.getConversationById(targetConversationId)?.let {
+            val type = conversationRepository.getConversationById(targetConversationId).fold({
+                ConversationType.Unknown
+            }, {
                 callMapper.fromConversationToConversationType(it)
-            } ?: ConversationType.Unknown
+            })
 
             wcall_recv_msg(
                 inst = deferredHandle.await(),
@@ -278,9 +280,11 @@ class CallManagerImpl internal constructor(
                     "${conversationId.toLogString()}.."
         )
         val isCameraOn = callType == CallType.VIDEO
-        val type = conversationRepository.getConversationById(conversationId)?.let {
+        val type = conversationRepository.getConversationById(conversationId).fold({
+            ConversationType.Unknown
+        }, {
             callMapper.fromConversationToConversationType(it)
-        } ?: ConversationType.Unknown
+        })
 
         callRepository.createCall(
             conversationId = conversationId,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
@@ -201,7 +201,7 @@ internal class ConversationGroupRepositoryImpl(
             legalHoldHandler.handleConversationMembersChanged(conversationEntity.id.toModel())
         }.flatMap {
             wrapStorageRequest {
-                conversationDAO.getConversationByQualifiedID(conversationEntity.id)?.let {
+                conversationDAO.getConversationById(conversationEntity.id)?.let {
                     conversationMapper.fromDaoModel(it)
                 }
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -59,7 +59,6 @@ import kotlin.time.toDuration
 
 interface ConversationMapper {
     fun fromApiModelToDaoModel(apiModel: ConversationResponse, mlsGroupState: GroupState?, selfUserTeamId: TeamId?): ConversationEntity
-    fun fromDaoModel(daoModel: ConversationViewEntity): Conversation
     fun fromDaoModel(daoModel: ConversationEntity): Conversation
     fun fromDaoModelToDetails(
         daoModel: ConversationViewEntity,
@@ -128,7 +127,7 @@ internal class ConversationMapperImpl(
         legalHoldStatus = ConversationEntity.LegalHoldStatus.DISABLED
     )
 
-    override fun fromDaoModel(daoModel: ConversationViewEntity): Conversation = with(daoModel) {
+    private fun fromConversationViewToEntity(daoModel: ConversationViewEntity): Conversation = with(daoModel) {
         val lastReadDateEntity = if (type == ConversationEntity.Type.CONNECTION_PENDING) Instant.UNIX_FIRST_DATE
         else lastReadDate
 
@@ -194,12 +193,12 @@ internal class ConversationMapperImpl(
         with(daoModel) {
             when (type) {
                 ConversationEntity.Type.SELF -> {
-                    ConversationDetails.Self(fromDaoModel(daoModel))
+                    ConversationDetails.Self(fromConversationViewToEntity(daoModel))
                 }
 
                 ConversationEntity.Type.ONE_ON_ONE -> {
                     ConversationDetails.OneOne(
-                        conversation = fromDaoModel(daoModel),
+                        conversation = fromConversationViewToEntity(daoModel),
                         otherUser = OtherUser(
                             id = otherUserId.requireField("otherUserID in OneOnOne").toModel(),
                             name = name,
@@ -227,7 +226,7 @@ internal class ConversationMapperImpl(
 
                 ConversationEntity.Type.GROUP -> {
                     ConversationDetails.Group(
-                        conversation = fromDaoModel(daoModel),
+                        conversation = fromConversationViewToEntity(daoModel),
                         hasOngoingCall = callStatus != null, // todo: we can do better!
                         unreadEventCount = unreadEventCount ?: mapOf(),
                         lastMessage = lastMessage,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -87,7 +87,16 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.datetime.Instant
 
+@Suppress("TooManyFunctions")
 interface ConversationRepository {
+    // region Get/Observe by id
+
+    suspend fun observeConversationById(conversationId: ConversationId): Flow<Either<StorageFailure, Conversation>>
+    suspend fun observeConversationDetailsById(conversationID: ConversationId): Flow<Either<StorageFailure, ConversationDetails>>
+    suspend fun getConversationById(conversationId: ConversationId): Either<StorageFailure, Conversation>
+
+    // endregion
+
     @DelicateKaliumApi("This function does not get values from cache")
     suspend fun getProteusSelfConversationId(): Either<StorageFailure, ConversationId>
 
@@ -128,15 +137,9 @@ interface ConversationRepository {
 
     suspend fun fetchMlsOneToOneConversation(userId: UserId): Either<CoreFailure, Conversation>
     suspend fun getTeamConversationIdsReadyToCompleteMigration(teamId: TeamId): Either<StorageFailure, List<QualifiedID>>
-    suspend fun observeConversationDetailsById(conversationID: ConversationId): Flow<Either<StorageFailure, ConversationDetails>>
     suspend fun fetchConversation(conversationID: ConversationId): Either<CoreFailure, Unit>
     suspend fun fetchSentConnectionConversation(conversationID: ConversationId): Either<CoreFailure, Unit>
     suspend fun fetchConversationIfUnknown(conversationID: ConversationId): Either<CoreFailure, Unit>
-    suspend fun observeById(conversationId: ConversationId): Flow<Either<StorageFailure, Conversation>>
-    suspend fun getConversationById(conversationId: ConversationId): Conversation?
-    suspend fun observeCacheDetailsById(conversationId: ConversationId): Either<StorageFailure, Flow<Conversation?>>
-    suspend fun detailsById(conversationId: ConversationId): Either<StorageFailure, Conversation>
-    suspend fun baseInfoById(conversationId: ConversationId): Either<StorageFailure, Conversation>
     suspend fun getConversationRecipients(conversationId: ConversationId): Either<CoreFailure, List<Recipient>>
     suspend fun getRecipientById(conversationId: ConversationId, userIDList: List<UserId>): Either<StorageFailure, List<Recipient>>
     suspend fun getConversationRecipientsForCalling(conversationId: ConversationId): Either<CoreFailure, List<Recipient>>
@@ -324,8 +327,37 @@ internal class ConversationDataSource internal constructor(
     private val receiptModeMapper: ReceiptModeMapper = MapperProvider.receiptModeMapper()
 ) : ConversationRepository {
 
-    // TODO:I would suggest preparing another suspend func getSelfUser to get nullable self user,
-    // this will help avoid some functions getting stuck when observeSelfUser will filter nullable values
+    // region Get/Observe by id
+
+    override suspend fun observeConversationById(conversationId: ConversationId): Flow<Either<StorageFailure, Conversation>> =
+        conversationDAO.observeConversationById(conversationId.toDao()).filterNotNull()
+            .map(conversationMapper::fromDaoModel)
+            .wrapStorageRequest()
+
+    override suspend fun getConversationById(conversationId: ConversationId): Either<StorageFailure, Conversation> = wrapStorageRequest {
+        conversationDAO.getConversationById(conversationId.toDao())?.let {
+            conversationMapper.fromDaoModel(it)
+        }
+    }
+
+    override suspend fun observeConversationDetailsById(conversationID: ConversationId): Flow<Either<StorageFailure, ConversationDetails>> =
+        conversationDAO.observeConversationDetailsById(conversationID.toDao())
+            .wrapStorageRequest()
+            // TODO we don't need last message and unread count here, we should discuss to divide model for list and for details
+            .map { eitherConversationView ->
+                eitherConversationView.flatMap {
+                    try {
+                        Either.Right(conversationMapper.fromDaoModelToDetails(it, null, mapOf()))
+                    } catch (error: IllegalArgumentException) {
+                        kaliumLogger.e("require field in conversation Details", error)
+                        Either.Left(StorageFailure.DataNotFound)
+                    }
+                }
+            }
+            .distinctUntilChanged()
+
+    // endregion
+
     override suspend fun fetchConversations(): Either<CoreFailure, Unit> {
         kaliumLogger.withFeatureId(CONVERSATIONS).d("Fetching conversations")
         return fetchAllConversationsFromAPI()
@@ -379,7 +411,7 @@ internal class ConversationDataSource internal constructor(
         selfUserTeamId: String?,
         originatedFromEvent: Boolean
     ): Either<CoreFailure, Boolean> = wrapStorageRequest {
-        val isNewConversation = conversationDAO.getConversationBaseInfoByQualifiedID(conversation.id.toDao()) == null
+        val isNewConversation = conversationDAO.getConversationById(conversation.id.toDao()) == null
         if (isNewConversation) {
             conversationDAO.insertConversation(
                 conversationMapper.fromApiModelToDaoModel(
@@ -513,7 +545,7 @@ internal class ConversationDataSource internal constructor(
                 selfUserTeamId = selfUserTeamId
             ).map { conversationResponse }
         }.flatMap { response ->
-            baseInfoById(response.id.toModel())
+            this.getConversationById(response.id.toModel())
         }
 
     private fun addOtherMemberIfMissing(
@@ -556,25 +588,6 @@ internal class ConversationDataSource internal constructor(
                 .map { it.toModel() }
         }
 
-    /**
-     * Gets a flow that allows observing of
-     */
-    override suspend fun observeConversationDetailsById(conversationID: ConversationId): Flow<Either<StorageFailure, ConversationDetails>> =
-        conversationDAO.observeGetConversationByQualifiedID(conversationID.toDao())
-            .wrapStorageRequest()
-            // TODO we don't need last message and unread count here, we should discuss to divide model for list and for details
-            .map { eitherConversationView ->
-                eitherConversationView.flatMap {
-                    try {
-                        Either.Right(conversationMapper.fromDaoModelToDetails(it, null, mapOf()))
-                    } catch (error: IllegalArgumentException) {
-                        kaliumLogger.e("require field in conversation Details", error)
-                        Either.Left(StorageFailure.DataNotFound)
-                    }
-                }
-            }
-            .distinctUntilChanged()
-
     override suspend fun fetchConversation(conversationID: ConversationId): Either<CoreFailure, Unit> {
         return wrapApiRequest {
             conversationApi.fetchConversationDetails(conversationID.toApi())
@@ -598,46 +611,12 @@ internal class ConversationDataSource internal constructor(
     }
 
     override suspend fun fetchConversationIfUnknown(conversationID: ConversationId): Either<CoreFailure, Unit> = wrapStorageRequest {
-        conversationDAO.getConversationByQualifiedID(QualifiedIDEntity(conversationID.value, conversationID.domain))
+        conversationDAO.getConversationDetailsById(QualifiedIDEntity(conversationID.value, conversationID.domain))
     }.run {
         if (isLeft()) {
             fetchConversation(conversationID)
         } else {
             Either.Right(Unit)
-        }
-    }
-
-    // Deprecated notice, so we can use newer versions of Kalium on Reloaded without breaking things.
-    @Deprecated("This doesn't return conversation details", ReplaceWith("detailsById"))
-    override suspend fun observeById(conversationId: ConversationId): Flow<Either<StorageFailure, Conversation>> =
-        conversationDAO.observeGetConversationByQualifiedID(conversationId.toDao()).filterNotNull()
-            .map(conversationMapper::fromDaoModel)
-            .wrapStorageRequest()
-
-    // TODO: refactor. 3 Ways different ways to return conversation details?!
-    override suspend fun getConversationById(conversationId: ConversationId): Conversation? =
-        conversationDAO.observeGetConversationByQualifiedID(conversationId.toDao())
-            .map { conversationEntity ->
-                conversationEntity?.let { conversationMapper.fromDaoModel(it) }
-            }.firstOrNull()
-
-    override suspend fun observeCacheDetailsById(conversationId: ConversationId): Either<StorageFailure, Flow<Conversation?>> =
-        wrapStorageRequest {
-            conversationDAO.observeConversationDetailsById(conversationId.toDao())
-                .map { conversationViewEntity ->
-                    conversationViewEntity?.let { conversationMapper.fromDaoModel(it) }
-                }
-        }
-
-    override suspend fun detailsById(conversationId: ConversationId): Either<StorageFailure, Conversation> = wrapStorageRequest {
-        conversationDAO.getConversationByQualifiedID(conversationId.toDao())?.let {
-            conversationMapper.fromDaoModel(it)
-        }
-    }
-
-    override suspend fun baseInfoById(conversationId: ConversationId): Either<StorageFailure, Conversation> = wrapStorageRequest {
-        conversationDAO.getConversationBaseInfoByQualifiedID(conversationId.toDao())?.let {
-            conversationMapper.fromDaoModel(it)
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationUseCase.kt
@@ -72,7 +72,7 @@ internal class JoinExistingMLSConversationUseCaseImpl(
             kaliumLogger.d("Skip re-join existing MLS conversation, since MLS is not supported.")
             Either.Right(Unit)
         } else {
-            conversationRepository.baseInfoById(conversationId).fold({
+            conversationRepository.getConversationById(conversationId).fold({
                 Either.Left(StorageFailure.DataNotFound)
             }, { conversation ->
                 withContext(dispatcher) {
@@ -106,7 +106,7 @@ internal class JoinExistingMLSConversationUseCaseImpl(
                         } else {
                             conversationRepository.fetchConversation(conversation.id)
                         }.flatMap {
-                            conversationRepository.baseInfoById(conversation.id).flatMap { conversation ->
+                            conversationRepository.getConversationById(conversation.id).flatMap { conversation ->
                                 joinOrEstablishMLSGroup(conversation)
                             }
                         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetIncomingCallsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetIncomingCallsUseCase.kt
@@ -93,7 +93,7 @@ internal class GetIncomingCallsUseCaseImpl internal constructor(
 
             // Filter calls if ConversationDetails for it were not found
             val allowedConversations = calls.mapNotNull { call ->
-                conversationRepository.baseInfoById(call.conversationId).nullableFold({ null }, { it })
+                conversationRepository.getConversationById(call.conversationId).nullableFold({ null }, { it })
             }.filter { conversationDetails ->
                 // Don't display call if that Conversation is muted
                 conversationDetails.mutedStatus != MutedConversationStatus.AllMuted

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetConversationUseCase.kt
@@ -40,7 +40,7 @@ class GetConversationUseCase(
     }
 
     suspend operator fun invoke(conversationId: QualifiedID): Flow<Result> {
-        return conversationRepository.observeById(conversationId)
+        return conversationRepository.observeConversationById(conversationId)
             .map { it.fold({ Result.Failure(it) }, { Result.Success(it) }) }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCase.kt
@@ -73,7 +73,7 @@ internal class GetOrCreateOneToOneConversationUseCaseImpl(
                 user = otherUser,
                 invalidateCurrentKnownProtocols = true
             )
-        }.flatMap { conversationId -> conversationRepository.detailsById(conversationId) }
+        }.flatMap { conversationId -> conversationRepository.getConversationById(conversationId) }
 
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationMembersUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationMembersUseCase.kt
@@ -49,6 +49,7 @@ class ObserveConversationMembersUseCaseImpl internal constructor(
     @OptIn(ExperimentalCoroutinesApi::class)
     override suspend operator fun invoke(conversationId: ConversationId): Flow<List<MemberDetails>> {
         return conversationRepository.observeConversationMembers(conversationId).map { members ->
+            // TODO(perf): can be improved to fetch in a single query
             members.map { member ->
                 userRepository.observeUser(member.id).filterNotNull().map {
                     MemberDetails(it, member.role)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveSecurityClassificationLabelUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveSecurityClassificationLabelUseCase.kt
@@ -50,7 +50,7 @@ internal class ObserveSecurityClassificationLabelUseCaseImpl(
     override suspend fun invoke(conversationId: ConversationId): Flow<SecurityClassificationType> {
         return combine(
             observeConversationMembers(conversationId),
-            conversationRepository.observeById(conversationId)
+            conversationRepository.observeConversationById(conversationId)
         ) { conversationMembers, eitherConversation -> eitherConversation.map { Pair(conversationMembers, it) } }
             .mapRight { (conversationMembers, conversation) ->
                 val trustedDomains = getClassifiedDomainsStatus()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
@@ -21,7 +21,6 @@ package com.wire.kalium.logic.feature.conversation
 import com.benasher44.uuid.uuid4
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.CoreFailure
-import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
@@ -75,9 +74,7 @@ class UpdateConversationReadDateUseCase internal constructor(
 
     private val worker = ConversationTimeEventWorker { (conversationId, time) ->
         coroutineScope {
-            conversationRepository.observeCacheDetailsById(conversationId).flatMap {
-                it.first()?.let { Either.Right(it) } ?: Either.Left(StorageFailure.DataNotFound)
-            }.onFailure {
+            conversationRepository.observeConversationById(conversationId).first().onFailure {
                 logger.w("Failed to update conversation read date; StorageFailure $it")
             }.onSuccess { conversation ->
                 if (conversation.lastReadDate >= time) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/FetchConversationMLSVerificationStatusUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/FetchConversationMLSVerificationStatusUseCase.kt
@@ -35,7 +35,7 @@ internal class FetchConversationMLSVerificationStatusUseCaseImpl(
 ) : FetchConversationMLSVerificationStatusUseCase {
 
     override suspend fun invoke(conversationId: ConversationId) {
-        conversationRepository.detailsById(conversationId).onSuccess {
+        conversationRepository.getConversationById(conversationId).onSuccess {
             val protocol = it.protocol
             if (protocol is Conversation.ProtocolInfo.MLSCapable)
                 fetchMLSVerificationStatusUseCase(protocol.groupId)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/confirmation/ConfirmationDeliveryHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/confirmation/ConfirmationDeliveryHandler.kt
@@ -38,11 +38,10 @@ import com.wire.kalium.logic.logStructuredJson
 import com.wire.kalium.logic.sync.SyncManager
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.datetime.Clock
@@ -96,9 +95,8 @@ internal class ConfirmationDeliveryHandlerImpl(
                 kaliumLogger.d("Started collecting pending messages for delivery confirmation")
                 with(pendingConfirmationMessages.iterator()) {
                     forEach { (conversationId, messages) ->
-                        conversationRepository.observeCacheDetailsById(conversationId).flatMap { conversationFlow: Flow<Conversation?> ->
-                            val conversation = conversationFlow.firstOrNull()
-                            if (conversation != null && conversation.type == Conversation.Type.ONE_ON_ONE) {
+                        conversationRepository.observeConversationById(conversationId).first().flatMap { conversation ->
+                            if (conversation.type == Conversation.Type.ONE_ON_ONE) {
                                 sendDeliveredSignal(
                                     conversation = conversation,
                                     messages = messages.toList()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/receipt/SendConfirmationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/receipt/SendConfirmationUseCase.kt
@@ -133,7 +133,7 @@ internal fun SendConfirmationUseCase(
         } else emptyList()
 
     private suspend fun isReceiptsEnabledForConversation(conversationId: ConversationId) =
-        conversationRepository.baseInfoById(conversationId).fold({
+        conversationRepository.getConversationById(conversationId).fold({
             false
         }, { conversation ->
             when (conversation.type) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/ObserveSelfDeletionTimerSettingsForConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/ObserveSelfDeletionTimerSettingsForConversationUseCase.kt
@@ -55,7 +55,7 @@ class ObserveSelfDeletionTimerSettingsForConversationUseCaseImpl internal constr
         withContext(dispatcher.io) {
             userConfigRepository.observeTeamSettingsSelfDeletingStatus()
                 .combine(
-                    conversationRepository.observeById(conversationId)
+                    conversationRepository.observeConversationById(conversationId)
                 ) { teamSettings, conversationDetailsEither ->
                     teamSettings.fold({
                         onTeamEnabled(conversationDetailsEither, considerSelfUserSettings)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandler.kt
@@ -73,7 +73,7 @@ internal class MemberJoinEventHandlerImpl(
                 userRepository.fetchUsersIfUnknownByIds(event.members.map { it.id }.toSet())
                 conversationRepository.persistMembers(event.members, event.conversationId)
             }.onSuccess {
-                conversationRepository.detailsById(event.conversationId).onSuccess { conversation ->
+                conversationRepository.getConversationById(event.conversationId).onSuccess { conversation ->
                     if (conversation.type == Conversation.Type.GROUP) addSystemMessage(event)
                 }
                 legalHoldHandler.handleConversationMembersChanged(event.conversationId)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
@@ -69,7 +69,6 @@ import io.mockative.twice
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
-import kotlinx.datetime.toInstant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -514,7 +513,7 @@ class ConnectionRepositoryTest {
 
         suspend fun withSuccessfulGetConversationById(conversationId: QualifiedIDEntity): Arrangement {
             coEvery {
-                conversationDAO.observeGetConversationByQualifiedID(eq(conversationId))
+                conversationDAO.observeConversationDetailsById(eq(conversationId))
             }.returns(flowOf(TestConversation.VIEW_ENTITY))
 
             return this

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
@@ -53,7 +53,6 @@ import com.wire.kalium.logic.util.thenReturnSequentially
 import com.wire.kalium.network.api.authenticated.conversation.AddServiceRequest
 import com.wire.kalium.network.api.authenticated.conversation.ConvProtocol
 import com.wire.kalium.network.api.authenticated.conversation.ConvProtocol.MLS
-import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
 import com.wire.kalium.network.api.authenticated.conversation.ConversationMemberAddedResponse
 import com.wire.kalium.network.api.authenticated.conversation.ConversationMemberDTO
 import com.wire.kalium.network.api.authenticated.conversation.ConversationMemberRemovedResponse
@@ -64,6 +63,7 @@ import com.wire.kalium.network.api.authenticated.conversation.guestroomlink.Conv
 import com.wire.kalium.network.api.authenticated.conversation.messagetimer.ConversationMessageTimerDTO
 import com.wire.kalium.network.api.authenticated.conversation.model.ConversationCodeInfo
 import com.wire.kalium.network.api.authenticated.notification.EventContentDTO
+import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
 import com.wire.kalium.network.api.model.ConversationAccessDTO
 import com.wire.kalium.network.api.model.ConversationAccessRoleDTO
 import com.wire.kalium.network.api.model.ErrorResponse
@@ -103,7 +103,7 @@ class ConversationGroupRepositoryTest {
             .withCreateNewConversationAPIResponses(arrayOf(NetworkResponse.Success(CONVERSATION_RESPONSE, emptyMap(), 201)))
             .withSelfTeamId(Either.Right(TestUser.SELF.teamId))
             .withInsertConversationSuccess()
-            .withConversationDetailsById(TestConversation.GROUP_VIEW_ENTITY(PROTEUS_PROTOCOL_INFO))
+            .withConversationById(TestConversation.ENTITY_GROUP.copy(protocolInfo = PROTEUS_PROTOCOL_INFO))
             .withSuccessfulNewConversationGroupStartedHandled()
             .withSuccessfulNewConversationMemberHandled()
             .withSuccessfulNewConversationGroupStartedUnverifiedWarningHandled()
@@ -135,7 +135,7 @@ class ConversationGroupRepositoryTest {
             .withCreateNewConversationAPIResponses(arrayOf(NetworkResponse.Success(CONVERSATION_RESPONSE, emptyMap(), 201)))
             .withSelfTeamId(Either.Right(null))
             .withInsertConversationSuccess()
-            .withConversationDetailsById(TestConversation.GROUP_VIEW_ENTITY(PROTEUS_PROTOCOL_INFO))
+            .withConversationById(TestConversation.ENTITY_GROUP.copy(protocolInfo = PROTEUS_PROTOCOL_INFO))
             .withSuccessfulNewConversationGroupStartedHandled()
             .withSuccessfulNewConversationMemberHandled()
             .withSuccessfulNewConversationGroupStartedUnverifiedWarningHandled()
@@ -167,7 +167,7 @@ class ConversationGroupRepositoryTest {
             .withCreateNewConversationAPIResponses(arrayOf(NetworkResponse.Success(CONVERSATION_RESPONSE, emptyMap(), 201)))
             .withSelfTeamId(Either.Right(TestUser.SELF.teamId))
             .withInsertConversationSuccess()
-            .withConversationDetailsById(TestConversation.GROUP_VIEW_ENTITY(PROTEUS_PROTOCOL_INFO))
+            .withConversationById(TestConversation.ENTITY_GROUP.copy(protocolInfo = PROTEUS_PROTOCOL_INFO))
             .withSuccessfulNewConversationGroupStartedHandled()
             .withSuccessfulNewConversationMemberHandled()
             .withSuccessfulNewConversationGroupStartedUnverifiedWarningHandled()
@@ -198,7 +198,7 @@ class ConversationGroupRepositoryTest {
             )
             .withSelfTeamId(Either.Right(null))
             .withInsertConversationSuccess()
-            .withConversationDetailsById(TestConversation.GROUP_VIEW_ENTITY(PROTEUS_PROTOCOL_INFO))
+            .withConversationById(TestConversation.ENTITY_GROUP.copy(protocolInfo = PROTEUS_PROTOCOL_INFO))
             .withSuccessfulNewConversationGroupStartedHandled()
             .withSuccessfulNewConversationMemberHandled()
             .withSuccessfulNewConversationGroupStartedUnverifiedWarningHandled()
@@ -302,7 +302,7 @@ class ConversationGroupRepositoryTest {
             )
             .withSelfTeamId(Either.Right(TestUser.SELF.teamId))
             .withInsertConversationSuccess()
-            .withConversationDetailsById(TestConversation.GROUP_VIEW_ENTITY(PROTEUS_PROTOCOL_INFO))
+            .withConversationById(TestConversation.ENTITY_GROUP.copy(protocolInfo = PROTEUS_PROTOCOL_INFO))
             .withSuccessfulNewConversationGroupStartedHandled()
             .withSuccessfulNewConversationMemberHandled()
             .withSuccessfulNewConversationGroupStartedUnverifiedWarningHandled()
@@ -401,7 +401,7 @@ class ConversationGroupRepositoryTest {
             .withSelfTeamId(Either.Right(TestUser.SELF.teamId))
             .withInsertConversationSuccess()
             .withMlsConversationEstablished(MLSAdditionResult(setOf(TestUser.USER_ID), emptySet()))
-            .withConversationDetailsById(TestConversation.GROUP_VIEW_ENTITY(PROTEUS_PROTOCOL_INFO))
+            .withConversationById(TestConversation.ENTITY_GROUP.copy(protocolInfo = PROTEUS_PROTOCOL_INFO))
             .withSuccessfulNewConversationGroupStartedHandled()
             .withSuccessfulNewConversationMemberHandled()
             .withSuccessfulNewConversationGroupStartedUnverifiedWarningHandled()
@@ -443,7 +443,7 @@ class ConversationGroupRepositoryTest {
                 .withSelfTeamId(Either.Right(TestUser.SELF.teamId))
                 .withInsertConversationSuccess()
                 .withMlsConversationEstablished(MLSAdditionResult(setOf(TestUser.USER_ID), notAddedUsers = missingMembersFromMLSGroup))
-                .withConversationDetailsById(TestConversation.GROUP_VIEW_ENTITY(PROTEUS_PROTOCOL_INFO))
+                .withConversationById(TestConversation.ENTITY_GROUP.copy(protocolInfo = PROTEUS_PROTOCOL_INFO))
                 .withSuccessfulNewConversationGroupStartedHandled()
                 .withSuccessfulNewConversationMemberHandled()
                 .withSuccessfulNewConversationGroupStartedUnverifiedWarningHandled()
@@ -1361,7 +1361,7 @@ class ConversationGroupRepositoryTest {
             .withCreateNewConversationAPIResponses(arrayOf(NetworkResponse.Success(CONVERSATION_RESPONSE, emptyMap(), 201)))
             .withSelfTeamId(Either.Right(null))
             .withInsertConversationSuccess()
-            .withConversationDetailsById(TestConversation.GROUP_VIEW_ENTITY(PROTEUS_PROTOCOL_INFO))
+            .withConversationById(TestConversation.ENTITY_GROUP.copy(protocolInfo = PROTEUS_PROTOCOL_INFO))
             .withSuccessfulNewConversationGroupStartedHandled()
             .withSuccessfulNewConversationMemberHandled()
             .withSuccessfulNewConversationGroupStartedUnverifiedWarningHandled()
@@ -1779,13 +1779,19 @@ class ConversationGroupRepositoryTest {
 
         suspend fun withConversationDetailsById(conversation: Conversation) = apply {
             coEvery {
-                conversationRepository.baseInfoById(any())
+                conversationRepository.getConversationById(any())
             }.returns(Either.Right(conversation))
         }
 
         suspend fun withConversationDetailsById(result: ConversationViewEntity?) = apply {
             coEvery {
-                conversationDAO.getConversationByQualifiedID(any())
+                conversationDAO.getConversationDetailsById(any())
+            }.returns(result)
+        }
+
+        suspend fun withConversationById(result: ConversationEntity?) = apply {
+            coEvery {
+                conversationDAO.getConversationById(any())
             }.returns(result)
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/GetIncomingCallsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/GetIncomingCallsUseCaseTest.kt
@@ -207,9 +207,9 @@ class GetIncomingCallsUseCaseTest {
         }
 
         suspend fun withConversationDetails(detailsGetter: (ConversationId) -> Either<StorageFailure, Conversation>): Arrangement {
-            coEvery { conversationRepository.baseInfoById(any()) }
+            coEvery { conversationRepository.getConversationById(any()) }
             coEvery {
-                conversationRepository.baseInfoById(any())
+                conversationRepository.getConversationById(any())
             }.invokes { id -> detailsGetter(id.first() as ConversationId) }
             return this
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCaseTest.kt
@@ -238,7 +238,7 @@ class JoinExistingMLSConversationUseCaseTest {
         suspend fun withGetConversationsByIdSuccessful(conversation: Conversation = MLS_CONVERSATION1) =
             apply {
                 coEvery {
-                    conversationRepository.baseInfoById(any())
+                    conversationRepository.getConversationById(any())
                 }.returns(Either.Right(conversation))
             }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveSecurityClassificationLabelUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveSecurityClassificationLabelUseCaseTest.kt
@@ -174,7 +174,7 @@ class ObserveSecurityClassificationLabelUseCaseTest {
 
         suspend fun withObserveConversationSuccess(conversationDomain: String) = apply {
             coEvery {
-                conversationRepository.observeById(any())
+                conversationRepository.observeConversationById(any())
             }.returns(
                 flowOf(
                     Either.Right(
@@ -190,7 +190,7 @@ class ObserveSecurityClassificationLabelUseCaseTest {
 
         suspend fun withObserveConversationError() = apply {
             coEvery {
-                conversationRepository.observeById(any())
+                conversationRepository.observeConversationById(any())
             }.returns(flowOf(Either.Left(StorageFailure.Generic(Throwable("error")))))
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCaseTest.kt
@@ -56,7 +56,7 @@ class UpdateConversationReadDateUseCaseTest {
         val persistedLastRead = Clock.System.now()
         val conversationId = TestConversation.CONVERSATION.id
         val (arrangement, updateConversationReadDateUseCase) = arrange {
-            withCachedInfoByIdReturning(
+            withObserveByIdReturning(
                 TestConversation.CONVERSATION.copy(lastReadDate = persistedLastRead)
             )
         }
@@ -80,7 +80,7 @@ class UpdateConversationReadDateUseCaseTest {
         val newLastRead = persistedLastRead + 1.seconds
         val conversationId = TestConversation.CONVERSATION.id
         val (arrangement, updateConversationReadDateUseCase) = arrange {
-            withCachedInfoByIdReturning(
+            withObserveByIdReturning(
                 TestConversation.CONVERSATION.copy(lastReadDate = persistedLastRead)
             )
         }
@@ -98,7 +98,7 @@ class UpdateConversationReadDateUseCaseTest {
         val newLastRead = persistedLastRead + 1.seconds
         val conversationId = TestConversation.CONVERSATION.id
         val (arrangement, updateConversationReadDateUseCase) = arrange {
-            withCachedInfoByIdReturning(
+            withObserveByIdReturning(
                 TestConversation.CONVERSATION.copy(lastReadDate = persistedLastRead)
             )
         }
@@ -116,7 +116,7 @@ class UpdateConversationReadDateUseCaseTest {
         val newLastRead = persistedLastRead + 1.seconds
         val conversationId = TestConversation.CONVERSATION.id
         val (arrangement, updateConversationReadDateUseCase) = arrange {
-            withCachedInfoByIdReturning(
+            withObserveByIdReturning(
                 TestConversation.CONVERSATION.copy(lastReadDate = persistedLastRead)
             )
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/receipt/SendConfirmationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/receipt/SendConfirmationUseCaseTest.kt
@@ -129,7 +129,7 @@ class SendConfirmationUseCaseTest {
 
         suspend fun withGetConversationByIdSuccessful() = apply {
             coEvery {
-                conversationRepository.baseInfoById(any())
+                conversationRepository.getConversationById(any())
             }.returns(Either.Right(TestConversation.CONVERSATION))
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/ObserveSelfDeletingMessagesUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/selfDeletingMessages/ObserveSelfDeletingMessagesUseCaseTest.kt
@@ -189,7 +189,7 @@ class ObserveSelfDeletingMessagesUseCaseTest {
             arrangement.userConfigRepository.observeTeamSettingsSelfDeletingStatus()
         }.wasInvoked(exactly = once)
         coVerify {
-            arrangement.conversationRepository.observeById(any())
+            arrangement.conversationRepository.observeConversationById(any())
         }.wasInvoked(exactly = once)
 
         assertEquals(storedConversationStatus.messageTimer, result.first().duration)
@@ -212,7 +212,7 @@ class ObserveSelfDeletingMessagesUseCaseTest {
 
         suspend fun withStoredConversation(conversation: Conversation) = apply {
             coEvery {
-                conversationRepository.observeById(any())
+                conversationRepository.observeConversationById(any())
             }.returns(flowOf(Either.Right(conversation)))
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -294,6 +294,9 @@ object TestConversation {
         proteusVerificationStatus = ConversationEntity.VerificationStatus.NOT_VERIFIED,
         legalHoldStatus = ConversationEntity.LegalHoldStatus.DISABLED
     )
+    val ENTITY_GROUP = ENTITY.copy(
+        type = ConversationEntity.Type.GROUP
+    )
     val VIEW_ENTITY = ConversationViewEntity(
         id = ENTITY_ID,
         name = "convo name",

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/DeletedConversationEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/DeletedConversationEventHandlerTest.kt
@@ -44,7 +44,7 @@ class DeletedConversationEventHandlerTest {
     fun givenADeletedConversationEvent_whenHandlingItAndNotExists_thenShouldSkipTheDeletion() = runTest {
         val event = TestEvent.deletedConversation()
         val (arrangement, eventHandler) = arrange {
-            withGetConversation(null)
+            withGetConversationByIdReturning(null)
             withObserveUser(userId = EqualsMatcher(event.senderUserId))
             withDeletingConversationSucceeding(EqualsMatcher(TestConversation.ID))
         }
@@ -64,7 +64,7 @@ class DeletedConversationEventHandlerTest {
         val conversation = TestConversation.CONVERSATION
         val otherUser = TestUser.OTHER
         val (arrangement, eventHandler) = arrange {
-            withGetConversation(conversation)
+            withGetConversationByIdReturning(conversation)
             withObserveUser(flowOf(otherUser), EqualsMatcher(event.senderUserId))
             withDeletingConversationSucceeding(EqualsMatcher(TestConversation.ID))
         }
@@ -96,7 +96,7 @@ class DeletedConversationEventHandlerTest {
         val conversation = TestConversation.CONVERSATION
         val otherUser = TestUser.OTHER
         val (arrangement, eventHandler) = arrange {
-            withGetConversation(conversation)
+            withGetConversationByIdReturning(conversation)
             withObserveUser(flowOf(otherUser), EqualsMatcher(event.senderUserId))
             withDeletingConversationFailing()
         }

--- a/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/PlatformDatabaseData.kt
+++ b/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/PlatformDatabaseData.kt
@@ -50,14 +50,14 @@ fun databaseDriver(
             schema = schema,
             context = context,
             name = dbName,
-            factory = SupportOpenHelperFactory(passphrase, enableWAL)
+            factory = SupportOpenHelperFactory(passphrase, enableWAL),
         )
     } else {
         AndroidSqliteDriver(
             schema = schema,
             context = context,
             name = dbName,
-            callback = SqliteCallback(schema, enableWAL)
+            callback = SqliteCallback(schema, enableWAL),
         )
     }
 }

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -289,7 +289,7 @@ WHERE
 ORDER BY lastModifiedDate DESC, name IS NULL, name COLLATE NOCASE ASC;
 
 selectAllConversations:
-SELECT * FROM ConversationDetails WHERE type IS NOT 'CONNECTION_PENDING' ORDER BY last_modified_date DESC, name ASC;
+SELECT * FROM Conversation WHERE type IS NOT 'CONNECTION_PENDING' ORDER BY last_modified_date DESC, name ASC;
 
 selectAllTeamProteusConversationsReadyForMigration:
 SELECT
@@ -303,7 +303,9 @@ selectByQualifiedId:
 SELECT * FROM ConversationDetails WHERE qualifiedId = ?;
 
 selectConversationByQualifiedId:
-SELECT qualified_id, name, type, team_id, mls_group_id, mls_group_state, mls_epoch, mls_proposal_timer, protocol, muted_status, muted_time, creator_id, last_modified_date, last_notified_date, last_read_date, access_list, access_role_list, mls_last_keying_material_update_date, mls_cipher_suite, receipt_mode, message_timer, user_message_timer, archived, archived_date_time, verification_status, proteus_verification_status, legal_hold_status FROM Conversation WHERE qualified_id = ?;
+SELECT
+    Conversation.*
+FROM Conversation WHERE qualified_id = ?;
 
 selectProtocolInfoByQualifiedId:
 SELECT protocol, mls_group_id, mls_group_state, mls_epoch ,
@@ -316,11 +318,11 @@ selectByGroupId:
 SELECT * FROM ConversationDetails WHERE mls_group_id = ?;
 
 selectByGroupState:
-SELECT * FROM ConversationDetails WHERE mls_group_state = ? AND (protocol IS 'MLS' OR protocol IS 'MIXED');
+SELECT * FROM Conversation WHERE mls_group_state = ? AND (protocol IS 'MLS' OR protocol IS 'MIXED');
 
 selectActiveOneOnOneConversation:
-SELECT * FROM ConversationDetails
-WHERE qualifiedId = (SELECT active_one_on_one_conversation_id FROM User WHERE qualified_id = :user_id);
+SELECT * FROM Conversation
+WHERE qualified_id = (SELECT active_one_on_one_conversation_id FROM User WHERE qualified_id = :user_id);
 
 selectOneOnOneConversationIdsByProtocol:
 SELECT Member.conversation FROM Member

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Members.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Members.sq
@@ -45,33 +45,7 @@ SELECT * FROM Member WHERE conversation = :conversation;
 
 selectConversationsByMember:
 SELECT
-    qualified_id,
-    name,
-    type,
-    team_id,
-    mls_group_id,
-    mls_group_state,
-    mls_epoch,
-    mls_proposal_timer,
-    protocol,
-    muted_status,
-    muted_time,
-    creator_id,
-    last_modified_date,
-    last_notified_date,
-    last_read_date,
-    access_list,
-    access_role_list,
-    mls_last_keying_material_update_date,
-    mls_cipher_suite,
-    receipt_mode,
-    message_timer,
-    user_message_timer,
-    archived,
-    archived_date_time,
-    verification_status,
-    proteus_verification_status,
-    legal_hold_status
+    Conversation.*
 FROM Member
 JOIN Conversation ON Conversation.qualified_id = Member.conversation
 WHERE Member.user = ?;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/MetadataDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/MetadataDAOImpl.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.withContext
@@ -56,9 +57,7 @@ class MetadataDAOImpl internal constructor(
             .mapToOneOrNull()
     }
 
-    override suspend fun valueByKey(key: String): String? = withContext(queriesContext) {
-        metadataQueries.selectValueByKey(key).executeAsOneOrNull()
-    }
+    override suspend fun valueByKey(key: String): String? = valueByKeyFlow(key).first()
 
     override suspend fun clear(keysToKeep: List<String>?) = withContext(queriesContext) {
         if (keysToKeep == null) {
@@ -81,6 +80,7 @@ class MetadataDAOImpl internal constructor(
     }
 
     override fun <T> observeSerializable(key: String, kSerializer: KSerializer<T>): Flow<T?> {
+        // TODO: Cache
         return metadataQueries.selectValueByKey(key)
             .asFlow()
             .mapToOneOrNull()

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
@@ -29,7 +29,17 @@ data class ProposalTimerEntity(
     val firingDate: Instant
 )
 
+@Suppress("TooManyFunctions")
 interface ConversationDAO {
+    //region Get/Observe by ID
+
+    suspend fun observeConversationById(qualifiedID: QualifiedIDEntity): Flow<ConversationEntity?>
+    suspend fun getConversationById(qualifiedID: QualifiedIDEntity): ConversationEntity?
+    suspend fun getConversationDetailsById(qualifiedID: QualifiedIDEntity): ConversationViewEntity?
+    suspend fun observeConversationDetailsById(conversationId: QualifiedIDEntity): Flow<ConversationViewEntity?>
+
+    //endregion
+
     suspend fun getSelfConversationId(protocol: ConversationEntity.Protocol): QualifiedIDEntity?
     suspend fun getE2EIConversationClientInfoByClientId(clientId: String): E2EIConversationClientInfoEntity?
     suspend fun insertConversation(conversationEntity: ConversationEntity)
@@ -45,7 +55,7 @@ interface ConversationDAO {
     suspend fun updateConversationNotificationDate(qualifiedID: QualifiedIDEntity)
     suspend fun updateConversationReadDate(conversationID: QualifiedIDEntity, date: Instant)
     suspend fun updateAllConversationsNotificationDate()
-    suspend fun getAllConversations(): Flow<List<ConversationViewEntity>>
+    suspend fun getAllConversations(): Flow<List<ConversationEntity>>
     suspend fun getAllConversationDetails(fromArchive: Boolean): Flow<List<ConversationViewEntity>>
     suspend fun getConversationIds(
         type: ConversationEntity.Type,
@@ -54,20 +64,16 @@ interface ConversationDAO {
     ): List<QualifiedIDEntity>
 
     suspend fun getTeamConversationIdsReadyToCompleteMigration(teamId: String): List<QualifiedIDEntity>
-    suspend fun observeGetConversationByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<ConversationViewEntity?>
-    suspend fun observeGetConversationBaseInfoByQualifiedID(qualifiedID: QualifiedIDEntity): Flow<ConversationEntity?>
-    suspend fun getConversationBaseInfoByQualifiedID(qualifiedID: QualifiedIDEntity): ConversationEntity?
-    suspend fun getConversationByQualifiedID(qualifiedID: QualifiedIDEntity): ConversationViewEntity?
     suspend fun getOneOnOneConversationIdsWithOtherUser(
         userId: UserIDEntity,
         protocol: ConversationEntity.Protocol
     ): List<QualifiedIDEntity>
 
-    suspend fun observeOneOnOneConversationWithOtherUser(userId: UserIDEntity): Flow<ConversationViewEntity?>
+    suspend fun observeOneOnOneConversationWithOtherUser(userId: UserIDEntity): Flow<ConversationEntity?>
     suspend fun getConversationProtocolInfo(qualifiedID: QualifiedIDEntity): ConversationEntity.ProtocolInfo?
     suspend fun observeConversationByGroupID(groupID: String): Flow<ConversationViewEntity?>
     suspend fun getConversationIdByGroupID(groupID: String): QualifiedIDEntity?
-    suspend fun getConversationsByGroupState(groupState: ConversationEntity.GroupState): List<ConversationViewEntity>
+    suspend fun getConversationsByGroupState(groupState: ConversationEntity.GroupState): List<ConversationEntity>
     suspend fun deleteConversationByQualifiedID(qualifiedID: QualifiedIDEntity)
 
     suspend fun updateConversationMutedStatus(
@@ -132,11 +138,6 @@ interface ConversationDAO {
     suspend fun getEstablishedSelfMLSGroupId(): String?
 
     suspend fun selectGroupStatusMembersNamesAndHandles(groupID: String): EpochChangesDataEntity?
-
-    /**
-     * TODO: Remove later when implementing general conversation cache in the app.
-     */
-    suspend fun observeConversationDetailsById(conversationId: QualifiedIDEntity): Flow<ConversationViewEntity?>
 }
 
 data class NameAndHandleEntity(

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationMapper.kt
@@ -17,66 +17,116 @@
  */
 package com.wire.kalium.persistence.dao.conversation
 
+import com.wire.kalium.persistence.dao.BotIdEntity
+import com.wire.kalium.persistence.dao.ConnectionEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.persistence.dao.SupportedProtocolEntity
+import com.wire.kalium.persistence.dao.UserAvailabilityStatusEntity
+import com.wire.kalium.persistence.dao.UserTypeEntity
+import com.wire.kalium.persistence.dao.call.CallEntity
+import com.wire.kalium.persistence.dao.member.MemberEntity
 import kotlinx.datetime.Instant
-import com.wire.kalium.persistence.ConversationDetails as SQLDelightConversationView
 
 internal class ConversationMapper {
-    fun toModel(conversation: SQLDelightConversationView): ConversationViewEntity = with(conversation) {
-        ConversationViewEntity(
-            id = qualifiedId,
-            name = name,
-            type = type,
-            teamId = teamId,
-            protocolInfo = mapProtocolInfo(
-                protocol,
-                mls_group_id,
-                mls_group_state,
-                mls_epoch,
-                mls_last_keying_material_update_date,
-                mls_cipher_suite
-            ),
-            isCreator = isCreator,
-            mutedStatus = mutedStatus,
-            mutedTime = muted_time,
-            creatorId = creator_id,
-            lastNotificationDate = lastNotifiedMessageDate,
-            lastModifiedDate = last_modified_date,
-            lastReadDate = lastReadDate,
-            accessList = access_list,
-            accessRoleList = access_role_list,
-            protocol = protocol,
-            mlsCipherSuite = mls_cipher_suite,
-            mlsEpoch = mls_epoch,
-            mlsGroupId = mls_group_id,
-            mlsLastKeyingMaterialUpdateDate = mls_last_keying_material_update_date,
-            mlsGroupState = mls_group_state,
-            mlsProposalTimer = mls_proposal_timer,
-            callStatus = callStatus,
-            previewAssetId = previewAssetId,
-            userAvailabilityStatus = userAvailabilityStatus,
-            userType = userType,
-            botService = botService,
-            userDeleted = userDeleted,
-            connectionStatus = connectionStatus,
-            otherUserId = otherUserId,
-            selfRole = selfRole,
-            receiptMode = receipt_mode,
-            messageTimer = message_timer,
-            userMessageTimer = user_message_timer,
-            userDefederated = userDefederated,
-            archived = archived,
-            archivedDateTime = archived_date_time,
-            mlsVerificationStatus = mls_verification_status,
-            userSupportedProtocols = userSupportedProtocols,
-            userActiveOneOnOneConversationId = otherUserActiveConversationId,
-            proteusVerificationStatus = proteus_verification_status,
-            legalHoldStatus = legal_hold_status
-        )
-    }
+    @Suppress("LongParameterList", "UnusedParameter", "FunctionParameterNaming")
+    fun fromViewToModel(
+        qualifiedId: QualifiedIDEntity,
+        name: String?,
+        type: ConversationEntity.Type,
+        callStatus: CallEntity.Status?,
+        previewAssetId: QualifiedIDEntity?,
+        mutedStatus: ConversationEntity.MutedStatus,
+        teamId: String?,
+        lastModifiedDate_: Instant?,
+        lastReadDate: Instant,
+        userAvailabilityStatus: UserAvailabilityStatusEntity?,
+        userType: UserTypeEntity?,
+        botService: BotIdEntity?,
+        userDeleted: Boolean?,
+        userDefederated: Boolean?,
+        userSupportedProtocols: Set<SupportedProtocolEntity>?,
+        connectionStatus: ConnectionEntity.State?,
+        otherUserId: QualifiedIDEntity?,
+        otherUserActiveConversationId: QualifiedIDEntity?,
+        isCreator: Long,
+        isActive: Long,
+        lastNotifiedMessageDate: Instant?,
+        selfRole: MemberEntity.Role?,
+        protocol: ConversationEntity.Protocol,
+        mlsCipherSuite: ConversationEntity.CipherSuite,
+        mlsEpoch: Long,
+        mlsGroupId: String?,
+        mlsLastKeyingMaterialUpdateDate: Instant,
+        mlsGroupState: ConversationEntity.GroupState,
+        accessList: List<ConversationEntity.Access>,
+        accessRoleList: List<ConversationEntity.AccessRole>,
+        teamId_: String?,
+        mlsProposalTimer: String?,
+        mutedTime: Long,
+        creatorId: String,
+        lastModifiedDate: Instant,
+        receiptMode: ConversationEntity.ReceiptMode,
+        messageTimer: Long?,
+        userMessageTimer: Long?,
+        incompleteMetadata: Boolean,
+        archived: Boolean,
+        archivedDateTime: Instant?,
+        mlsVerificationStatus: ConversationEntity.VerificationStatus,
+        proteusVerificationStatus: ConversationEntity.VerificationStatus,
+        legalHoldStatus: ConversationEntity.LegalHoldStatus,
+    ): ConversationViewEntity = ConversationViewEntity(
+        id = qualifiedId,
+        name = name,
+        type = type,
+        teamId = teamId,
+        protocolInfo = mapProtocolInfo(
+            protocol,
+            mlsGroupId,
+            mlsGroupState,
+            mlsEpoch,
+            mlsLastKeyingMaterialUpdateDate,
+            mlsCipherSuite
+        ),
+        isCreator = isCreator,
+        mutedStatus = mutedStatus,
+        mutedTime = mutedTime,
+        creatorId = creatorId,
+        lastNotificationDate = lastNotifiedMessageDate,
+        lastModifiedDate = lastModifiedDate,
+        lastReadDate = lastReadDate,
+        accessList = accessList,
+        accessRoleList = accessRoleList,
+        protocol = protocol,
+        mlsCipherSuite = mlsCipherSuite,
+        mlsEpoch = mlsEpoch,
+        mlsGroupId = mlsGroupId,
+        mlsLastKeyingMaterialUpdateDate = mlsLastKeyingMaterialUpdateDate,
+        mlsGroupState = mlsGroupState,
+        mlsProposalTimer = mlsProposalTimer,
+        callStatus = callStatus,
+        previewAssetId = previewAssetId,
+        userAvailabilityStatus = userAvailabilityStatus,
+        userType = userType,
+        botService = botService,
+        userDeleted = userDeleted,
+        connectionStatus = connectionStatus,
+        otherUserId = otherUserId,
+        selfRole = selfRole,
+        receiptMode = receiptMode,
+        messageTimer = messageTimer,
+        userMessageTimer = userMessageTimer,
+        userDefederated = userDefederated,
+        archived = archived,
+        archivedDateTime = archivedDateTime,
+        mlsVerificationStatus = mlsVerificationStatus,
+        userSupportedProtocols = userSupportedProtocols,
+        userActiveOneOnOneConversationId = otherUserActiveConversationId,
+        proteusVerificationStatus = proteusVerificationStatus,
+        legalHoldStatus = legalHoldStatus
+    )
 
-    @Suppress("LongParameterList")
-    fun toModel(
+    @Suppress("LongParameterList", "UnusedParameter")
+    fun fromViewToModel(
         qualifiedId: QualifiedIDEntity,
         name: String?,
         type: ConversationEntity.Type,
@@ -97,13 +147,18 @@ internal class ConversationMapper {
         mlsLastKeyingMaterialUpdateDate: Instant,
         mlsCipherSuite: ConversationEntity.CipherSuite,
         receiptMode: ConversationEntity.ReceiptMode,
+        guestRoomLink: String?,
         messageTimer: Long?,
         userMessageTimer: Long?,
+        incompleteMetadata: Boolean,
+        mlsDegradedNotified: Boolean,
+        isGuestPasswordProtected: Boolean,
         archived: Boolean,
         archivedDateTime: Instant?,
-        mlsVerificationStatus: ConversationEntity.VerificationStatus,
+        verificationStatus: ConversationEntity.VerificationStatus,
         proteusVerificationStatus: ConversationEntity.VerificationStatus,
-        legalHoldStatus: ConversationEntity.LegalHoldStatus
+        degradedConversationNotified: Boolean,
+        legalHoldStatus: ConversationEntity.LegalHoldStatus,
     ) = ConversationEntity(
         id = qualifiedId,
         name = name,
@@ -130,7 +185,7 @@ internal class ConversationMapper {
         userMessageTimer = userMessageTimer,
         archived = archived,
         archivedInstant = archivedDateTime,
-        mlsVerificationStatus = mlsVerificationStatus,
+        mlsVerificationStatus = verificationStatus,
         proteusVerificationStatus = proteusVerificationStatus,
         legalHoldStatus = legalHoldStatus
     )

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/UserDatabaseDataGenerator.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/UserDatabaseDataGenerator.kt
@@ -32,7 +32,6 @@ import com.wire.kalium.persistence.dao.UserTypeEntity
 import com.wire.kalium.persistence.dao.asset.AssetEntity
 import com.wire.kalium.persistence.dao.call.CallEntity
 import com.wire.kalium.persistence.dao.conversation.ConversationEntity
-import com.wire.kalium.persistence.dao.conversation.ConversationViewEntity
 import com.wire.kalium.persistence.dao.member.MemberEntity
 import com.wire.kalium.persistence.dao.message.MessageEntity
 import com.wire.kalium.persistence.dao.message.MessageEntityContent
@@ -239,7 +238,7 @@ class UserDatabaseDataGenerator(
         conversationAmount: Int,
         messagePerConversation: Int,
         messageType: MessageType
-    ): List<ConversationViewEntity> {
+    ): List<ConversationEntity> {
         val conversationPrefix = "${databasePrefix}Conversation${generatedConversationsCount}"
 
         for (index in generatedConversationsCount + 1..conversationAmount) {
@@ -434,7 +433,7 @@ class UserDatabaseDataGenerator(
     suspend fun generateAndInsertGroupConversations(
         conversationAmount: Int,
         membersPerGroup: Int
-    ): List<ConversationViewEntity> {
+    ): List<ConversationEntity> {
         val groupConversationPrefix = "${databasePrefix}GroupConversation${generatedConversationsCount}"
 
         for (index in generatedConversationsCount + 1..conversationAmount) {
@@ -482,7 +481,7 @@ class UserDatabaseDataGenerator(
     suspend fun generateAndInsertGroupConversations(
         conversationAmount: Int,
         membersGenerate: (ConversationIDEntity) -> List<MemberEntity>
-    ): List<ConversationViewEntity> {
+    ): List<ConversationEntity> {
         val groupConversationPrefix = "${databasePrefix}GroupConversation${generatedConversationsCount}"
 
         for (index in generatedConversationsCount + 1..conversationAmount) {
@@ -589,7 +588,7 @@ class UserDatabaseDataGenerator(
     suspend fun generateAndInsertMessageAssetContent(
         conversationAmount: Int,
         assetAmountPerConversation: Int
-    ): List<ConversationViewEntity> {
+    ): List<ConversationEntity> {
         val conversationPrefix = "${databasePrefix}Conversation${generatedConversationsCount}"
 
         for (index in generatedConversationsCount + 1..conversationAmount) {

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -93,7 +93,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
     fun givenConversationIsInserted_whenFetchingById_thenConversationIsReturned() = runTest {
         conversationDAO.insertConversation(conversationEntity1)
         insertTeamUserAndMember(team, user1, conversationEntity1.id)
-        val result = conversationDAO.getConversationByQualifiedID(conversationEntity1.id)
+        val result = conversationDAO.getConversationDetailsById(conversationEntity1.id)
         assertEquals(conversationEntity1.toViewEntity(user1), result)
     }
 
@@ -102,8 +102,8 @@ class ConversationDAOTest : BaseDatabaseTest() {
         conversationDAO.insertConversations(listOf(conversationEntity1, conversationEntity2))
         insertTeamUserAndMember(team, user1, conversationEntity1.id)
         insertTeamUserAndMember(team, user2, conversationEntity2.id)
-        val result1 = conversationDAO.getConversationByQualifiedID(conversationEntity1.id)
-        val result2 = conversationDAO.getConversationByQualifiedID(conversationEntity2.id)
+        val result1 = conversationDAO.getConversationDetailsById(conversationEntity1.id)
+        val result2 = conversationDAO.getConversationDetailsById(conversationEntity2.id)
         assertEquals(conversationEntity1.toViewEntity(user1), result1)
         assertEquals(conversationEntity2.toViewEntity(user2), result2)
     }
@@ -113,7 +113,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
         conversationDAO.insertConversation(conversationEntity1)
         conversationDAO.deleteConversationByQualifiedID(conversationEntity1.id)
         val result = try {
-            conversationDAO.getConversationByQualifiedID(conversationEntity1.id)
+            conversationDAO.getConversationDetailsById(conversationEntity1.id)
         } catch (npe: NullPointerException) {
             null
         }
@@ -126,7 +126,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
         insertTeamUserAndMember(team, user1, conversationEntity1.id)
         val updatedConversation1Entity = conversationEntity1.copy(name = "Updated conversation1")
         conversationDAO.updateConversation(updatedConversation1Entity)
-        val result = conversationDAO.getConversationByQualifiedID(conversationEntity1.id)
+        val result = conversationDAO.getConversationDetailsById(conversationEntity1.id)
         assertEquals(updatedConversation1Entity.toViewEntity(user1), result)
     }
 
@@ -165,7 +165,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
         insertTeamUserAndMember(team, user2, conversationEntity6.id)
         val result =
             conversationDAO.getConversationsByGroupState(ConversationEntity.GroupState.ESTABLISHED)
-        assertEquals(listOf(conversationEntity6.toViewEntity(user2)), result)
+        assertEquals(listOf(conversationEntity6), result)
     }
 
     @Test
@@ -220,7 +220,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
         insertTeamUserAndMember(team, user2, conversationEntity2.id)
         val result =
             conversationDAO.getConversationsByGroupState(ConversationEntity.GroupState.ESTABLISHED)
-        assertEquals(listOf(conversationEntity2.toViewEntity(user2)), result)
+        assertEquals(listOf(conversationEntity2), result)
     }
 
     @Test
@@ -260,7 +260,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             ConversationEntity.GroupState.PENDING_WELCOME_MESSAGE,
             (conversationEntity2.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId
         )
-        val result = conversationDAO.getConversationByQualifiedID(conversationEntity2.id)
+        val result = conversationDAO.getConversationDetailsById(conversationEntity2.id)
         assertEquals(
             (result?.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupState, ConversationEntity.GroupState.PENDING_WELCOME_MESSAGE
         )
@@ -274,7 +274,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             ConversationEntity.CipherSuite.MLS_256_DHKEMP521_AES256GCM_SHA512_P521,
             (conversationEntity2.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId,
         )
-        val result = conversationDAO.getConversationByQualifiedID(conversationEntity2.id)
+        val result = conversationDAO.getConversationDetailsById(conversationEntity2.id)
         assertEquals(
             (result?.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupState, ConversationEntity.GroupState.PENDING_WELCOME_MESSAGE
         )
@@ -290,7 +290,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
         insertTeamUserAndMember(team, user1, conversationEntity1.id)
         val updatedConversation1Entity = conversationEntity1.copy(name = "Updated conversation1")
         conversationDAO.insertConversation(updatedConversation1Entity)
-        val result = conversationDAO.getConversationByQualifiedID(conversationEntity1.id)
+        val result = conversationDAO.getConversationDetailsById(conversationEntity1.id)
         assertEquals(updatedConversation1Entity.toViewEntity(user1), result)
     }
 
@@ -303,7 +303,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             mutedStatusTimestamp = 1649702788L
         )
 
-        val result = conversationDAO.getConversationByQualifiedID(conversationEntity2.id)
+        val result = conversationDAO.getConversationDetailsById(conversationEntity2.id)
 
         assertEquals(ConversationEntity.MutedStatus.ONLY_MENTIONS_AND_REPLIES_ALLOWED, result?.mutedStatus)
     }
@@ -330,7 +330,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
         insertTeamUserAndMember(team, user1, convStored.id)
         conversationDAO.insertConversation(convAfterSync)
 
-        val actual = conversationDAO.getConversationByQualifiedID(convAfterSync.id)
+        val actual = conversationDAO.getConversationDetailsById(convAfterSync.id)
         assertEquals(expected.toViewEntity(user1), actual)
     }
 
@@ -351,7 +351,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
 
         conversationDAO.updateAccess(convStored.id, newAccess, newAccessRole)
 
-        conversationDAO.getConversationByQualifiedID(convStored.id).also { actual ->
+        conversationDAO.getConversationDetailsById(convStored.id).also { actual ->
             assertEquals(expected.toViewEntity(user1), actual)
         }
 
@@ -368,7 +368,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
         conversationDAO.updateConversationReadDate(conversationEntity1.id, expectedLastReadDate)
 
         // then
-        val actual = conversationDAO.getConversationByQualifiedID(conversationEntity1.id)
+        val actual = conversationDAO.getConversationDetailsById(conversationEntity1.id)
 
         assertNotNull(actual)
         assertEquals(expectedLastReadDate, actual.lastReadDate)
@@ -383,7 +383,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             teamDAO.insertTeam(team)
             launch {
                 // when
-                conversationDAO.observeGetConversationByQualifiedID(conversationEntity1.id).test {
+                conversationDAO.observeConversationDetailsById(conversationEntity1.id).test {
                     // then
                     val initialConversation = awaitItem()
 
@@ -451,9 +451,9 @@ class ConversationDAOTest : BaseDatabaseTest() {
             conversationDAO.updateConversationProtocolAndCipherSuite(conversation.id, groupId, updatedProtocol, updatedCipherSuite)
 
         assertTrue(changed)
-        assertEquals(conversationDAO.getConversationByQualifiedID(conversation.id)?.protocol, updatedProtocol)
-        assertEquals(conversationDAO.getConversationByQualifiedID(conversation.id)?.mlsGroupId, groupId)
-        assertEquals(conversationDAO.getConversationByQualifiedID(conversation.id)?.mlsCipherSuite, updatedCipherSuite)
+        assertEquals(conversationDAO.getConversationDetailsById(conversation.id)?.protocol, updatedProtocol)
+        assertEquals(conversationDAO.getConversationDetailsById(conversation.id)?.mlsGroupId, groupId)
+        assertEquals(conversationDAO.getConversationDetailsById(conversation.id)?.mlsCipherSuite, updatedCipherSuite)
     }
 
     @Test
@@ -798,7 +798,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             "NEW-NAME",
             Instant.parse("2023-11-22T15:36:00.000Z")
         )
-        val updatedConversation = conversationDAO.getConversationByQualifiedID(conversationEntity3.id)
+        val updatedConversation = conversationDAO.getConversationDetailsById(conversationEntity3.id)
 
         // then
         assertEquals("NEW-NAME", updatedConversation!!.name)
@@ -829,7 +829,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
         conversationDAO.updateConversationReceiptMode(conversationEntity1.id, ConversationEntity.ReceiptMode.DISABLED)
 
         // then
-        val conversation = conversationDAO.getConversationByQualifiedID(conversationEntity1.id)
+        val conversation = conversationDAO.getConversationDetailsById(conversationEntity1.id)
         assertEquals(ConversationEntity.ReceiptMode.DISABLED, conversation?.receiptMode)
     }
 
@@ -842,7 +842,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
         memberDAO.insertMember(MemberEntity(user2.id, MemberEntity.Role.Member), conversationEntity3.id)
 
         // when
-        val result = conversationDAO.getConversationByQualifiedID(conversationEntity3.id)
+        val result = conversationDAO.getConversationDetailsById(conversationEntity3.id)
 
         // then
         assertEquals(false, result?.isMember)
@@ -856,7 +856,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
         conversationDAO.updateMessageTimer(conversationEntity3.id, messageTimer)
 
         // when
-        val result = conversationDAO.getConversationByQualifiedID(conversationEntity3.id)
+        val result = conversationDAO.getConversationDetailsById(conversationEntity3.id)
 
         // then
         assertEquals(messageTimer, result?.messageTimer)
@@ -871,7 +871,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
         insertTeamUserAndMember(team, user2, conversationEntity3.id)
 
         // when
-        val result = conversationDAO.getConversationByQualifiedID(conversationEntity3.id)
+        val result = conversationDAO.getConversationDetailsById(conversationEntity3.id)
 
         // then
         assertEquals(1L, result?.isCreator)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/MigrationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/MigrationDAOTest.kt
@@ -48,13 +48,13 @@ class MigrationDAOTest : BaseDatabaseTest() {
         val conversationFromMigration = conversation.copy(type = ConversationEntity.Type.ONE_ON_ONE, name = "migration name")
 
         conversationDAO.insertConversation(conversation)
-        conversationDAO.getConversationByQualifiedID(conversation.id).also {
+        conversationDAO.getConversationDetailsById(conversation.id).also {
             assertEquals(conversation.type, it?.type)
             assertEquals(conversation.name, it?.name)
         }
 
         migrationDAO.insertConversation(listOf(conversationFromMigration))
-        conversationDAO.getConversationByQualifiedID(conversationFromMigration.id).also {
+        conversationDAO.getConversationDetailsById(conversationFromMigration.id).also {
             assertEquals(conversation.type, it?.type)
             assertEquals(conversation.name, it?.name)
         }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserConversationDAOIntegrationTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserConversationDAOIntegrationTest.kt
@@ -259,7 +259,7 @@ class UserConversationDAOIntegrationTest : BaseDatabaseTest() {
 
         userDAO.updateActiveOneOnOneConversation(user1.id, conversationEntity1.id)
 
-        val result = conversationDAO.getConversationByQualifiedID(conversationEntity1.id)
+        val result = conversationDAO.getConversationDetailsById(conversationEntity1.id)
         assertEquals(conversationEntity1.id, result?.userActiveOneOnOneConversationId)
     }
 
@@ -269,7 +269,7 @@ class UserConversationDAOIntegrationTest : BaseDatabaseTest() {
         conversationDAO.insertConversation(conversationEntity1)
         memberDAO.insertMember(member1, conversationEntity1.id)
 
-        val result = conversationDAO.getConversationByQualifiedID(conversationEntity1.id)
+        val result = conversationDAO.getConversationDetailsById(conversationEntity1.id)
         assertNotNull(result)
         assertNull(result.userActiveOneOnOneConversationId)
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10298" title="WPB-10298" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10298</a>  [Android] Cleanup ConversationRepository's multiple ways of getting conversation by ID
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We have _too many_ ways of getting or observing conversations by ID.

### Causes

Technical debt as the codebase changed.

### Solutions


Cleanup from queries to repositories, as described below:


#### Queries

- Some queries were fetching the detailed `ConversationView` and then being mapped to simple `ConversationEntity` in the DAO, fetching unnecessary data. These are now just fetching the simple `ConversationEntity`.

#### DAO / Entity Mapper

- As said above, some queries were fetching unnecessary data. They do not anymore. DAOs were adjusted to only fetch the necessary.

- Some DAO operations were querying and _then_ mapping the data. Now the mapper is being passed to avoid double mapping.

- One repeated "observe conversation by ID" function was removed.

- Functions that fetch by ID (without observing) are now getting the flow from the FlowCache. This has the advantage of avoiding fetching the DB again if some part of the application is already observing the wanted ID.

| Before                                      | Now                                                       | Reasoning                                            |
|---------------------------------------------|-----------------------------------------------------------|------------------------------------------------------|
| getConversationByQualifiedID                | getConversationById                                       | Unnecessary "Qualified" name                         |
| observeGetConversationBaseInfoByQualifiedID | observeConversationById                                   | Weird name ("observe get"); Unnecessary "base" name. |
| getConversationByQualifiedID                | getConversationDetailsById                                | Unnecessary "Qualified" name                         |
| observeGetConversationByQualifiedID         | ❌ Removed. `observeConversationDetailsById` does the same | Weird name ("observe get")                           |


#### ConversationRepository

| Before                         | Now                                        | Reasoning                                                                                        |
|--------------------------------|--------------------------------------------|--------------------------------------------------------------------------------------------------|
| observeConversationDetailsById | ✅ No changes!                              | Does exactly what it claims to, has sensible name.                                               |
| observeById                    | observeConversationById                    | Too generic of a name                                                                            |
| getConversationById            | ⚠️ Changed return type. Now returns Either | Used to return just a nullable conversation                                                      |
| observeCacheDetailsById        | ❌ Removed                                  | `observeConversationDetailsById` does the exact same now that we have caching for all operations |
| detailsById                    | ❌ Removed                                  | Doesn't return details. It is exactly like    `getConversationById`                              |
| baseInfoById                   | ❌ Removed                                  | It is exactly like    `getConversationById`                                                      |


- Removed repeated functions for reading. Adjusted code as necessary.

### Testing

N/A

Compiler and current tests do the trick :)

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
