### PR TITLE
fix: Catch excecption on Asset uploading [WPB-10700]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetRepository.kt
@@ -182,7 +182,7 @@ internal class AssetDataSource(
             }
         } catch (e: IOException) {
             kaliumLogger.e("Something went wrong when uploading the Asset Message. $e")
-            return Either.Left(EncryptionFailure.GenericEncryptionError)
+            return Either.Left(CoreFailure.Unknown(e))
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10700" title="WPB-10700" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10700</a>  [Android] file not found when sending assets
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

`FileNotFoundException` on sending asset message. 

### Causes (Optional)

Couldn't reproduce it, or find out the actual reason. 

### Solutions

Wrap it to `try catch` to at least not crash the app. 