### PR TITLE
fix: 404 when getting client domain crl [WPB-11243]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/CheckCrlRevocationListUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/CheckCrlRevocationListUseCase.kt
@@ -45,6 +45,6 @@ class CheckCrlRevocationListUseCase internal constructor(
                     }
                 }
             }
-        }
+        } ?: logger.w("No CRLs found.")
     }
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unbound/acme/ACMEApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unbound/acme/ACMEApi.kt
@@ -19,7 +19,6 @@ package com.wire.kalium.network.api.base.unbound.acme
 
 import com.wire.kalium.network.UnboundNetworkClient
 import com.wire.kalium.network.exceptions.KaliumException
-import com.wire.kalium.network.kaliumLogger
 import com.wire.kalium.network.serialization.JoseJson
 import com.wire.kalium.network.tools.KtxSerializer
 import com.wire.kalium.network.utils.CustomErrors
@@ -38,7 +37,6 @@ import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.ContentType
 import io.ktor.http.URLBuilder
-import io.ktor.http.URLProtocol
 import io.ktor.http.Url
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unbound/acme/ACMEApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unbound/acme/ACMEApi.kt
@@ -19,6 +19,7 @@ package com.wire.kalium.network.api.base.unbound.acme
 
 import com.wire.kalium.network.UnboundNetworkClient
 import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.network.kaliumLogger
 import com.wire.kalium.network.serialization.JoseJson
 import com.wire.kalium.network.tools.KtxSerializer
 import com.wire.kalium.network.utils.CustomErrors
@@ -262,8 +263,11 @@ class ACMEApiImpl internal constructor(
         }
 
         return wrapKaliumResponse {
-            val httpUrl = if (proxyUrl.isNullOrEmpty()) URLBuilder(url).apply { this.protocol = URLProtocol.HTTP }.build()
-            else URLBuilder(proxyUrl).apply { this.pathSegments = this.pathSegments.plus(url) }.build()
+            val crlUrlBuilder: URLBuilder = URLBuilder(url)
+            val proxyUrlBuilder: URLBuilder? = if (proxyUrl.isNullOrEmpty()) null else URLBuilder(proxyUrl)
+
+            val httpUrl = proxyUrlBuilder?.apply { this.pathSegments += crlUrlBuilder.host }?.build()
+                ?: crlUrlBuilder.build()
 
             clearTextTrafficHttpClient.get(httpUrl)
         }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/common/ACMEApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/common/ACMEApiTest.kt
@@ -207,6 +207,49 @@ internal class ACMEApiTest : ApiTest() {
         }
     }
 
+    @Test
+    fun givenProxyAndCrl_whenGettingClientDomainCRL_thenUseProxyUrlWithCRLHostAddedToPath() = runTest {
+        val crlUrl = "https://crl.wire.com/crl"
+        val proxyUrl = "https://proxy.wire:9000/proxy"
+        val expected = "$proxyUrl/crl.wire.com"
+        val networkClient = mockUnboundNetworkClient(
+            "",
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertJson()
+                assertUrlEqual(expected)
+                assertGet()
+                assertNoQueryParams()
+            }
+        )
+        val acmeApi: ACMEApi = ACMEApiImpl(networkClient, networkClient)
+
+        acmeApi.getClientDomainCRL(url = crlUrl, proxyUrl = proxyUrl).also { actual ->
+            assertIs<NetworkResponse.Success<CertificateChain>>(actual)
+        }
+    }
+
+    @Test
+    fun givenCRLWithHttpsProtocol_whenGettingClientDomainCRL_thenItShouldNotBeChanged() = runTest {
+        val crlUrl = "https://crl.wire.com/crl"
+        val expected = crlUrl
+        val networkClient = mockUnboundNetworkClient(
+            "",
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertJson()
+                assertUrlEqual(expected)
+                assertGet()
+                assertNoQueryParams()
+            }
+        )
+        val acmeApi: ACMEApi = ACMEApiImpl(networkClient, networkClient)
+
+        acmeApi.getClientDomainCRL(url = crlUrl, proxyUrl = null).also { actual ->
+            assertIs<NetworkResponse.Success<CertificateChain>>(actual)
+        }
+    }
+
     companion object {
         private const val ACME_DISCOVERY_URL = "https://balderdash.hogwash.work:9000/acme/google-android/directory"
         private const val ACME_DIRECTORIES_PATH = "https://balderdash.hogwash.work:9000/acme/google-android/directory"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1. 404 when getting client domain crl
2. app setting the crl protocol to http regardless of what is set ap

### Solutions

1. add only the crl host to the path of the proxy url
2. remove the hard codded protocol 

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
