### PR TITLE
fix: Missed call message does not get marked as read if self user called (WPB-10208)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/PersistMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/PersistMessageUseCase.kt
@@ -43,11 +43,12 @@ internal class PersistMessageUseCaseImpl(
 ) : PersistMessageUseCase {
     override suspend operator fun invoke(message: Message.Standalone): Either<CoreFailure, Unit> {
         val modifiedMessage = getExpectsReadConfirmationFromMessage(message)
-
         val isSelfSender = message.isSelfTheSender(selfUserId)
+        val shouldUpdateConversationReadDate = modifiedMessage.content !is MessageContent.MissedCall && isSelfSender
+
         return messageRepository.persistMessage(
             message = modifiedMessage,
-            updateConversationReadDate = isSelfSender,
+            updateConversationReadDate = shouldUpdateConversationReadDate,
             updateConversationModifiedDate = message.content.shouldUpdateConversationOrder()
         ).onSuccess {
             val isConversationMuted = it == InsertMessageResult.INSERTED_INTO_MUTED_CONVERSATION

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/PersistMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/PersistMessageUseCaseTest.kt
@@ -1,0 +1,164 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.message
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.notification.NotificationEventsManager
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.framework.TestMessage
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.util.shouldFail
+import com.wire.kalium.logic.util.shouldSucceed
+import com.wire.kalium.persistence.dao.message.InsertMessageResult
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.coEvery
+import io.mockative.coVerify
+import io.mockative.eq
+import io.mockative.mock
+import io.mockative.once
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class PersistMessageUseCaseTest {
+
+    @Test
+    fun givenMessageRepositoryFailure_whenPersistingMessage_thenReturnFailure() = runTest {
+        val (arrangement, persistMessage) = Arrangement()
+            .withPersistMessageFailure()
+            .withReceiptMode()
+            .arrange()
+        val message = TestMessage.TEXT_MESSAGE
+
+        val result = persistMessage.invoke(message)
+
+        result.shouldFail()
+
+        coVerify {
+            arrangement.messageRepository.persistMessage(any(), any(), any())
+        }.wasInvoked(once)
+
+        coVerify {
+            arrangement.messageRepository.getReceiptModeFromGroupConversationByQualifiedID(any())
+        }.wasInvoked(once)
+    }
+
+    @Test
+    fun givenAMessageAndMessageRepositorySuccess_whenPersistingMessage_thenScheduleRegularNotificationChecking() =
+        runTest {
+            val (arrangement, persistMessage) = Arrangement()
+                .withPersistMessageSuccess()
+                .withReceiptMode()
+                .arrange()
+            val message = TestMessage.TEXT_MESSAGE.copy(
+                senderUserId = UserId("id", "domain"),
+            )
+
+            val result = persistMessage.invoke(message)
+
+            result.shouldSucceed()
+
+            coVerify {
+                arrangement.messageRepository.persistMessage(any(), any(), any())
+            }.wasInvoked(once)
+
+            coVerify {
+                arrangement.messageRepository.getReceiptModeFromGroupConversationByQualifiedID(any())
+            }.wasInvoked(once)
+
+            coVerify {
+                arrangement.notificationEventsManager.scheduleRegularNotificationChecking()
+            }.wasInvoked(once)
+        }
+
+    @Test
+    fun givenSelfMessageAndMessageRepositorySuccess_whenPersistingMessage_thenDoNotScheduleRegularNotificationChecking() =
+        runTest {
+            val (arrangement, persistMessage) = Arrangement()
+                .withPersistMessageSuccess()
+                .withReceiptMode()
+                .arrange()
+            val message = TestMessage.TEXT_MESSAGE
+
+            val result = persistMessage.invoke(message)
+
+            result.shouldSucceed()
+
+            coVerify {
+                arrangement.messageRepository.persistMessage(any(), any(), any())
+            }.wasInvoked(once)
+
+            coVerify {
+                arrangement.messageRepository.getReceiptModeFromGroupConversationByQualifiedID(any())
+            }.wasInvoked(once)
+
+            coVerify {
+                arrangement.notificationEventsManager.scheduleRegularNotificationChecking()
+            }.wasNotInvoked()
+        }
+
+    @Test
+    fun givenMissedCallMessage_whenRunningUseCase_thenCallPersistMessageWithUpdateConversationReadDateIsFalse() =
+        runTest {
+            val (arrangement, persistMessage) = Arrangement()
+                .withPersistMessageSuccess()
+                .arrange()
+            val missedCallMessage = TestMessage.MISSED_CALL_MESSAGE
+
+            val result = persistMessage.invoke(missedCallMessage)
+
+            result.shouldSucceed()
+            coVerify {
+                arrangement.messageRepository.persistMessage(any(), eq(false), any())
+            }.wasInvoked(once)
+        }
+
+    private class Arrangement {
+        @Mock
+        val messageRepository = mock(MessageRepository::class)
+
+        @Mock
+        val notificationEventsManager = mock(NotificationEventsManager::class)
+
+        fun arrange() = this to PersistMessageUseCaseImpl(
+            messageRepository = messageRepository,
+            selfUserId = TestUser.USER_ID,
+            notificationEventsManager = notificationEventsManager
+        )
+
+        suspend fun withPersistMessageSuccess() = apply {
+            coEvery {
+                messageRepository.persistMessage(any(), any(), any())
+            }.returns(Either.Right(InsertMessageResult.INSERTED_NEED_TO_NOTIFY_USER))
+        }
+
+        suspend fun withPersistMessageFailure() = apply {
+            coEvery {
+                messageRepository.persistMessage(any(), any(), any())
+            }.returns(Either.Left(CoreFailure.InvalidEventSenderID))
+        }
+
+        suspend fun withReceiptMode() = apply {
+            coEvery {
+                messageRepository.getReceiptModeFromGroupConversationByQualifiedID(any())
+            }.returns(Either.Right(Conversation.ReceiptMode.ENABLED))
+        }
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10208" title="WPB-10208" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10208</a>  [Android] Missed call message does not get marked as read if self user called
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Missed call message does not get marked as read if self user called

### Causes (Optional)

We are updating `ConversationReadDate` if the message is coming from selfUser

### Solutions

Exclude missedCall type so `ConversationReadDate` will be updated if the message is coming from self user and not a missed call.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
