### PR TITLE
feat: Get Current Analytics Tracking Identifier (WPB-10600)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfig.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfig.kt
@@ -134,6 +134,19 @@ data class ServerConfig(
             isOnPremises = false,
             apiProxy = null
         )
+
+        val DUMMY = Links(
+            api = """https://dummy-nginz-https.zinfra.io""",
+            accounts = """https://wire-account-dummy.zinfra.io""",
+            webSocket = """https://dummy-nginz-ssl.zinfra.io""",
+            teams = """https://wire-teams-dummy.zinfra.io""",
+            blackList = """https://clientblacklist.wire.com/dummy""",
+            website = """https://dummy.wire.com""",
+            title = "dummy",
+            isOnPremises = false,
+            apiProxy = null
+        )
+
         val DEFAULT = PRODUCTION
 
         private const val FORGOT_PASSWORD_PATH = "forgot"

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -153,6 +153,7 @@ import com.wire.kalium.logic.di.PlatformUserStorageProperties
 import com.wire.kalium.logic.di.RootPathsProvider
 import com.wire.kalium.logic.di.UserStorageProvider
 import com.wire.kalium.logic.feature.analytics.AnalyticsIdentifierManager
+import com.wire.kalium.logic.feature.analytics.GetCurrentAnalyticsTrackingIdentifierUseCase
 import com.wire.kalium.logic.feature.analytics.ObserveAnalyticsTrackingIdentifierStatusUseCase
 import com.wire.kalium.logic.feature.applock.AppLockTeamFeatureConfigObserver
 import com.wire.kalium.logic.feature.applock.AppLockTeamFeatureConfigObserverImpl
@@ -1494,6 +1495,9 @@ class UserSessionScope internal constructor(
 
     val observeAnalyticsTrackingIdentifierStatus: ObserveAnalyticsTrackingIdentifierStatusUseCase
         get() = ObserveAnalyticsTrackingIdentifierStatusUseCase(userConfigRepository, userScopedLogger)
+
+    val getCurrentAnalyticsTrackingIdentifier: GetCurrentAnalyticsTrackingIdentifierUseCase
+        get() = GetCurrentAnalyticsTrackingIdentifierUseCase(userConfigRepository)
 
     val analyticsIdentifierManager: AnalyticsIdentifierManager
         get() = AnalyticsIdentifierManager(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/analytics/GetCurrentAnalyticsTrackingIdentifierUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/analytics/GetCurrentAnalyticsTrackingIdentifierUseCase.kt
@@ -1,0 +1,40 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.analytics
+
+import com.wire.kalium.logic.configuration.UserConfigRepository
+
+/**
+ * Use case that returns the current analytics tracking identifier
+ */
+interface GetCurrentAnalyticsTrackingIdentifierUseCase {
+    /**
+     * Use case [GetCurrentAnalyticsTrackingIdentifierUseCase] operation
+     *
+     * @return a [String] containing the current tracking identifier
+     */
+    suspend operator fun invoke(): String?
+}
+
+@Suppress("FunctionNaming")
+internal fun GetCurrentAnalyticsTrackingIdentifierUseCase(
+    userConfigRepository: UserConfigRepository
+) = object : GetCurrentAnalyticsTrackingIdentifierUseCase {
+
+    override suspend fun invoke(): String? = userConfigRepository.getCurrentTrackingIdentifier()
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/analytics/GetCurrentAnalyticsTrackingIdentifierUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/analytics/GetCurrentAnalyticsTrackingIdentifierUseCaseTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.analytics
+
+import com.wire.kalium.logic.util.arrangement.repository.UserConfigRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.repository.UserConfigRepositoryArrangementImpl
+import io.mockative.coVerify
+import io.mockative.once
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GetCurrentAnalyticsTrackingIdentifierUseCaseTest {
+
+    @Test
+    fun givenCurrentAnalyticsTrackingId_whenGettingTrackingId_thenCurrentTrackingIdIsReturned() = runTest {
+        // given
+        val (arrangement, useCase) = Arrangement().arrange {
+            withGetTrackingIdentifier(CURRENT_IDENTIFIER)
+        }
+
+        // when
+        val result = useCase()
+
+        // then
+        assertEquals(CURRENT_IDENTIFIER, result)
+        coVerify {
+            arrangement.userConfigRepository.getCurrentTrackingIdentifier()
+        }.wasInvoked(exactly = once)
+    }
+
+    private companion object {
+        const val CURRENT_IDENTIFIER = "efgh-5678"
+    }
+
+    private class Arrangement : UserConfigRepositoryArrangement by UserConfigRepositoryArrangementImpl() {
+
+        private val useCase: GetCurrentAnalyticsTrackingIdentifierUseCase = GetCurrentAnalyticsTrackingIdentifierUseCase(
+            userConfigRepository = userConfigRepository
+        )
+
+        fun arrange(block: suspend Arrangement.() -> Unit): Pair<Arrangement, GetCurrentAnalyticsTrackingIdentifierUseCase> {
+            runBlocking { block() }
+            return this to useCase
+        }
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10600" title="WPB-10600" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10600</a>  [Android] Show countly details in debug settings
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There was no possible way of getting current analytics tracking identifier directly (only existing way is a observer/flow)

### Causes (Optional)

Not implemented

### Solutions

Implement usecase and add tests

### Dependencies (Optional)

Needs releases with:

AR PR will follow

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

There is no way to test this PR for now, as it will be used in conjunction with AR