### PR TITLE
chore: Remove call to deleteSubConversation after ending 1:1 call (WPB-11007)

### DIFF
--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -198,11 +198,7 @@ class CallManagerImpl internal constructor(
                     .keepingStrongReference(),
                 closeCallHandler = OnCloseCall(
                     callRepository = callRepository,
-                    callHelper = CallHelperImpl(
-                        callRepository = callRepository,
-                        subconversationRepository = subconversationRepository,
-                        userConfigRepository = userConfigRepository
-                    ),
+                    callHelper = CallHelperImpl(),
                     scope = scope,
                     qualifiedIdMapper = qualifiedIdMapper
                 ).keepingStrongReference(),
@@ -478,11 +474,7 @@ class CallManagerImpl internal constructor(
                     participantMapper = ParticipantMapperImpl(videoStateChecker, callMapper),
                     userRepository = userRepository,
                     userConfigRepository = userConfigRepository,
-                    callHelper = CallHelperImpl(
-                        callRepository = callRepository,
-                        subconversationRepository = subconversationRepository,
-                        userConfigRepository = userConfigRepository
-                    ),
+                    callHelper = CallHelperImpl(),
                     endCall = { endCall(it) },
                     callingScope = scope
                 ).keepingStrongReference()

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -33,11 +33,11 @@ import com.wire.kalium.logic.callingLogger
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.call.CallClient
 import com.wire.kalium.logic.data.call.CallClientList
+import com.wire.kalium.logic.data.call.CallHelperImpl
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.CallStatus
 import com.wire.kalium.logic.data.call.CallType
 import com.wire.kalium.logic.data.call.EpochInfo
-import com.wire.kalium.logic.data.call.CallHelperImpl
 import com.wire.kalium.logic.data.call.VideoState
 import com.wire.kalium.logic.data.call.VideoStateChecker
 import com.wire.kalium.logic.data.call.mapper.CallMapper
@@ -198,7 +198,6 @@ class CallManagerImpl internal constructor(
                     .keepingStrongReference(),
                 closeCallHandler = OnCloseCall(
                     callRepository = callRepository,
-                    callHelper = CallHelperImpl(),
                     scope = scope,
                     qualifiedIdMapper = qualifiedIdMapper
                 ).keepingStrongReference(),

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnCloseCall.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnCloseCall.kt
@@ -26,7 +26,6 @@ import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.callingLogger
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.CallStatus
-import com.wire.kalium.logic.data.call.CallHelper
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
@@ -36,7 +35,6 @@ import kotlinx.coroutines.launch
 @Suppress("LongParameterList")
 class OnCloseCall(
     private val callRepository: CallRepository,
-    private val callHelper: CallHelper,
     private val scope: CoroutineScope,
     private val qualifiedIdMapper: QualifiedIdMapper
 ) : CloseCallHandler {

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnCloseCall.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnCloseCall.kt
@@ -69,12 +69,10 @@ class OnCloseCall(
                 status = callStatus
             )
 
-            val conversationType =
-                callRepository.getCallMetadataProfile()[conversationIdWithDomain]?.conversationType
-
             if (callRepository.getCallMetadataProfile()[conversationIdWithDomain]?.protocol is Conversation.ProtocolInfo.MLS) {
-                callHelper.handleCallTermination(conversationIdWithDomain, conversationType)
+                callRepository.leaveMlsConference(conversationIdWithDomain)
             }
+
             callingLogger.i("[OnCloseCall] -> ConversationId: ${conversationId.obfuscateId()} | callStatus: $callStatus")
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallHelper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallHelper.kt
@@ -17,17 +17,8 @@
  */
 package com.wire.kalium.logic.data.call
 
-import com.wire.kalium.logic.callingLogger
-import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.conversation.Conversation
-import com.wire.kalium.logic.data.conversation.SubconversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.id.SubconversationId
-import com.wire.kalium.logic.data.id.toModel
-import com.wire.kalium.logic.functional.getOrElse
-import com.wire.kalium.logic.functional.onFailure
-import com.wire.kalium.logic.functional.onSuccess
-import com.wire.kalium.network.api.base.authenticated.conversation.SubconversationDeleteRequest
 
 /**
  * Helper class to handle call related operations.
@@ -53,27 +44,9 @@ interface CallHelper {
         newCallParticipants: List<Participant>,
         previousCallParticipants: List<Participant>
     ): Boolean
-
-    /**
-     * Handle the call termination.
-     * If the call is oneOneOne on SFT, then delete MLS sub conversation
-     * otherwise leave the MLS conference.
-     *
-     * @param conversationId the conversation id.
-     * @param callProtocol the call protocol.
-     * @param conversationType the conversation type.
-     */
-    suspend fun handleCallTermination(
-        conversationId: ConversationId,
-        conversationType: Conversation.Type?
-    )
 }
 
-class CallHelperImpl(
-    private val callRepository: CallRepository,
-    private val subconversationRepository: SubconversationRepository,
-    private val userConfigRepository: UserConfigRepository
-) : CallHelper {
+class CallHelperImpl : CallHelper {
 
     override fun shouldEndSFTOneOnOneCall(
         conversationId: ConversationId,
@@ -91,36 +64,6 @@ class CallHelperImpl(
                     newCallParticipants.size == TWO_PARTICIPANTS &&
                     previousCallParticipants.size == TWO_PARTICIPANTS &&
                     previousCallParticipants[1].hasEstablishedAudio && !newCallParticipants[1].hasEstablishedAudio
-        }
-    }
-
-    override suspend fun handleCallTermination(
-        conversationId: ConversationId,
-        conversationType: Conversation.Type?
-    ) {
-        if (userConfigRepository.shouldUseSFTForOneOnOneCalls().getOrElse(false) &&
-            conversationType == Conversation.Type.ONE_ON_ONE
-        ) {
-            callingLogger.i("[CallHelper] -> fetching remote MLS sub conversation details")
-            subconversationRepository.fetchRemoteSubConversationDetails(
-                conversationId,
-                CALL_SUBCONVERSATION_ID
-            ).onSuccess { subconversationDetails ->
-                callingLogger.i("[CallHelper] -> Deleting remote MLS sub conversation")
-                subconversationRepository.deleteRemoteSubConversation(
-                    subconversationDetails.parentId.toModel(),
-                    SubconversationId(subconversationDetails.id),
-                    SubconversationDeleteRequest(
-                        subconversationDetails.epoch,
-                        subconversationDetails.groupId
-                    )
-                )
-            }.onFailure {
-                callingLogger.e("[CallHelper] -> Error fetching remote MLS sub conversation details")
-            }
-        } else {
-            callingLogger.i("[CallHelper] -> Leaving MLS conference")
-            callRepository.leaveMlsConference(conversationId)
         }
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallHelperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallHelperTest.kt
@@ -36,7 +36,7 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class MLSCallHelperTest {
+class CallHelperTest {
 
     @Test
     fun givenMlsProtocol_whenShouldEndSFTOneOnOneCallIsCalled_thenReturnCorrectValue() =

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallHelperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallHelperTest.kt
@@ -111,19 +111,9 @@ class CallHelperTest {
     private class Arrangement {
 
         @Mock
-        val callRepository = mock(classOf<CallRepository>())
-
-        @Mock
-        val subconversationRepository = mock(classOf<SubconversationRepository>())
-
-        @Mock
         val userConfigRepository = mock(classOf<UserConfigRepository>())
 
-        private val mLSCallHelper: CallHelper = CallHelperImpl(
-            callRepository = callRepository,
-            subconversationRepository = subconversationRepository,
-            userConfigRepository = userConfigRepository
-        )
+        private val mLSCallHelper: CallHelper = CallHelperImpl()
 
         fun arrange() = this to mLSCallHelper
 

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/scenario/OnCloseCallTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/scenario/OnCloseCallTest.kt
@@ -33,6 +33,7 @@ import com.wire.kalium.logic.framework.TestUser
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.classOf
+import io.mockative.coVerify
 import io.mockative.eq
 import io.mockative.given
 import io.mockative.mock
@@ -280,6 +281,10 @@ class OnCloseCallTest {
             .suspendFunction(callRepository::updateCallStatusById)
             .with(eq(conversationId), eq(CallStatus.CLOSED))
             .wasInvoked(once)
+
+        coVerify {
+            callRepository.leaveMlsConference(eq(conversationId))
+        }.wasInvoked(once)
     }
 
     companion object {

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/scenario/OnCloseCallTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/scenario/OnCloseCallTest.kt
@@ -280,11 +280,6 @@ class OnCloseCallTest {
             .suspendFunction(callRepository::updateCallStatusById)
             .with(eq(conversationId), eq(CallStatus.CLOSED))
             .wasInvoked(once)
-
-        verify(callHelper)
-            .suspendFunction(callHelper::handleCallTermination)
-            .with(eq(conversationId), any())
-            .wasInvoked(once)
     }
 
     companion object {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Description

We need to remove the call to DELETE /conversations/:domain/:uuid/subconversations/conference and revert the call to leaveMlsConference after ending a 1:1 call on SFT.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
