### PR TITLE
fix: incorrect sender & receiver ID on generated events [WPB-11075]

### DIFF
--- a/cli/src/commonMain/kotlin/com/wire/kalium/cli/commands/GenerateEventsCommand.kt
+++ b/cli/src/commonMain/kotlin/com/wire/kalium/cli/commands/GenerateEventsCommand.kt
@@ -18,6 +18,7 @@
 package com.wire.kalium.cli.commands
 
 import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.PrintMessage
 import com.github.ajalt.clikt.core.requireObject
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.options.option
@@ -29,6 +30,7 @@ import com.wire.kalium.logic.data.id.QualifiedClientID
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.data.event.EventGenerator
+import com.wire.kalium.logic.functional.getOrFail
 import com.wire.kalium.network.api.authenticated.notification.NotificationResponse
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.toList
@@ -57,6 +59,7 @@ class GenerateEventsCommand : CliktCommand(name = "generate-events") {
 
     override fun run() = runBlocking {
         val selfUserId = userSession.users.getSelfUser().first().id
+        val selfClientId = userSession.clientIdProvider().getOrFail { throw PrintMessage("No self client is registered") }
         val targetUserId = UserId(value = targetUserId, domain = selfUserId.domain)
         val targetClientId = ClientId(targetClientId)
 
@@ -65,7 +68,7 @@ class GenerateEventsCommand : CliktCommand(name = "generate-events") {
             clientId = targetClientId
         )
         val generator = EventGenerator(
-            selfUserID = selfUserId,
+            selfClient = QualifiedClientID(clientId = selfClientId, userId = selfUserId),
             targetClient = QualifiedClientID(clientId = targetClientId, userId = targetUserId),
             proteusClient = userSession.proteusClientProvider.getOrCreate()
         )

--- a/cli/src/commonMain/kotlin/com/wire/kalium/cli/commands/GenerateEventsCommand.kt
+++ b/cli/src/commonMain/kotlin/com/wire/kalium/cli/commands/GenerateEventsCommand.kt
@@ -68,8 +68,14 @@ class GenerateEventsCommand : CliktCommand(name = "generate-events") {
             clientId = targetClientId
         )
         val generator = EventGenerator(
-            selfClient = QualifiedClientID(clientId = selfClientId, userId = selfUserId),
-            targetClient = QualifiedClientID(clientId = targetClientId, userId = targetUserId),
+            selfClient = QualifiedClientID(
+                clientId = selfClientId,
+                userId = selfUserId
+            ),
+            targetClient = QualifiedClientID(
+                clientId = targetClientId,
+                userId = targetUserId
+            ),
             proteusClient = userSession.proteusClientProvider.getOrCreate()
         )
         val events = generator.generateEvents(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventGenerator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventGenerator.kt
@@ -40,10 +40,17 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.datetime.Clock
 
-class EventGenerator(private val selfUserID: UserId, targetClient: QualifiedClientID, val proteusClient: ProteusClient) {
+class EventGenerator(private val selfClient: QualifiedClientID, targetClient: QualifiedClientID, val proteusClient: ProteusClient) {
 
-    private val protoContentMapper: ProtoContentMapper = MapperProvider.protoContentMapper(selfUserID)
-    private val sessionId = CryptoSessionId(targetClient.userId.toCrypto(), CryptoClientId(targetClient.clientId.value))
+    private val protoContentMapper: ProtoContentMapper = MapperProvider.protoContentMapper(selfClient.userId)
+    private val targetSessionId = CryptoSessionId(
+        targetClient.userId.toCrypto(),
+        CryptoClientId(targetClient.clientId.value)
+    )
+    private val selfSessionId = CryptoSessionId(
+        selfClient.userId.toCrypto(),
+        CryptoClientId(selfClient.clientId.value)
+    )
 
     fun generateEvents(
         limit: Int,
@@ -52,8 +59,8 @@ class EventGenerator(private val selfUserID: UserId, targetClient: QualifiedClie
         return flow {
             repeat(limit) { count ->
                 val protobuf = generateProtoContent(generateTextContent(count))
-                val message = encryptMessage(protobuf, proteusClient, sessionId, sessionId)
-                val event = generateNewMessageDTO(selfUserID, conversationId, message)
+                val message = encryptMessage(protobuf, proteusClient, selfSessionId, targetSessionId)
+                val event = generateNewMessageDTO(selfClient.userId, conversationId, message)
                 emit(generateEventResponse(event))
             }
         }
@@ -87,8 +94,8 @@ class EventGenerator(private val selfUserID: UserId, targetClient: QualifiedClie
     ): MessageEventData {
         return MessageEventData(
             text = proteusClient.encrypt(message.data, recipient).encodeBase64(),
-            sender = sender.value,
-            recipient = recipient.value,
+            sender = sender.cryptoClientId.value,
+            recipient = recipient.cryptoClientId.value,
             encryptedExternalData = null
         )
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11075" title="WPB-11075" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-11075</a>  Add debug tool for importing events from an external file
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1. The sender and receiver IDs shouldn't be qualified on the `conversation.new-otr-message` event.
2. The same ID was set for both sender and receiver

The IOS client discards event because of this.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
