### PR TITLE
fix: black screen when last caller in a group #WPB-10652

### DIFF
--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedId.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedId.kt
@@ -33,7 +33,8 @@ data class QualifiedID(
     @SerialName("domain")
     val domain: String
 ) {
-    override fun toString(): String = if (domain.isEmpty()) value else "$value$VALUE_DOMAIN_SEPARATOR$domain"
+    override fun toString(): String =
+        if (domain.isEmpty()) value else "$value$VALUE_DOMAIN_SEPARATOR$domain"
 
     fun toLogString(): String = if (domain.isEmpty()) {
         value.obfuscateId()
@@ -48,7 +49,7 @@ data class QualifiedID(
      * To be used when when of the instance do not have domain due to the API limitations.
      */
     fun equalsIgnoringBlankDomain(other: QualifiedID): Boolean {
-        if(domain.isBlank() || other.domain.isBlank()) {
+        if (domain.isBlank() || other.domain.isBlank()) {
             return value == other.value
         }
         return this == other

--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedId.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedId.kt
@@ -43,6 +43,16 @@ data class QualifiedID(
 
     fun toPlainID(): PlainId = PlainId(value)
 
+    /**
+     * This checks if the domain in either instances is blank. If it is, it will compare only the value.
+     * To be used when when of the instance do not have domain due to the API limitations.
+     */
+    fun equalsIgnoringBlankDomain(other: QualifiedID): Boolean {
+        if(domain.isBlank() || other.domain.isBlank()) {
+            return value == other.value
+        }
+        return this == other
+    }
 }
 
 const val VALUE_DOMAIN_SEPARATOR = '@'

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/id/QualifiedIdTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/id/QualifiedIdTest.kt
@@ -1,0 +1,72 @@
+import com.wire.kalium.logic.data.id.QualifiedID
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+
+class QualifiedIdTest {
+    @Test
+    fun givenIdsWithoutDomains_whenEqualsIgnoringBlankDomain_thenReturnsTrue() {
+        // Given
+        val qualifiedId1 = QualifiedID("id1", "")
+        val qualifiedId2 = QualifiedID("id1", "")
+
+        // When
+        val result = qualifiedId1.equalsIgnoringBlankDomain(qualifiedId2)
+
+        // Then
+        assertTrue(result)
+    }
+
+    @Test
+    fun givenOneIdWithoutDomain_whenEqualsIgnoringBlankDomain_thenReturnsTrue() {
+        // Given
+        val qualifiedId1 = QualifiedID("id1", "")
+        val qualifiedId2 = QualifiedID("id1", "domain")
+
+        // When
+        val result = qualifiedId1.equalsIgnoringBlankDomain(qualifiedId2)
+
+        // Then
+        assertTrue(result)
+    }
+
+    @Test
+    fun givenIdsWithSameDomains_whenEqualsIgnoringBlankDomain_thenReturnsTrue() {
+        // Given
+        val qualifiedId1 = QualifiedID("id1", "domain")
+        val qualifiedId2 = QualifiedID("id1", "domain")
+
+        // When
+        val result = qualifiedId1.equalsIgnoringBlankDomain(qualifiedId2)
+
+        // Then
+        assertTrue(result)
+    }
+
+    @Test
+    fun givenIdsWithDifferentDomains_whenEqualsIgnoringBlankDomain_thenReturnsFalse() {
+        // Given
+        val qualifiedId1 = QualifiedID("id1", "domain1")
+        val qualifiedId2 = QualifiedID("id1", "domain2")
+
+        // When
+        val result = qualifiedId1.equalsIgnoringBlankDomain(qualifiedId2)
+
+        // Then
+        assertTrue(!result)
+    }
+
+    @Test
+    fun givenIdsWithDifferentValues_whenEqualsIgnoringBlankDomain_thenReturnsFalse() {
+        // Given
+        val qualifiedId1 = QualifiedID("id1", "")
+        val qualifiedId2 = QualifiedID("id2", "")
+
+        // When
+        val result = qualifiedId1.equalsIgnoringBlankDomain(qualifiedId2)
+
+        // Then
+        assertFalse(result)
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10652" title="WPB-10652" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-10652</a>  [Android] calling PiP mode
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

Couldn't reproduce the original issue but was able to reproduce black screen in following scenario:
- call to a group from account A
- join to call with account B
- enable video on account A
- leave the call with account B
- user A was left with a black screen instead of their own camera preview

### Causes (Optional)

There was assumption that on list of participants first account is user currently logged it. Based on that `first()` was called. This was no longer true with picture in picture enabled as self participant was then removed.

### Solutions

Used currently logged in UserId and compared it to a participant to decide if given call tile is selfUser. 

### Testing

#### How to Test

- call to a group from account A
- join to call with account B
- enable video on account A
- leave the call with account B
- user A should see own preview video

### Attachments (Optional)
Before: 

https://github.com/user-attachments/assets/b3970943-b37a-43a1-951e-f387b9d549c1 

After:

https://github.com/user-attachments/assets/cff0179b-e4d7-4b67-98a9-641dd94bb339

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
