### PR TITLE
fix: random decryption errors after ending 1:1 on SFT (WPB-11213)

### DIFF
--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/CoreCryptoExceptionMapper.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/CoreCryptoExceptionMapper.kt
@@ -32,6 +32,7 @@ actual fun mapMLSException(exception: Exception): MLSFailure =
             is CryptoError.StaleCommit -> MLSFailure.StaleCommit
             is CryptoError.ConversationAlreadyExists -> MLSFailure.ConversationAlreadyExists
             is CryptoError.MessageEpochTooOld -> MLSFailure.MessageEpochTooOld
+            is CryptoError.MlsException -> MLSFailure.InternalErrors
             else -> MLSFailure.Generic(exception)
         }
     } else {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreFailure.kt
@@ -197,6 +197,7 @@ interface MLSFailure : CoreFailure {
     data object ConversationDoesNotSupportMLS : MLSFailure
     data object StaleProposal : MLSFailure
     data object StaleCommit : MLSFailure
+    data object InternalErrors : MLSFailure
 
     data class Generic(internal val exception: Exception) : MLSFailure {
         val rootCause: Throwable get() = exception

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageFailureHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageFailureHandler.kt
@@ -42,6 +42,7 @@ internal object MLSMessageFailureHandler {
             is MLSFailure.StaleProposal -> MLSMessageFailureResolution.Ignore
             is MLSFailure.StaleCommit -> MLSMessageFailureResolution.Ignore
             is MLSFailure.MessageEpochTooOld -> MLSMessageFailureResolution.Ignore
+            is MLSFailure.InternalErrors -> MLSMessageFailureResolution.Ignore
             else -> MLSMessageFailureResolution.InformUser
         }
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some random decryption errors after ending 1:1 on SFT.

### Causes (Optional)

A race condition when we try to delete or decrypt a message related to the call and the sub conversation.

### Solutions

Ignore MlsException to not show the decryption
 (iOS and web already ignoring it)

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
