### PR TITLE
fix: Migration message not shown in 1:1 conversations (WPB-11194)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1032,7 +1032,8 @@ class UserSessionScope internal constructor(
             conversationGroupRepository,
             conversationRepository,
             messageRepository,
-            userRepository
+            userRepository,
+            systemMessageInserter
         )
     private val oneOnOneResolver: OneOnOneResolver
         get() = OneOnOneResolverImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneMigrator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneMigrator.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.logic.data.conversation.ConversationGroupRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.data.message.SystemMessageInserter
 import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.data.user.type.isTeammate
@@ -44,7 +45,8 @@ internal class OneOnOneMigratorImpl(
     private val conversationGroupRepository: ConversationGroupRepository,
     private val conversationRepository: ConversationRepository,
     private val messageRepository: MessageRepository,
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val systemMessageInserter: SystemMessageInserter
 ) : OneOnOneMigrator {
 
     override suspend fun migrateToProteus(user: OtherUser): Either<CoreFailure, ConversationId> =
@@ -87,6 +89,12 @@ internal class OneOnOneMigratorImpl(
                             userId = user.id
                         ).map {
                             mlsConversation
+                        }.also {
+                            systemMessageInserter.insertProtocolChangedSystemMessage(
+                                conversationId = mlsConversation,
+                                senderUserId = user.id,
+                                protocol = Conversation.Protocol.MLS
+                            )
                         }
                     }
             }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneMigratorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneMigratorTest.kt
@@ -132,6 +132,10 @@ class OneOnOneMigratorTest {
         coVerify {
             arrangement.messageRepository.moveMessagesToAnotherConversation(any(), any())
         }.wasNotInvoked()
+
+        coVerify {
+            arrangement.systemMessageInserter.insertProtocolChangedSystemMessage(any(), any(), any())
+        }.wasNotInvoked()
     }
 
     @Test
@@ -141,7 +145,7 @@ class OneOnOneMigratorTest {
         )
         val failure = CoreFailure.MissingClientRegistration
 
-        val (_, oneOnOneMigrator) = arrange {
+        val (arrangement, oneOnOneMigrator) = arrange {
             withResolveConversationReturning(Either.Left(failure))
         }
 
@@ -170,6 +174,10 @@ class OneOnOneMigratorTest {
 
         coVerify {
             arrangement.userRepository.updateActiveOneOnOneConversation(any(), any())
+        }.wasNotInvoked()
+
+        coVerify {
+            arrangement.systemMessageInserter.insertProtocolChangedSystemMessage(any(), any(), any())
         }.wasNotInvoked()
     }
 
@@ -212,6 +220,10 @@ class OneOnOneMigratorTest {
         coVerify {
             arrangement.messageRepository.moveMessagesToAnotherConversation(eq(originalConversationId), eq(resolvedConversationId))
         }.wasInvoked(exactly = once)
+
+        coVerify {
+            arrangement.systemMessageInserter.insertProtocolChangedSystemMessage(any(), any(), any())
+        }.wasInvoked(exactly = once)
     }
 
     @Test
@@ -234,6 +246,10 @@ class OneOnOneMigratorTest {
         coVerify {
             arrangement.userRepository.updateActiveOneOnOneConversation(eq(user.id), eq(resolvedConversationId))
         }.wasInvoked(exactly = once)
+
+        coVerify {
+            arrangement.systemMessageInserter.insertProtocolChangedSystemMessage(any(), any(), any())
+        }.wasInvoked(exactly = once)
     }
 
     private class Arrangement(private val block: suspend Arrangement.() -> Unit) :
@@ -249,7 +265,8 @@ class OneOnOneMigratorTest {
                 conversationGroupRepository = conversationGroupRepository,
                 conversationRepository = conversationRepository,
                 messageRepository = messageRepository,
-                userRepository = userRepository
+                userRepository = userRepository,
+                systemMessageInserter = systemMessageInserter
             )
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/MessageRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/MessageRepositoryArrangement.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.data.message.SystemMessageInserter
 import com.wire.kalium.logic.data.notification.LocalNotification
 import com.wire.kalium.logic.functional.Either
 import io.mockative.Mock
@@ -36,6 +37,9 @@ import io.mockative.mock
 internal interface MessageRepositoryArrangement {
     @Mock
     val messageRepository: MessageRepository
+
+    @Mock
+    val systemMessageInserter: SystemMessageInserter
 
     suspend fun withGetMessageById(
         result: Either<StorageFailure, Message>,
@@ -67,6 +71,8 @@ internal interface MessageRepositoryArrangement {
 internal open class MessageRepositoryArrangementImpl : MessageRepositoryArrangement {
     @Mock
     override val messageRepository: MessageRepository = mock(MessageRepository::class)
+
+    override val systemMessageInserter = mock(SystemMessageInserter::class)
 
     override suspend fun withGetMessageById(
         result: Either<StorageFailure, Message>,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11194" title="WPB-11194" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11194</a>  [Android] Migration message not shown in 1:1 conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We don't show any system messages after dowing the migration from Proteus to MLS in 1:1 conversations

### Causes (Optional)

Not implemented

### Solutions

Call `insertProtocolChangedSystemMessage` after finishing the migration for 1:1 conversations 

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
