### PR TITLE
fix(proteus): prevent missing messages by using transactions [WPB-10873]

### DIFF
--- a/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/ProteusClientCoreCryptoImpl.kt
+++ b/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/ProteusClientCoreCryptoImpl.kt
@@ -85,15 +85,20 @@ class ProteusClientCoreCryptoImpl private constructor(
         wrapException { coreCrypto.proteusSessionFromPrekey(sessionId.value, preKeyCrypto.encodedData.decodeBase64Bytes()) }
     }
 
-    override suspend fun decrypt(message: ByteArray, sessionId: CryptoSessionId): ByteArray {
+    override suspend fun <T : Any> decrypt(
+        message: ByteArray,
+        sessionId: CryptoSessionId,
+        handleDecryptedMessage: suspend (decryptedMessage: ByteArray) -> T
+    ): T {
         val sessionExists = doesSessionExist(sessionId)
 
         return wrapException {
-            if (sessionExists) {
+            val decryptedMessage = if (sessionExists) {
                 coreCrypto.proteusDecrypt(sessionId.value, message)
             } else {
                 coreCrypto.proteusSessionFromMessage(sessionId.value, message)
             }
+            handleDecryptedMessage(decryptedMessage)
         }
     }
 

--- a/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/ProteusClient.kt
+++ b/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/ProteusClient.kt
@@ -81,8 +81,18 @@ interface ProteusClient {
     @Throws(ProteusException::class, CancellationException::class)
     suspend fun createSession(preKeyCrypto: PreKeyCrypto, sessionId: CryptoSessionId)
 
+    /**
+     * Decrypts a message.
+     * In case of success, calls [handleDecryptedMessage] with the decrypted bytes.
+     * @throws ProteusException in case of failure
+     * @throws CancellationException
+     */
     @Throws(ProteusException::class, CancellationException::class)
-    suspend fun decrypt(message: ByteArray, sessionId: CryptoSessionId): ByteArray
+    suspend fun <T : Any> decrypt(
+        message: ByteArray,
+        sessionId: CryptoSessionId,
+        handleDecryptedMessage: suspend (decryptedMessage: ByteArray) -> T
+    ): T
 
     @Throws(ProteusException::class, CancellationException::class)
     suspend fun encrypt(message: ByteArray, sessionId: CryptoSessionId): ByteArray

--- a/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/ProteusClientTest.kt
+++ b/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/ProteusClientTest.kt
@@ -190,6 +190,7 @@ class ProteusClientTest : BaseProteusClientTest() {
 
     // TODO: Implement on CoreCrypto as well once it supports transactions
     @IgnoreJS
+    @IgnoreJvm
     @IgnoreIOS
     @Test
     fun givenNonEncryptedClient_whenThrowingDuringTransaction_thenShouldNotSaveSessionAndBeAbleToDecryptAgain() = runTest {

--- a/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/ProteusClientTest.kt
+++ b/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/ProteusClientTest.kt
@@ -190,6 +190,7 @@ class ProteusClientTest : BaseProteusClientTest() {
 
     // TODO: Implement on CoreCrypto as well once it supports transactions
     @IgnoreJS
+    @IgnoreIOS
     @Test
     fun givenNonEncryptedClient_whenThrowingDuringTransaction_thenShouldNotSaveSessionAndBeAbleToDecryptAgain() = runTest {
         val aliceRef = createProteusStoreRef(alice.id)

--- a/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/ProteusClientTest.kt
+++ b/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/ProteusClientTest.kt
@@ -1,20 +1,20 @@
- /*
- * Wire
- * Copyright (C) 2024 Wire Swiss GmbH
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see http://www.gnu.org/licenses/.
- */
+/*
+* Wire
+* Copyright (C) 2024 Wire Swiss GmbH
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program. If not, see http://www.gnu.org/licenses/.
+*/
 
 package com.wire.kalium.cryptography
 
@@ -93,7 +93,7 @@ class ProteusClientTest : BaseProteusClientTest() {
         val message = "Hi Alice!"
         val aliceKey = aliceClient.newPreKeys(0, 10).first()
         val encryptedMessage = bobClient.encryptWithPreKey(message.encodeToByteArray(), aliceKey, aliceSessionId)
-        val decryptedMessage = aliceClient.decrypt(encryptedMessage, bobSessionId)
+        val decryptedMessage = aliceClient.decrypt(encryptedMessage, bobSessionId) { it }
         assertEquals(message, decryptedMessage.decodeToString())
     }
 
@@ -105,11 +105,11 @@ class ProteusClientTest : BaseProteusClientTest() {
         val aliceKey = aliceClient.newPreKeys(0, 10).first()
         val message1 = "Hi Alice!"
         val encryptedMessage1 = bobClient.encryptWithPreKey(message1.encodeToByteArray(), aliceKey, aliceSessionId)
-        aliceClient.decrypt(encryptedMessage1, bobSessionId)
+        aliceClient.decrypt(encryptedMessage1, bobSessionId) {}
 
         val message2 = "Hi again Alice!"
         val encryptedMessage2 = bobClient.encrypt(message2.encodeToByteArray(), aliceSessionId)
-        val decryptedMessage2 = aliceClient.decrypt(encryptedMessage2, bobSessionId)
+        val decryptedMessage2 = aliceClient.decrypt(encryptedMessage2, bobSessionId) { it }
 
         assertEquals(message2, decryptedMessage2.decodeToString())
     }
@@ -124,10 +124,10 @@ class ProteusClientTest : BaseProteusClientTest() {
         val aliceKey = aliceClient.newPreKeys(0, 10).first()
         val message1 = "Hi Alice!"
         val encryptedMessage1 = bobClient.encryptWithPreKey(message1.encodeToByteArray(), aliceKey, aliceSessionId)
-        aliceClient.decrypt(encryptedMessage1, bobSessionId)
+        aliceClient.decrypt(encryptedMessage1, bobSessionId) {}
 
         val exception: ProteusException = assertFailsWith {
-            aliceClient.decrypt(encryptedMessage1, bobSessionId)
+            aliceClient.decrypt(encryptedMessage1, bobSessionId) {}
         }
         assertEquals(ProteusException.Code.DUPLICATE_MESSAGE, exception.code)
     }
@@ -188,8 +188,42 @@ class ProteusClientTest : BaseProteusClientTest() {
         }
     }
 
+    // TODO: Implement on CoreCrypto as well once it supports transactions
+    @IgnoreJS
+    @Test
+    fun givenNonEncryptedClient_whenThrowingDuringTransaction_thenShouldNotSaveSessionAndBeAbleToDecryptAgain() = runTest {
+        val aliceRef = createProteusStoreRef(alice.id)
+        val failedAliceClient = createProteusClient(aliceRef)
+        val bobClient = createProteusClient(createProteusStoreRef(bob.id))
+
+        val aliceKey = failedAliceClient.newPreKeys(0, 10).first()
+        val message1 = "Hi Alice!"
+
+        var decryptedCount = 0
+
+        val encryptedMessage1 = bobClient.encryptWithPreKey(message1.encodeToByteArray(), aliceKey, aliceSessionId)
+        try {
+            failedAliceClient.decrypt(encryptedMessage1, bobSessionId) {
+                decryptedCount++
+                throw NullPointerException("")
+            }
+        } catch (ignore: Throwable) {
+            /** No-op **/
+        }
+        // Assume that the app crashed after decrypting but before saving session.
+        // Trying to decrypt again should succeed.
+
+        val secondAliceClient = createProteusClient(aliceRef)
+
+        val result = secondAliceClient.decrypt(encryptedMessage1, bobSessionId) { result ->
+            decryptedCount++
+            result
+        }
+        assertEquals(message1, result.decodeToString())
+        assertEquals(2, decryptedCount)
+    }
+
     companion object {
         val PROTEUS_DB_SECRET = ProteusDBSecret("secret")
     }
-
 }

--- a/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/ProteusClientCryptoBoxImpl.kt
+++ b/cryptography/src/jsMain/kotlin/com/wire/kalium/cryptography/ProteusClientCryptoBoxImpl.kt
@@ -102,12 +102,13 @@ class ProteusClientCryptoBoxImpl : ProteusClient {
         box.session_from_prekey(sessionId.value, preKeyBundle.toArrayBuffer()).await()
     }
 
-    override suspend fun decrypt(
+    override suspend fun <T : Any> decrypt(
         message: ByteArray,
-        sessionId: CryptoSessionId
-    ): ByteArray {
+        sessionId: CryptoSessionId,
+        handleDecryptedMessage: suspend (decryptedMessage: ByteArray) -> T
+    ): T {
         val decryptedMessage = box.decrypt(sessionId.value, message.toArrayBuffer()).await()
-        return Int8Array(decryptedMessage.buffer).unsafeCast<ByteArray>()
+        return handleDecryptedMessage(Int8Array(decryptedMessage.buffer).unsafeCast<ByteArray>())
     }
 
     override suspend fun encrypt(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ProteusMessageUnpacker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ProteusMessageUnpacker.kt
@@ -46,7 +46,10 @@ import io.ktor.utils.io.core.toByteArray
 
 internal interface ProteusMessageUnpacker {
 
-    suspend fun unpackProteusMessage(event: Event.Conversation.NewMessage): Either<CoreFailure, MessageUnpackResult>
+    suspend fun <T : Any> unpackProteusMessage(
+        event: Event.Conversation.NewMessage,
+        handleMessage: suspend (applicationMessage: MessageUnpackResult.ApplicationMessage) -> T
+    ): Either<CoreFailure, T>
 
 }
 
@@ -59,7 +62,10 @@ internal class ProteusMessageUnpackerImpl(
 
     private val logger get() = kaliumLogger.withFeatureId(KaliumLogger.Companion.ApplicationFlow.EVENT_RECEIVER)
 
-    override suspend fun unpackProteusMessage(event: Event.Conversation.NewMessage): Either<CoreFailure, MessageUnpackResult> {
+    override suspend fun <T : Any> unpackProteusMessage(
+        event: Event.Conversation.NewMessage,
+        handleMessage: suspend (applicationMessage: MessageUnpackResult.ApplicationMessage) -> T
+    ): Either<CoreFailure, T> {
         val decodedContentBytes = Base64.decodeFromBase64(event.content.toByteArray())
         val cryptoSessionId = CryptoSessionId(
             idMapper.toCryptoQualifiedIDId(event.senderUserId),
@@ -68,37 +74,45 @@ internal class ProteusMessageUnpackerImpl(
         return proteusClientProvider.getOrError()
             .flatMap {
                 wrapProteusRequest {
-                    it.decrypt(decodedContentBytes, cryptoSessionId)
-                }
-            }
-            .map { PlainMessageBlob(it) }
-            .flatMap { plainMessageBlob -> getReadableMessageContent(plainMessageBlob, event.encryptedExternalContent) }
-            .onFailure {
-                when (it) {
-                    is CoreFailure.Unknown -> logger.e("UnknownFailure when processing message: $it", it.rootCause)
-
-                    is ProteusFailure -> {
-                        val loggableException =
-                            "{ \"code\": \"${it.proteusException.code.name}\", \"message\": \"${it.proteusException.message}\", " +
-                                    "\"error\": \"${it.proteusException.stackTraceToString()}\"," +
-                                    "\"senderClientId\": \"${event.senderClientId.value.obfuscateId()}\"," +
-                                    "\"senderUserId\": \"${event.senderUserId.value.obfuscateId()}\"," +
-                                    "\"cryptoClientId\": \"${cryptoSessionId.cryptoClientId.value.obfuscateId()}\"," +
-                                    "\"cryptoUserId\": \"${cryptoSessionId.userId.value.obfuscateId()}\"}"
-                        logger.e("ProteusFailure when processing message detail: $loggableException")
+                    it.decrypt(decodedContentBytes, cryptoSessionId) {
+                        val plainMessageBlob = PlainMessageBlob(it)
+                        getReadableMessageContent(plainMessageBlob, event.encryptedExternalContent).map { readableContent ->
+                            val appMessage = MessageUnpackResult.ApplicationMessage(
+                                conversationId = event.conversationId,
+                                instant = event.messageInstant,
+                                senderUserId = event.senderUserId,
+                                senderClientId = event.senderClientId,
+                                content = readableContent
+                            )
+                            handleMessage(appMessage)
+                        }
                     }
-
-                    else -> logger.e("Failure when processing message: $it")
                 }
-            }.map { readableContent ->
-                MessageUnpackResult.ApplicationMessage(
-                    conversationId = event.conversationId,
-                    instant = event.messageInstant,
-                    senderUserId = event.senderUserId,
-                    senderClientId = event.senderClientId,
-                    content = readableContent
-                )
+            }.flatMap { it }
+            .onFailure { logUnpackingError(it, event, cryptoSessionId) }
+    }
+
+    private fun logUnpackingError(
+        it: CoreFailure,
+        event: Event.Conversation.NewMessage,
+        cryptoSessionId: CryptoSessionId
+    ) {
+        when (it) {
+            is CoreFailure.Unknown -> logger.e("UnknownFailure when processing message: $it", it.rootCause)
+
+            is ProteusFailure -> {
+                val loggableException =
+                    "{ \"code\": \"${it.proteusException.code.name}\", \"message\": \"${it.proteusException.message}\", " +
+                            "\"error\": \"${it.proteusException.stackTraceToString()}\"," +
+                            "\"senderClientId\": \"${event.senderClientId.value.obfuscateId()}\"," +
+                            "\"senderUserId\": \"${event.senderUserId.value.obfuscateId()}\"," +
+                            "\"cryptoClientId\": \"${cryptoSessionId.cryptoClientId.value.obfuscateId()}\"," +
+                            "\"cryptoUserId\": \"${cryptoSessionId.userId.value.obfuscateId()}\"}"
+                logger.e("ProteusFailure when processing message detail: $loggableException")
             }
+
+            else -> logger.e("Failure when processing message: $it")
+        }
     }
 
     private fun getReadableMessageContent(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
@@ -35,9 +35,9 @@ import com.wire.kalium.logic.feature.message.ephemeral.EphemeralMessageDeletionH
 import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.isRight
 import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldHandler
 import com.wire.kalium.util.DateTimeUtil
-import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.coEvery
@@ -48,7 +48,6 @@ import io.mockative.once
 import io.mockative.verify
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
-import kotlinx.datetime.toInstant
 import kotlin.test.Test
 
 class NewMessageEventHandlerTest {
@@ -56,7 +55,7 @@ class NewMessageEventHandlerTest {
     @Test
     fun givenProteusEvent_whenHandling_shouldAskProteusUnpackerToDecrypt() = runTest {
         val (arrangement, newMessageEventHandler) = Arrangement()
-            .withProteusUnpackerReturning(Either.Right(MessageUnpackResult.HandshakeMessage))
+            .withProteusUnpackerReturning(Either.Left(CoreFailure.InvalidEventSenderID))
             .arrange()
 
         val newMessageEvent = TestEvent.newMessageEvent("encryptedContent")
@@ -64,7 +63,7 @@ class NewMessageEventHandlerTest {
         newMessageEventHandler.handleNewProteusMessage(newMessageEvent, TestEvent.liveDeliveryInfo)
 
         coVerify {
-            arrangement.proteusMessageUnpacker.unpackProteusMessage(eq(newMessageEvent))
+            arrangement.proteusMessageUnpacker.unpackProteusMessage<Any>(eq(newMessageEvent), any())
         }.wasInvoked(exactly = once)
     }
 
@@ -88,7 +87,7 @@ class NewMessageEventHandlerTest {
         newMessageEventHandler.handleNewProteusMessage(newMessageEvent, TestEvent.liveDeliveryInfo)
 
         coVerify {
-            arrangement.proteusMessageUnpacker.unpackProteusMessage(eq(newMessageEvent))
+            arrangement.proteusMessageUnpacker.unpackProteusMessage<Any>(eq(newMessageEvent), any())
         }.wasInvoked(exactly = once)
 
         coVerify {
@@ -116,7 +115,7 @@ class NewMessageEventHandlerTest {
         newMessageEventHandler.handleNewProteusMessage(newMessageEvent, TestEvent.liveDeliveryInfo)
 
         coVerify {
-            arrangement.proteusMessageUnpacker.unpackProteusMessage(eq(newMessageEvent))
+            arrangement.proteusMessageUnpacker.unpackProteusMessage<Any>(eq(newMessageEvent), any())
         }.wasInvoked(exactly = once)
 
         coVerify {
@@ -210,7 +209,7 @@ class NewMessageEventHandlerTest {
         newMessageEventHandler.handleNewProteusMessage(newMessageEvent, TestEvent.liveDeliveryInfo)
 
         coVerify {
-            arrangement.proteusMessageUnpacker.unpackProteusMessage(eq(newMessageEvent))
+            arrangement.proteusMessageUnpacker.unpackProteusMessage<Any>(eq(newMessageEvent), any())
         }.wasInvoked(exactly = once)
 
         coVerify {
@@ -234,7 +233,7 @@ class NewMessageEventHandlerTest {
         newMessageEventHandler.handleNewProteusMessage(newMessageEvent, TestEvent.liveDeliveryInfo)
 
         coVerify {
-            arrangement.proteusMessageUnpacker.unpackProteusMessage(eq(newMessageEvent))
+            arrangement.proteusMessageUnpacker.unpackProteusMessage<Any>(eq(newMessageEvent), any())
         }.wasInvoked(exactly = once)
 
         coVerify {
@@ -255,7 +254,7 @@ class NewMessageEventHandlerTest {
         val newMessageEvent = TestEvent.newMessageEvent("encryptedContent")
         newMessageEventHandler.handleNewProteusMessage(newMessageEvent, TestEvent.liveDeliveryInfo)
 
-        coVerify { arrangement.proteusMessageUnpacker.unpackProteusMessage(eq(newMessageEvent)) }.wasInvoked(exactly = once)
+        coVerify { arrangement.proteusMessageUnpacker.unpackProteusMessage<Any>(eq(newMessageEvent), any()) }.wasInvoked(exactly = once)
         coVerify { arrangement.applicationMessageHandler.handleDecryptionError(any(), any(), any(), any(), any(), any()) }.wasNotInvoked()
         coVerify { arrangement.confirmationDeliveryHandler.enqueueConfirmationDelivery(any(), any()) }.wasNotInvoked()
     }
@@ -270,7 +269,7 @@ class NewMessageEventHandlerTest {
         val newMessageEvent = TestEvent.newMessageEvent("encryptedContent")
         newMessageEventHandler.handleNewProteusMessage(newMessageEvent, TestEvent.liveDeliveryInfo)
 
-        coVerify { arrangement.proteusMessageUnpacker.unpackProteusMessage(eq(newMessageEvent)) }.wasInvoked(exactly = once)
+        coVerify { arrangement.proteusMessageUnpacker.unpackProteusMessage<Any>(eq(newMessageEvent), any()) }.wasInvoked(exactly = once)
         coVerify { arrangement.applicationMessageHandler.handleDecryptionError(any(), any(), any(), any(), any(), any()) }.wasNotInvoked()
         coVerify { arrangement.confirmationDeliveryHandler.enqueueConfirmationDelivery(any(), any()) }.wasNotInvoked()
     }
@@ -284,7 +283,7 @@ class NewMessageEventHandlerTest {
         val newMessageEvent = TestEvent.newMessageEvent("encryptedContent")
         newMessageEventHandler.handleNewProteusMessage(newMessageEvent, TestEvent.liveDeliveryInfo)
 
-        coVerify { arrangement.proteusMessageUnpacker.unpackProteusMessage(eq(newMessageEvent)) }.wasInvoked(exactly = once)
+        coVerify { arrangement.proteusMessageUnpacker.unpackProteusMessage<Any>(eq(newMessageEvent), any()) }.wasInvoked(exactly = once)
         coVerify { arrangement.applicationMessageHandler.handleDecryptionError(any(), any(), any(), any(), any(), any()) }.wasNotInvoked()
         coVerify { arrangement.confirmationDeliveryHandler.enqueueConfirmationDelivery(any(), any()) }.wasInvoked(exactly = once)
     }
@@ -323,7 +322,7 @@ class NewMessageEventHandlerTest {
         newMessageEventHandler.handleNewProteusMessage(newMessageEvent, TestEvent.liveDeliveryInfo)
 
         coVerify {
-            arrangement.proteusMessageUnpacker.unpackProteusMessage(eq(newMessageEvent))
+            arrangement.proteusMessageUnpacker.unpackProteusMessage<Any>(eq(newMessageEvent), any())
         }.wasInvoked(exactly = once)
 
         coVerify {
@@ -343,7 +342,7 @@ class NewMessageEventHandlerTest {
         newMessageEventHandler.handleNewProteusMessage(newMessageEvent, TestEvent.liveDeliveryInfo)
 
         coVerify {
-            arrangement.proteusMessageUnpacker.unpackProteusMessage(eq(newMessageEvent))
+            arrangement.proteusMessageUnpacker.unpackProteusMessage<Any>(eq(newMessageEvent), any())
         }.wasInvoked(exactly = once)
 
         coVerify {
@@ -433,10 +432,17 @@ class NewMessageEventHandlerTest {
             staleEpochVerifier
         )
 
-        suspend fun withProteusUnpackerReturning(result: Either<CoreFailure, MessageUnpackResult>) = apply {
+        suspend fun withProteusUnpackerReturning(result: Either<CoreFailure, MessageUnpackResult.ApplicationMessage>) = apply {
             coEvery {
-                proteusMessageUnpacker.unpackProteusMessage(any())
-            }.returns(result)
+                proteusMessageUnpacker.unpackProteusMessage<MessageUnpackResult.ApplicationMessage>(any(), any())
+            }.invokes { args ->
+                if (result is Either.Right) {
+                    val lambda = args[1] as suspend (MessageUnpackResult.ApplicationMessage) -> MessageUnpackResult.ApplicationMessage
+                    Either.Right(lambda(result.value))
+                } else {
+                    result
+                }
+            }
         }
 
         suspend fun withHandleLegalHoldSuccess() = apply {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10873" title="WPB-10873" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10873</a>  Version 4.8 does not deliver all attachments in a group chat
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some clients reported missing messages. 
We found that it is not that hard to kill the app by swiping it away between decryption and DB insertion.

### Solutions

- CoreCrypto doesn't support transactions yet: every decrypt persist state and if the app dies after decrypting, the message is forever gone.
- CryptoBox does to some degree. It doesn't support rolling back a transaction gracefully. It requires recreating a CoreCrypto instance using the same files. So we can at least simulate app killing by recreating this.

By not saving the session before inserting the messages into the DB, we can try to process this event again and recover this message.

Changed the API so instead of returning ByteArray, the Proteus clients will accept a lambda to process the output.
After allowing processing the output, the Proteus clients will persist the session.
CoreCrypto (that doesn't support saving session later) will decrypt and call the lambda normally.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
