### PR TITLE
fix: event delay handling [WPB-11490]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt
@@ -22,27 +22,24 @@ import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider
-import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapStorageRequest
-import com.wire.kalium.network.api.base.authenticated.notification.NotificationApi
 import com.wire.kalium.network.api.authenticated.notification.NotificationResponse
+import com.wire.kalium.network.api.base.authenticated.notification.NotificationApi
 import com.wire.kalium.network.api.base.authenticated.notification.WebSocketEvent
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.isSuccessful
 import com.wire.kalium.persistence.dao.MetadataDAO
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.flattenConcat
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.isActive
 import kotlinx.serialization.json.Json
 import kotlin.coroutines.coroutineContext
@@ -103,26 +100,31 @@ class EventDataSource(
         currentClientId().flatMap { clientId -> liveEventsFlow(clientId) }
 
     private suspend fun liveEventsFlow(clientId: ClientId): Either<NetworkFailure, Flow<WebSocketEvent<EventEnvelope>>> =
-        wrapApiRequest { notificationApi.listenToLiveEvents(clientId.value) }.map {
-            it.map { webSocketEvent ->
-                when (webSocketEvent) {
-                    is WebSocketEvent.Open -> {
-                        flowOf(WebSocketEvent.Open())
-                    }
+        wrapApiRequest { notificationApi.listenToLiveEvents(clientId.value) }.map { webSocketEventFlow ->
+            flow {
+                webSocketEventFlow.collect { webSocketEvent ->
+                    when (webSocketEvent) {
+                        is WebSocketEvent.Open -> {
+                            emit(WebSocketEvent.Open())
+                        }
 
-                    is WebSocketEvent.NonBinaryPayloadReceived -> {
-                        flowOf(WebSocketEvent.NonBinaryPayloadReceived<EventEnvelope>(webSocketEvent.payload))
-                    }
+                        is WebSocketEvent.NonBinaryPayloadReceived -> {
+                            emit(WebSocketEvent.NonBinaryPayloadReceived(webSocketEvent.payload))
+                        }
 
-                    is WebSocketEvent.Close -> {
-                        flowOf(WebSocketEvent.Close(webSocketEvent.cause))
-                    }
+                        is WebSocketEvent.Close -> {
+                            emit(WebSocketEvent.Close(webSocketEvent.cause))
+                        }
 
-                    is WebSocketEvent.BinaryPayloadReceived -> {
-                        eventMapper.fromDTO(webSocketEvent.payload, true).asFlow().map { WebSocketEvent.BinaryPayloadReceived(it) }
+                        is WebSocketEvent.BinaryPayloadReceived -> {
+                            val events = eventMapper.fromDTO(webSocketEvent.payload, true)
+                            events.forEach { eventEnvelope ->
+                                emit(WebSocketEvent.BinaryPayloadReceived(eventEnvelope))
+                            }
+                        }
                     }
                 }
-            }.flattenConcat()
+            }
         }
 
     private suspend fun pendingEventsFlow(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -67,6 +67,8 @@ import com.wire.kalium.logic.feature.message.composite.SendButtonActionMessageUs
 import com.wire.kalium.logic.feature.message.composite.SendButtonMessageUseCase
 import com.wire.kalium.logic.feature.message.confirmation.ConfirmationDeliveryHandler
 import com.wire.kalium.logic.feature.message.confirmation.ConfirmationDeliveryHandlerImpl
+import com.wire.kalium.logic.feature.message.confirmation.SendDeliverSignalUseCase
+import com.wire.kalium.logic.feature.message.confirmation.SendDeliverSignalUseCaseImpl
 import com.wire.kalium.logic.feature.message.draft.GetMessageDraftUseCase
 import com.wire.kalium.logic.feature.message.draft.GetMessageDraftUseCaseImpl
 import com.wire.kalium.logic.feature.message.draft.RemoveMessageDraftUseCase
@@ -177,12 +179,17 @@ class MessageScope internal constructor(
             kaliumLogger = kaliumLogger
         )
 
+    private val sendDeliverSignalUseCase: SendDeliverSignalUseCase = SendDeliverSignalUseCaseImpl(
+        selfUserId = selfUserId,
+        messageSender = messageSender,
+        currentClientIdProvider = currentClientIdProvider,
+        kaliumLogger = kaliumLogger
+    )
+
     internal val confirmationDeliveryHandler: ConfirmationDeliveryHandler = ConfirmationDeliveryHandlerImpl(
         syncManager = syncManager,
-        selfUserId = selfUserId,
-        currentClientIdProvider = currentClientIdProvider,
         conversationRepository = conversationRepository,
-        messageSender = messageSender,
+        sendDeliverSignalUseCase = sendDeliverSignalUseCase,
         kaliumLogger = kaliumLogger,
     )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/confirmation/ConfirmationDeliveryHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/confirmation/ConfirmationDeliveryHandler.kt
@@ -17,22 +17,16 @@
  */
 package com.wire.kalium.logic.feature.message.confirmation
 
-import com.benasher44.uuid.uuid4
+import co.touchlab.stately.collections.ConcurrentMutableMap
 import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.id.MessageId
-import com.wire.kalium.logic.data.message.Message
-import com.wire.kalium.logic.data.message.MessageContent
-import com.wire.kalium.logic.data.message.receipt.ReceiptType
-import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.functional.flatMap
-import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.functional.right
 import com.wire.kalium.logic.logStructuredJson
 import com.wire.kalium.logic.sync.SyncManager
@@ -42,9 +36,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
-import kotlinx.datetime.Clock
 
 /**
  * Internal: Handles the send of delivery confirmation of messages.
@@ -54,23 +45,20 @@ internal interface ConfirmationDeliveryHandler {
     suspend fun sendPendingConfirmations()
 }
 
-@Suppress("LongParameterList")
 internal class ConfirmationDeliveryHandlerImpl(
     private val syncManager: SyncManager,
-    private val selfUserId: UserId,
-    private val currentClientIdProvider: CurrentClientIdProvider,
     private val conversationRepository: ConversationRepository,
-    private val messageSender: MessageSender,
-    private val pendingConfirmationMessages: MutableMap<ConversationId, MutableSet<String>> = mutableMapOf(),
-    kaliumLogger: KaliumLogger,
+    private val sendDeliverSignalUseCase: SendDeliverSignalUseCase,
+    private val pendingConfirmationMessages: ConcurrentMutableMap<ConversationId, MutableSet<String>> =
+        ConcurrentMutableMap(),
+    kaliumLogger: KaliumLogger
 ) : ConfirmationDeliveryHandler {
 
     private val kaliumLogger = kaliumLogger.withTextTag("ConfirmationDeliveryHandler")
     private val holder = MutableSharedFlow<Unit>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
-    private val mutex = Mutex()
 
-    override suspend fun enqueueConfirmationDelivery(conversationId: ConversationId, messageId: String) = mutex.withLock {
-        val conversationMessages = pendingConfirmationMessages[conversationId] ?: mutableSetOf()
+    override suspend fun enqueueConfirmationDelivery(conversationId: ConversationId, messageId: String) {
+        val conversationMessages = pendingConfirmationMessages.computeIfAbsent(conversationId) { mutableSetOf() }
         val isNewMessage = conversationMessages.add(messageId)
         if (isNewMessage) {
             kaliumLogger.logStructuredJson(
@@ -82,7 +70,6 @@ internal class ConfirmationDeliveryHandlerImpl(
                     "queueCount" to pendingConfirmationMessages.size
                 )
             )
-            pendingConfirmationMessages[conversationId] = conversationMessages
             holder.emit(Unit)
         }
     }
@@ -91,71 +78,40 @@ internal class ConfirmationDeliveryHandlerImpl(
     override suspend fun sendPendingConfirmations() {
         holder.debounce(DEBOUNCE_SEND_CONFIRMATION_TIME).collectLatest {
             syncManager.waitUntilLive()
-            mutex.withLock {
-                kaliumLogger.d("Started collecting pending messages for delivery confirmation")
-                with(pendingConfirmationMessages.iterator()) {
-                    forEach { (conversationId, messages) ->
-                        conversationRepository.observeConversationById(conversationId).first().flatMap { conversation ->
-                            if (conversation.type == Conversation.Type.ONE_ON_ONE) {
-                                sendDeliveredSignal(
-                                    conversation = conversation,
-                                    messages = messages.toList()
-                                )
-                            } else {
-                                kaliumLogger.logStructuredJson(
-                                    level = KaliumLogLevel.DEBUG,
-                                    leadingMessage = "Skipping group conversation: ${conversation?.id?.toLogString()}",
-                                    jsonStringKeyValues = mapOf(
-                                        "conversationId" to conversation?.id?.toLogString(),
-                                        "messages" to messages.joinToString { it.obfuscateId() },
-                                        "messageCount" to messages.size
-                                    )
-                                )
+            kaliumLogger.d("Started collecting pending messages for delivery confirmation")
+            val messagesToSend = pendingConfirmationMessages.block { it.toMap() }
+            messagesToSend.forEach { (conversationId, messages) ->
+                conversationRepository.observeConversationById(conversationId).first().flatMap { conversation ->
+                    if (conversation.type == Conversation.Type.ONE_ON_ONE) {
+                        sendDeliverSignalUseCase(
+                            conversation = conversation,
+                            messages = messages.toList()
+                        ).onSuccess {
+                            pendingConfirmationMessages.block {
+                                val currentMessages = it[conversationId]
+                                if (currentMessages != null) {
+                                    currentMessages.removeAll(messages.toSet())
+                                    if (currentMessages.isEmpty()) {
+                                        it.remove(conversationId)
+                                    }
+                                }
                             }
-                            remove() // safely clean the entry [conversationId to messages]
-                            Unit.right()
                         }
+                    } else {
+                        kaliumLogger.logStructuredJson(
+                            level = KaliumLogLevel.DEBUG,
+                            leadingMessage = "Skipping group conversation: ${conversation.id.toLogString()}",
+                            jsonStringKeyValues = mapOf(
+                                "conversationId" to conversation.id.toLogString(),
+                                "messages" to messages.joinToString { it.obfuscateId() },
+                                "messageCount" to messages.size
+                            )
+                        )
                     }
+                    Unit.right()
                 }
             }
-        }
-    }
-
-    private suspend fun sendDeliveredSignal(conversation: Conversation, messages: List<MessageId>) {
-        currentClientIdProvider().flatMap { currentClientId ->
-            val message = Message.Signaling(
-                id = uuid4().toString(),
-                content = MessageContent.Receipt(ReceiptType.DELIVERED, messages),
-                conversationId = conversation.id,
-                date = Clock.System.now(),
-                senderUserId = selfUserId,
-                senderClientId = currentClientId,
-                status = Message.Status.Pending,
-                isSelfMessage = true,
-                expirationData = null
-            )
-            messageSender.sendMessage(message).fold({ error ->
-                kaliumLogger.logStructuredJson(
-                    level = KaliumLogLevel.ERROR,
-                    leadingMessage = "Error while sending delivery confirmation for ${conversation.id.toLogString()}",
-                    jsonStringKeyValues = mapOf(
-                        "conversationId" to conversation.id.toLogString(),
-                        "messages" to messages.joinToString { it.obfuscateId() },
-                        "error" to error.toString()
-                    )
-                )
-            }, {
-                kaliumLogger.logStructuredJson(
-                    level = KaliumLogLevel.DEBUG,
-                    leadingMessage = "Delivery confirmation sent for ${conversation.id.toLogString()} and message count: ${messages.size}",
-                    jsonStringKeyValues = mapOf(
-                        "conversationId" to conversation.id.toLogString(),
-                        "messages" to messages.joinToString { it.obfuscateId() },
-                        "messageCount" to messages.size
-                    )
-                )
-            })
-            Unit.right()
+            kaliumLogger.d("Finished collecting pending messages for delivery confirmation")
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/confirmation/SendDeliverSignalUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/confirmation/SendDeliverSignalUseCase.kt
@@ -1,0 +1,94 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.message.confirmation
+
+import com.benasher44.uuid.uuid4
+import com.wire.kalium.logger.KaliumLogLevel
+import com.wire.kalium.logger.KaliumLogger
+import com.wire.kalium.logger.obfuscateId
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.id.CurrentClientIdProvider
+import com.wire.kalium.logic.data.id.MessageId
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.message.receipt.ReceiptType
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.message.MessageSender
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.onFailure
+import com.wire.kalium.logic.functional.onSuccess
+import com.wire.kalium.logic.logStructuredJson
+import kotlinx.datetime.Clock
+
+/**
+ * Use case for sending a delivery confirmation signal for a list of messages in a conversation.
+ */
+interface SendDeliverSignalUseCase {
+    suspend operator fun invoke(conversation: Conversation, messages: List<MessageId>): Either<CoreFailure, Unit>
+}
+
+internal class SendDeliverSignalUseCaseImpl(
+    private val selfUserId: UserId,
+    private val messageSender: MessageSender,
+    private val currentClientIdProvider: CurrentClientIdProvider,
+    private val kaliumLogger: KaliumLogger
+) : SendDeliverSignalUseCase {
+    override suspend fun invoke(
+        conversation: Conversation,
+        messages: List<MessageId>
+    ): Either<CoreFailure, Unit> = currentClientIdProvider()
+        .flatMap { currentClientId ->
+            val message = Message.Signaling(
+                id = uuid4().toString(),
+                content = MessageContent.Receipt(ReceiptType.DELIVERED, messages),
+                conversationId = conversation.id,
+                date = Clock.System.now(),
+                senderUserId = selfUserId,
+                senderClientId = currentClientId,
+                status = Message.Status.Pending,
+                isSelfMessage = true,
+                expirationData = null
+            )
+            messageSender.sendMessage(message)
+                .onFailure { error ->
+                    kaliumLogger.logStructuredJson(
+                        level = KaliumLogLevel.ERROR,
+                        leadingMessage = "Error while sending delivery confirmation for ${conversation.id.toLogString()}",
+                        jsonStringKeyValues = mapOf(
+                            "conversationId" to conversation.id.toLogString(),
+                            "messages" to messages.joinToString { it.obfuscateId() },
+                            "error" to error.toString()
+                        )
+                    )
+                }
+                .onSuccess {
+                    kaliumLogger.logStructuredJson(
+                        level = KaliumLogLevel.DEBUG,
+                        leadingMessage = "Delivery confirmation sent for ${conversation.id.toLogString()}" +
+                                " and message count: ${messages.size}",
+                        jsonStringKeyValues = mapOf(
+                            "conversationId" to conversation.id.toLogString(),
+                            "messages" to messages.joinToString { it.obfuscateId() },
+                            "messageCount" to messages.size
+                        )
+                    )
+                }
+        }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/confirmation/SendDeliverSignalUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/confirmation/SendDeliverSignalUseCaseTest.kt
@@ -1,0 +1,120 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.message.confirmation
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.id.CurrentClientIdProvider
+import com.wire.kalium.logic.feature.message.MessageSender
+import com.wire.kalium.logic.framework.TestClient
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestMessage
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.right
+import com.wire.kalium.logic.kaliumLogger
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.coEvery
+import io.mockative.coVerify
+import io.mockative.mock
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class SendDeliverSignalUseCaseTest {
+
+    @Test
+    fun givenValidClientIdAndMessage_whenInvoking_thenShouldSendMessageSuccessfully() = runTest {
+        val (arrangement, usecase) = Arrangement()
+            .withCurrentClientIdProvider()
+            .withMessageSenderResult()
+            .arrange()
+
+        val conversation = TestConversation.CONVERSATION
+        val messageIdList = listOf(TestMessage.TEST_MESSAGE_ID)
+
+        val result = usecase.invoke(conversation, messageIdList)
+
+        assertTrue(result is Either.Right)
+        coVerify { arrangement.messageSender.sendMessage(any(), any()) }.wasInvoked()
+    }
+
+    @Test
+    fun givenMessageSendingFailure_whenInvoking_thenShouldLogError() = runTest {
+        val (arrangement, usecase) = Arrangement()
+            .withCurrentClientIdProvider()
+            .withMessageSenderResult(Either.Left(CoreFailure.Unknown(RuntimeException("Sending failed"))))
+            .arrange()
+
+        val conversation = TestConversation.CONVERSATION
+        val messageIdList = listOf(TestMessage.TEST_MESSAGE_ID)
+
+        val result = usecase.invoke(conversation, messageIdList)
+
+        assertTrue(result is Either.Left)
+        coVerify { arrangement.messageSender.sendMessage(any(), any()) }.wasInvoked()
+    }
+
+    @Test
+    fun givenClientIdProviderFailure_whenInvoking_thenShouldReturnFailure() = runTest {
+        val (arrangement, usecase) = Arrangement()
+            .withCurrentClientIdProviderError()
+            .arrange()
+
+        val conversation = TestConversation.CONVERSATION
+        val messageIdList = listOf(TestMessage.TEST_MESSAGE_ID)
+
+        val result = usecase.invoke(conversation, messageIdList)
+
+        assertTrue(result is Either.Left)
+        coVerify { arrangement.messageSender.sendMessage(any(), any()) }.wasNotInvoked()
+    }
+
+    private class Arrangement {
+
+        @Mock
+        private val currentClientIdProvider = mock(CurrentClientIdProvider::class)
+
+        @Mock
+        val messageSender = mock(MessageSender::class)
+
+        suspend fun withCurrentClientIdProvider() = apply {
+            coEvery { currentClientIdProvider.invoke() }.returns(Either.Right(TestClient.CLIENT_ID))
+        }
+
+        suspend fun withCurrentClientIdProviderError() = apply {
+            coEvery { currentClientIdProvider.invoke() }.returns(
+                Either.Left(
+                    CoreFailure.Unknown(
+                        RuntimeException("Client ID not available")
+                    )
+                )
+            )
+        }
+
+        suspend fun withMessageSenderResult(result: Either<CoreFailure, Unit> = Unit.right()) = apply {
+            coEvery { messageSender.sendMessage(any(), any()) }.returns(result)
+        }
+
+        fun arrange() = this to SendDeliverSignalUseCaseImpl(
+            selfUserId = TestClient.USER_ID,
+            currentClientIdProvider = currentClientIdProvider,
+            messageSender = messageSender,
+            kaliumLogger = kaliumLogger,
+        )
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11490" title="WPB-11490" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11490</a>  Text messages are stuck in handling when there is unstable internet connection
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The use of Mutex in `ConfirmationDeliveryHandlerImpl` led to blocking and concurrency issues when handling message confirmations. This caused message processing to potentially get stuck, especially during high-load scenarios where multiple messages were queued for delivery.

### Causes (Optional)

- The `Mutex` was synchronizing access to the shared map (pendingConfirmationMessages), which led to contention and potential deadlocks, especially when the sendPendingConfirmations coroutine tried to acquire the lock while other coroutines were working with the same messages.
- The original flow of event processing and handling relied on multiple nested flows, which was less efficient and harder to maintain.

### Solutions

- Removed the `Mutex` and replaced the shared map with `ConcurrentMutableMap` to handle concurrent operations in a non-blocking way.
- Extracted the message sending logic into a new use case, SendDeliverSignalUseCase, to improve modularity and separate the concerns of message queue management and sending.
- Refactored the event flow processing (EventRepository) to simplify event handling by using a single flow with collect and emit.
- Improved message removal after sending to ensure that only successfully sent messages are removed from the pending queue.

Added and updated unit tests to verify:
- Proper message removal after sending.
- Separation of message queue management and message delivery logic.
- Handling of concurrency issues using ConcurrentMutableMap.
