### PR TITLE
fix: Asset message resend transfer status #WPB-11035

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/RetryFailedMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/RetryFailedMessageUseCase.kt
@@ -178,7 +178,10 @@ class RetryFailedMessageUseCase internal constructor(
 
             else -> handleError("Asset message with transfer status $assetTransferStatus cannot be retried")
         }
-            .onSuccess { retrySendingMessage(it) }
+            .onSuccess {
+                updateAssetMessageTransferStatus(AssetTransferStatus.UPLOADED, message.conversationId, message.id)
+                retrySendingMessage(it)
+            }
             .map { /* returns Unit */ }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/RetryFailedMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/RetryFailedMessageUseCase.kt
@@ -160,6 +160,7 @@ class RetryFailedMessageUseCase internal constructor(
                                 .map { updatedMessage } // we need to persist new asset remoteData and status
                         }
                     }
+                    .onSuccess { updateAssetMessageTransferStatus(AssetTransferStatus.UPLOADED, message.conversationId, message.id) }
                     .onFailure {
                         kaliumLogger.e("Failed to retry sending asset message. Failure = $it")
                         updateAssetMessageTransferStatus(AssetTransferStatus.FAILED_UPLOAD, message.conversationId, message.id)
@@ -178,10 +179,7 @@ class RetryFailedMessageUseCase internal constructor(
 
             else -> handleError("Asset message with transfer status $assetTransferStatus cannot be retried")
         }
-            .onSuccess {
-                updateAssetMessageTransferStatus(AssetTransferStatus.UPLOADED, message.conversationId, message.id)
-                retrySendingMessage(it)
-            }
+            .onSuccess { retrySendingMessage(it) }
             .map { /* returns Unit */ }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11035" title="WPB-11035" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11035</a>  [Android] No error displayed when sending imaged or gifs without internet being availble
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

https://wearezeta.atlassian.net/browse/WPB-11035

# What's new in this PR?

### Issues

When we resended asset message, we're not updating its status to uploaded hence the message was stuck with `Uploading` indicator forever

### Solutions

Change the status to Uploaded before trying to again send the message

### Testing

#### How to Test

- Send any asset message while not having connection, turn on connection again, tap resend, message arrive on the second end and should not be in `Uploading` state

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
