### PR TITLE
fix(e2ei): set ciphersuites when replacing KeyPackages (WPB-10238)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -669,7 +669,9 @@ internal class MLSConversationDataSource(
             }
             if (!isNewClient) {
                 kaliumLogger.w("enrollment for existing client: upload new keypackages and drop old ones")
-                keyPackageRepository.replaceKeyPackages(clientId, rotateBundle.newKeyPackages).flatMapLeft {
+                keyPackageRepository
+                    .replaceKeyPackages(clientId, rotateBundle.newKeyPackages, CipherSuite.fromTag(mlsClient.getDefaultCipherSuite()))
+                    .flatMapLeft {
                     return E2EIFailure.RotationAndMigration(it).left()
                 }
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepository.kt
@@ -61,7 +61,7 @@ interface KeyPackageRepository {
 
     suspend fun uploadKeyPackages(clientId: ClientId, keyPackages: List<ByteArray>): Either<CoreFailure, Unit>
 
-    suspend fun replaceKeyPackages(clientId: ClientId, keyPackages: List<ByteArray>): Either<CoreFailure, Unit>
+    suspend fun replaceKeyPackages(clientId: ClientId, keyPackages: List<ByteArray>, cipherSuite: CipherSuite): Either<CoreFailure, Unit>
 
     suspend fun getAvailableKeyPackageCount(clientId: ClientId): Either<NetworkFailure, KeyPackageCountDTO>
 
@@ -124,10 +124,11 @@ class KeyPackageDataSource(
 
     override suspend fun replaceKeyPackages(
         clientId: ClientId,
-        keyPackages: List<ByteArray>
+        keyPackages: List<ByteArray>,
+        cipherSuite: CipherSuite
     ): Either<CoreFailure, Unit> =
         wrapApiRequest {
-            keyPackageApi.replaceKeyPackages(clientId.value, keyPackages.map { it.encodeBase64() })
+            keyPackageApi.replaceKeyPackages(clientId.value, keyPackages.map { it.encodeBase64() }, cipherSuite.tag)
         }
 
     override suspend fun validKeyPackageCount(clientId: ClientId): Either<CoreFailure, Int> =

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -1269,6 +1269,7 @@ class MLSConversationRepositoryTest {
     fun givenSuccessResponse_whenRotatingKeysAndMigratingConversation_thenReturnsSuccess() = runTest {
         val (arrangement, mlsConversationRepository) = Arrangement()
             .withGetMLSClientSuccessful()
+            .withGetDefaultCipherSuiteSuccessful()
             .withRotateAllSuccessful()
             .withSendCommitBundleSuccessful()
             .withKeyPackageLimits(10)
@@ -1305,6 +1306,7 @@ class MLSConversationRepositoryTest {
     fun givenNewDistributionsCRL_whenRotatingKeys_thenCheckRevocationList() = runTest {
         val (arrangement, mlsConversationRepository) = Arrangement()
             .withGetMLSClientSuccessful()
+            .withGetDefaultCipherSuiteSuccessful()
             .withRotateAllSuccessful(ROTATE_BUNDLE.copy(crlNewDistributionPoints = listOf("url")))
             .withSendCommitBundleSuccessful()
             .withKeyPackageLimits(10)
@@ -1332,6 +1334,7 @@ class MLSConversationRepositoryTest {
     fun givenReplacingKeypackagesFailed_whenRotatingKeysAndMigratingConversation_thenReturnsFailure() = runTest {
         val (arrangement, mlsConversationRepository) = Arrangement()
             .withGetMLSClientSuccessful()
+            .withGetDefaultCipherSuiteSuccessful()
             .withRotateAllSuccessful()
             .withKeyPackageLimits(10)
             .withReplaceKeyPackagesReturning(TEST_FAILURE)
@@ -1363,6 +1366,7 @@ class MLSConversationRepositoryTest {
     fun givenSendingCommitBundlesFails_whenRotatingKeysAndMigratingConversation_thenReturnsFailure() = runTest {
         val (arrangement, mlsConversationRepository) = Arrangement()
             .withGetMLSClientSuccessful()
+            .withGetDefaultCipherSuiteSuccessful()
             .withRotateAllSuccessful()
             .withKeyPackageLimits(10)
             .withReplaceKeyPackagesReturning(Either.Right(Unit))
@@ -1758,7 +1762,7 @@ class MLSConversationRepositoryTest {
         fun withReplaceKeyPackagesReturning(result: Either<CoreFailure, Unit>) = apply {
             given(keyPackageRepository)
                 .suspendFunction(keyPackageRepository::replaceKeyPackages)
-                .whenInvokedWith(anything(), anything())
+                .whenInvokedWith(anything(), anything(), anything())
                 .thenReturn(result)
         }
 
@@ -1774,6 +1778,13 @@ class MLSConversationRepositoryTest {
                 .suspendFunction(mlsClientProvider::getMLSClient)
                 .whenInvokedWith(anything())
                 .then { Either.Right(mlsClient) }
+        }
+
+        fun withGetDefaultCipherSuiteSuccessful() = apply {
+            given(mlsClient)
+                .function(mlsClient::getDefaultCipherSuite)
+                .whenInvoked()
+                .then { CIPHER_SUITE.tag.toUShort() }
         }
 
         fun withGetExternalSenderKeySuccessful() = apply {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/keypackage/KeyPackageApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/keypackage/KeyPackageApi.kt
@@ -73,7 +73,11 @@ interface KeyPackageApi {
      * @param keyPackages list of key packages
      *
      */
-    suspend fun replaceKeyPackages(clientId: String, keyPackages: List<KeyPackage>): NetworkResponse<Unit>
+    suspend fun replaceKeyPackages(
+        clientId: String,
+        keyPackages: List<KeyPackage>,
+        cipherSuite: Int
+    ): NetworkResponse<Unit>
 
     /**
      * Get the number of available key packages for the self client

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/KeyPackageApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/KeyPackageApiV0.kt
@@ -41,7 +41,8 @@ internal open class KeyPackageApiV0 internal constructor() : KeyPackageApi {
 
     override suspend fun replaceKeyPackages(
         clientId: String,
-        keyPackages: List<KeyPackage>
+        keyPackages: List<KeyPackage>,
+        cipherSuite: Int
     ): NetworkResponse<Unit> = NetworkResponse.Error(
         APINotSupported("MLS: replaceKeyPackages api is only available on API V5")
     )

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/KeyPackageApiV5.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/KeyPackageApiV5.kt
@@ -30,7 +30,7 @@ import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.handleUnsuccessfulResponse
 import com.wire.kalium.network.utils.wrapFederationResponse
 import com.wire.kalium.network.utils.wrapKaliumResponse
-import com.wire.kalium.util.int.toHex
+import com.wire.kalium.util.int.toHexString
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.client.request.post
@@ -75,7 +75,7 @@ internal open class KeyPackageApiV5 internal constructor(
             kaliumLogger.v("Keypackages Count to replace: ${keyPackages.size}")
             httpClient.put("$PATH_KEY_PACKAGES/$PATH_SELF/$clientId") {
                 setBody(KeyPackageList(keyPackages))
-                parameter(QUERY_CIPHER_SUITES, cipherSuite.toHex())
+                parameter(QUERY_CIPHER_SUITES, cipherSuite.toHexString())
             }
         }
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/KeyPackageApiV5.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/KeyPackageApiV5.kt
@@ -30,6 +30,7 @@ import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.handleUnsuccessfulResponse
 import com.wire.kalium.network.utils.wrapFederationResponse
 import com.wire.kalium.network.utils.wrapKaliumResponse
+import com.wire.kalium.util.int.toHex
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.client.request.post
@@ -67,12 +68,14 @@ internal open class KeyPackageApiV5 internal constructor(
 
     override suspend fun replaceKeyPackages(
         clientId: String,
-        keyPackages: List<KeyPackage>
+        keyPackages: List<KeyPackage>,
+        cipherSuite: Int
     ): NetworkResponse<Unit> =
         wrapKaliumResponse {
             kaliumLogger.v("Keypackages Count to replace: ${keyPackages.size}")
             httpClient.put("$PATH_KEY_PACKAGES/$PATH_SELF/$clientId") {
                 setBody(KeyPackageList(keyPackages))
+                parameter(QUERY_CIPHER_SUITES, cipherSuite.toHex())
             }
         }
 
@@ -86,5 +89,6 @@ internal open class KeyPackageApiV5 internal constructor(
         const val PATH_COUNT = "count"
         const val QUERY_SKIP_OWN = "skip_own"
         const val QUERY_CIPHER_SUITE = "ciphersuite"
+        const val QUERY_CIPHER_SUITES = "ciphersuites"
     }
 }

--- a/util/src/commonMain/kotlin/com.wire.kalium.util/int/IntExt.kt
+++ b/util/src/commonMain/kotlin/com.wire.kalium.util/int/IntExt.kt
@@ -27,3 +27,8 @@ fun Int.toByteArray(): ByteArray {
         this.toByte()
     )
 }
+
+@Suppress("MagicNumber")
+fun Int.toHexString(minDigits: Int = 4): String {
+    return "0x" + this.toString(16).padStart(minDigits, '0')
+}

--- a/util/src/commonTest/kotlin/com/wire/kalium/util/IntExtTests.kt
+++ b/util/src/commonTest/kotlin/com/wire/kalium/util/IntExtTests.kt
@@ -16,14 +16,16 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.kalium.util.string
+package com.wire.kalium.util
 
 import com.wire.kalium.util.int.toByteArray
+import com.wire.kalium.util.int.toHexString
 import com.wire.kalium.util.long.toByteArray
+import com.wire.kalium.util.string.toHexString
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class NumberByteArrayTest {
+class IntExtTests {
 
     @Test
     fun givenMaxLongValue_whenConvertingToByteArray_HexStringIsEqualToTheExpected() {
@@ -67,4 +69,10 @@ class NumberByteArrayTest {
         assertEquals("00000002540BE400", result.toHexString().uppercase())
     }
 
+    @Test
+    fun givenAnInteger_whenConvertingToHex_HexValueIsAsExpected(){
+        val given = 2
+        val expected= "0x000$given"
+        assertEquals(expected, given.toHexString())
+    }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
After finding some issues on the backend, now it's mandatory to set the CipherSuite when replacing keypackages after E2EI.



### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
