### PR TITLE
refactor: remove network from registerToken #WPB-9476

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/notificationToken/PushTokenUpdater.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/notificationToken/PushTokenUpdater.kt
@@ -15,7 +15,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-@file:Suppress("konsist.useCasesShouldNotAccessNetworkLayerDirectly")
 
 package com.wire.kalium.logic.feature.notificationToken
 
@@ -27,7 +26,6 @@ import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.isRight
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.kaliumLogger
-import com.wire.kalium.network.api.model.PushTokenBody
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
@@ -51,18 +49,18 @@ internal class PushTokenUpdater(
                 notificationTokenRepository.getNotificationToken()
                     .flatMap { notificationToken ->
                         clientRepository.registerToken(
-                            body = PushTokenBody(
-                                senderId = notificationToken.applicationId,
-                                client = clientId.value,
-                                token = notificationToken.token,
-                                transport = notificationToken.transport
-                            )
+                            senderId = notificationToken.applicationId,
+                            client = clientId.value,
+                            token = notificationToken.token,
+                            transport = notificationToken.transport
                         )
                     }
                     .onFailure {
                         kaliumLogger.i(
                             "$TAG Error while registering Firebase token " +
-                                    "for the client: ${clientId.toString().obfuscateId()} error: $it"
+                                    "for the client: ${
+                                        clientId.toString().obfuscateId()
+                                    } error: $it"
                         )
                     }
             }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/notificationToken/PushTokenUpdaterTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/notificationToken/PushTokenUpdaterTest.kt
@@ -123,7 +123,7 @@ class PushTokenUpdaterTest {
     }
 
     companion object {
-        private const val MOCK_TOKEN = "72391"
+        private const val MOCK_TOKEN = "7239"
         private const val MOCK_TRANSPORT = "GCM"
         private const val MOCK_APP_ID = "applicationId"
         private const val MOCK_CLIENT_ID = "clientId"

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/notificationToken/PushTokenUpdaterTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/notificationToken/PushTokenUpdaterTest.kt
@@ -123,7 +123,7 @@ class PushTokenUpdaterTest {
     }
 
     companion object {
-        private const val MOCK_TOKEN = "7239"
+        private const val MOCK_TOKEN = "72391"
         private const val MOCK_TRANSPORT = "GCM"
         private const val MOCK_APP_ID = "applicationId"
         private const val MOCK_CLIENT_ID = "clientId"

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/notificationToken/PushTokenUpdaterTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/notificationToken/PushTokenUpdaterTest.kt
@@ -59,7 +59,7 @@ class PushTokenUpdaterTest {
         }.wasNotInvoked()
 
         coVerify {
-            arrangement.clientRepository.registerToken(any())
+            arrangement.clientRepository.registerToken(any(), any(), any(), any())
         }.wasNotInvoked()
 
         coVerify {
@@ -81,7 +81,7 @@ class PushTokenUpdaterTest {
         }.wasNotInvoked()
 
         coVerify {
-            arrangement.clientRepository.registerToken(any())
+            arrangement.clientRepository.registerToken(any(), any(), any(), any())
         }.wasNotInvoked()
 
         coVerify {
@@ -94,14 +94,27 @@ class PushTokenUpdaterTest {
         val (arrangement, pushTokenUpdater) = Arrangement()
             .withUpdateFirebaseTokenFlag(true)
             .withCurrentClientId(ClientId(MOCK_CLIENT_ID))
-            .withNotificationToken(Either.Right(NotificationToken(MOCK_TOKEN, MOCK_TRANSPORT, MOCK_APP_ID)))
+            .withNotificationToken(
+                Either.Right(
+                    NotificationToken(
+                        MOCK_TOKEN,
+                        MOCK_TRANSPORT,
+                        MOCK_APP_ID
+                    )
+                )
+            )
             .withRegisterTokenResult(Either.Right(Unit))
             .arrange()
 
         pushTokenUpdater.monitorTokenChanges()
 
         coVerify {
-            arrangement.clientRepository.registerToken(eq(pushTokenRequestBody))
+            arrangement.clientRepository.registerToken(
+                eq(pushTokenRequestBody.senderId),
+                eq(pushTokenRequestBody.client),
+                eq(pushTokenRequestBody.token),
+                eq(pushTokenRequestBody.transport),
+            )
         }.wasInvoked(once)
 
         coVerify {
@@ -129,7 +142,8 @@ class PushTokenUpdaterTest {
         val clientRepository: ClientRepository = mock(ClientRepository::class)
 
         @Mock
-        val notificationTokenRepository: NotificationTokenRepository = mock(NotificationTokenRepository::class)
+        val notificationTokenRepository: NotificationTokenRepository =
+            mock(NotificationTokenRepository::class)
 
         @Mock
         val pushTokenRepository: PushTokenRepository = mock(PushTokenRepository::class)
@@ -148,7 +162,7 @@ class PushTokenUpdaterTest {
 
         suspend fun withRegisterTokenResult(result: Either<NetworkFailure, Unit>) = apply {
             coEvery {
-                clientRepository.registerToken(any())
+                clientRepository.registerToken(any(), any(), any(), any())
             }.returns(result)
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9476" title="WPB-9476" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-9476</a>  Add a button in the debug settings screen to re-register the FCM push token with the backend
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


# What's new in this PR?

### Issues

removed Suppress and changed function so it doesn't expose network layer

### Dependencies (Optional)

Same function is used here https://github.com/wireapp/kalium/pull/3050
If this PR will be merged before those changes can be applied also there

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
