### PR TITLE
feat: network observer cover from not connected and blocked to connected (WPB-11200)

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/network/NetworkStateObserverImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/network/NetworkStateObserverImpl.kt
@@ -110,8 +110,16 @@ internal actual class NetworkStateObserverImpl(
             override fun onBlockedStatusChanged(network: Network, blocked: Boolean) {
                 kaliumLogger.i("${NetworkStateObserver.TAG} block connection changed to $blocked")
                 defaultNetworkDataStateFlow.update {
-                    if (it is DefaultNetworkData.Connected) it.copy(isBlocked = blocked)
-                    else it
+                    when (it) {
+                        is DefaultNetworkData.Connected -> {
+                            it.copy(isBlocked = blocked)
+                        }
+
+                        is DefaultNetworkData.NotConnected -> {
+                            if (blocked) it
+                            else DefaultNetworkData.Connected(network)
+                        }
+                    }
                 }
                 super.onBlockedStatusChanged(network, blocked)
             }

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/network/NetworkStateObserverImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/network/NetworkStateObserverImpl.kt
@@ -110,6 +110,8 @@ internal actual class NetworkStateObserverImpl(
             override fun onBlockedStatusChanged(network: Network, blocked: Boolean) {
                 kaliumLogger.i("${NetworkStateObserver.TAG} block connection changed to $blocked")
                 defaultNetworkDataStateFlow.update {
+                    kaliumLogger.withTextTag(NetworkStateObserver.TAG)
+                        .d("block connection changed to $blocked current state is $it")
                     when (it) {
                         is DefaultNetworkData.Connected -> {
                             it.copy(isBlocked = blocked)

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/network/NetworkStateObserverImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/network/NetworkStateObserverImpl.kt
@@ -29,9 +29,11 @@ import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -70,6 +72,7 @@ internal actual class NetworkStateObserverImpl(
                     else networkData.networkCapabilities.toState()
                 } else NetworkState.NotConnected
             }
+            .buffer(capacity = 0)
             .stateIn(scope, SharingStarted.Eagerly, initialState)
 
         val callback = object : ConnectivityManager.NetworkCallback() {

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/network/NetworkStateObserverImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/network/NetworkStateObserverImpl.kt
@@ -110,8 +110,7 @@ internal actual class NetworkStateObserverImpl(
             override fun onBlockedStatusChanged(network: Network, blocked: Boolean) {
                 kaliumLogger.i("${NetworkStateObserver.TAG} block connection changed to $blocked")
                 defaultNetworkDataStateFlow.update {
-                    kaliumLogger.withTextTag(NetworkStateObserver.TAG)
-                        .d("block connection changed to $blocked current state is $it")
+                    kaliumLogger.d("${NetworkStateObserver.TAG} block connection changed to $blocked current state is $it")
                     when (it) {
                         is DefaultNetworkData.Connected -> {
                             it.copy(isBlocked = blocked)

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/network/NetworkStateObserverImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/network/NetworkStateObserverImpl.kt
@@ -29,7 +29,6 @@ import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow

--- a/logic/src/androidUnitTest/kotlin/com/wire/kalium/logic/network/NetworkStateObserverImplTest.kt
+++ b/logic/src/androidUnitTest/kotlin/com/wire/kalium/logic/network/NetworkStateObserverImplTest.kt
@@ -230,6 +230,21 @@ class NetworkStateObserverImplTest {
         }
 
     @Test
+    fun givenNetworkNotConnectedAndButBlocked_whenItChangesToNotBlocked_thenStateChangesToConnectedWithInternet() =
+        runTest(dispatcher.default) {
+            // given
+            val (arrangement, networkStateObserverImpl) = Arrangement()
+                .arrange()
+            // when-then
+            networkStateObserverImpl.observeNetworkState().test {
+                assertEquals(NetworkState.NotConnected, awaitItem())
+                arrangement.connectNetwork(networkType = NetworkType.MOBILE, setAsDefault = true, withInternetValidated = true)
+                arrangement.changeNetworkBlocked(networkType = NetworkType.MOBILE, false)
+                assertEquals(NetworkState.ConnectedWithInternet, awaitItem())
+            }
+        }
+
+    @Test
     fun givenOneNetworkConnectedWithoutInternetValidated_whenItChangesToBlocked_thenStateDoesNotChange() = runTest(dispatcher.default) {
         // given
         val (arrangement, networkStateObserverImpl) = Arrangement()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11200" title="WPB-11200" target="_blank"><img alt="Spike" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10820?size=medium" />WPB-11200</a>  [Android] investigate the posintial of connectivity observer blocking sync
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There is one case that seems to be not covered by the network state observer being:

`Not connected -> to Unblocked = Connected`

### Causes (Optional)

Potentially hanging the state until a new connected state is triggered.

### Solutions

Covering all grounds by adding this case and some logs to help debugging in datadog


### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

### Notes (Optional)

For now I'm testing this in an local build, to gather logs and monitor improvements

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
