### PR TITLE
fix: return all incoming calls [WPB-10430]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetIncomingCallsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetIncomingCallsUseCase.kt
@@ -82,9 +82,7 @@ internal class GetIncomingCallsUseCaseImpl internal constructor(
                         val callIds = calls.map { call -> call.conversationId }.joinToString()
                         logger.d("$TAG; Found calls: $callIds")
                     }
-                    .distinctUntilChanged { old, new ->
-                        old.firstOrNull()?.conversationId == new.firstOrNull()?.conversationId
-                    }
+                    .distinctUntilChanged()
             }
 
     private fun Flow<List<Call>>.onlyCallsInNotMutedConversations(): Flow<List<Call>> =


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10430" title="WPB-10430" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10430</a>  [Android] When 2 Incoming call notifications at the same time, the app only displays one
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The use case to return incoming calls was not emitting updated list of incoming calls when another incoming call appeared.

### Causes

Use case had a `distinctUntilChanged` which was comparing first element on the list and it was not emitting new list if the first element hasn't changed.

### Solutions

Make the use case propagate incoming call list changes when more calls appear.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
