### PR TITLE
feat: conversation list pagination, pt1 - queries [WPB-9433]

### DIFF
--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -293,15 +293,11 @@ sealed class ConversationDetails(open val conversation: Conversation) {
         override val conversation: Conversation,
         val otherUser: OtherUser,
         val userType: UserType,
-        val unreadEventCount: UnreadEventCount,
-        val lastMessage: MessagePreview?
     ) : ConversationDetails(conversation)
 
     data class Group(
         override val conversation: Conversation,
         val hasOngoingCall: Boolean = false,
-        val unreadEventCount: UnreadEventCount,
-        val lastMessage: MessagePreview?,
         val isSelfUserMember: Boolean,
         val isSelfUserCreator: Boolean,
         val selfRole: Conversation.Member.Role?
@@ -343,6 +339,13 @@ sealed class ConversationDetails(open val conversation: Conversation) {
         )
     )
 }
+
+data class ConversationDetailsWithEvents(
+    val conversationDetails: ConversationDetails,
+    val unreadEventCount: UnreadEventCount = emptyMap(),
+    val lastMessage: MessagePreview? = null,
+    val hasNewActivitiesToShow: Boolean = false,
+)
 
 fun ConversationDetails.interactionAvailability(): InteractionAvailability {
     val availability = when (this) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -39,7 +39,6 @@ import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.id.toModel
 import com.wire.kalium.logic.data.message.MessageMapper
 import com.wire.kalium.logic.data.message.SelfDeletionTimer
-import com.wire.kalium.logic.data.message.UnreadEventType
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
@@ -75,16 +74,11 @@ import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 import com.wire.kalium.persistence.dao.conversation.ConversationMetaDataDAO
 import com.wire.kalium.persistence.dao.member.MemberDAO
 import com.wire.kalium.persistence.dao.message.MessageDAO
-import com.wire.kalium.persistence.dao.message.draft.MessageDraftDAO
-import com.wire.kalium.persistence.dao.unread.UnreadEventTypeEntity
 import com.wire.kalium.util.DelicateKaliumApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.datetime.Instant
 
@@ -131,6 +125,11 @@ interface ConversationRepository {
     suspend fun getConversationList(): Either<StorageFailure, Flow<List<Conversation>>>
     suspend fun observeConversationList(): Flow<List<Conversation>>
     suspend fun observeConversationListDetails(fromArchive: Boolean): Flow<List<ConversationDetails>>
+    suspend fun observeConversationListDetailsWithEvents(
+        fromArchive: Boolean = false,
+        onlyInteractionsEnabled: Boolean = false,
+        newActivitiesOnTop: Boolean = false,
+    ): Flow<List<ConversationDetailsWithEvents>>
     suspend fun getConversationIds(
         type: Conversation.Type,
         protocol: Conversation.Protocol,
@@ -319,7 +318,6 @@ internal class ConversationDataSource internal constructor(
     private val clientDAO: ClientDAO,
     private val clientApi: ClientApi,
     private val conversationMetaDataDAO: ConversationMetaDataDAO,
-    private val messageDraftDAO: MessageDraftDAO,
     private val idMapper: IdMapper = MapperProvider.idMapper(),
     private val conversationMapper: ConversationMapper = MapperProvider.conversationMapper(selfUserId),
     private val memberMapper: MemberMapper = MapperProvider.memberMapper(),
@@ -352,11 +350,10 @@ internal class ConversationDataSource internal constructor(
     override suspend fun observeConversationDetailsById(conversationID: ConversationId): Flow<Either<StorageFailure, ConversationDetails>> =
         conversationDAO.observeConversationDetailsById(conversationID.toDao())
             .wrapStorageRequest()
-            // TODO we don't need last message and unread count here, we should discuss to divide model for list and for details
             .map { eitherConversationView ->
                 eitherConversationView.flatMap {
                     try {
-                        Either.Right(conversationMapper.fromDaoModelToDetails(it, null, mapOf()))
+                        Either.Right(conversationMapper.fromDaoModelToDetails(it))
                     } catch (error: IllegalArgumentException) {
                         kaliumLogger.e("require field in conversation Details", error)
                         Either.Left(StorageFailure.DataNotFound)
@@ -515,32 +512,21 @@ internal class ConversationDataSource internal constructor(
     }
 
     override suspend fun observeConversationListDetails(fromArchive: Boolean): Flow<List<ConversationDetails>> =
-        combine(
-            conversationDAO.getAllConversationDetails(fromArchive),
-            if (fromArchive) flowOf(listOf()) else messageDAO.observeLastMessages(),
-            messageDAO.observeConversationsUnreadEvents(),
-            messageDraftDAO.observeMessageDrafts()
-        ) { conversationList, lastMessageList, unreadEvents, drafts ->
-            val lastMessageMap = lastMessageList.associateBy { it.conversationId }
-            val messageDraftMap = drafts.filter { it.text.isNotBlank() }.associateBy { it.conversationId }
-
-            conversationList.map { conversation ->
-                conversationMapper.fromDaoModelToDetails(
-                    conversation,
-                    lastMessage = messageDraftMap[conversation.id]?.let { messageMapper.fromDraftToMessagePreview(it) }
-                        ?: lastMessageMap[conversation.id]?.let { messageMapper.fromEntityToMessagePreview(it) },
-                    unreadEventCount = unreadEvents.firstOrNull { it.conversationId == conversation.id }?.unreadEvents?.mapKeys {
-                        when (it.key) {
-                            UnreadEventTypeEntity.KNOCK -> UnreadEventType.KNOCK
-                            UnreadEventTypeEntity.MISSED_CALL -> UnreadEventType.MISSED_CALL
-                            UnreadEventTypeEntity.MENTION -> UnreadEventType.MENTION
-                            UnreadEventTypeEntity.REPLY -> UnreadEventType.REPLY
-                            UnreadEventTypeEntity.MESSAGE -> UnreadEventType.MESSAGE
-                        }
-                    }
-                )
-            }
+        conversationDAO.getAllConversationDetails(fromArchive).map { conversationViewEntityList ->
+            conversationViewEntityList.map { conversationViewEntity -> conversationMapper.fromDaoModelToDetails(conversationViewEntity) }
         }
+
+    override suspend fun observeConversationListDetailsWithEvents(
+        fromArchive: Boolean,
+        onlyInteractionsEnabled: Boolean,
+        newActivitiesOnTop: Boolean,
+    ): Flow<List<ConversationDetailsWithEvents>> =
+        conversationDAO.getAllConversationDetailsWithEvents(fromArchive, onlyInteractionsEnabled, newActivitiesOnTop)
+            .map { conversationDetailsWithEventsViewEntityList ->
+                conversationDetailsWithEventsViewEntityList.map { conversationDetailsWithEventsViewEntity ->
+                    conversationMapper.fromDaoModelToDetailsWithEvents(conversationDetailsWithEventsViewEntity)
+                }
+            }
 
     override suspend fun fetchMlsOneToOneConversation(userId: UserId): Either<CoreFailure, Conversation> =
         wrapApiRequest {
@@ -994,7 +980,7 @@ internal class ConversationDataSource internal constructor(
 
     override suspend fun getConversationDetailsByMLSGroupId(mlsGroupId: GroupID): Either<CoreFailure, ConversationDetails> =
         wrapStorageRequest { conversationDAO.getConversationByGroupID(mlsGroupId.value) }
-            .map { conversationMapper.fromDaoModelToDetails(it, null, mapOf()) }
+            .map { conversationMapper.fromDaoModelToDetails(it) }
 
     override suspend fun observeUnreadArchivedConversationsCount(): Flow<Long> =
         conversationDAO.observeUnreadArchivedConversationsCount()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/di/MapperProvider.kt
@@ -128,7 +128,8 @@ internal object MapperProvider {
             AvailabilityStatusMapperImpl(),
             DomainUserTypeMapperImpl(),
             ConnectionStatusMapperImpl(),
-            ConversationRoleMapperImpl()
+            ConversationRoleMapperImpl(),
+            MessageMapperImpl(selfUserId),
         )
 
     fun conversationRoleMapper(): ConversationRoleMapper = ConversationRoleMapperImpl()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -711,7 +711,6 @@ class UserSessionScope internal constructor(
             userStorage.database.clientDAO,
             authenticatedNetworkContainer.clientApi,
             userStorage.database.conversationMetaDataDAO,
-            userStorage.database.messageDraftDAO
         )
 
     private val conversationGroupRepository: ConversationGroupRepository

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
@@ -82,7 +82,6 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import kotlinx.datetime.Clock
 import kotlin.test.Test
-import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -174,10 +173,8 @@ class CallRepositoryTest {
                         ConversationDetails.Group(
                             Arrangement.groupConversation,
                             false,
-                            lastMessage = null,
                             isSelfUserMember = true,
                             isSelfUserCreator = true,
-                            unreadEventCount = emptyMap(),
                             selfRole = Conversation.Member.Role.Member
                         )
                     )
@@ -214,10 +211,8 @@ class CallRepositoryTest {
                     Either.Right(
                         ConversationDetails.Group(
                             Arrangement.groupConversation,
-                            lastMessage = null,
                             isSelfUserMember = true,
                             isSelfUserCreator = true,
-                            unreadEventCount = emptyMap(),
                             selfRole = Conversation.Member.Role.Member
                         )
                     )
@@ -270,10 +265,8 @@ class CallRepositoryTest {
                     Either.Right(
                         ConversationDetails.Group(
                             Arrangement.groupConversation,
-                            lastMessage = null,
                             isSelfUserMember = true,
                             isSelfUserCreator = true,
-                            unreadEventCount = emptyMap(),
                             selfRole = Conversation.Member.Role.Member
                         )
                     )
@@ -315,10 +308,8 @@ class CallRepositoryTest {
                     Either.Right(
                         ConversationDetails.Group(
                             Arrangement.groupConversation,
-                            lastMessage = null,
                             isSelfUserMember = true,
                             isSelfUserCreator = true,
-                            unreadEventCount = emptyMap(),
                             selfRole = Conversation.Member.Role.Member
                         )
                     )
@@ -374,10 +365,8 @@ class CallRepositoryTest {
                     Either.Right(
                         ConversationDetails.Group(
                             Arrangement.groupConversation,
-                            lastMessage = null,
                             isSelfUserMember = true,
                             isSelfUserCreator = true,
-                            unreadEventCount = emptyMap(),
                             selfRole = Conversation.Member.Role.Member
                         )
                     )
@@ -1819,8 +1808,6 @@ class CallRepositoryTest {
                 conversation = oneOnOneConversation,
                 otherUser = TestUser.OTHER,
                 userType = UserType.INTERNAL,
-                lastMessage = null,
-                unreadEventCount = emptyMap()
             )
 
             val mlsProtocolInfo = Conversation.ProtocolInfo.MLS(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCaseTest.kt
@@ -248,8 +248,6 @@ class EndCallOnConversationChangeUseCaseTest {
         private val groupConversationDetail = ConversationDetails.Group(
             conversation = conversation,
             hasOngoingCall = true,
-            unreadEventCount = mapOf(),
-            lastMessage = null,
             isSelfUserMember = false,
             isSelfUserCreator = false,
             selfRole = null
@@ -258,8 +256,6 @@ class EndCallOnConversationChangeUseCaseTest {
         private val oneOnOneConversationDetail = ConversationDetails.OneOne(
             conversation = conversation,
             otherUser = otherUser,
-            unreadEventCount = mapOf(),
-            lastMessage = null,
             userType = UserType.ADMIN
         )
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCaseTest.kt
@@ -80,20 +80,16 @@ class ObserveConversationDetailsUseCaseTest {
                 Either.Right(
                     ConversationDetails.Group(
                         conversation,
-                        lastMessage = null,
                         isSelfUserMember = true,
                         isSelfUserCreator = true,
-                        unreadEventCount = emptyMap(),
                         selfRole = Conversation.Member.Role.Member
                     )
                 ),
                 Either.Right(
                     ConversationDetails.Group(
                         conversation.copy(name = "New Name"),
-                        lastMessage = null,
                         isSelfUserMember = true,
                         isSelfUserCreator = true,
-                        unreadEventCount = emptyMap(),
                         selfRole = Conversation.Member.Role.Member
                     )
                 )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCaseTest.kt
@@ -64,10 +64,8 @@ class ObserveConversationListDetailsUseCaseTest {
         val groupConversationDetails =
             ConversationDetails.Group(
                 groupConversation,
-                lastMessage = null,
                 isSelfUserMember = true,
                 isSelfUserCreator = true,
-                unreadEventCount = emptyMap(),
                 selfRole = Conversation.Member.Role.Member
             )
 
@@ -101,19 +99,15 @@ class ObserveConversationListDetailsUseCaseTest {
         val groupConversationDetails1 =
             ConversationDetails.Group(
                 groupConversation1,
-                lastMessage = null,
                 isSelfUserMember = true,
                 isSelfUserCreator = true,
-                unreadEventCount = emptyMap(),
                 selfRole = Conversation.Member.Role.Member
             )
         val groupConversationDetails2 =
             ConversationDetails.Group(
                 groupConversation2,
-                lastMessage = null,
                 isSelfUserMember = true,
                 isSelfUserCreator = true,
-                unreadEventCount = emptyMap(),
                 selfRole = Conversation.Member.Role.Member
             )
 
@@ -146,10 +140,8 @@ class ObserveConversationListDetailsUseCaseTest {
         val selfConversationDetails = ConversationDetails.Self(selfConversation)
         val groupConversationDetails = ConversationDetails.Group(
             conversation = groupConversation,
-            lastMessage = null,
             isSelfUserMember = true,
             isSelfUserCreator = true,
-            unreadEventCount = emptyMap(),
             selfRole = Conversation.Member.Role.Member
         )
 
@@ -182,10 +174,8 @@ class ObserveConversationListDetailsUseCaseTest {
         val groupConversationUpdates = listOf(
             ConversationDetails.Group(
                 groupConversation,
-                lastMessage = null,
                 isSelfUserMember = true,
                 isSelfUserCreator = true,
-                unreadEventCount = emptyMap(),
                 selfRole = Conversation.Member.Role.Member
             )
         )
@@ -194,15 +184,11 @@ class ObserveConversationListDetailsUseCaseTest {
             oneOnOneConversation,
             TestUser.OTHER,
             UserType.INTERNAL,
-            lastMessage = null,
-            unreadEventCount = emptyMap()
         )
         val secondOneOnOneDetails = ConversationDetails.OneOne(
             oneOnOneConversation,
             TestUser.OTHER.copy(name = "New User Name"),
             UserType.INTERNAL,
-            lastMessage = null,
-            unreadEventCount = emptyMap()
         )
 
         val oneOnOneDetailsChannel = Channel<ConversationDetails.OneOne>(Channel.UNLIMITED)
@@ -236,10 +222,8 @@ class ObserveConversationListDetailsUseCaseTest {
         val fetchArchivedConversations = false
         val groupConversationDetails = ConversationDetails.Group(
             groupConversation,
-            lastMessage = null,
             isSelfUserMember = true,
             isSelfUserCreator = true,
-            unreadEventCount = emptyMap(),
             selfRole = Conversation.Member.Role.Member
         )
 
@@ -273,10 +257,8 @@ class ObserveConversationListDetailsUseCaseTest {
         val fetchArchivedConversations = false
         val groupConversationDetails = ConversationDetails.Group(
             groupConversation,
-            lastMessage = null,
             isSelfUserMember = true,
             isSelfUserCreator = true,
-            unreadEventCount = emptyMap(),
             selfRole = Conversation.Member.Role.Member
         )
 
@@ -304,10 +286,8 @@ class ObserveConversationListDetailsUseCaseTest {
 
         val groupConversationDetails = ConversationDetails.Group(
             groupConversation,
-            lastMessage = null,
             isSelfUserMember = true,
             isSelfUserCreator = true,
-            unreadEventCount = emptyMap(),
             selfRole = Conversation.Member.Role.Member
         )
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversationDetails.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversationDetails.kt
@@ -41,16 +41,12 @@ object TestConversationDetails {
         TestConversation.ONE_ON_ONE(),
         TestUser.OTHER,
         UserType.EXTERNAL,
-        lastMessage = null,
-        unreadEventCount = emptyMap()
     )
 
     val CONVERSATION_GROUP = ConversationDetails.Group(
         conversation = TestConversation.GROUP(),
-        lastMessage = null,
         isSelfUserCreator = true,
         isSelfUserMember = true,
-        unreadEventCount = emptyMap(),
         selfRole = Conversation.Member.Role.Member
     )
 

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -278,6 +278,120 @@ LEFT JOIN Connection ON Connection.qualified_conversation = Conversation.qualifi
 LEFT JOIN User AS connection_user ON Connection.qualified_to = connection_user.qualified_id
 LEFT JOIN Call ON Call.id IS (SELECT id FROM Call WHERE Call.conversation_id = Conversation.qualified_id AND Call.status IS 'STILL_ONGOING' ORDER BY created_at DESC LIMIT 1);
 
+CREATE VIEW IF NOT EXISTS ConversationDetailsWithEvents AS
+SELECT
+    ConversationDetails.*,
+    CASE
+        WHEN ConversationDetails.type = 'GROUP' THEN
+            CASE
+                WHEN ConversationDetails.selfRole IS NOT NULL THEN 1
+                ELSE 0
+            END
+        WHEN ConversationDetails.type = 'ONE_ON_ONE' THEN
+            CASE
+                WHEN userDefederated = 1 THEN 0
+                WHEN userDeleted = 1 THEN 0
+                WHEN connectionStatus = 'BLOCKED' THEN 0
+                WHEN legal_hold_status = 'DEGRADED' THEN 0
+                ELSE 1
+            END
+        ELSE 0
+    END AS interactionEnabled,
+    UnreadEventCountsGrouped.knocksCount AS unreadKnocksCount,
+    UnreadEventCountsGrouped.missedCallsCount AS unreadMissedCallsCount,
+    UnreadEventCountsGrouped.mentionsCount AS unreadMentionsCount,
+    UnreadEventCountsGrouped.repliesCount AS unreadRepliesCount,
+    UnreadEventCountsGrouped.messagesCount AS unreadMessagesCount,
+    CASE
+        WHEN ConversationDetails.callStatus = 'STILL_ONGOING' AND ConversationDetails.type = 'GROUP' THEN 1 -- if ongoing call in a group, move it to the top
+        WHEN ConversationDetails.mutedStatus = 'ALL_ALLOWED' THEN
+           CASE
+                WHEN knocksCount + missedCallsCount + mentionsCount + repliesCount + messagesCount > 0 THEN 1 -- if any unread events, move it to the top
+                WHEN ConversationDetails.type = 'CONNECTION_PENDING' AND ConversationDetails.connectionStatus = 'PENDING' THEN 1 -- if received connection request, move it to the top
+                ELSE 0
+            END
+        WHEN ConversationDetails.mutedStatus = 'ONLY_MENTIONS_AND_REPLIES_ALLOWED' THEN
+            CASE
+                WHEN mentionsCount + repliesCount > 0 THEN 1 -- only if unread mentions or replies, move it to the top
+                WHEN ConversationDetails.type = 'CONNECTION_PENDING' AND ConversationDetails.connectionStatus = 'PENDING' THEN 1 -- if received connection request, move it to the top
+                ELSE 0
+            END
+        ELSE 0
+    END AS hasNewActivitiesToShow,
+    LastMessagePreview.id AS lastMessageId,
+    LastMessagePreview.contentType AS lastMessageContentType,
+    LastMessagePreview.date AS lastMessageDate,
+    LastMessagePreview.visibility AS lastMessageVisibility,
+    LastMessagePreview.senderUserId AS lastMessageSenderUserId,
+    LastMessagePreview.isEphemeral AS lastMessageIsEphemeral,
+    LastMessagePreview.senderName AS lastMessageSenderName,
+    LastMessagePreview.senderConnectionStatus AS lastMessageSenderConnectionStatus,
+    LastMessagePreview.senderIsDeleted AS lastMessageSenderIsDeleted,
+    LastMessagePreview.selfUserId AS lastMessageSelfUserId,
+    LastMessagePreview.isSelfMessage AS lastMessageIsSelfMessage,
+    LastMessagePreview.memberChangeList AS lastMessageMemberChangeList,
+    LastMessagePreview.memberChangeType AS lastMessageMemberChangeType,
+    LastMessagePreview.updateConversationName AS lastMessageUpdateConversationName,
+    LastMessagePreview.conversationName AS lastMessageConversationName,
+    LastMessagePreview.isMentioningSelfUser AS lastMessageIsMentioningSelfUser,
+    LastMessagePreview.isQuotingSelfUser AS lastMessageIsQuotingSelfUser,
+    LastMessagePreview.text AS lastMessageText,
+    LastMessagePreview.assetMimeType AS lastMessageAssetMimeType,
+    LastMessagePreview.isUnread AS lastMessageIsUnread,
+    LastMessagePreview.shouldNotify AS lastMessageShouldNotify,
+    LastMessagePreview.mutedStatus AS lastMessageMutedStatus,
+    LastMessagePreview.conversationType AS lastMessageConversationType,
+    MessageDraft.text AS messageDraftText,
+    MessageDraft.edit_message_id AS messageDraftEditMessageId,
+    MessageDraft.quoted_message_id AS messageDraftQuotedMessageId,
+    MessageDraft.mention_list AS messageDraftMentionList
+FROM ConversationDetails
+LEFT JOIN UnreadEventCountsGrouped
+    ON ConversationDetails.qualifiedId = UnreadEventCountsGrouped.conversationId
+LEFT JOIN LastMessagePreview ON ConversationDetails.qualifiedId = LastMessagePreview.conversationId AND ConversationDetails.archived = 0 -- only return last message for non-archived conversations
+LEFT JOIN MessageDraft ON ConversationDetails.qualifiedId = MessageDraft.conversation_id AND ConversationDetails.archived = 0 -- only return message draft for non-archived conversations
+WHERE
+    type IS NOT 'SELF'
+    AND (
+    type IS 'GROUP'
+    OR (type IS 'ONE_ON_ONE' AND (name IS NOT NULL AND otherUserId IS NOT NULL)) -- show 1:1 convos if they have user metadata
+    OR (type IS 'ONE_ON_ONE' AND userDeleted = 1) -- show deleted 1:1 convos to maintain prev, logic
+    OR (type IS 'CONNECTION_PENDING' AND otherUserId IS NOT NULL) -- show connection requests even without metadata
+    )
+    AND (protocol IS 'PROTEUS' OR protocol IS 'MIXED' OR (protocol IS 'MLS' AND mls_group_state IS 'ESTABLISHED'))
+    AND isActive;
+
+selectAllConversationDetailsWithEvents:
+SELECT * FROM ConversationDetailsWithEvents
+WHERE archived = :fromArchive
+    AND CASE WHEN :onlyInteractionsEnabled THEN interactionEnabled = 1 ELSE 1 END
+ORDER BY
+    CASE WHEN :newActivitiesOnTop THEN hasNewActivitiesToShow ELSE 0 END DESC,
+    lastModifiedDate DESC,
+    name IS NULL,
+    name COLLATE NOCASE ASC;
+
+selectConversationDetailsWithEventsFromSearch:
+SELECT * FROM ConversationDetailsWithEvents
+WHERE
+    archived = :fromArchive
+    AND CASE WHEN :onlyInteractionsEnabled THEN interactionEnabled = 1 ELSE 1 END
+    AND name LIKE ('%' || :searchQuery || '%')
+ORDER BY
+    CASE WHEN :newActivitiesOnTop THEN hasNewActivitiesToShow ELSE 0 END DESC,
+    lastModifiedDate DESC,
+    name IS NULL,
+    name COLLATE NOCASE ASC
+LIMIT :limit
+OFFSET :offset;
+
+countConversationDetailsWithEventsFromSearch:
+SELECT COUNT(*) FROM ConversationDetailsWithEvents
+WHERE
+    archived = :fromArchive
+    AND CASE WHEN :onlyInteractionsEnabled THEN interactionEnabled = 1 ELSE 1 END
+    AND name LIKE ('%' || :searchQuery || '%');
+
 selectAllConversationDetails:
 SELECT * FROM ConversationDetails
 WHERE

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/MessagePreview.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/MessagePreview.sq
@@ -45,13 +45,41 @@ LEFT JOIN MessageConversationChangedContent AS ConversationNameChangedContent ON
 LEFT JOIN MessageAssetContent AS AssetContent ON Message.id = AssetContent.message_id AND Message.conversation_id = AssetContent.conversation_id
 LEFT JOIN MessageTextContent AS TextContent ON Message.id = TextContent.message_id AND Message.conversation_id = TextContent.conversation_id;
 
-getLastMessages:
-SELECT * FROM MessagePreview AS message
-WHERE id IN (
-	SELECT id FROM Message
-	WHERE
-		Message.visibility IN ('VISIBLE', 'DELETED') AND
-		Message.content_type IN ('TEXT', 'ASSET', 'KNOCK', 'MISSED_CALL', 'CONVERSATION_RENAMED', 'MEMBER_CHANGE', 'COMPOSITE', 'CONVERSATION_DEGRADED_MLS', 'CONVERSATION_DEGRADED_PROTEUS', 'CONVERSATION_VERIFIED_MLS', 'CONVERSATION_VERIFIED_PROTEUS', 'LOCATION')
-	GROUP BY Message.conversation_id
-	HAVING Message.creation_date = MAX(Message.creation_date)
+CREATE VIEW IF NOT EXISTS LastMessagePreview
+AS SELECT
+    MessagePreview.id AS id,
+    MessagePreview.conversationId AS conversationId,
+    MessagePreview.contentType AS contentType,
+    MessagePreview.date AS date,
+    MessagePreview.visibility AS visibility,
+    MessagePreview.senderUserId AS senderUserId,
+    MessagePreview.isEphemeral AS isEphemeral,
+    MessagePreview.senderName AS senderName,
+    MessagePreview.senderConnectionStatus AS senderConnectionStatus,
+    MessagePreview.senderIsDeleted AS senderIsDeleted,
+    MessagePreview.selfUserId AS selfUserId,
+    MessagePreview.isSelfMessage AS isSelfMessage,
+    MessagePreview.memberChangeList AS memberChangeList,
+    MessagePreview.memberChangeType AS memberChangeType,
+    MessagePreview.updateConversationName AS updateConversationName,
+    MessagePreview.conversationName AS conversationName,
+    MessagePreview.isMentioningSelfUser AS isMentioningSelfUser,
+    MessagePreview.isQuotingSelfUser AS isQuotingSelfUser,
+    MessagePreview.text AS text,
+    MessagePreview.assetMimeType AS assetMimeType,
+    MessagePreview.isUnread AS isUnread,
+    MessagePreview.shouldNotify AS shouldNotify,
+    MessagePreview.mutedStatus AS mutedStatus,
+    MessagePreview.conversationType AS conversationType
+FROM MessagePreview
+WHERE MessagePreview.id IN (
+   	SELECT id FROM Message
+   	WHERE
+   		Message.visibility IN ('VISIBLE', 'DELETED') AND
+   		Message.content_type IN ('TEXT', 'ASSET', 'KNOCK', 'MISSED_CALL', 'CONVERSATION_RENAMED', 'MEMBER_CHANGE', 'COMPOSITE', 'CONVERSATION_DEGRADED_MLS', 'CONVERSATION_DEGRADED_PROTEUS', 'CONVERSATION_VERIFIED_MLS', 'CONVERSATION_VERIFIED_PROTEUS', 'LOCATION')
+   	GROUP BY Message.conversation_id
+   	HAVING Message.creation_date = MAX(Message.creation_date)
 );
+
+getLastMessages:
+SELECT * FROM LastMessagePreview;

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/UnreadEvents.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/UnreadEvents.sq
@@ -30,7 +30,15 @@ WHERE id = :id AND conversation_id = :conversation_id;
 getUnreadEvents:
 SELECT conversation_id, type FROM UnreadEvent;
 
-getConversationsUnreadEvents:
+getConversationUnreadEventsCount:
+SELECT COUNT(*) FROM UnreadEvent WHERE conversation_id = ?;
+
+getUnreadArchivedConversationsCount:
+SELECT COUNT(DISTINCT ue.conversation_id) FROM UnreadEvent ue
+INNER JOIN Conversation c ON ue.conversation_id = c.qualified_id
+WHERE c.archived = 1;
+
+CREATE VIEW IF NOT EXISTS UnreadEventCountsGrouped AS
 SELECT
     conversation_id AS conversationId,
     SUM(CASE WHEN type = 'KNOCK' THEN 1 ELSE 0 END) AS knocksCount,
@@ -41,13 +49,5 @@ SELECT
 FROM UnreadEvent
 GROUP BY conversation_id;
 
-getPaginatedUnreadEvents:
-SELECT * FROM UnreadEvent LIMIT ? OFFSET ?;
-
-getConversationUnreadEventsCount:
-SELECT COUNT(*) FROM UnreadEvent WHERE  conversation_id = ?;
-
-getUnreadArchivedConversationsCount:
-SELECT COUNT(DISTINCT ue.conversation_id) FROM UnreadEvent ue
-INNER JOIN Conversation c ON ue.conversation_id = c.qualified_id
-WHERE c.archived = 1;
+getConversationsUnreadEventCountsGrouped:
+SELECT * FROM UnreadEventCountsGrouped;

--- a/persistence/src/commonMain/db_user/migrations/87.sqm
+++ b/persistence/src/commonMain/db_user/migrations/87.sqm
@@ -1,0 +1,129 @@
+CREATE VIEW IF NOT EXISTS LastMessagePreview
+AS SELECT
+    MessagePreview.id AS id,
+    MessagePreview.conversationId AS conversationId,
+    MessagePreview.contentType AS contentType,
+    MessagePreview.date AS date,
+    MessagePreview.visibility AS visibility,
+    MessagePreview.senderUserId AS senderUserId,
+    MessagePreview.isEphemeral AS isEphemeral,
+    MessagePreview.senderName AS senderName,
+    MessagePreview.senderConnectionStatus AS senderConnectionStatus,
+    MessagePreview.senderIsDeleted AS senderIsDeleted,
+    MessagePreview.selfUserId AS selfUserId,
+    MessagePreview.isSelfMessage AS isSelfMessage,
+    MessagePreview.memberChangeList AS memberChangeList,
+    MessagePreview.memberChangeType AS memberChangeType,
+    MessagePreview.updateConversationName AS updateConversationName,
+    MessagePreview.conversationName AS conversationName,
+    MessagePreview.isMentioningSelfUser AS isMentioningSelfUser,
+    MessagePreview.isQuotingSelfUser AS isQuotingSelfUser,
+    MessagePreview.text AS text,
+    MessagePreview.assetMimeType AS assetMimeType,
+    MessagePreview.isUnread AS isUnread,
+    MessagePreview.shouldNotify AS shouldNotify,
+    MessagePreview.mutedStatus AS mutedStatus,
+    MessagePreview.conversationType AS conversationType
+FROM MessagePreview
+WHERE MessagePreview.id IN (
+   	SELECT id FROM Message
+   	WHERE
+   		Message.visibility IN ('VISIBLE', 'DELETED') AND
+   		Message.content_type IN ('TEXT', 'ASSET', 'KNOCK', 'MISSED_CALL', 'CONVERSATION_RENAMED', 'MEMBER_CHANGE', 'COMPOSITE', 'CONVERSATION_DEGRADED_MLS', 'CONVERSATION_DEGRADED_PROTEUS', 'CONVERSATION_VERIFIED_MLS', 'CONVERSATION_VERIFIED_PROTEUS', 'LOCATION')
+   	GROUP BY Message.conversation_id
+   	HAVING Message.creation_date = MAX(Message.creation_date)
+);
+
+CREATE VIEW IF NOT EXISTS UnreadEventCountsGrouped AS
+SELECT
+    conversation_id AS conversationId,
+    SUM(CASE WHEN type = 'KNOCK' THEN 1 ELSE 0 END) AS knocksCount,
+    SUM(CASE WHEN type = 'MISSED_CALL' THEN 1 ELSE 0 END) AS missedCallsCount,
+    SUM(CASE WHEN type = 'MENTION' THEN 1 ELSE 0 END) AS mentionsCount,
+    SUM(CASE WHEN type = 'REPLY' THEN 1 ELSE 0 END) AS repliesCount,
+    SUM(CASE WHEN type = 'MESSAGE' THEN 1 ELSE 0 END) AS messagesCount
+FROM UnreadEvent
+GROUP BY conversation_id;
+
+CREATE VIEW IF NOT EXISTS ConversationDetailsWithEvents AS
+SELECT
+    ConversationDetails.*,
+    CASE
+        WHEN ConversationDetails.type = 'GROUP' THEN
+            CASE
+                WHEN ConversationDetails.selfRole IS NOT NULL THEN 1
+                ELSE 0
+            END
+        WHEN ConversationDetails.type = 'ONE_ON_ONE' THEN
+            CASE
+                WHEN userDefederated = 1 THEN 0
+                WHEN userDeleted = 1 THEN 0
+                WHEN connectionStatus = 'BLOCKED' THEN 0
+                WHEN legal_hold_status = 'DEGRADED' THEN 0
+                ELSE 1
+            END
+        ELSE 0
+    END AS interactionEnabled,
+    UnreadEventCountsGrouped.knocksCount AS unreadKnocksCount,
+    UnreadEventCountsGrouped.missedCallsCount AS unreadMissedCallsCount,
+    UnreadEventCountsGrouped.mentionsCount AS unreadMentionsCount,
+    UnreadEventCountsGrouped.repliesCount AS unreadRepliesCount,
+    UnreadEventCountsGrouped.messagesCount AS unreadMessagesCount,
+    CASE
+        WHEN ConversationDetails.callStatus = 'STILL_ONGOING' AND ConversationDetails.type = 'GROUP' THEN 1 -- if ongoing call in a group, move it to the top
+        WHEN ConversationDetails.mutedStatus = 'ALL_ALLOWED' THEN
+           CASE
+                WHEN knocksCount + missedCallsCount + mentionsCount + repliesCount + messagesCount > 0 THEN 1 -- if any unread events, move it to the top
+                WHEN ConversationDetails.type = 'CONNECTION_PENDING' AND ConversationDetails.connectionStatus = 'PENDING' THEN 1 -- if received connection request, move it to the top
+                ELSE 0
+            END
+        WHEN ConversationDetails.mutedStatus = 'ONLY_MENTIONS_AND_REPLIES_ALLOWED' THEN
+            CASE
+                WHEN mentionsCount + repliesCount > 0 THEN 1 -- only if unread mentions or replies, move it to the top
+                WHEN ConversationDetails.type = 'CONNECTION_PENDING' AND ConversationDetails.connectionStatus = 'PENDING' THEN 1 -- if received connection request, move it to the top
+                ELSE 0
+            END
+        ELSE 0
+    END AS hasNewActivitiesToShow,
+    LastMessagePreview.id AS lastMessageId,
+    LastMessagePreview.contentType AS lastMessageContentType,
+    LastMessagePreview.date AS lastMessageDate,
+    LastMessagePreview.visibility AS lastMessageVisibility,
+    LastMessagePreview.senderUserId AS lastMessageSenderUserId,
+    LastMessagePreview.isEphemeral AS lastMessageIsEphemeral,
+    LastMessagePreview.senderName AS lastMessageSenderName,
+    LastMessagePreview.senderConnectionStatus AS lastMessageSenderConnectionStatus,
+    LastMessagePreview.senderIsDeleted AS lastMessageSenderIsDeleted,
+    LastMessagePreview.selfUserId AS lastMessageSelfUserId,
+    LastMessagePreview.isSelfMessage AS lastMessageIsSelfMessage,
+    LastMessagePreview.memberChangeList AS lastMessageMemberChangeList,
+    LastMessagePreview.memberChangeType AS lastMessageMemberChangeType,
+    LastMessagePreview.updateConversationName AS lastMessageUpdateConversationName,
+    LastMessagePreview.conversationName AS lastMessageConversationName,
+    LastMessagePreview.isMentioningSelfUser AS lastMessageIsMentioningSelfUser,
+    LastMessagePreview.isQuotingSelfUser AS lastMessageIsQuotingSelfUser,
+    LastMessagePreview.text AS lastMessageText,
+    LastMessagePreview.assetMimeType AS lastMessageAssetMimeType,
+    LastMessagePreview.isUnread AS lastMessageIsUnread,
+    LastMessagePreview.shouldNotify AS lastMessageShouldNotify,
+    LastMessagePreview.mutedStatus AS lastMessageMutedStatus,
+    LastMessagePreview.conversationType AS lastMessageConversationType,
+    MessageDraft.text AS messageDraftText,
+    MessageDraft.edit_message_id AS messageDraftEditMessageId,
+    MessageDraft.quoted_message_id AS messageDraftQuotedMessageId,
+    MessageDraft.mention_list AS messageDraftMentionList
+FROM ConversationDetails
+LEFT JOIN UnreadEventCountsGrouped
+    ON ConversationDetails.qualifiedId = UnreadEventCountsGrouped.conversationId
+LEFT JOIN LastMessagePreview ON ConversationDetails.qualifiedId = LastMessagePreview.conversationId AND ConversationDetails.archived = 0 -- only return last message for non-archived conversations
+LEFT JOIN MessageDraft ON ConversationDetails.qualifiedId = MessageDraft.conversation_id AND ConversationDetails.archived = 0 -- only return message draft for non-archived conversations
+WHERE
+    type IS NOT 'SELF'
+    AND (
+    type IS 'GROUP'
+    OR (type IS 'ONE_ON_ONE' AND (name IS NOT NULL AND otherUserId IS NOT NULL)) -- show 1:1 convos if they have user metadata
+    OR (type IS 'ONE_ON_ONE' AND userDeleted = 1) -- show deleted 1:1 convos to maintain prev, logic
+    OR (type IS 'CONNECTION_PENDING' AND otherUserId IS NOT NULL) -- show connection requests even without metadata
+    )
+    AND (protocol IS 'PROTEUS' OR protocol IS 'MIXED' OR (protocol IS 'MLS' AND mls_group_state IS 'ESTABLISHED'))
+    AND isActive;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
@@ -57,6 +57,11 @@ interface ConversationDAO {
     suspend fun updateAllConversationsNotificationDate()
     suspend fun getAllConversations(): Flow<List<ConversationEntity>>
     suspend fun getAllConversationDetails(fromArchive: Boolean): Flow<List<ConversationViewEntity>>
+    suspend fun getAllConversationDetailsWithEvents(
+        fromArchive: Boolean = false,
+        onlyInteractionEnabled: Boolean = false,
+        newActivitiesOnTop: Boolean = false,
+    ): Flow<List<ConversationDetailsWithEventsEntity>>
     suspend fun getConversationIds(
         type: ConversationEntity.Type,
         protocol: ConversationEntity.Protocol,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
@@ -58,6 +58,8 @@ internal class ConversationDAOImpl internal constructor(
     private val unreadEventsQueries: UnreadEventsQueries,
     private val coroutineContext: CoroutineContext,
 ) : ConversationDAO {
+    private val conversationMapper = ConversationMapper
+    private val conversationDetailsWithEventsMapper = ConversationDetailsWithEventsMapper
 
     // region Get/Observe by ID
 
@@ -90,7 +92,6 @@ internal class ConversationDAOImpl internal constructor(
 
     // endregion
 
-    private val conversationMapper = ConversationMapper()
     override suspend fun getSelfConversationId(protocol: ConversationEntity.Protocol) = withContext(coroutineContext) {
         conversationQueries.selfConversationId(protocol).executeAsOneOrNull()
     }
@@ -210,6 +211,18 @@ internal class ConversationDAOImpl internal constructor(
     override suspend fun getAllConversationDetails(fromArchive: Boolean): Flow<List<ConversationViewEntity>> {
         return conversationQueries.selectAllConversationDetails(fromArchive, conversationMapper::fromViewToModel)
             .asFlow()
+            .mapToList()
+            .flowOn(coroutineContext)
+    }
+
+    override suspend fun getAllConversationDetailsWithEvents(
+        fromArchive: Boolean,
+        onlyInteractionEnabled: Boolean,
+        newActivitiesOnTop: Boolean,
+    ): Flow<List<ConversationDetailsWithEventsEntity>> {
+        return conversationQueries.selectAllConversationDetailsWithEvents(
+            fromArchive, onlyInteractionEnabled, newActivitiesOnTop, conversationDetailsWithEventsMapper::fromViewToModel
+        ).asFlow()
             .mapToList()
             .flowOn(coroutineContext)
     }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
@@ -221,7 +221,10 @@ internal class ConversationDAOImpl internal constructor(
         newActivitiesOnTop: Boolean,
     ): Flow<List<ConversationDetailsWithEventsEntity>> {
         return conversationQueries.selectAllConversationDetailsWithEvents(
-            fromArchive, onlyInteractionEnabled, newActivitiesOnTop, conversationDetailsWithEventsMapper::fromViewToModel
+            fromArchive = fromArchive,
+            onlyInteractionsEnabled = onlyInteractionEnabled,
+            newActivitiesOnTop = newActivitiesOnTop,
+            mapper = conversationDetailsWithEventsMapper::fromViewToModel
         ).asFlow()
             .mapToList()
             .flowOn(coroutineContext)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDetailsWithEventsEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDetailsWithEventsEntity.kt
@@ -1,0 +1,30 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.persistence.dao.conversation
+
+import com.wire.kalium.persistence.dao.message.MessagePreviewEntity
+import com.wire.kalium.persistence.dao.message.draft.MessageDraftEntity
+import com.wire.kalium.persistence.dao.unread.ConversationUnreadEventEntity
+
+data class ConversationDetailsWithEventsEntity(
+    val conversationViewEntity: ConversationViewEntity,
+    val lastMessage: MessagePreviewEntity? = null,
+    val messageDraft: MessageDraftEntity? = null,
+    val unreadEvents: ConversationUnreadEventEntity = ConversationUnreadEventEntity(conversationViewEntity.id, mapOf()),
+    val hasNewActivitiesToShow: Boolean = false,
+)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDetailsWithEventsMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDetailsWithEventsMapper.kt
@@ -1,0 +1,214 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.persistence.dao.conversation
+
+import com.wire.kalium.persistence.dao.BotIdEntity
+import com.wire.kalium.persistence.dao.ConnectionEntity
+import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.persistence.dao.SupportedProtocolEntity
+import com.wire.kalium.persistence.dao.UserAvailabilityStatusEntity
+import com.wire.kalium.persistence.dao.UserTypeEntity
+import com.wire.kalium.persistence.dao.call.CallEntity
+import com.wire.kalium.persistence.dao.member.MemberEntity
+import com.wire.kalium.persistence.dao.message.MessageEntity
+import com.wire.kalium.persistence.dao.message.MessageMapper
+import com.wire.kalium.persistence.dao.message.draft.MessageDraftMapper
+import com.wire.kalium.persistence.dao.unread.UnreadEventMapper
+import kotlinx.datetime.Instant
+
+data object ConversationDetailsWithEventsMapper {
+    @Suppress("LongParameterList", "FunctionParameterNaming")
+    fun fromViewToModel(
+        qualifiedId: QualifiedIDEntity,
+        name: String?,
+        type: ConversationEntity.Type,
+        callStatus: CallEntity.Status?,
+        previewAssetId: QualifiedIDEntity?,
+        mutedStatus: ConversationEntity.MutedStatus,
+        teamId: String?,
+        lastModifiedDate_: Instant?,
+        lastReadDate: Instant,
+        userAvailabilityStatus: UserAvailabilityStatusEntity?,
+        userType: UserTypeEntity?,
+        botService: BotIdEntity?,
+        userDeleted: Boolean?,
+        userDefederated: Boolean?,
+        userSupportedProtocols: Set<SupportedProtocolEntity>?,
+        connectionStatus: ConnectionEntity.State?,
+        otherUserId: QualifiedIDEntity?,
+        otherUserActiveConversationId: QualifiedIDEntity?,
+        isCreator: Long,
+        isActive: Long,
+        accentId: Int?,
+        lastNotifiedMessageDate: Instant?,
+        selfRole: MemberEntity.Role?,
+        protocol: ConversationEntity.Protocol,
+        mlsCipherSuite: ConversationEntity.CipherSuite,
+        mlsEpoch: Long,
+        mlsGroupId: String?,
+        mlsLastKeyingMaterialUpdateDate: Instant,
+        mlsGroupState: ConversationEntity.GroupState,
+        accessList: List<ConversationEntity.Access>,
+        accessRoleList: List<ConversationEntity.AccessRole>,
+        teamId_: String?,
+        mlsProposalTimer: String?,
+        mutedTime: Long,
+        creatorId: String,
+        lastModifiedDate: Instant,
+        receiptMode: ConversationEntity.ReceiptMode,
+        messageTimer: Long?,
+        userMessageTimer: Long?,
+        incompleteMetadata: Boolean,
+        archived: Boolean,
+        archivedDateTime: Instant?,
+        mlsVerificationStatus: ConversationEntity.VerificationStatus,
+        proteusVerificationStatus: ConversationEntity.VerificationStatus,
+        legalHoldStatus: ConversationEntity.LegalHoldStatus,
+        interactionEnabled: Long,
+        unreadKnocksCount: Long?,
+        unreadMissedCallsCount: Long?,
+        unreadMentionsCount: Long?,
+        unreadRepliesCount: Long?,
+        unreadMessagesCount: Long?,
+        hasNewActivitiesToShow: Long,
+        lastMessageId: String?,
+        lastMessageContentType: MessageEntity.ContentType?,
+        lastMessageDate: Instant?,
+        lastMessageVisibility: MessageEntity.Visibility?,
+        lastMessageSenderUserId: QualifiedIDEntity?,
+        lastMessageIsEphemeral: Boolean?,
+        lastMessageSenderName: String?,
+        lastMessageSenderConnectionStatus: ConnectionEntity.State?,
+        lastMessageSenderIsDeleted: Boolean?,
+        lastMessageSelfUserId: QualifiedIDEntity?,
+        lastMessageIsSelfMessage: Boolean?,
+        lastMessageMemberChangeList: List<QualifiedIDEntity>?,
+        lastMessageMemberChangeType: MessageEntity.MemberChangeType?,
+        lastMessageUpdateConversationName: String?,
+        lastMessageConversationName: String?,
+        lastMessageIsMentioningSelfUser: Boolean?,
+        lastMessageIsQuotingSelfUser: Boolean?,
+        lastMessageText: String?,
+        lastMessageAssetMimeType: String?,
+        lastMessageIsUnread: Boolean?,
+        lastMessageShouldNotify: Long?,
+        lastMessageMutedStatus: ConversationEntity.MutedStatus?,
+        lastMessageConversationType: ConversationEntity.Type?,
+        messageDraftText: String?,
+        messageDraftEditMessageId: String?,
+        messageDraftQuotedMessageId: String?,
+        messageDraftMentionList: List<MessageEntity.Mention>?,
+    ): ConversationDetailsWithEventsEntity = ConversationDetailsWithEventsEntity(
+        conversationViewEntity = ConversationMapper.fromViewToModel(
+            qualifiedId = qualifiedId,
+            name = name,
+            type = type,
+            callStatus = callStatus,
+            previewAssetId = previewAssetId,
+            mutedStatus = mutedStatus,
+            teamId = teamId,
+            lastModifiedDate_ = lastModifiedDate_,
+            lastReadDate = lastReadDate,
+            userAvailabilityStatus = userAvailabilityStatus,
+            userType = userType,
+            botService = botService,
+            userDeleted = userDeleted,
+            userDefederated = userDefederated,
+            userSupportedProtocols = userSupportedProtocols,
+            connectionStatus = connectionStatus,
+            otherUserId = otherUserId,
+            otherUserActiveConversationId = otherUserActiveConversationId,
+            isCreator = isCreator,
+            isActive = isActive,
+            accentId = accentId,
+            lastNotifiedMessageDate = lastNotifiedMessageDate,
+            selfRole = selfRole,
+            protocol = protocol,
+            mlsCipherSuite = mlsCipherSuite,
+            mlsEpoch = mlsEpoch,
+            mlsGroupId = mlsGroupId,
+            mlsLastKeyingMaterialUpdateDate = mlsLastKeyingMaterialUpdateDate,
+            mlsGroupState = mlsGroupState,
+            accessList = accessList,
+            accessRoleList = accessRoleList,
+            teamId_ = teamId_,
+            mlsProposalTimer = mlsProposalTimer,
+            mutedTime = mutedTime,
+            creatorId = creatorId,
+            lastModifiedDate = lastModifiedDate,
+            receiptMode = receiptMode,
+            messageTimer = messageTimer,
+            userMessageTimer = userMessageTimer,
+            incompleteMetadata = incompleteMetadata,
+            archived = archived,
+            archivedDateTime = archivedDateTime,
+            mlsVerificationStatus = mlsVerificationStatus,
+            proteusVerificationStatus = proteusVerificationStatus,
+            legalHoldStatus = legalHoldStatus,
+        ),
+        unreadEvents = UnreadEventMapper.toConversationUnreadEntity(
+            conversationId = qualifiedId,
+            knocksCount = unreadKnocksCount,
+            missedCallsCount = unreadMissedCallsCount,
+            mentionsCount = unreadMentionsCount,
+            repliesCount = unreadRepliesCount,
+            messagesCount = unreadMessagesCount,
+        ),
+        lastMessage = if (lastMessageId != null && lastMessageContentType != null && lastMessageDate != null
+            && lastMessageVisibility != null && lastMessageSenderUserId != null && lastMessageIsEphemeral != null
+            && lastMessageIsSelfMessage != null && lastMessageIsMentioningSelfUser != null && lastMessageIsUnread != null
+            && lastMessageShouldNotify != null) {
+            MessageMapper.toPreviewEntity(
+                id = lastMessageId,
+                conversationId = qualifiedId,
+                contentType = lastMessageContentType,
+                date = lastMessageDate,
+                visibility = lastMessageVisibility,
+                senderUserId = lastMessageSenderUserId,
+                isEphemeral = lastMessageIsEphemeral,
+                senderName = lastMessageSenderName,
+                senderConnectionStatus = lastMessageSenderConnectionStatus,
+                senderIsDeleted = lastMessageSenderIsDeleted,
+                selfUserId = lastMessageSelfUserId,
+                isSelfMessage = lastMessageIsSelfMessage,
+                memberChangeList = lastMessageMemberChangeList,
+                memberChangeType = lastMessageMemberChangeType,
+                updatedConversationName = lastMessageUpdateConversationName,
+                conversationName = lastMessageConversationName,
+                isMentioningSelfUser = lastMessageIsMentioningSelfUser,
+                isQuotingSelfUser = lastMessageIsQuotingSelfUser,
+                text = lastMessageText,
+                assetMimeType = lastMessageAssetMimeType,
+                isUnread = lastMessageIsUnread,
+                isNotified = lastMessageShouldNotify,
+                mutedStatus = lastMessageMutedStatus,
+                conversationType = lastMessageConversationType,
+            )
+        } else null,
+        messageDraft = if (!messageDraftText.isNullOrBlank()) {
+            MessageDraftMapper.toDao(
+                conversationId = qualifiedId,
+                text = messageDraftText,
+                editMessageId = messageDraftEditMessageId,
+                quotedMessageId = messageDraftQuotedMessageId,
+                mentionList = messageDraftMentionList ?: emptyList(),
+            )
+        } else null,
+        hasNewActivitiesToShow = hasNewActivitiesToShow > 0L,
+    )
+}

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDetailsWithEventsMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDetailsWithEventsMapper.kt
@@ -32,7 +32,8 @@ import com.wire.kalium.persistence.dao.unread.UnreadEventMapper
 import kotlinx.datetime.Instant
 
 data object ConversationDetailsWithEventsMapper {
-    @Suppress("LongParameterList", "FunctionParameterNaming")
+    // suppressed because the method cannot be shortened and there are unused parameters because sql view returns some duplicated fields
+    @Suppress("LongParameterList", "LongMethod", "UnusedParameter")
     fun fromViewToModel(
         qualifiedId: QualifiedIDEntity,
         name: String?,
@@ -41,7 +42,7 @@ data object ConversationDetailsWithEventsMapper {
         previewAssetId: QualifiedIDEntity?,
         mutedStatus: ConversationEntity.MutedStatus,
         teamId: String?,
-        lastModifiedDate_: Instant?,
+        lastModifiedDate: Instant?,
         lastReadDate: Instant,
         userAvailabilityStatus: UserAvailabilityStatusEntity?,
         userType: UserTypeEntity?,
@@ -65,11 +66,11 @@ data object ConversationDetailsWithEventsMapper {
         mlsGroupState: ConversationEntity.GroupState,
         accessList: List<ConversationEntity.Access>,
         accessRoleList: List<ConversationEntity.AccessRole>,
-        teamId_: String?,
+        unusedTeamId: String?,
         mlsProposalTimer: String?,
         mutedTime: Long,
         creatorId: String,
-        lastModifiedDate: Instant,
+        unusedLastModifiedDate: Instant,
         receiptMode: ConversationEntity.ReceiptMode,
         messageTimer: Long?,
         userMessageTimer: Long?,
@@ -122,7 +123,7 @@ data object ConversationDetailsWithEventsMapper {
             previewAssetId = previewAssetId,
             mutedStatus = mutedStatus,
             teamId = teamId,
-            lastModifiedDate_ = lastModifiedDate_,
+            lastModifiedDate = lastModifiedDate,
             lastReadDate = lastReadDate,
             userAvailabilityStatus = userAvailabilityStatus,
             userType = userType,
@@ -146,11 +147,11 @@ data object ConversationDetailsWithEventsMapper {
             mlsGroupState = mlsGroupState,
             accessList = accessList,
             accessRoleList = accessRoleList,
-            teamId_ = teamId_,
+            unusedTeamId = unusedTeamId,
             mlsProposalTimer = mlsProposalTimer,
             mutedTime = mutedTime,
             creatorId = creatorId,
-            lastModifiedDate = lastModifiedDate,
+            unusedLastModifiedDate = unusedLastModifiedDate,
             receiptMode = receiptMode,
             messageTimer = messageTimer,
             userMessageTimer = userMessageTimer,
@@ -169,10 +170,14 @@ data object ConversationDetailsWithEventsMapper {
             repliesCount = unreadRepliesCount,
             messagesCount = unreadMessagesCount,
         ),
-        lastMessage = if (lastMessageId != null && lastMessageContentType != null && lastMessageDate != null
+        lastMessage =
+        @Suppress("ComplexCondition") // we need to check all these fields
+        if (
+            lastMessageId != null && lastMessageContentType != null && lastMessageDate != null
             && lastMessageVisibility != null && lastMessageSenderUserId != null && lastMessageIsEphemeral != null
             && lastMessageIsSelfMessage != null && lastMessageIsMentioningSelfUser != null && lastMessageIsUnread != null
-            && lastMessageShouldNotify != null) {
+            && lastMessageShouldNotify != null
+        ) {
             MessageMapper.toPreviewEntity(
                 id = lastMessageId,
                 conversationId = qualifiedId,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationMapper.kt
@@ -27,7 +27,7 @@ import com.wire.kalium.persistence.dao.call.CallEntity
 import com.wire.kalium.persistence.dao.member.MemberEntity
 import kotlinx.datetime.Instant
 
-internal class ConversationMapper {
+data object ConversationMapper {
     @Suppress("LongParameterList", "UnusedParameter", "FunctionParameterNaming")
     fun fromViewToModel(
         qualifiedId: QualifiedIDEntity,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationMapper.kt
@@ -28,7 +28,8 @@ import com.wire.kalium.persistence.dao.member.MemberEntity
 import kotlinx.datetime.Instant
 
 data object ConversationMapper {
-    @Suppress("LongParameterList", "UnusedParameter", "FunctionParameterNaming")
+    // suppressed because the method cannot be shortened and there are unused parameters because sql view returns some duplicated fields
+    @Suppress("LongParameterList", "LongMethod", "UnusedParameter")
     fun fromViewToModel(
         qualifiedId: QualifiedIDEntity,
         name: String?,
@@ -37,7 +38,7 @@ data object ConversationMapper {
         previewAssetId: QualifiedIDEntity?,
         mutedStatus: ConversationEntity.MutedStatus,
         teamId: String?,
-        lastModifiedDate_: Instant?,
+        lastModifiedDate: Instant?,
         lastReadDate: Instant,
         userAvailabilityStatus: UserAvailabilityStatusEntity?,
         userType: UserTypeEntity?,
@@ -61,11 +62,11 @@ data object ConversationMapper {
         mlsGroupState: ConversationEntity.GroupState,
         accessList: List<ConversationEntity.Access>,
         accessRoleList: List<ConversationEntity.AccessRole>,
-        teamId_: String?,
+        unusedTeamId: String?,
         mlsProposalTimer: String?,
         mutedTime: Long,
         creatorId: String,
-        lastModifiedDate: Instant,
+        unusedLastModifiedDate: Instant,
         receiptMode: ConversationEntity.ReceiptMode,
         messageTimer: Long?,
         userMessageTimer: Long?,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -374,7 +374,7 @@ internal class MessageDAOImpl internal constructor(
         messagePreviewQueries.getLastMessages(mapper::toPreviewEntity).asFlow().flowOn(coroutineContext).mapToList()
 
     override suspend fun observeConversationsUnreadEvents(): Flow<List<ConversationUnreadEventEntity>> {
-        return unreadEventsQueries.getConversationsUnreadEvents(unreadEventMapper::toConversationUnreadEntity)
+        return unreadEventsQueries.getConversationsUnreadEventCountsGrouped(unreadEventMapper::toConversationUnreadEntity)
             .asFlow().mapToList()
     }
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/draft/MessageDraftDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/draft/MessageDraftDAOImpl.kt
@@ -20,8 +20,7 @@ package com.wire.kalium.persistence.dao.message.draft
 import app.cash.sqldelight.coroutines.asFlow
 import com.wire.kalium.persistence.MessageDraftsQueries
 import com.wire.kalium.persistence.dao.ConversationIDEntity
-import com.wire.kalium.persistence.dao.QualifiedIDEntity
-import com.wire.kalium.persistence.dao.message.MessageEntity
+import com.wire.kalium.persistence.dao.message.draft.MessageDraftMapper.toDao
 import com.wire.kalium.persistence.util.mapToList
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
@@ -57,19 +56,4 @@ class MessageDraftDAOImpl internal constructor(
         .asFlow()
         .flowOn(coroutineContext)
         .mapToList()
-
-    private fun toDao(
-        conversationId: QualifiedIDEntity,
-        text: String?,
-        editMessageId: String?,
-        quotedMessageId: String?,
-        mentionList: List<MessageEntity.Mention>
-    ): MessageDraftEntity =
-        MessageDraftEntity(
-            conversationId = conversationId,
-            text = text.orEmpty(),
-            editMessageId = editMessageId,
-            quotedMessageId = quotedMessageId,
-            selectedMentionList = mentionList
-        )
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/draft/MessageDraftMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/draft/MessageDraftMapper.kt
@@ -1,0 +1,31 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.persistence.dao.message.draft
+
+import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.persistence.dao.message.MessageEntity
+
+data object MessageDraftMapper {
+    fun toDao(
+        conversationId: QualifiedIDEntity,
+        text: String?,
+        editMessageId: String?,
+        quotedMessageId: String?,
+        mentionList: List<MessageEntity.Mention>
+    ): MessageDraftEntity = MessageDraftEntity(conversationId, text.orEmpty(), editMessageId, quotedMessageId, mentionList)
+}

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -22,6 +22,8 @@ import app.cash.turbine.test
 import com.wire.kalium.persistence.BaseDatabaseTest
 import com.wire.kalium.persistence.dao.asset.AssetDAO
 import com.wire.kalium.persistence.dao.asset.AssetEntity
+import com.wire.kalium.persistence.dao.call.CallDAO
+import com.wire.kalium.persistence.dao.call.CallEntity
 import com.wire.kalium.persistence.dao.client.ClientDAO
 import com.wire.kalium.persistence.dao.client.InsertClientParam
 import com.wire.kalium.persistence.dao.conversation.ConversationDAO
@@ -38,8 +40,11 @@ import com.wire.kalium.persistence.dao.member.MemberEntity
 import com.wire.kalium.persistence.dao.message.MessageDAO
 import com.wire.kalium.persistence.dao.message.MessageEntity
 import com.wire.kalium.persistence.dao.message.MessageEntityContent
+import com.wire.kalium.persistence.dao.message.draft.MessageDraftDAO
+import com.wire.kalium.persistence.dao.unread.UnreadEventTypeEntity
 import com.wire.kalium.persistence.utils.IgnoreIOS
 import com.wire.kalium.persistence.utils.stubs.newConversationEntity
+import com.wire.kalium.persistence.utils.stubs.newDraftMessageEntity
 import com.wire.kalium.persistence.utils.stubs.newRegularMessageEntity
 import com.wire.kalium.persistence.utils.stubs.newSystemMessageEntity
 import com.wire.kalium.persistence.utils.stubs.newUserEntity
@@ -69,10 +74,12 @@ class ConversationDAOTest : BaseDatabaseTest() {
     private lateinit var clientDao: ClientDAO
     private lateinit var connectionDAO: ConnectionDAO
     private lateinit var messageDAO: MessageDAO
+    private lateinit var messageDraftDAO: MessageDraftDAO
     private lateinit var userDAO: UserDAO
     private lateinit var teamDAO: TeamDAO
     private lateinit var memberDAO: MemberDAO
     private lateinit var assertDAO: AssetDAO
+    private lateinit var callDAO: CallDAO
     private val selfUserId = UserIDEntity("selfValue", "selfDomain")
 
     @BeforeTest
@@ -83,14 +90,16 @@ class ConversationDAOTest : BaseDatabaseTest() {
         clientDao = db.clientDAO
         connectionDAO = db.connectionDAO
         messageDAO = db.messageDAO
+        messageDraftDAO = db.messageDraftDAO
         userDAO = db.userDAO
         teamDAO = db.teamDAO
         memberDAO = db.memberDAO
         assertDAO = db.assetDAO
+        callDAO = db.callDAO
     }
 
     @Test
-    fun givenConversationIsInserted_whenFetchingById_thenConversationIsReturned() = runTest {
+    fun givenConversationIsInserted_whenFetchingById_thenConversationIsReturned() = runTest(dispatcher) {
         conversationDAO.insertConversation(conversationEntity1)
         insertTeamUserAndMember(team, user1, conversationEntity1.id)
         val result = conversationDAO.getConversationDetailsById(conversationEntity1.id)
@@ -98,7 +107,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenListOfConversations_ThenMultipleConversationsCanBeInsertedAtOnce() = runTest {
+    fun givenListOfConversations_ThenMultipleConversationsCanBeInsertedAtOnce() = runTest(dispatcher) {
         conversationDAO.insertConversations(listOf(conversationEntity1, conversationEntity2))
         insertTeamUserAndMember(team, user1, conversationEntity1.id)
         insertTeamUserAndMember(team, user2, conversationEntity2.id)
@@ -109,7 +118,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenExistingConversation_ThenConversationCanBeDeleted() = runTest {
+    fun givenExistingConversation_ThenConversationCanBeDeleted() = runTest(dispatcher) {
         conversationDAO.insertConversation(conversationEntity1)
         conversationDAO.deleteConversationByQualifiedID(conversationEntity1.id)
         val result = try {
@@ -121,7 +130,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenExistingConversation_WhenReinserting_ThenGroupStateIsUpdated() = runTest {
+    fun givenExistingConversation_WhenReinserting_ThenGroupStateIsUpdated() = runTest(dispatcher) {
         conversationDAO.insertConversation(conversationEntity2)
         conversationDAO.insertConversation(conversationEntity2.copy(
             protocolInfo = mlsProtocolInfo1.copy(
@@ -133,7 +142,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenExistingConversation_ThenConversationCanBeUpdated() = runTest {
+    fun givenExistingConversation_ThenConversationCanBeUpdated() = runTest(dispatcher) {
         conversationDAO.insertConversation(conversationEntity1)
         insertTeamUserAndMember(team, user1, conversationEntity1.id)
         val updatedConversation1Entity = conversationEntity1.copy(name = "Updated conversation1")
@@ -266,7 +275,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenExistingConversation_ThenConversationGroupStateCanBeUpdated() = runTest {
+    fun givenExistingConversation_ThenConversationGroupStateCanBeUpdated() = runTest(dispatcher) {
         conversationDAO.insertConversation(conversationEntity2)
         conversationDAO.updateConversationGroupState(
             ConversationEntity.GroupState.PENDING_WELCOME_MESSAGE,
@@ -279,7 +288,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenExistingConversation_ThenConversationGroupStateCanBeUpdatedToEstablished() = runTest {
+    fun givenExistingConversation_ThenConversationGroupStateCanBeUpdatedToEstablished() = runTest(dispatcher) {
         conversationDAO.insertConversation(conversationEntity2)
         conversationDAO.updateMlsGroupStateAndCipherSuite(
             ConversationEntity.GroupState.PENDING_WELCOME_MESSAGE,
@@ -297,7 +306,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenExistingConversation_ThenConversationIsUpdatedOnInsert() = runTest {
+    fun givenExistingConversation_ThenConversationIsUpdatedOnInsert() = runTest(dispatcher) {
         conversationDAO.insertConversation(conversationEntity1)
         insertTeamUserAndMember(team, user1, conversationEntity1.id)
         val updatedConversation1Entity = conversationEntity1.copy(name = "Updated conversation1")
@@ -307,7 +316,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenAnExistingConversation_WhenUpdatingTheMutingStatus_ThenConversationShouldBeUpdated() = runTest {
+    fun givenAnExistingConversation_WhenUpdatingTheMutingStatus_ThenConversationShouldBeUpdated() = runTest(dispatcher) {
         conversationDAO.insertConversation(conversationEntity2)
         conversationDAO.updateConversationMutedStatus(
             conversationId = conversationEntity2.id,
@@ -322,7 +331,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
 
     @Test
     @IgnoreIOS
-    fun givenConversation_whenInsertingStoredConversation_thenLastChangesTimeIsNotChanged() = runTest {
+    fun givenConversation_whenInsertingStoredConversation_thenLastChangesTimeIsNotChanged() = runTest(dispatcher) {
         val convStored = conversationEntity1.copy(
             lastNotificationDate = "2022-04-30T15:36:00.000Z".toInstant(),
             lastModifiedDate = "2022-03-30T15:36:00.000Z".toInstant(),
@@ -347,7 +356,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenConversation_whenUpdatingAccessInfo_thenItsUpdated() = runTest {
+    fun givenConversation_whenUpdatingAccessInfo_thenItsUpdated() = runTest(dispatcher) {
         val convStored = conversationEntity1.copy(
             accessRole = listOf(ConversationEntity.AccessRole.TEAM_MEMBER), access = listOf(ConversationEntity.Access.INVITE)
         )
@@ -370,7 +379,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenExistingConversation_whenUpdatingTheConversationLastReadDate_ThenTheConversationHasTheDate() = runTest {
+    fun givenExistingConversation_whenUpdatingTheConversationLastReadDate_ThenTheConversationHasTheDate() = runTest(dispatcher) {
         // given
         val expectedLastReadDate = Instant.fromEpochMilliseconds(1648654560000)
 
@@ -388,7 +397,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
 
     @Test
     fun givenExistingConversation_whenUpdatingTheConversationSeenDate_thenEmitTheNewConversationStateWithTheUpdatedSeenDate() =
-        runTest {
+        runTest(dispatcher) {
             // given
             val expectedConversationSeenDate = Instant.fromEpochMilliseconds(1648654560000)
 
@@ -452,7 +461,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenNewValue_whenUpdatingProtocol_thenItsUpdatedAndReportedAsChanged() = runTest {
+    fun givenNewValue_whenUpdatingProtocol_thenItsUpdatedAndReportedAsChanged() = runTest(dispatcher) {
         val conversation = conversationEntity5
         val groupId = "groupId"
         val updatedCipherSuite = ConversationEntity.CipherSuite.MLS_256_DHKEMP521_AES256GCM_SHA512_P521
@@ -799,7 +808,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenAConversation_whenChangingTheName_itReturnsTheUpdatedName() = runTest {
+    fun givenAConversation_whenChangingTheName_itReturnsTheUpdatedName() = runTest(dispatcher) {
         // given
         conversationDAO.insertConversation(conversationEntity3)
         insertTeamUserAndMember(team, user1, conversationEntity3.id)
@@ -833,7 +842,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenAConversation_whenUpdatingReceiptMode_itReturnsTheUpdatedValue() = runTest {
+    fun givenAConversation_whenUpdatingReceiptMode_itReturnsTheUpdatedValue() = runTest(dispatcher) {
         // given
         conversationDAO.insertConversation(conversationEntity1.copy(receiptMode = ConversationEntity.ReceiptMode.ENABLED))
 
@@ -846,7 +855,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenSelfUserIsNotMemberOfConversation_whenGettingConversationDetails_itReturnsCorrectDetails() = runTest {
+    fun givenSelfUserIsNotMemberOfConversation_whenGettingConversationDetails_itReturnsCorrectDetails() = runTest(dispatcher) {
         // given
         conversationDAO.insertConversation(conversationEntity3)
         teamDAO.insertTeam(team)
@@ -861,7 +870,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenConversation_whenUpdatingMessageTimer_itReturnsCorrectTimer() = runTest {
+    fun givenConversation_whenUpdatingMessageTimer_itReturnsCorrectTimer() = runTest(dispatcher) {
         // given
         conversationDAO.insertConversation(conversationEntity3)
         val messageTimer = 60000L
@@ -875,7 +884,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenSelfUserIsCreatorOfConversation_whenGettingConversationDetails_itReturnsCorrectDetails() = runTest {
+    fun givenSelfUserIsCreatorOfConversation_whenGettingConversationDetails_itReturnsCorrectDetails() = runTest(dispatcher) {
         // given
         conversationDAO.insertConversation(conversationEntity3.copy(creatorId = selfUserId.value))
         teamDAO.insertTeam(team)
@@ -996,6 +1005,13 @@ class ConversationDAOTest : BaseDatabaseTest() {
             assertEquals(conversationId, result.id)
             assertEquals(ConversationEntity.Type.CONNECTION_PENDING, result.type)
         }
+        conversationDAO.getAllConversationDetailsWithEvents(fromArchive).first().let {
+            assertEquals(1, it.size)
+            val result = it.first()
+
+            assertEquals(conversationId, result.conversationViewEntity.id)
+            assertEquals(ConversationEntity.Type.CONNECTION_PENDING, result.conversationViewEntity.type)
+        }
     }
 
     @Test
@@ -1020,6 +1036,9 @@ class ConversationDAOTest : BaseDatabaseTest() {
         conversationDAO.getAllConversationDetails(fromArchive).first().let {
             assertEquals(1, it.size)
         }
+        conversationDAO.getAllConversationDetailsWithEvents(fromArchive).first().let {
+            assertEquals(1, it.size)
+        }
     }
 
     @Test
@@ -1038,6 +1057,10 @@ class ConversationDAOTest : BaseDatabaseTest() {
             assertEquals(1, it.size)
             assertEquals(conversationEntity1.id, it.first().id)
         }
+        conversationDAO.getAllConversationDetailsWithEvents(fromArchive).first().let {
+            assertEquals(1, it.size)
+            assertEquals(conversationEntity1.id, it.first().conversationViewEntity.id)
+        }
     }
 
     @Test
@@ -1053,9 +1076,12 @@ class ConversationDAOTest : BaseDatabaseTest() {
         memberDAO.insertMember(member1, conversationEntity1.id)
         memberDAO.insertMember(member2, conversationEntity2.id)
 
-        val result = conversationDAO.getAllConversationDetails(fromArchive).first()
-
-        assertEquals(2, result.size)
+        conversationDAO.getAllConversationDetails(fromArchive).first().let {
+            assertEquals(2, it.size)
+        }
+        conversationDAO.getAllConversationDetailsWithEvents(fromArchive).first().let {
+            assertEquals(2, it.size)
+        }
     }
 
     @Test
@@ -1071,9 +1097,12 @@ class ConversationDAOTest : BaseDatabaseTest() {
         memberDAO.insertMember(member1, conversationEntity1.id)
         memberDAO.insertMember(member2, conversationEntity2.id)
 
-        val result = conversationDAO.getAllConversationDetails(fromArchive).first()
-
-        assertEquals(2, result.size)
+        conversationDAO.getAllConversationDetails(fromArchive).first().let {
+            assertEquals(2, it.size)
+        }
+        conversationDAO.getAllConversationDetailsWithEvents(fromArchive).first().let {
+            assertEquals(2, it.size)
+        }
     }
 
     @Test
@@ -1086,9 +1115,12 @@ class ConversationDAOTest : BaseDatabaseTest() {
 
         // when
         val result = conversationDAO.getAllConversationDetails(fromArchive).first()
+        val resultWithEvents = conversationDAO.getAllConversationDetailsWithEvents(fromArchive).first()
 
         // then
-        assertEquals(conversation.toViewEntity(user1).copy(accentId = 0), result.firstOrNull { it.id == conversation.id })
+        val expected = conversation.toViewEntity(user1).copy(accentId = 0)
+        assertEquals(expected, result.firstOrNull { it.id == conversation.id })
+        assertEquals(expected, resultWithEvents.firstOrNull { it.conversationViewEntity.id == conversation.id }?.conversationViewEntity)
     }
 
     @Test
@@ -1101,9 +1133,11 @@ class ConversationDAOTest : BaseDatabaseTest() {
 
         // when
         val result = conversationDAO.getAllConversationDetails(fromArchive).first()
+        val resultWithEvents = conversationDAO.getAllConversationDetailsWithEvents(fromArchive).first()
 
         // then
-        assertNull(result.firstOrNull { it.id == conversation.id })
+        assertEquals(null, result.firstOrNull { it.id == conversation.id })
+        assertEquals(null, resultWithEvents.firstOrNull { it.conversationViewEntity.id == conversation.id })
     }
 
     @Test
@@ -1132,10 +1166,13 @@ class ConversationDAOTest : BaseDatabaseTest() {
 
         // when
         val result = conversationDAO.getAllConversationDetails(fromArchive).first()
+        val resultWithEvents = conversationDAO.getAllConversationDetailsWithEvents(fromArchive).first()
 
         // then
         assertEquals(conversation2.id, result[0].id)
+        assertEquals(conversation2.id, resultWithEvents[0].conversationViewEntity.id)
         assertEquals(conversation1.id, result[1].id)
+        assertEquals(conversation1.id, resultWithEvents[1].conversationViewEntity.id)
     }
 
     @Test
@@ -1166,11 +1203,15 @@ class ConversationDAOTest : BaseDatabaseTest() {
 
         // when
         val result = conversationDAO.getAllConversationDetails(fromArchive).first()
+        val resultWithEvents = conversationDAO.getAllConversationDetailsWithEvents(fromArchive).first()
 
         // then
         assertTrue(result.size == 1)
+        assertTrue(resultWithEvents.size == 1)
         assertTrue(!result[0].archived)
+        assertTrue(!resultWithEvents[0].conversationViewEntity.archived)
         assertEquals(conversation2.id, result[0].id)
+        assertEquals(conversation2.id, resultWithEvents[0].conversationViewEntity.id)
     }
 
     @Test
@@ -1240,6 +1281,312 @@ class ConversationDAOTest : BaseDatabaseTest() {
         conversationDAO.getAllConversationDetails(fromArchive = false).first().let {
             assertEquals(1, it.size)
             assertEquals(conversationEntity1.id, it.first().id)
+        }
+        conversationDAO.getAllConversationDetailsWithEvents(fromArchive = false).first().let {
+            assertEquals(1, it.size)
+            assertEquals(conversationEntity1.id, it.first().conversationViewEntity.id)
+        }
+    }
+
+    @Test
+    fun givenConversationWithUnreadMessageAndDraft_whenGettingAllConversationsWithEvents_thenShouldReturnCorrectValues() = runTest {
+        val conversationEntity = conversationEntity1.copy(lastReadDate = Instant.fromEpochMilliseconds(0))
+        conversationDAO.insertConversation(conversationEntity)
+
+        userDAO.upsertUser(user1.copy(activeOneOnOneConversationId = conversationEntity.id))
+
+        memberDAO.insertMember(member1, conversationEntity.id)
+        memberDAO.insertMember(member2, conversationEntity.id)
+
+        val messageEntity = newRegularMessageEntity(
+            id = "unread_message_id",
+            conversationId = conversationEntity.id,
+            senderUserId = user1.id,
+            date = conversationEntity.lastReadDate.plus(1.seconds) // message received after last read date so it should be unread
+        )
+        messageDAO.insertOrIgnoreMessage(messageEntity)
+
+        val draftMessageEntity = newDraftMessageEntity(conversationId = conversationEntity.id)
+        messageDraftDAO.upsertMessageDraft(draftMessageEntity)
+
+        conversationDAO.getAllConversationDetailsWithEvents(fromArchive = false).first().let {
+            assertEquals(conversationEntity.id, it.first().conversationViewEntity.id)
+            assertEquals(1, it.first().unreadEvents.unreadEvents[UnreadEventTypeEntity.MESSAGE])
+            assertEquals(draftMessageEntity.text, it.first().messageDraft?.text)
+            assertEquals(messageEntity.id, it.first().lastMessage?.id)
+        }
+    }
+
+    @Test
+    fun givenConversationWithoutEvents_whenGettingAllConversationsWithEvents_thenShouldReturnCorrectValues() = runTest {
+        val conversationEntity = conversationEntity1.copy(lastReadDate = Instant.fromEpochMilliseconds(0))
+        conversationDAO.insertConversation(conversationEntity)
+
+        userDAO.upsertUser(user1.copy(activeOneOnOneConversationId = conversationEntity.id))
+
+        memberDAO.insertMember(member1, conversationEntity.id)
+        memberDAO.insertMember(member2, conversationEntity.id)
+
+        conversationDAO.getAllConversationDetailsWithEvents(fromArchive = false).first().let {
+            assertEquals(conversationEntity.id, it.first().conversationViewEntity.id)
+            assertEquals(0, it.first().unreadEvents.unreadEvents.size)
+            assertEquals(null, it.first().messageDraft)
+            assertEquals(null, it.first().lastMessage)
+        }
+    }
+
+    @Test
+    fun givenArchiveConversationWithUnreadMessageAndDraft_whenGettingAllConversationsWithEvents_thenShouldReturnCorrectValues() = runTest {
+        val conversationEntity = conversationEntity1.copy(
+            archived = true,
+            lastReadDate = Instant.fromEpochMilliseconds(0L)
+        )
+        conversationDAO.insertConversation(conversationEntity)
+
+        userDAO.upsertUser(user1.copy(activeOneOnOneConversationId = conversationEntity.id))
+
+        memberDAO.insertMember(member1, conversationEntity.id)
+        memberDAO.insertMember(member2, conversationEntity.id)
+
+        val messageEntity = newRegularMessageEntity(
+            id = "unread_message_id",
+            conversationId = conversationEntity.id,
+            senderUserId = user1.id,
+            date = conversationEntity.lastReadDate.plus(1.seconds) // message received after last read date so it should be unread
+        )
+        messageDAO.insertOrIgnoreMessage(messageEntity)
+
+        val draftMessageEntity = newDraftMessageEntity(conversationId = conversationEntity.id)
+        messageDraftDAO.upsertMessageDraft(draftMessageEntity)
+
+        conversationDAO.getAllConversationDetailsWithEvents(fromArchive = true).first().let {
+            assertEquals(conversationEntity.id, it.first().conversationViewEntity.id)
+            assertEquals(1, it.first().unreadEvents.unreadEvents[UnreadEventTypeEntity.MESSAGE])
+            assertEquals(null, it.first().messageDraft) // do not return draft for archived conversation
+            assertEquals(null, it.first().lastMessage) // do not return last message for archived conversation
+        }
+    }
+
+    @Test
+    fun givenConversationWithStillOngoingCall_whenGettingAllConversationsWithEventsAndNewActivitiesOnTop_thenReturnRightOrder() = runTest {
+        val conversationEntity1 = conversationEntity1.copy(
+            id = ConversationIDEntity("conversation1", "domain"),
+            type = ConversationEntity.Type.GROUP,
+            mutedStatus = ConversationEntity.MutedStatus.ALL_ALLOWED,
+            lastModifiedDate = Instant.fromEpochMilliseconds(2) // conversation 1 is more recent than conversation 2
+        )
+        val conversationEntity2 = conversationEntity1.copy(
+            id = ConversationIDEntity("conversation2", "domain"),
+            type = ConversationEntity.Type.GROUP,
+            mutedStatus = ConversationEntity.MutedStatus.ALL_ALLOWED,
+            lastModifiedDate = Instant.fromEpochMilliseconds(1) // conversation 2 is less recent than conversation 1
+        )
+        conversationDAO.insertConversation(conversationEntity1)
+        conversationDAO.insertConversation(conversationEntity2)
+        userDAO.upsertUser(user1)
+        val callEntity = CallEntity(
+            conversationId = conversationEntity1.id,
+            id = "call_id",
+            status = CallEntity.Status.STILL_ONGOING,
+            callerId = "callerId",
+            conversationType = ConversationEntity.Type.GROUP,
+            type = CallEntity.Type.CONFERENCE
+        )
+        callDAO.insertCall(callEntity.copy(conversationId = conversationEntity2.id)) // but conversation 2 has ongoing call
+        conversationDAO.getAllConversationDetailsWithEvents(newActivitiesOnTop = true).first().let {
+            assertEquals(conversationEntity2.id, it[0].conversationViewEntity.id) // first is the one with ongoing call
+            assertEquals(conversationEntity1.id, it[1].conversationViewEntity.id) // second is the other one even if it is more recent
+        }
+    }
+
+    @Test
+    fun givenConversationWithUnreadEvents_whenGettingAllConversationsWithEventsAndNewActivitiesOnTop_thenReturnRightOrder() = runTest {
+        val conversationEntity1 = conversationEntity1.copy(
+            id = ConversationIDEntity("conversation1", "domain"),
+            type = ConversationEntity.Type.GROUP,
+            lastModifiedDate = Instant.fromEpochMilliseconds(2), // conversation 1 is more recent than conversation 2
+            lastReadDate = Instant.fromEpochMilliseconds(2) // but it's also already read
+        )
+        val conversationEntity2 = conversationEntity1.copy(
+            id = ConversationIDEntity("conversation2", "domain"),
+            type = ConversationEntity.Type.GROUP,
+            lastModifiedDate = Instant.fromEpochMilliseconds(0), // conversation 2 is less recent than conversation 1
+            lastReadDate = Instant.fromEpochMilliseconds(0) // but it's still unread
+        )
+        conversationDAO.insertConversation(conversationEntity1)
+        conversationDAO.insertConversation(conversationEntity2)
+        userDAO.upsertUser(user1)
+        val messageEntity = newRegularMessageEntity(
+            id = "unread_message_id",
+            conversationId = conversationEntity2.id,
+            senderUserId = user1.id,
+            date = Instant.fromEpochMilliseconds(1) // message received after last read date so it should be unread
+        )
+        messageDAO.insertOrIgnoreMessage(messageEntity)
+        conversationDAO.getAllConversationDetailsWithEvents(newActivitiesOnTop = true).first().let {
+            assertEquals(conversationEntity2.id, it[0].conversationViewEntity.id) // first is the one with unread event
+            assertEquals(conversationEntity1.id, it[1].conversationViewEntity.id) // second is the other one even if it is more recent
+        }
+    }
+
+    @Test
+    fun givenConversationWithUnreadEventsButMuted_whenGettingAllConversationsWithEventsAndNewActivitiesOnTop_thenReturnRightOrder() =
+        runTest {
+            val conversationEntity1 = conversationEntity1.copy(
+                id = ConversationIDEntity("conversation1", "domain"),
+                type = ConversationEntity.Type.GROUP,
+                lastModifiedDate = Instant.fromEpochMilliseconds(2), // conversation 1 is more recent than conversation 2
+                lastReadDate = Instant.fromEpochMilliseconds(0),
+                mutedStatus = ConversationEntity.MutedStatus.ONLY_MENTIONS_AND_REPLIES_ALLOWED, // but new messages are muted
+            )
+            val conversationEntity2 = conversationEntity1.copy(
+                id = ConversationIDEntity("conversation2", "domain"),
+                type = ConversationEntity.Type.GROUP,
+                lastModifiedDate = Instant.fromEpochMilliseconds(1), // conversation 2 is less recent than conversation 1
+                lastReadDate = Instant.fromEpochMilliseconds(0),
+                mutedStatus = ConversationEntity.MutedStatus.ALL_ALLOWED, // but new messages are not muted
+            )
+            conversationDAO.insertConversation(conversationEntity1)
+            conversationDAO.insertConversation(conversationEntity2)
+            userDAO.upsertUser(user1)
+            val messageEntity1 = newRegularMessageEntity(
+                id = "unread_message_id_1",
+                conversationId = conversationEntity1.id,
+                senderUserId = user1.id,
+                date = Instant.fromEpochMilliseconds(1) // message received after last read date so it should be unread
+            )
+            val messageEntity2 = newRegularMessageEntity(
+                id = "unread_message_id_2",
+                conversationId = conversationEntity2.id,
+                senderUserId = user1.id,
+                date = Instant.fromEpochMilliseconds(1) // message received after last read date so it should be unread
+            )
+            messageDAO.insertOrIgnoreMessage(messageEntity1)
+            messageDAO.insertOrIgnoreMessage(messageEntity2)
+            conversationDAO.getAllConversationDetailsWithEvents(newActivitiesOnTop = true).first().let {
+                assertEquals(conversationEntity2.id, it[0].conversationViewEntity.id) // first is the one with not muted new message
+                assertEquals(conversationEntity1.id, it[1].conversationViewEntity.id) // second is the other one even if it is more recent
+            }
+        }
+
+    @Test
+    fun givenConversationWithUnreadEvents_whenGettingAllConversationsWithEventsAndNotNewActivitiesOnTop_thenReturnRightOrder() = runTest {
+        val conversationEntity1 = conversationEntity1.copy(
+            id = ConversationIDEntity("conversation1", "domain"),
+            type = ConversationEntity.Type.GROUP,
+            lastModifiedDate = Instant.fromEpochMilliseconds(2), // conversation 1 is more recent than conversation 2
+            lastReadDate = Instant.fromEpochMilliseconds(2) // but it's also already read
+        )
+        val conversationEntity2 = conversationEntity1.copy(
+            id = ConversationIDEntity("conversation2", "domain"),
+            type = ConversationEntity.Type.GROUP,
+            lastModifiedDate = Instant.fromEpochMilliseconds(0), // conversation 2 is less recent than conversation 1
+            lastReadDate = Instant.fromEpochMilliseconds(0) // but it's still unread
+        )
+        conversationDAO.insertConversation(conversationEntity1)
+        conversationDAO.insertConversation(conversationEntity2)
+        userDAO.upsertUser(user1)
+        val messageEntity = newRegularMessageEntity(
+            id = "unread_message_id",
+            conversationId = conversationEntity2.id,
+            senderUserId = user1.id,
+            date = Instant.fromEpochMilliseconds(1) // message received after last read date so it should be unread
+        )
+        messageDAO.insertOrIgnoreMessage(messageEntity)
+        conversationDAO.getAllConversationDetailsWithEvents(newActivitiesOnTop = false).first().let {
+            assertEquals(conversationEntity1.id, it[0].conversationViewEntity.id) // first is the more recent one even if it's already read
+            assertEquals(conversationEntity2.id, it[1].conversationViewEntity.id) // second is the other one even if it has unread events
+        }
+    }
+
+    @Test
+    fun givenReceivedConnectionRequest_whenGettingAllConversationsWithEventsAndNewActivitiesOnTop_thenReturnRightOrder() = runTest {
+        val conversationEntity1 = conversationEntity1.copy(
+            id = ConversationIDEntity("conversation1", "domain"),
+            type = ConversationEntity.Type.GROUP,
+            lastModifiedDate = Instant.fromEpochMilliseconds(2), // conversation 1 is more recent than conversation 2
+        )
+        val conversationEntity2 = conversationEntity1.copy(
+            id = ConversationIDEntity("conversation2", "domain"),
+            type = ConversationEntity.Type.CONNECTION_PENDING,
+            lastModifiedDate = Instant.fromEpochMilliseconds(1), // conversation 1 is more recent than conversation 2
+        )
+        val userEntity = user1.copy(connectionStatus = ConnectionEntity.State.PENDING)
+        val connectionEntity = ConnectionEntity(
+            conversationId = conversationEntity2.id.value,
+            from = userEntity.id.value,
+            lastUpdateDate = Instant.fromEpochMilliseconds(1),
+            qualifiedConversationId = conversationEntity2.id,
+            qualifiedToId = userEntity.id,
+            status = ConnectionEntity.State.PENDING,
+            toId = userEntity.id.value,
+        )
+        conversationDAO.insertConversation(conversationEntity1)
+        conversationDAO.insertConversation(conversationEntity2)
+        connectionDAO.insertConnection(connectionEntity)
+        userDAO.upsertUser(userEntity)
+        conversationDAO.getAllConversationDetailsWithEvents(newActivitiesOnTop = true).first().let {
+            assertEquals(conversationEntity2.id, it[0].conversationViewEntity.id) // first is the one with received connection request
+            assertEquals(conversationEntity1.id, it[1].conversationViewEntity.id) // second is the other one even if it is more recent
+        }
+    }
+
+    @Test
+    fun givenConnectionRequest_whenGettingAllConversationsWithEventsAndOnlyEnabledInteractions_thenDoNotReturnIt() = runTest {
+        val conversationEntity1 = conversationEntity1.copy(
+            id = ConversationIDEntity("conversation1", "domain"),
+            type = ConversationEntity.Type.CONNECTION_PENDING,
+            lastModifiedDate = Instant.fromEpochMilliseconds(2), // conversation 1 is more recent than conversation 2
+        )
+        val userEntity = user1.copy(connectionStatus = ConnectionEntity.State.PENDING)
+        val connectionEntity = ConnectionEntity(
+            conversationId = conversationEntity1.id.value,
+            from = userEntity.id.value,
+            lastUpdateDate = Instant.fromEpochMilliseconds(1),
+            qualifiedConversationId = conversationEntity1.id,
+            qualifiedToId = userEntity.id,
+            status = ConnectionEntity.State.PENDING,
+            toId = userEntity.id.value,
+        )
+        conversationDAO.insertConversation(conversationEntity1)
+        connectionDAO.insertConnection(connectionEntity)
+        userDAO.upsertUser(userEntity)
+        conversationDAO.getAllConversationDetailsWithEvents(onlyInteractionEnabled = true).first().let {
+            assertEquals(0, it.size)
+        }
+    }
+
+    @Test
+    fun givenAGroupConvWhichSelfUserLeft_whenGettingAllConversationsWithEventsAndOnlyEnabledInteractions_thenDoNotReturnIt() = runTest {
+        val conversationEntity1 = conversationEntity1.copy(
+            id = ConversationIDEntity("conversation1", "domain"),
+            type = ConversationEntity.Type.GROUP,
+        )
+        val conversationEntity2 = conversationEntity1.copy(id = ConversationIDEntity("conversation2", "domain"))
+        conversationDAO.insertConversation(conversationEntity1)
+        conversationDAO.insertConversation(conversationEntity2)
+        userDAO.upsertUser(user1)
+        memberDAO.insertMember(MemberEntity(selfUserId, MemberEntity.Role.Member), conversationEntity1.id)
+        conversationDAO.getAllConversationDetailsWithEvents(onlyInteractionEnabled = true).first().let {
+            assertEquals(1, it.size) // self user is a member of only conversation1
+            assertEquals(conversationEntity1.id, it.first().conversationViewEntity.id)
+        }
+    }
+
+    @Test
+    fun givenAOneOneConvWithDeletedUser_whenGettingAllConversationsWithEventsAndOnlyEnabledInteractions_thenDoNotReturnIt() = runTest {
+        val conversationEntity1 = conversationEntity1.copy(
+            id = ConversationIDEntity("conversation1", "domain"),
+            type = ConversationEntity.Type.ONE_ON_ONE,
+        )
+        val conversationEntity2 = conversationEntity1.copy(id = ConversationIDEntity("conversation2", "domain"))
+        conversationDAO.insertConversation(conversationEntity1)
+        conversationDAO.insertConversation(conversationEntity2)
+        userDAO.upsertUser(user1.copy(deleted = true))
+        memberDAO.insertMember(MemberEntity(selfUserId, MemberEntity.Role.Member), conversationEntity1.id)
+        memberDAO.insertMember(MemberEntity(user1.id, MemberEntity.Role.Member), conversationEntity1.id)
+        conversationDAO.getAllConversationDetailsWithEvents(onlyInteractionEnabled = true).first().let {
+            assertEquals(0, it.size)
         }
     }
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/MessageStubs.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/MessageStubs.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.persistence.dao.UserDetailsEntity
 import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.dao.message.MessageEntity
 import com.wire.kalium.persistence.dao.message.MessageEntityContent
+import com.wire.kalium.persistence.dao.message.draft.MessageDraftEntity
 import kotlinx.datetime.Instant
 
 @Suppress("LongParameterList")
@@ -84,3 +85,11 @@ fun newSystemMessageEntity(
     selfDeletionEndDate = null,
     readCount = 0
 )
+
+fun newDraftMessageEntity(
+    conversationId: QualifiedIDEntity = QualifiedIDEntity("convId", "convDomain"),
+    text: String = "draft text",
+    editMessageId: String? = null,
+    quotedMessageId: String? = null,
+    selectedMentionList: List<MessageEntity.Mention> = emptyList()
+) = MessageDraftEntity(conversationId, text, editMessageId, quotedMessageId, selectedMentionList)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9433" title="WPB-9433" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-9433</a>  [Android] Implement Pagination for Conversation Screen Data Retrieval
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

In order to make conversation lists paginated, new queries and sql views are needed.
In this PR, getting `ConversationDetails` and unread events with last message or draft is moved to the sql view with all required tables joined, so that it can be paginated. New queries are created to be able to fetch paginated results on different screens - currently we have two different types: 
- on home we show list of all conversations with connections and different interaction types, where new activities are on top (calls, unread messages, etc.)
- on import media screen, without connections and conversations with non-enabled interactions (deleted user, blocked, etc.)
and to handle both, two additional parameters are added to queries and functions.
Also, two other sql views are created which are just queries that we were already using, to make it reusable (`LastMessagePreview` to return only preview of last message for the conversation and `UnreadEventCountsGrouped` to count different unread events).

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
