### PR TITLE
fix: missing notifications due to LegalHold not Notified (WPB-10351)

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Notification.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Notification.sq
@@ -16,12 +16,12 @@ SELECT
     Conversation.type AS conversationType,
     Conversation.degraded_conversation_notified AS degradedConversationNotified,
     Conversation.legal_hold_status AS legalHoldStatus,
-    LegalHoldNotified.legal_hold_status_change_notified AS legalHoldStatusChangeNotified
+    IFNULL(LegalHoldNotified.legal_hold_status_change_notified, 1) == 1 AS legalHoldStatusChangeNotified
 FROM Message
 LEFT JOIN SelfUser
 JOIN User ON Message.sender_user_id = User.qualified_id AND Message.content_type IN  ('TEXT', 'RESTRICTED_ASSET', 'ASSET', 'KNOCK', 'MISSED_CALL', 'LOCATION')
 JOIN Conversation AS Conversation ON Message.conversation_id == Conversation.qualified_id AND (Message.creation_date > IFNULL(Conversation.last_notified_date, 0))
-JOIN ConversationLegalHoldStatusChangeNotified AS LegalHoldNotified ON Message.conversation_id == LegalHoldNotified.conversation_id AND (Message.creation_date > IFNULL(Conversation.last_notified_date, 0))
+LEFT JOIN ConversationLegalHoldStatusChangeNotified AS LegalHoldNotified ON Message.conversation_id == LegalHoldNotified.conversation_id AND (Message.creation_date > IFNULL(Conversation.last_notified_date, 0))
 LEFT JOIN MessageAssetContent AS AssetContent ON Message.id = AssetContent.message_id AND Message.conversation_id = AssetContent.conversation_id
 LEFT JOIN MessageTextContent AS TextContent ON Message.id = TextContent.message_id AND Message.conversation_id = TextContent.conversation_id
 WHERE

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageNotificationsTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageNotificationsTest.kt
@@ -23,7 +23,6 @@ import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserAvailabilityStatusEntity
 import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 import com.wire.kalium.persistence.utils.stubs.newRegularMessageEntity
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import kotlin.test.Test
@@ -32,7 +31,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.hours
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class MessageNotificationsTest : BaseMessageTest() {
 
     @Test
@@ -113,6 +111,22 @@ class MessageNotificationsTest : BaseMessageTest() {
             val notifications = awaitItem()
             assertEquals(2, notifications.size)
             assertEquals(false, notifications.any { it.isQuotingSelf })
+        }
+    }
+
+    @Test
+    fun givenConversation_whenNoLegalHoldNotified_thenNotificationIsPresent() = runTest {
+        val message = OTHER_MESSAGE
+        val messageOtherConvo2 = OTHER_MESSAGE_CONVO2
+        super.insertInitialData()
+        conversationDAO.updateLegalHoldStatusChangeNotified(TEST_CONVERSATION_1.id, false)
+        messageDAO.insertOrIgnoreMessages(listOf(message, messageOtherConvo2))
+
+        messageDAO.getNotificationMessage().test {
+            val notifications = awaitItem()
+            assertEquals(2, notifications.size)
+            assertEquals(false, notifications.first { it.conversationId == TEST_CONVERSATION_1.id  }.legalHoldStatusChangeNotified)
+            assertEquals(true, notifications.first { it.conversationId == TEST_CONVERSATION_2.id  }.legalHoldStatusChangeNotified)
         }
     }
 
@@ -388,6 +402,13 @@ class MessageNotificationsTest : BaseMessageTest() {
         val OTHER_MESSAGE = newRegularMessageEntity(
             id = "OTHER_MESSAGE",
             conversationId = TEST_CONVERSATION_1.id,
+            senderUserId = ORIGINAL_MESSAGE_SENDER.id,
+            content = MessageEntityContent.Text(OTHER_MESSAGE_CONTENT)
+        )
+
+        val OTHER_MESSAGE_CONVO2 = newRegularMessageEntity(
+            id = "OTHER_MESSAGE",
+            conversationId = TEST_CONVERSATION_2.id,
             senderUserId = ORIGINAL_MESSAGE_SENDER.id,
             content = MessageEntityContent.Text(OTHER_MESSAGE_CONTENT)
         )

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageNotificationsTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageNotificationsTest.kt
@@ -118,7 +118,9 @@ class MessageNotificationsTest : BaseMessageTest() {
     fun givenConversation_whenNoLegalHoldNotified_thenNotificationIsPresent() = runTest {
         val message = OTHER_MESSAGE
         val messageOtherConvo2 = OTHER_MESSAGE_CONVO2
+        // going to super to not insert legal hold values
         super.insertInitialData()
+        // just inserting legal hold for one conversation
         conversationDAO.updateLegalHoldStatusChangeNotified(TEST_CONVERSATION_1.id, false)
         messageDAO.insertOrIgnoreMessages(listOf(message, messageOtherConvo2))
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

This PR solves a bug introduced by #2874 , assuming that we have always a notification about LH in the conversations

### Causes (Optional)

Notifications not being received

### Solutions

LEFT join and assume true (same default value for the table) in case missing.
Added test to cover the case.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
