### PR TITLE
fix: delete assets locally when message is deleted [WPB-9466]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetRepository.kt
@@ -368,13 +368,13 @@ internal class AssetDataSource(
             .flatMap { deleteAssetLocally(assetId) }
 
     override suspend fun deleteAssetLocally(assetId: String): Either<CoreFailure, Unit> =
-        deleteAssetFileLocally(assetId).flatMap {
+        deleteAssetFileLocally(assetId).let {
             wrapStorageRequest {
                 assetDao.deleteAsset(assetId)
             }
         }
 
-    private suspend fun deleteAssetFileLocally(assetId: String): Either<CoreFailure, Unit> =
+    private suspend fun deleteAssetFileLocally(assetId: String) {
         wrapStorageRequest {
             assetDao.getAssetByKey(assetId).firstOrNull()
         }.map {
@@ -383,6 +383,7 @@ internal class AssetDataSource(
                 kaliumFileSystem.delete(path = it.dataPath.toPath(), mustExist = false)
             }
         }
+    }
 }
 
 private fun buildFileName(name: String, extension: String?): String =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetRepository.kt
@@ -133,6 +133,7 @@ interface AssetRepository {
     suspend fun fetchDecodedAsset(assetId: String): Either<CoreFailure, Path>
 }
 
+@Suppress("TooManyFunctions")
 internal class AssetDataSource(
     private val assetApi: AssetApi,
     private val assetDao: AssetDAO,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
@@ -183,7 +183,10 @@ class DebugScope internal constructor(
         )
 
     private val deleteEphemeralMessageForSelfUserAsSender: DeleteEphemeralMessageForSelfUserAsSenderUseCaseImpl
-        get() = DeleteEphemeralMessageForSelfUserAsSenderUseCaseImpl(messageRepository)
+        get() = DeleteEphemeralMessageForSelfUserAsSenderUseCaseImpl(
+            messageRepository = messageRepository,
+            assetRepository = assetRepository,
+        )
 
     private val ephemeralMessageDeletionHandler =
         EphemeralMessageDeletionHandlerImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -186,9 +186,6 @@ class MessageScope internal constructor(
         kaliumLogger = kaliumLogger,
     )
 
-    private val deleteEphemeralMessageForSelfUserAsSender: DeleteEphemeralMessageForSelfUserAsSenderUseCaseImpl
-        get() = DeleteEphemeralMessageForSelfUserAsSenderUseCaseImpl(messageRepository)
-
     val enqueueMessageSelfDeletion: EnqueueMessageSelfDeletionUseCase = EnqueueMessageSelfDeletionUseCaseImpl(
         ephemeralMessageDeletionHandler = ephemeralMessageDeletionHandler
     )
@@ -416,6 +413,12 @@ class MessageScope internal constructor(
             messageSendFailureHandler = messageSendFailureHandler,
             userPropertyRepository = userPropertyRepository,
             scope = scope
+        )
+
+    private val deleteEphemeralMessageForSelfUserAsSender: DeleteEphemeralMessageForSelfUserAsSenderUseCaseImpl
+        get() = DeleteEphemeralMessageForSelfUserAsSenderUseCaseImpl(
+            messageRepository = messageRepository,
+            assetRepository = assetRepository,
         )
 
     private val deleteEphemeralMessageForSelfUserAsReceiver: DeleteEphemeralMessageForSelfUserAsReceiverUseCaseImpl

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/asset/AssetRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/asset/AssetRepositoryTest.kt
@@ -561,6 +561,51 @@ class AssetRepositoryTest {
     }
 
     @Test
+    fun givenAssetFileExists_whenDeletingRemotelyAsset_thenFileShouldBeDeleted() = runTest {
+        // Given
+        val assetKey = UserAssetId("value1", "domain1")
+        val assetRawData = "some-dummy-data".toByteArray()
+        val assetFile = fakeKaliumFileSystem.providePersistentAssetPath(assetKey.toString())
+
+        val (_, assetRepository) = Arrangement()
+            .withSuccessDeleteRemotelyResponse()
+            .withSuccessDeleteLocallyResponse()
+            .withRawStoredData(assetRawData, assetFile)
+            .withMockedAssetDaoGetByKeyCall(assetKey, stubAssetEntity(assetKey.value, assetFile, assetRawData.size.toLong()))
+            .arrange()
+
+        assertEquals(true, fakeKaliumFileSystem.exists(assetFile))
+
+        // When
+        assetRepository.deleteAsset(assetKey.value, assetKey.domain, "asset-token")
+
+        // Then
+        assertEquals(false, fakeKaliumFileSystem.exists(assetFile))
+    }
+
+    @Test
+    fun givenAssetFileExists_whenDeletingLocallyAsset_thenFileShouldBeDeleted() = runTest {
+        // Given
+        val assetKey = UserAssetId("value1", "domain1")
+        val assetRawData = "some-dummy-data".toByteArray()
+        val assetFile = fakeKaliumFileSystem.providePersistentAssetPath(assetKey.toString())
+
+        val (_, assetRepository) = Arrangement()
+            .withSuccessDeleteLocallyResponse()
+            .withRawStoredData(assetRawData, assetFile)
+            .withMockedAssetDaoGetByKeyCall(assetKey, stubAssetEntity(assetKey.value, assetFile, assetRawData.size.toLong()))
+            .arrange()
+
+        assertEquals(true, fakeKaliumFileSystem.exists(assetFile))
+
+        // When
+        assetRepository.deleteAssetLocally(assetKey.value)
+
+        // Then
+        assertEquals(false, fakeKaliumFileSystem.exists(assetFile))
+    }
+
+    @Test
     fun givenValidParams_whenPersistingAsset_thenShouldSucceedWithAPathResponse() = runTest {
         // Given
         val dataNamePath = "temp-data-path"

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/asset/AssetRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/asset/AssetRepositoryTest.kt
@@ -544,6 +544,7 @@ class AssetRepositoryTest {
         val (arrangement, assetRepository) = Arrangement()
             .withSuccessDeleteRemotelyResponse()
             .withSuccessDeleteLocallyResponse()
+            .withMockedAssetDaoGetByKeyCall(assetKey, null)
             .arrange()
 
         // When

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ephemeral/DeleteEphemeralMessageForSelfUserAsSenderUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ephemeral/DeleteEphemeralMessageForSelfUserAsSenderUseCaseTest.kt
@@ -1,0 +1,135 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.message.ephemeral
+
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.AssetContent
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.message.MessageEncryptionAlgorithm
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.message.ephemeral.DeleteEphemeralMessageForSelfUserAsSenderUseCase
+import com.wire.kalium.logic.feature.message.ephemeral.DeleteEphemeralMessageForSelfUserAsSenderUseCaseImpl
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.arrangement.MessageSenderArrangement
+import com.wire.kalium.logic.util.arrangement.MessageSenderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.SelfConversationIdProviderArrangement
+import com.wire.kalium.logic.util.arrangement.SelfConversationIdProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CurrentClientIdProviderArrangement
+import com.wire.kalium.logic.util.arrangement.provider.CurrentClientIdProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.repository.AssetRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.repository.AssetRepositoryArrangementImpl
+import com.wire.kalium.logic.util.arrangement.repository.MessageRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.repository.MessageRepositoryArrangementImpl
+import com.wire.kalium.logic.util.shouldSucceed
+import io.mockative.any
+import io.mockative.coVerify
+import io.mockative.matchers.EqualsMatcher
+import io.mockative.once
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+
+class DeleteEphemeralMessageForSelfUserAsSenderUseCaseTest {
+
+    @Test
+    fun givenMessage_whenDeleting_thenMarkMessageAsDeleted() = runTest {
+        val message = MESSAGE_REGULAR
+        val (arrangement, useCase) = Arrangement()
+            .arrange {
+                withMarkAsDeleted(Either.Right(Unit), EqualsMatcher(message.id), EqualsMatcher(message.conversationId))
+                withGetMessageById(Either.Right(message), EqualsMatcher(message.id), EqualsMatcher(message.conversationId))
+            }
+
+        useCase(message.conversationId, message.id).shouldSucceed()
+
+        coVerify {
+            arrangement.messageRepository.markMessageAsDeleted(any(), any())
+        }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenAssetMessage_whenDeleting_thenDeleteAssetLocally() = runTest {
+        val assetContent = ASSET_IMAGE_CONTENT
+        val message = MESSAGE_REGULAR.copy(
+            content = MessageContent.Asset(assetContent)
+        )
+        val (arrangement, useCase) = Arrangement()
+            .arrange {
+                withMarkAsDeleted(Either.Right(Unit), EqualsMatcher(message.id), EqualsMatcher(message.conversationId))
+                withGetMessageById(Either.Right(message), EqualsMatcher(message.id), EqualsMatcher(message.conversationId))
+                withDeleteAssetLocally(Either.Right(Unit), EqualsMatcher(assetContent.remoteData.assetId))
+            }
+
+        useCase(message.conversationId, message.id).shouldSucceed()
+
+        coVerify {
+            arrangement.assetRepository.deleteAssetLocally(assetContent.remoteData.assetId)
+        }.wasInvoked(exactly = once)
+    }
+
+    private companion object {
+        val CURRENT_CLIENT_ID = ClientId("currentClientId")
+        val ASSET_CONTENT_REMOTE_DATA = AssetContent.RemoteData(
+            otrKey = ByteArray(0),
+            sha256 = ByteArray(16),
+            assetId = "asset-id",
+            assetToken = "==some-asset-token",
+            assetDomain = "some-asset-domain.com",
+            encryptionAlgorithm = MessageEncryptionAlgorithm.AES_GCM
+        )
+        val ASSET_IMAGE_CONTENT = AssetContent(
+            0L,
+            "name",
+            "image/jpg",
+            AssetContent.AssetMetadata.Image(100, 100),
+            ASSET_CONTENT_REMOTE_DATA
+        )
+        val MESSAGE_REGULAR = Message.Regular(
+            id = "messageId",
+            content = MessageContent.Text("text"),
+            conversationId = ConversationId("conversationId", "conversationDomain"),
+            date = Instant.DISTANT_FUTURE,
+            senderUserId = UserId("senderId", "senderDomain"),
+            senderClientId = CURRENT_CLIENT_ID,
+            status = Message.Status.Pending,
+            editStatus = Message.EditStatus.NotEdited,
+            isSelfMessage = true
+        )
+    }
+
+    private class Arrangement :
+        CurrentClientIdProviderArrangement by CurrentClientIdProviderArrangementImpl(),
+        MessageRepositoryArrangement by MessageRepositoryArrangementImpl(),
+        MessageSenderArrangement by MessageSenderArrangementImpl(),
+        SelfConversationIdProviderArrangement by SelfConversationIdProviderArrangementImpl(),
+        AssetRepositoryArrangement by AssetRepositoryArrangementImpl() {
+
+        private val useCase: DeleteEphemeralMessageForSelfUserAsSenderUseCase =
+            DeleteEphemeralMessageForSelfUserAsSenderUseCaseImpl(
+                messageRepository = messageRepository,
+                assetRepository = assetRepository,
+            )
+
+        suspend fun arrange(block: suspend Arrangement.() -> Unit): Pair<Arrangement, DeleteEphemeralMessageForSelfUserAsSenderUseCase> {
+            block()
+            return this to useCase
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/AssetRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/AssetRepositoryArrangement.kt
@@ -17,16 +17,38 @@
  */
 package com.wire.kalium.logic.util.arrangement.repository
 
+import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.asset.AssetRepository
+import com.wire.kalium.logic.functional.Either
 import io.mockative.Mock
+import io.mockative.coEvery
+import io.mockative.fake.valueOf
+import io.mockative.matchers.AnyMatcher
+import io.mockative.matchers.Matcher
 import io.mockative.mock
 
 internal interface AssetRepositoryArrangement {
     @Mock
     val assetRepository: AssetRepository
+
+    suspend fun withDeleteAssetLocally(
+        result: Either<CoreFailure, Unit>,
+        assetID: Matcher<String> = AnyMatcher(valueOf()),
+    )
 }
 
 internal open class AssetRepositoryArrangementImpl : AssetRepositoryArrangement {
     @Mock
     override val assetRepository: AssetRepository = mock(AssetRepository::class)
+
+    override suspend fun withDeleteAssetLocally(
+        result: Either<CoreFailure, Unit>,
+        assetID: Matcher<String>,
+    ) {
+        coEvery {
+            assetRepository.deleteAssetLocally(
+                io.mockative.matches { assetID.matches(it) },
+            )
+        }.returns(result)
+    }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9466" title="WPB-9466" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9466</a>  [Android] locally downloaded assets are not deleted when a message is deleted
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When deleting an assets message the local file inside the app is not deleted.

### Solutions

Implement removing asset from assets table and asset file downloaded and stored locally when the message containing this asset is removed. For sent self-deleting message, assets are removed when the message is marked as deleted and content is cleared.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Remove some messages with assets and check if assets are still in app `files` directory and/or these assets are still in assets table.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
