### PR TITLE
fix: secure message draft saving [WPB-11325]

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -488,6 +488,9 @@ UPDATE Message
 SET id = :newId
 WHERE id = :oldId AND conversation_id = :conversationId;
 
+getMessage:
+SELECT * FROM Message WHERE id = ? AND conversation_id = ?;
+
 selectById:
 SELECT * FROM MessageDetailsView WHERE id = ? AND conversationId = ?;
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/draft/MessageDraftDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/draft/MessageDraftDAOImpl.kt
@@ -18,7 +18,9 @@
 package com.wire.kalium.persistence.dao.message.draft
 
 import app.cash.sqldelight.coroutines.asFlow
+import com.wire.kalium.persistence.ConversationsQueries
 import com.wire.kalium.persistence.MessageDraftsQueries
+import com.wire.kalium.persistence.MessagesQueries
 import com.wire.kalium.persistence.dao.ConversationIDEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.message.MessageEntity
@@ -30,11 +32,36 @@ import kotlin.coroutines.CoroutineContext
 
 class MessageDraftDAOImpl internal constructor(
     private val queries: MessageDraftsQueries,
+    private val messagesQueries: MessagesQueries,
+    private val conversationsQueries: ConversationsQueries,
     private val coroutineContext: CoroutineContext,
 ) : MessageDraftDAO {
 
     override suspend fun upsertMessageDraft(messageDraft: MessageDraftEntity) =
         withContext(coroutineContext) {
+            val conversationExists = conversationsQueries.selectConversationByQualifiedId(messageDraft.conversationId)
+                .executeAsOneOrNull() != null
+
+            if (!conversationExists) {
+                return@withContext
+            }
+
+            if (messageDraft.editMessageId != null) {
+                val messageExists = messagesQueries.getMessage(messageDraft.editMessageId, messageDraft.conversationId)
+                    .executeAsOneOrNull() != null
+                if (!messageExists) {
+                    return@withContext
+                }
+            }
+
+            if (messageDraft.quotedMessageId != null) {
+                val quotedMessageExists = messagesQueries.getMessage(messageDraft.quotedMessageId, messageDraft.conversationId)
+                    .executeAsOneOrNull() != null
+                if (!quotedMessageExists) {
+                    return@withContext
+                }
+            }
+
             queries.upsertDraft(
                 conversation_id = messageDraft.conversationId,
                 text = messageDraft.text,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
@@ -256,6 +256,8 @@ class UserDatabaseBuilder internal constructor(
 
     val messageDraftDAO = MessageDraftDAOImpl(
         database.messageDraftsQueries,
+        database.messagesQueries,
+        database.conversationsQueries,
         queriesContext
     )
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/draft/MessageDraftDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/draft/MessageDraftDAOTest.kt
@@ -113,6 +113,48 @@ class MessageDraftDAOTest : BaseDatabaseTest() {
         assertEquals(null, removedResult)
     }
 
+    @Test
+    fun givenMessageIsRemoved_whenUpsertingDraft_thenItShouldIgnore() = runTest {
+        // Given
+        insertInitialData()
+        messageDAO.deleteMessage("editMessageId", conversationEntity1.id)
+
+        // When
+        messageDraftDAO.upsertMessageDraft(MESSAGE_DRAFT)
+
+        // Then
+        val result = messageDraftDAO.getMessageDraft(MESSAGE_DRAFT.conversationId)
+        assertEquals(null, result)
+    }
+
+    @Test
+    fun givenConversationIsRemoved_whenUpsertingDraft_thenItShouldIgnore() = runTest {
+        // Given
+        insertInitialData()
+        conversationDAO.deleteConversationByQualifiedID(conversationEntity1.id)
+
+        // When
+        messageDraftDAO.upsertMessageDraft(MESSAGE_DRAFT)
+
+        // Then
+        val result = messageDraftDAO.getMessageDraft(MESSAGE_DRAFT.conversationId)
+        assertEquals(null, result)
+    }
+
+    @Test
+    fun givenQuotedMessageIsRemoved_whenUpsertingDraft_thenItShouldIgnore() = runTest {
+        // Given
+        insertInitialData()
+        messageDAO.deleteMessage("quotedMessageId", conversationEntity1.id)
+
+        // When
+        messageDraftDAO.upsertMessageDraft(MESSAGE_DRAFT)
+
+        // Then
+        val result = messageDraftDAO.getMessageDraft(MESSAGE_DRAFT.conversationId)
+        assertEquals(null, result)
+    }
+
     private suspend fun insertInitialData() {
         userDAO.upsertUsers(listOf(userEntity1))
         conversationDAO.insertConversation(conversationEntity1)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11325" title="WPB-11325" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11325</a>  [Android] Can not open conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There were situations when saving message draft cause error in db `android.database.sqlite.SQLiteConstraintException: FOREIGN KEY constraint failed (code 787)` 

### Causes (Optional)

Not working conversations when there was some saved draft

### Solutions

Secure draft saving with checks needed to save a draft

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

1. Start typing message in conversation with some reply or editting message
2. Remove on web message only for you which you are editing or replying to
3. continue typing on android
4. there should not be any issues with db on logs
