### PR TITLE
fix: prevent cancellation midway through event processing [WPB-7070]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -929,6 +929,7 @@ class UserSessionScope internal constructor(
             featureConfigEventReceiver,
             userPropertiesEventReceiver,
             federationEventReceiver,
+            this@UserSessionScope,
             userScopedLogger,
         )
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessorTest.kt
@@ -34,14 +34,23 @@ import com.wire.kalium.logic.util.arrangement.eventHandler.FeatureConfigEventRec
 import com.wire.kalium.logic.util.shouldFail
 import io.mockative.Mock
 import io.mockative.any
-import io.mockative.eq
 import io.mockative.coEvery
 import io.mockative.coVerify
+import io.mockative.eq
 import io.mockative.mock
 import io.mockative.once
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 
 class EventProcessorTest {
 
@@ -50,7 +59,7 @@ class EventProcessorTest {
         // Given
         val event = TestEvent.memberJoin()
 
-        val (arrangement, eventProcessor) = Arrangement().arrange {
+        val (arrangement, eventProcessor) = Arrangement(this).arrange {
             withUpdateLastProcessedEventId(event.id, Either.Right(Unit))
         }
 
@@ -68,7 +77,7 @@ class EventProcessorTest {
         // Given
         val event = TestEvent.memberJoin()
 
-        val (arrangement, eventProcessor) = Arrangement()
+        val (arrangement, eventProcessor) = Arrangement(this)
             .withUpdateLastProcessedEventId(event.id, Either.Right(Unit))
             .arrange()
 
@@ -87,7 +96,7 @@ class EventProcessorTest {
         val event = TestEvent.memberJoin()
         val failure = CoreFailure.MissingClientRegistration
 
-        val (arrangement, eventProcessor) = Arrangement().arrange {
+        val (arrangement, eventProcessor) = Arrangement(this).arrange {
             withConversationEventReceiverFailingWith(failure)
             withUpdateLastProcessedEventId(event.id, Either.Right(Unit))
         }
@@ -107,7 +116,7 @@ class EventProcessorTest {
         // Given
         val event = TestEvent.newConnection()
 
-        val (arrangement, eventProcessor) = Arrangement().arrange {
+        val (arrangement, eventProcessor) = Arrangement(this).arrange {
             withUpdateLastProcessedEventId(event.id, Either.Right(Unit))
         }
 
@@ -126,7 +135,7 @@ class EventProcessorTest {
         val event = TestEvent.newConnection()
         val failure = CoreFailure.MissingClientRegistration
 
-        val (arrangement, eventProcessor) = Arrangement().arrange {
+        val (arrangement, eventProcessor) = Arrangement(this).arrange {
             withUserEventReceiverFailingWith(failure)
             withUpdateLastProcessedEventId(event.id, Either.Right(Unit))
         }
@@ -146,7 +155,7 @@ class EventProcessorTest {
         // Given
         val envelope = TestEvent.newConnection().wrapInEnvelope(isTransient = false)
 
-        val (arrangement, eventProcessor) = Arrangement().arrange {
+        val (arrangement, eventProcessor) = Arrangement(this).arrange {
             withUpdateLastProcessedEventId(envelope.event.id, Either.Right(Unit))
         }
 
@@ -164,7 +173,7 @@ class EventProcessorTest {
         // Given
         val event = TestEvent.newConnection().wrapInEnvelope(isTransient = true)
 
-        val (arrangement, eventProcessor) = Arrangement().arrange()
+        val (arrangement, eventProcessor) = Arrangement(this).arrange()
 
         // When
         eventProcessor.processEvent(event)
@@ -180,7 +189,7 @@ class EventProcessorTest {
         // Given
         val event = TestEvent.userPropertyReadReceiptMode()
 
-        val (arrangement, eventProcessor) = Arrangement().arrange {
+        val (arrangement, eventProcessor) = Arrangement(this).arrange {
             withUpdateLastProcessedEventId(event.id, Either.Right(Unit))
         }
 
@@ -197,7 +206,7 @@ class EventProcessorTest {
         val event = TestEvent.userPropertyReadReceiptMode()
         val failure = CoreFailure.MissingClientRegistration
 
-        val (arrangement, eventProcessor) = Arrangement().arrange {
+        val (arrangement, eventProcessor) = Arrangement(this).arrange {
             withUserPropertiesEventReceiverFailingWith(failure)
             withUpdateLastProcessedEventId(event.id, Either.Right(Unit))
         }
@@ -212,7 +221,88 @@ class EventProcessorTest {
         }.wasNotInvoked()
     }
 
-    private class Arrangement : FeatureConfigEventReceiverArrangement by FeatureConfigEventReceiverArrangementImpl() {
+    @Test
+    fun givenEvent_whenCallerIsCancelled_thenShouldStillProcessNormally() = runTest {
+        val event = TestEvent.userPropertyReadReceiptMode()
+
+        val callerScope = CoroutineScope(Job())
+
+        val (arrangement, eventProcessor) = Arrangement(this).arrange {
+            withUpdateLastProcessedEventId(event.id, Either.Right(Unit))
+            withUserPropertiesEventReceiverInvoking {
+                callerScope.cancel() // Cancel during event processing
+                Either.Right(Unit)
+            }
+        }
+
+        callerScope.launch {
+            eventProcessor.processEvent(event.wrapInEnvelope())
+        }.join()
+        advanceUntilIdle()
+        assertFalse(callerScope.isActive)
+        // Then
+        coVerify {
+            arrangement.userPropertiesEventReceiver.onEvent(any(), any())
+        }.wasInvoked(exactly = once)
+        coVerify {
+            arrangement.eventRepository.updateLastProcessedEventId(any())
+        }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenEvent_whenProcessingScopeIsCancelledMidwayThrough_thenShouldProceedAnywayAndCancellationIsPropagated() = runTest {
+        val event = TestEvent.userPropertyReadReceiptMode()
+
+        val processingScope = CoroutineScope(Job())
+
+        val (arrangement, eventProcessor) = Arrangement(processingScope).arrange {
+            withUpdateLastProcessedEventId(event.id, Either.Right(Unit))
+            withUserPropertiesEventReceiverInvoking {
+                processingScope.cancel() // Cancel during event processing
+                Either.Right(Unit)
+            }
+        }
+
+        assertFailsWith(CancellationException::class) {
+            eventProcessor.processEvent(event.wrapInEnvelope())
+            advanceUntilIdle()
+        }
+        // Then
+        coVerify {
+            arrangement.userPropertiesEventReceiver.onEvent(any(), any())
+        }.wasInvoked(exactly = once)
+        coVerify {
+            arrangement.eventRepository.updateLastProcessedEventId(any())
+        }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenEvent_whenProcessingScopeIsAlreadyCancelled_thenShouldNotProcessAndPropagateCancellation() = runTest {
+        val event = TestEvent.userPropertyReadReceiptMode()
+
+        val processingScope = CoroutineScope(Job())
+        processingScope.cancel()
+
+        val (arrangement, eventProcessor) = Arrangement(processingScope).arrange {
+            withUpdateLastProcessedEventId(event.id, Either.Right(Unit))
+        }
+
+        assertFailsWith(CancellationException::class) {
+            eventProcessor.processEvent(event.wrapInEnvelope())
+            advanceUntilIdle()
+        }
+        // Then
+        coVerify {
+            arrangement.userPropertiesEventReceiver.onEvent(any(), any())
+        }.wasNotInvoked()
+        coVerify {
+            arrangement.eventRepository.updateLastProcessedEventId(any())
+        }.wasNotInvoked()
+    }
+
+    private class Arrangement(
+        val processingScope: CoroutineScope
+    ) : FeatureConfigEventReceiverArrangement by FeatureConfigEventReceiverArrangementImpl() {
 
         @Mock
         val eventRepository = mock(EventRepository::class)
@@ -276,6 +366,12 @@ class EventProcessorTest {
             }.returns(result)
         }
 
+        suspend fun withUserPropertiesEventReceiverInvoking(invocation: () -> Either<CoreFailure, Unit>) = apply {
+            coEvery {
+                userPropertiesEventReceiver.onEvent(any(), any())
+            }.invokes(invocation)
+        }
+
         suspend fun withUserPropertiesEventReceiverSucceeding() = withUserPropertiesEventReceiverReturning(Either.Right(Unit))
 
         suspend fun withUserPropertiesEventReceiverFailingWith(failure: CoreFailure) = withUserPropertiesEventReceiverReturning(
@@ -295,7 +391,8 @@ class EventProcessorTest {
                 teamEventReceiver,
                 featureConfigEventReceiver,
                 userPropertiesEventReceiver,
-                federationEventReceiver
+                federationEventReceiver,
+                processingScope
             )
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7070" title="WPB-7070" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7070</a>  [Android] Missing message on flaky internet
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

It's possible to have event processing being cancelled midway through and we would still mark them as processed.

### Causes

Although unlikely, if we cancel the event processing midway through due to connectivity changing or websocket closing, we may swallow cancellation exceptions in `wrapStorageRequest`, and we do not return success/failure to the EventProcessor itself, as it expects exceptions to be thrown.

### Solutions

The idea is to completely forbid cancellation midway through event processing, by:
1. Using the UserSessionScope as the CoroutineScope for event processing. Making it so it will only be cancelled when the user logs out.
2. Wrap the actual event processing with `withContext(NonCancellable) {}`

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
