### PR TITLE
fix: delete asset file when removing self-deleting msg [WPB-1807]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/SelfDeletionEventLogger.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/SelfDeletionEventLogger.kt
@@ -44,6 +44,7 @@ internal sealed class LoggingSelfDeletionEvent(
     fun toJson(): String {
         return EPHEMERAL_LOG_TAG + mapOf(
             "message" to (message as Message.Sendable).toLogMap(),
+            "expiration-data" to expirationData.toLogMap(),
         )
             .toMutableMap()
             .plus(toLogMap())

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -558,11 +558,9 @@ WHERE conversation_id = :conversation_id AND status = 'PENDING';
 selectPendingEphemeralMessages:
 SELECT * FROM MessageDetailsView
 WHERE expireAfterMillis NOT NULL
+AND selfDeletionEndDate NOT NULL
 AND visibility = "VISIBLE"
-AND (
-    selfDeletionEndDate IS NULL
-    OR selfDeletionEndDate > STRFTIME('%s', 'now') * 1000 -- Checks if message end date is higher than current time in millis
-);
+AND selfDeletionEndDate > STRFTIME('%s', 'now') * 1000; -- Checks if message end date is higher than current time in millis
 
 selectAlreadyEndedEphemeralMessages:
 SELECT * FROM MessageDetailsView

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOTest.kt
@@ -2031,8 +2031,17 @@ class MessageDAOTest : BaseDatabaseTest() {
             status = MessageEntity.Status.SENT,
             senderName = userEntity1.name!!,
         )
-        val expectedMessages = listOf(alreadyEndedEphemeralMessage)
-        val allMessages = expectedMessages + listOf(pendingEphemeralMessage, nonEphemeralMessage)
+        val notYetStartedEphemeralMessage = newRegularMessageEntity(
+            "4",
+            conversationId = conversationEntity1.id,
+            senderUserId = userEntity1.id,
+            status = MessageEntity.Status.SENT,
+            senderName = userEntity1.name!!,
+            selfDeletionEndDate = null,
+            expireAfterMs = 1.seconds.inWholeSeconds
+        )
+        val expectedMessages = listOf(pendingEphemeralMessage)
+        val allMessages = expectedMessages + listOf(alreadyEndedEphemeralMessage, nonEphemeralMessage, notYetStartedEphemeralMessage)
 
         messageDAO.insertOrIgnoreMessages(allMessages)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-1807" title="WPB-1807" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-1807</a>  Self-deleting: Delete assets from internal storage once the timer runs out
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Asset file is not removed from the storage once the self-deleting asset message timer runs out.

### Causes (Optional)

Wrong order of actions:
- the message is marked as deleted, which means that the content is cleared in db
- attempt to send "deleted" messages
- remove message completely from the db
- try to remove the asset from the db and its file from the storage - at this point, because of the first step, the content of the message is already empty so the app doesn't know the id of the asset to remove and no file is being removed. Also, the app tries to remove the asset remotely by making a request which ends up with 403 error, probably because this asset belongs to someone other. 

### Solutions

Change the order of actions, so that now it will look like this:
- get the content of the message
- mark the message as deleted and clear the content from the db
- use the retrieved content data from first step to remove asset, but only locally, together with deleting associated file from the storage
- attempt to send "deleted" messages
- remove message completely from the db
Thanks to that, the asset file and asset data will be removed from the asset table right when the content of the message is being cleared and marked as deleted. Asset is being removed only locally, there's no need to make a request that will probably fail.
Also, `selectPendingEphemeralMessages` is fixed to return only real pending messages, so messages that has yet not started (messages without end time) should be filtered out, to make sure that only messages that has been shown to the user are enqueued.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Send a self-deleting message with asset, wait until that message disappears and check if "used storage" has changed.

### Attachments (Optional)

| Before | After |
| ----------- | ------------ |
| <video src="https://github.com/user-attachments/assets/91603b9f-6abc-44ce-aa83-26ccbb4aa967"/> | <video src="https://github.com/user-attachments/assets/469e4e5d-dddc-48de-ac37-54073c5e9f84"/> |

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
