### PR TITLE
fix: read receipts are not sent when the app is in background (WPB-8756)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/receipt/ConversationTimeEventWork.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/receipt/ConversationTimeEventWork.kt
@@ -27,7 +27,8 @@ import kotlinx.datetime.Instant
  */
 internal data class ConversationTimeEventInput(
     val conversationId: ConversationId,
-    val eventTime: Instant
+    val eventTime: Instant,
+    val shouldWaitUntilLive: Boolean
 )
 
 /**

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/receipt/SendConfirmationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/receipt/SendConfirmationUseCase.kt
@@ -57,7 +57,8 @@ internal interface SendConfirmationUseCase {
     suspend operator fun invoke(
         conversationId: ConversationId,
         afterDateTime: Instant,
-        untilDateTime: Instant
+        untilDateTime: Instant,
+        shouldWaitUntilLive: Boolean = true
     ): Either<CoreFailure, Unit>
 }
 
@@ -81,9 +82,12 @@ internal fun SendConfirmationUseCase(
     override suspend operator fun invoke(
         conversationId: ConversationId,
         afterDateTime: Instant,
-        untilDateTime: Instant
+        untilDateTime: Instant,
+        shouldWaitUntilLive: Boolean
     ): Either<CoreFailure, Unit> {
-        syncManager.waitUntilLive()
+        if (shouldWaitUntilLive) {
+            syncManager.waitUntilLive()
+        }
 
         val messageIds = getPendingUnreadMessagesIds(
             conversationId,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/receipt/ParallelConversationWorkQueueTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/receipt/ParallelConversationWorkQueueTest.kt
@@ -178,6 +178,6 @@ class ParallelConversationWorkQueueTest {
     private fun workInput(
         convIdValue: String = "abc",
         time: Instant = Instant.DISTANT_PAST
-    ) = ConversationTimeEventInput(ConversationId(convIdValue, "domain"), time)
+    ) = ConversationTimeEventInput(ConversationId(convIdValue, "domain"), time, true)
 
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8756" title="WPB-8756" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-8756</a>  [Android] Read receipts not generated when responding from notification popup
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Read receipts are not being sent when the app is in the background.

### Causes (Optional)

In `SendConfirmationUseCase` we wait until app is live to send confirmations.

### Solutions

Add a flag to the use case to ignore this wait if the user replies from notification.
 
Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
