### PR TITLE
chore: mock websocket session [WPB-9999]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -446,6 +446,7 @@ import com.wire.kalium.network.NetworkStateObserver
 import com.wire.kalium.network.networkContainer.AuthenticatedNetworkContainer
 import com.wire.kalium.network.session.SessionManager
 import com.wire.kalium.network.utils.MockUnboundNetworkClient
+import com.wire.kalium.network.utils.MockWebSocketSession
 import com.wire.kalium.persistence.client.ClientRegistrationStorage
 import com.wire.kalium.persistence.client.ClientRegistrationStorageImpl
 import com.wire.kalium.persistence.db.GlobalDatabaseBuilder
@@ -586,6 +587,7 @@ class UserSessionScope internal constructor(
         userAgent = userAgent,
         certificatePinning = kaliumConfigs.certPinningConfig,
         mockEngine = kaliumConfigs.mockedRequests?.let { MockUnboundNetworkClient.createMockEngine(it) },
+        mockWebSocketSession = if (kaliumConfigs.mockedWebSocket) MockWebSocketSession() else null,
         kaliumLogger = userScopedLogger
     )
     private val featureSupport: FeatureSupport = FeatureSupportImpl(
@@ -916,11 +918,12 @@ class UserSessionScope internal constructor(
             kaliumFileSystem = kaliumFileSystem
         )
 
-    private val eventGatherer: EventGatherer get() = EventGathererImpl(
-        eventRepository,
-        incrementalSyncRepository,
-        userScopedLogger,
-    )
+    private val eventGatherer: EventGatherer
+        get() = EventGathererImpl(
+            eventRepository,
+            incrementalSyncRepository,
+            userScopedLogger,
+        )
 
     private val eventProcessor: EventProcessor by lazy {
         EventProcessorImpl(
@@ -1994,12 +1997,13 @@ class UserSessionScope internal constructor(
             appLockConfigHandler
         )
 
-    val team: TeamScope get() = TeamScope(
-        teamRepository = teamRepository,
-        conversationRepository = conversationRepository,
-        slowSyncRepository = slowSyncRepository,
-        selfTeamIdProvider = selfTeamId
-    )
+    val team: TeamScope
+        get() = TeamScope(
+            teamRepository = teamRepository,
+            conversationRepository = conversationRepository,
+            slowSyncRepository = slowSyncRepository,
+            selfTeamIdProvider = selfTeamId
+        )
 
     val service: ServiceScope
         get() = ServiceScope(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/KaliumConfigs.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/KaliumConfigs.kt
@@ -43,6 +43,7 @@ data class KaliumConfigs(
     val certPinningConfig: Map<String, List<String>> = emptyMap(),
     val mockedRequests: List<TestRequestHandler>? = null,
     val mockNetworkStateObserver: NetworkStateObserver? = null,
+    val mockedWebSocket: Boolean = false,
     // Interval between attempts to advance the proteus to MLS migration
     val mlsMigrationInterval: Duration = 24.hours,
     // limit for the number of team members to fetch during slow sync

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/NotificationApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/NotificationApiV0.kt
@@ -43,13 +43,12 @@ import com.wire.kalium.network.utils.deleteSensitiveItemsFromJson
 import com.wire.kalium.network.utils.mapSuccess
 import com.wire.kalium.network.utils.setWSSUrl
 import com.wire.kalium.network.utils.wrapKaliumResponse
-import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
-import io.ktor.client.plugins.websocket.webSocket
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 import io.ktor.websocket.Frame
+import io.ktor.websocket.WebSocketSession
 import io.ktor.websocket.close
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
@@ -118,19 +117,16 @@ internal open class NotificationApiV0 internal constructor(
                 //       exceptions when the backend returns 401 instead of triggering a token refresh.
                 //       This call to lastNotification will make sure that if the token is expired, it will be refreshed
                 //       before attempting to open the websocket
-                authenticatedWebSocketClient
-                    .createDisposableHttpClient()
-                    .webSocket({
-                        setWSSUrl(Url(serverLinks.webSocket), PATH_AWAIT)
-                        parameter(CLIENT_QUERY_KEY, clientId)
-                    }) {
-                        emitWebSocketEvents(this)
-                    }
+                val webSocketSession = authenticatedWebSocketClient.createWebSocketSession(clientId) {
+                    setWSSUrl(Url(serverLinks.webSocket), PATH_AWAIT)
+                    parameter(CLIENT_QUERY_KEY, clientId)
+                }
+                emitWebSocketEvents(webSocketSession)
             }
         }
 
     private suspend fun FlowCollector<WebSocketEvent<EventResponse>>.emitWebSocketEvents(
-        defaultClientWebSocketSession: DefaultClientWebSocketSession
+        defaultClientWebSocketSession: WebSocketSession
     ) {
         val logger = kaliumLogger.withFeatureId(EVENT_RECEIVER)
         logger.i("Websocket open")

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/networkContainer/AuthenticatedNetworkContainerV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/networkContainer/AuthenticatedNetworkContainerV0.kt
@@ -67,11 +67,13 @@ import com.wire.kalium.network.networkContainer.AuthenticatedNetworkContainer
 import com.wire.kalium.network.session.CertificatePinning
 import com.wire.kalium.network.session.SessionManager
 import io.ktor.client.engine.HttpClientEngine
+import io.ktor.websocket.WebSocketSession
 
 internal class AuthenticatedNetworkContainerV0 internal constructor(
     private val sessionManager: SessionManager,
     certificatePinning: CertificatePinning,
     mockEngine: HttpClientEngine?,
+    mockWebSocketSession: WebSocketSession?,
     kaliumLogger: KaliumLogger,
     engine: HttpClientEngine = mockEngine ?: defaultHttpEngine(
         serverConfigDTOApiProxy = sessionManager.serverConfig().links.apiProxy,
@@ -83,7 +85,12 @@ internal class AuthenticatedNetworkContainerV0 internal constructor(
         sessionManager = sessionManager,
         accessTokenApi = { httpClient -> AccessTokenApiV0(httpClient) },
         engine = engine,
-        kaliumLogger = kaliumLogger
+        kaliumLogger = kaliumLogger,
+        webSocketSessionProvider = if (mockWebSocketSession != null) {
+            { _, _ -> mockWebSocketSession }
+        } else {
+            null
+        }
     ) {
 
     override val accessTokenApi: AccessTokenApi get() = AccessTokenApiV0(networkClient.httpClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/authenticated/networkContainer/AuthenticatedNetworkContainerV2.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/authenticated/networkContainer/AuthenticatedNetworkContainerV2.kt
@@ -68,6 +68,7 @@ import com.wire.kalium.network.networkContainer.AuthenticatedNetworkContainer
 import com.wire.kalium.network.session.CertificatePinning
 import com.wire.kalium.network.session.SessionManager
 import io.ktor.client.engine.HttpClientEngine
+import io.ktor.websocket.WebSocketSession
 
 @Suppress("LongParameterList")
 internal class AuthenticatedNetworkContainerV2 internal constructor(
@@ -75,6 +76,7 @@ internal class AuthenticatedNetworkContainerV2 internal constructor(
     private val selfUserId: UserId,
     certificatePinning: CertificatePinning,
     mockEngine: HttpClientEngine?,
+    mockWebSocketSession: WebSocketSession?,
     kaliumLogger: KaliumLogger,
     engine: HttpClientEngine = mockEngine ?: defaultHttpEngine(
         serverConfigDTOApiProxy = sessionManager.serverConfig().links.apiProxy,
@@ -86,7 +88,12 @@ internal class AuthenticatedNetworkContainerV2 internal constructor(
         sessionManager = sessionManager,
         accessTokenApi = { httpClient -> AccessTokenApiV2(httpClient) },
         engine = engine,
-        kaliumLogger = kaliumLogger
+        kaliumLogger = kaliumLogger,
+        webSocketSessionProvider = if (mockWebSocketSession != null) {
+            { _, _ -> mockWebSocketSession }
+        } else {
+            null
+        }
     ) {
 
     override val accessTokenApi: AccessTokenApi get() = AccessTokenApiV2(networkClient.httpClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/authenticated/networkContainer/AuthenticatedNetworkContainerV3.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/authenticated/networkContainer/AuthenticatedNetworkContainerV3.kt
@@ -69,6 +69,7 @@ import com.wire.kalium.network.networkContainer.AuthenticatedNetworkContainer
 import com.wire.kalium.network.session.CertificatePinning
 import com.wire.kalium.network.session.SessionManager
 import io.ktor.client.engine.HttpClientEngine
+import io.ktor.websocket.WebSocketSession
 
 @Suppress("LongParameterList")
 internal class AuthenticatedNetworkContainerV3 internal constructor(
@@ -76,6 +77,7 @@ internal class AuthenticatedNetworkContainerV3 internal constructor(
     private val selfUserId: UserId,
     certificatePinning: CertificatePinning,
     mockEngine: HttpClientEngine?,
+    mockWebSocketSession: WebSocketSession?,
     kaliumLogger: KaliumLogger,
     engine: HttpClientEngine = mockEngine ?: defaultHttpEngine(
         serverConfigDTOApiProxy = sessionManager.serverConfig().links.apiProxy,
@@ -87,7 +89,12 @@ internal class AuthenticatedNetworkContainerV3 internal constructor(
         sessionManager = sessionManager,
         accessTokenApi = { httpClient -> AccessTokenApiV3(httpClient) },
         engine = engine,
-        kaliumLogger = kaliumLogger
+        kaliumLogger = kaliumLogger,
+        webSocketSessionProvider = if (mockWebSocketSession != null) {
+            { _, _ -> mockWebSocketSession }
+        } else {
+            null
+        }
     ) {
 
     override val accessTokenApi: AccessTokenApi get() = AccessTokenApiV3(networkClient.httpClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/networkContainer/AuthenticatedNetworkContainerV4.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/networkContainer/AuthenticatedNetworkContainerV4.kt
@@ -68,6 +68,7 @@ import com.wire.kalium.network.networkContainer.AuthenticatedNetworkContainer
 import com.wire.kalium.network.session.CertificatePinning
 import com.wire.kalium.network.session.SessionManager
 import io.ktor.client.engine.HttpClientEngine
+import io.ktor.websocket.WebSocketSession
 
 @Suppress("LongParameterList")
 internal class AuthenticatedNetworkContainerV4 internal constructor(
@@ -75,6 +76,7 @@ internal class AuthenticatedNetworkContainerV4 internal constructor(
     private val selfUserId: UserId,
     certificatePinning: CertificatePinning,
     mockEngine: HttpClientEngine?,
+    mockWebSocketSession: WebSocketSession?,
     kaliumLogger: KaliumLogger,
     engine: HttpClientEngine = mockEngine ?: defaultHttpEngine(
         serverConfigDTOApiProxy = sessionManager.serverConfig().links.apiProxy,
@@ -86,7 +88,12 @@ internal class AuthenticatedNetworkContainerV4 internal constructor(
         sessionManager = sessionManager,
         accessTokenApi = { httpClient -> AccessTokenApiV4(httpClient) },
         engine = engine,
-        kaliumLogger = kaliumLogger
+        kaliumLogger = kaliumLogger,
+        webSocketSessionProvider = if (mockWebSocketSession != null) {
+            { _, _ -> mockWebSocketSession }
+        } else {
+            null
+        }
     ) {
 
     override val accessTokenApi: AccessTokenApi get() = AccessTokenApiV4(networkClient.httpClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/networkContainer/AuthenticatedNetworkContainerV5.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/networkContainer/AuthenticatedNetworkContainerV5.kt
@@ -68,6 +68,7 @@ import com.wire.kalium.network.networkContainer.AuthenticatedNetworkContainer
 import com.wire.kalium.network.session.CertificatePinning
 import com.wire.kalium.network.session.SessionManager
 import io.ktor.client.engine.HttpClientEngine
+import io.ktor.websocket.WebSocketSession
 
 @Suppress("LongParameterList")
 internal class AuthenticatedNetworkContainerV5 internal constructor(
@@ -75,6 +76,7 @@ internal class AuthenticatedNetworkContainerV5 internal constructor(
     private val selfUserId: UserId,
     certificatePinning: CertificatePinning,
     mockEngine: HttpClientEngine?,
+    mockWebSocketSession: WebSocketSession?,
     kaliumLogger: KaliumLogger,
     engine: HttpClientEngine = mockEngine ?: defaultHttpEngine(
         serverConfigDTOApiProxy = sessionManager.serverConfig().links.apiProxy,
@@ -86,7 +88,12 @@ internal class AuthenticatedNetworkContainerV5 internal constructor(
         sessionManager = sessionManager,
         accessTokenApi = { httpClient -> AccessTokenApiV5(httpClient) },
         engine = engine,
-        kaliumLogger = kaliumLogger
+        kaliumLogger = kaliumLogger,
+        webSocketSessionProvider = if (mockWebSocketSession != null) {
+            { _, _ -> mockWebSocketSession }
+        } else {
+            null
+        }
     ) {
 
     override val accessTokenApi: AccessTokenApi get() = AccessTokenApiV5(networkClient.httpClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v6/authenticated/networkContainer/AuthenticatedNetworkContainerV6.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v6/authenticated/networkContainer/AuthenticatedNetworkContainerV6.kt
@@ -68,6 +68,7 @@ import com.wire.kalium.network.networkContainer.AuthenticatedNetworkContainer
 import com.wire.kalium.network.session.CertificatePinning
 import com.wire.kalium.network.session.SessionManager
 import io.ktor.client.engine.HttpClientEngine
+import io.ktor.websocket.WebSocketSession
 
 @Suppress("LongParameterList")
 internal class AuthenticatedNetworkContainerV6 internal constructor(
@@ -75,6 +76,7 @@ internal class AuthenticatedNetworkContainerV6 internal constructor(
     private val selfUserId: UserId,
     certificatePinning: CertificatePinning,
     mockEngine: HttpClientEngine?,
+    mockWebSocketSession: WebSocketSession?,
     kaliumLogger: KaliumLogger,
     engine: HttpClientEngine = mockEngine ?: defaultHttpEngine(
         serverConfigDTOApiProxy = sessionManager.serverConfig().links.apiProxy,
@@ -86,7 +88,12 @@ internal class AuthenticatedNetworkContainerV6 internal constructor(
         sessionManager = sessionManager,
         accessTokenApi = { httpClient -> AccessTokenApiV6(httpClient) },
         engine = engine,
-        kaliumLogger = kaliumLogger
+        kaliumLogger = kaliumLogger,
+        webSocketSessionProvider = if (mockWebSocketSession != null) {
+            { _, _ -> mockWebSocketSession }
+        } else {
+            null
+        }
     ) {
 
     override val accessTokenApi: AccessTokenApi get() = AccessTokenApiV6(networkClient.httpClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/networkContainer/AuthenticatedNetworkContainer.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/networkContainer/AuthenticatedNetworkContainer.kt
@@ -55,6 +55,7 @@ import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.plugins.auth.providers.BearerAuthProvider
 import io.ktor.client.plugins.auth.providers.BearerTokens
 import io.ktor.client.plugins.auth.providers.RefreshTokensParams
+import io.ktor.websocket.WebSocketSession
 
 @Suppress("MagicNumber")
 interface AuthenticatedNetworkContainer {
@@ -114,6 +115,7 @@ interface AuthenticatedNetworkContainer {
             userAgent: String,
             certificatePinning: CertificatePinning,
             mockEngine: HttpClientEngine?,
+            mockWebSocketSession: WebSocketSession?,
             kaliumLogger: KaliumLogger,
         ): AuthenticatedNetworkContainer {
 
@@ -124,14 +126,16 @@ interface AuthenticatedNetworkContainer {
                     sessionManager,
                     certificatePinning,
                     mockEngine,
-                    kaliumLogger,
+                    mockWebSocketSession,
+                    kaliumLogger
                 )
 
                 1 -> AuthenticatedNetworkContainerV0(
                     sessionManager,
                     certificatePinning,
                     mockEngine,
-                    kaliumLogger,
+                    mockWebSocketSession,
+                    kaliumLogger
                 )
 
                 2 -> AuthenticatedNetworkContainerV2(
@@ -139,7 +143,8 @@ interface AuthenticatedNetworkContainer {
                     selfUserId,
                     certificatePinning,
                     mockEngine,
-                    kaliumLogger,
+                    mockWebSocketSession,
+                    kaliumLogger
                 )
 
                 // this is intentional since we should drop support for api v3
@@ -149,7 +154,8 @@ interface AuthenticatedNetworkContainer {
                     selfUserId,
                     certificatePinning,
                     mockEngine,
-                    kaliumLogger,
+                    mockWebSocketSession,
+                    kaliumLogger
                 )
 
                 4 -> AuthenticatedNetworkContainerV4(
@@ -157,7 +163,8 @@ interface AuthenticatedNetworkContainer {
                     selfUserId,
                     certificatePinning,
                     mockEngine,
-                    kaliumLogger,
+                    mockWebSocketSession,
+                    kaliumLogger
                 )
 
                 5 -> AuthenticatedNetworkContainerV5(
@@ -165,7 +172,8 @@ interface AuthenticatedNetworkContainer {
                     selfUserId,
                     certificatePinning,
                     mockEngine,
-                    kaliumLogger,
+                    mockWebSocketSession,
+                    kaliumLogger
                 )
 
                 6 -> AuthenticatedNetworkContainerV6(
@@ -173,7 +181,8 @@ interface AuthenticatedNetworkContainer {
                     selfUserId,
                     certificatePinning,
                     mockEngine,
-                    kaliumLogger,
+                    mockWebSocketSession,
+                    kaliumLogger
                 )
 
                 else -> error("Unsupported version: $version")
@@ -194,6 +203,7 @@ internal class AuthenticatedHttpClientProviderImpl(
     private val sessionManager: SessionManager,
     private val accessTokenApi: (httpClient: HttpClient) -> AccessTokenApi,
     private val engine: HttpClientEngine,
+    private val webSocketSessionProvider: ((HttpClient, String) -> WebSocketSession)?,
     private val kaliumLogger: KaliumLogger,
 ) : AuthenticatedHttpClientProvider {
 
@@ -241,7 +251,8 @@ internal class AuthenticatedHttpClientProviderImpl(
             engine,
             bearerAuthProvider,
             sessionManager.serverConfig(),
-            kaliumLogger
+            kaliumLogger,
+            webSocketSessionProvider
         )
     }
     override val networkClientWithoutCompression by lazy {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/utils/MockWebSocketSession.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/utils/MockWebSocketSession.kt
@@ -1,0 +1,45 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.utils
+
+import io.ktor.websocket.Frame
+import io.ktor.websocket.WebSocketExtension
+import io.ktor.websocket.WebSocketSession
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.SendChannel
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+@Suppress("EmptyFunctionBlock")
+class MockWebSocketSession(
+    override val coroutineContext: CoroutineContext = EmptyCoroutineContext
+) : WebSocketSession {
+    override var masking: Boolean = false
+    override var maxFrameSize: Long = Long.MAX_VALUE
+
+    override val incoming: ReceiveChannel<Frame> = Channel(Channel.UNLIMITED)
+    override val outgoing: SendChannel<Frame> = Channel(Channel.UNLIMITED)
+
+    override val extensions: List<WebSocketExtension<*>> = emptyList()
+
+    override suspend fun flush() {}
+
+    @Suppress("DEPRECATION")
+    override fun terminate() {}
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/ApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/ApiTest.kt
@@ -121,7 +121,8 @@ internal abstract class ApiTest {
             sessionManager = TEST_SESSION_MANAGER,
             certificatePinning = emptyMap(),
             mockEngine = null,
-            kaliumLogger = kaliumLogger
+            kaliumLogger = kaliumLogger,
+            mockWebSocketSession = null
         ).networkClient
     }
 
@@ -134,7 +135,8 @@ internal abstract class ApiTest {
             sessionManager = TEST_SESSION_MANAGER,
             certificatePinning = emptyMap(),
             mockEngine = null,
-            kaliumLogger = kaliumLogger
+            kaliumLogger = kaliumLogger,
+            mockWebSocketSession = null
         ).websocketClient
     }
 
@@ -258,7 +260,8 @@ internal abstract class ApiTest {
             sessionManager = TEST_SESSION_MANAGER,
             certificatePinning = emptyMap(),
             mockEngine = null,
-            kaliumLogger = kaliumLogger
+            kaliumLogger = kaliumLogger,
+            mockWebSocketSession = null
         ).networkClient
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9999" title="WPB-9999" target="_blank"><img alt="Spike" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10820?size=medium" />WPB-9999</a>  [Android] Investigate the text message event handling bottleneck and spickes
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Added mock web socket session option to kalium config needed in tango tests.
In future this should be more customizable to have more control of web socket events in tango tests