### PR TITLE
fix: images form iOS are blocked when restrictions are applied [WPB-10830]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/asset/AssetMessageHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/asset/AssetMessageHandler.kt
@@ -59,23 +59,18 @@ internal class AssetMessageHandlerImpl(
                     // asset data then we can not decide now if it is allowed or not
                     // it is safe to continue and the code later will check the original
                     // asset message and decide if it is allowed or not
-                    if (
-                        message.content.value.name.isNullOrEmpty() &&
-                        message.content.value.isAssetDataComplete
-                    ) {
-                        kaliumLogger.e("The asset message trying to be processed has invalid data looking locally")
-                        AssetRestrictionContinuationStrategy.RestrictIfThereIsNotOldMessageWithTheSameAssetID
-                    } else {
-                        validateAssetMimeTypeUseCase(
+                    if (validateAssetMimeTypeUseCase(
                             fileName = messageContent.value.name,
                             mimeType = messageContent.value.mimeType,
                             allowedExtension = it.state.allowedType
-                        ).let { validateResult ->
-                            if (validateResult) {
-                                AssetRestrictionContinuationStrategy.Continue
-                            } else {
-                                AssetRestrictionContinuationStrategy.Restrict
-                            }
+                        )
+                    ) {
+                        AssetRestrictionContinuationStrategy.Continue
+                    } else {
+                        if (messageContent.value.name.isNullOrEmpty() && messageContent.value.isAssetDataComplete) {
+                            AssetRestrictionContinuationStrategy.RestrictIfThereIsNotOldMessageWithTheSameAssetID
+                        } else {
+                            AssetRestrictionContinuationStrategy.Restrict
                         }
                     }
                 }

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/sync/receiver/asset/AssetMessageHandlerTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/sync/receiver/asset/AssetMessageHandlerTest.kt
@@ -35,6 +35,7 @@ import com.wire.kalium.logic.sync.receiver.conversation.message.hasValidData
 import com.wire.kalium.logic.sync.receiver.conversation.message.hasValidRemoteData
 import io.mockative.Mock
 import io.mockative.any
+import io.mockative.anything
 import io.mockative.classOf
 import io.mockative.eq
 import io.mockative.given
@@ -261,7 +262,7 @@ class AssetMessageHandlerTest {
         val isFileSharingEnabled = FileSharingStatus.Value.EnabledSome(listOf("txt", "png", "zip"))
         val (arrangement, assetMessageHandler) = Arrangement()
             .withSuccessfulFileSharingFlag(isFileSharingEnabled)
-            .withValidateAssetMime(true)
+            .withValidateAssetFileType(true)
             .withSuccessfulStoredMessage(previewAssetMessage)
             .withSuccessfulPersistMessageUseCase(updateAssetMessage)
             .arrange()
@@ -286,8 +287,8 @@ class AssetMessageHandlerTest {
             .with(eq(previewAssetMessage.conversationId), eq(previewAssetMessage.id))
             .wasInvoked(exactly = once)
 
-        verify(arrangement.validateAssetMimeType)
-            .suspendFunction(arrangement.validateAssetMimeType::invoke)
+        verify(arrangement.validateAssetFileTypeUseCase)
+            .suspendFunction(arrangement.validateAssetFileTypeUseCase::invoke)
             .with(eq(COMPLETE_ASSET_CONTENT.value.name), eq("application/zip"), eq(isFileSharingEnabled.allowedType))
             .wasInvoked(exactly = once)
     }
@@ -300,7 +301,7 @@ class AssetMessageHandlerTest {
         val isFileSharingEnabled = FileSharingStatus.Value.EnabledSome(listOf("txt", "png"))
         val (arrangement, assetMessageHandler) = Arrangement()
             .withSuccessfulFileSharingFlag(isFileSharingEnabled)
-            .withValidateAssetMime(true)
+            .withValidateAssetFileType(true)
             .withSuccessfulStoredMessage(previewAssetMessage)
             .withSuccessfulPersistMessageUseCase(updateAssetMessage)
             .arrange()
@@ -325,8 +326,8 @@ class AssetMessageHandlerTest {
             .with(eq(previewAssetMessage.conversationId), eq(previewAssetMessage.id))
             .wasInvoked(exactly = once)
 
-        verify(arrangement.validateAssetMimeType)
-            .suspendFunction(arrangement.validateAssetMimeType::invoke)
+        verify(arrangement.validateAssetFileTypeUseCase)
+            .suspendFunction(arrangement.validateAssetFileTypeUseCase::invoke)
             .with(eq(COMPLETE_ASSET_CONTENT.value.name), eq("application/zip"), eq(isFileSharingEnabled.allowedType))
             .wasInvoked(exactly = once)
     }
@@ -339,7 +340,7 @@ class AssetMessageHandlerTest {
         val isFileSharingEnabled = FileSharingStatus.Value.Disabled
         val (arrangement, assetMessageHandler) = Arrangement()
             .withSuccessfulFileSharingFlag(isFileSharingEnabled)
-            .withValidateAssetMime(true)
+            .withValidateAssetFileType(true)
             .withSuccessfulStoredMessage(previewAssetMessage)
             .withSuccessfulPersistMessageUseCase(updateAssetMessage)
             .arrange()
@@ -364,8 +365,8 @@ class AssetMessageHandlerTest {
             .with(eq(previewAssetMessage.conversationId), eq(previewAssetMessage.id))
             .wasNotInvoked()
 
-        verify(arrangement.validateAssetMimeType)
-            .suspendFunction(arrangement.validateAssetMimeType::invoke)
+        verify(arrangement.validateAssetFileTypeUseCase)
+            .suspendFunction(arrangement.validateAssetFileTypeUseCase::invoke)
             .with(any<String>(), any<List<String>>())
             .wasNotInvoked()
     }
@@ -403,6 +404,7 @@ class AssetMessageHandlerTest {
         val (arrangement, assetMessageHandler) = Arrangement()
             .withSuccessfulFileSharingFlag(isFileSharingEnabled)
             .withSuccessfulStoredMessage(previewAssetMessage)
+            .withValidateAssetFileType(true)
             .arrange()
 
         // When
@@ -450,6 +452,7 @@ class AssetMessageHandlerTest {
             .withSuccessfulFileSharingFlag(isFileSharingEnabled)
             .withSuccessfulStoredMessage(null)
             .withSuccessfulPersistMessageUseCase(storedMessage)
+            .withValidateAssetFileType(true)
             .arrange()
 
         // When
@@ -479,15 +482,15 @@ class AssetMessageHandlerTest {
         val userConfigRepository = mock(classOf<UserConfigRepository>())
 
         @Mock
-        val validateAssetMimeType = mock(classOf<ValidateAssetFileTypeUseCase>())
+        val validateAssetFileTypeUseCase = mock(classOf<ValidateAssetFileTypeUseCase>())
 
         private val assetMessageHandlerImpl =
-            AssetMessageHandlerImpl(messageRepository, persistMessage, userConfigRepository, validateAssetMimeType)
+            AssetMessageHandlerImpl(messageRepository, persistMessage, userConfigRepository, validateAssetFileTypeUseCase)
 
-        fun withValidateAssetMime(result: Boolean) = apply {
-            given(validateAssetMimeType)
-                .function(validateAssetMimeType::invoke)
-                .whenInvokedWith(any(), any())
+        fun withValidateAssetFileType(result: Boolean) = apply {
+            given(validateAssetFileTypeUseCase)
+                .function(validateAssetFileTypeUseCase::invoke)
+                .whenInvokedWith(anything(), any(), any())
                 .thenReturn(result)
         }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

images form iOS are blocked when restrictions are applied

### Solutions

1. check if file extention or mime type are valid 
2. if not then and only then. we check if the message have complete meta data

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
