### PR TITLE
chore: Improve isSelfATeamMember UseCase (WPB-8978)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1976,7 +1976,12 @@ class UserSessionScope internal constructor(
             appLockConfigHandler
         )
 
-    val team: TeamScope get() = TeamScope(teamRepository, conversationRepository, selfTeamId)
+    val team: TeamScope get() = TeamScope(
+        teamRepository = teamRepository,
+        conversationRepository = conversationRepository,
+        slowSyncRepository = slowSyncRepository,
+        selfTeamIdProvider = selfTeamId
+    )
 
     val service: ServiceScope
         get() = ServiceScope(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/TeamScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/TeamScope.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.logic.feature.team
 
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.SelfTeamIdProvider
+import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.logic.feature.user.IsSelfATeamMemberUseCase
 import com.wire.kalium.logic.feature.user.IsSelfATeamMemberUseCaseImpl
@@ -27,6 +28,7 @@ import com.wire.kalium.logic.feature.user.IsSelfATeamMemberUseCaseImpl
 class TeamScope internal constructor(
     private val teamRepository: TeamRepository,
     private val conversationRepository: ConversationRepository,
+    private val slowSyncRepository: SlowSyncRepository,
     private val selfTeamIdProvider: SelfTeamIdProvider
 ) {
     val getUpdatedSelfTeamUseCase: GetUpdatedSelfTeamUseCase
@@ -42,5 +44,8 @@ class TeamScope internal constructor(
             conversationRepository = conversationRepository,
         )
 
-    val isSelfATeamMember: IsSelfATeamMemberUseCase get() = IsSelfATeamMemberUseCaseImpl(selfTeamIdProvider)
+    val isSelfATeamMember: IsSelfATeamMemberUseCase get() = IsSelfATeamMemberUseCaseImpl(
+        selfTeamIdProvider = selfTeamIdProvider,
+        slowSyncRepository = slowSyncRepository
+    )
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8978" title="WPB-8978" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-8978</a>  [Android] Countly analytics ID and user properties
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When first trying to get if self user is a team member, it would return the default(false) value if sync was not done before.

### Causes (Optional)

Sync was not done prior to the retrieval of this value.

### Solutions

Add SlowSyncRepository and observe last sync complete before returning a value, so it will now always get the correct value for the user.

### Dependencies (Optional)

Needs releases with:

- PR for AR will follow

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

Everything should continue running as is.