### PR TITLE
fix(mls-client): skip MLSClient registration if registered client is mlsCapable (WPB-10723)

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/VerifyExistingClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/VerifyExistingClientUseCaseTest.kt
@@ -80,6 +80,23 @@ class VerifyExistingClientUseCaseTest {
     }
 
     @Test
+    fun givenRegisteredClientIdAndMLSAllowedAndExistClientIsMLSCapable_whenRegisterMLSSucceed_thenReturnSuccessAndSkipMLSRegistration() = runTest {
+        val clientId = ClientId("clientId")
+        val client = TestClient.CLIENT.copy(id = clientId, isMLSCapable = true)
+        val (arrangement, useCase) = arrange {
+            withSelfClientsResult(Either.Right(listOf(client)))
+            withIsAllowedToRegisterMLSClient(true)
+        }
+        val result = useCase.invoke(clientId)
+        assertIs<VerifyExistingClientResult.Success>(result)
+        verify(arrangement.registerMLSClientUseCase)
+            .suspendFunction(arrangement.registerMLSClientUseCase::invoke)
+            .with(any())
+            .wasNotInvoked()
+        assertEquals(client, result.client)
+    }
+
+    @Test
     fun givenRegisteredClientIdAndMLSAllowed_whenRegisterMLSSucceed_thenReturnSuccess() = runTest {
         val clientId = ClientId("clientId")
         val client = TestClient.CLIENT.copy(id = clientId)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Check if the MLS Client has registered, then skip the registration.

### Issues
 When the user logs out without clearing the data, we were trying to register the exist MLSClient again; that lead to an error!

### Solutions

If the client has registered before and the user log in again to continue on a previously established session no need to register the client again and simply skip the api call.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Have a user with MLS Enabled on their team
1- Log in and log out without clearing the data
2- When you try to log in again with the same use, you should be able to proceed successfully

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
