### PR TITLE
feat: Initialize mls only according to backend feature flag #WPB-10117

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1051,6 +1051,8 @@ class UserSessionScope internal constructor(
             userConfigRepository,
             featureSupport,
             clientIdProvider,
+            mlsClientProvider,
+            mlsPublicKeysRepository,
             userScopedLogger
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateSelfUserSupportedProtocolsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateSelfUserSupportedProtocolsUseCase.kt
@@ -63,7 +63,7 @@ internal class UpdateSelfUserSupportedProtocolsUseCaseImpl(
 
     override suspend operator fun invoke(): Either<CoreFailure, Boolean> {
         val mlsKey = mlsClientProvider.getMLSClient().flatMap { mlsClient ->
-            val cipherSuite: CipherSuite = CipherSuite.fromTag(mlsClient.getDefaultCipherSuite())
+            val cipherSuite = CipherSuite.fromTag(mlsClient.getDefaultCipherSuite())
             mlsPublicKeysRepository.getKeyForCipherSuite(cipherSuite)
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10117" title="WPB-10117" target="_blank"><img alt="Epic" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10807?size=medium" />WPB-10117</a>  Clients should initialize MLS clients according to backend feature flag
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

https://wearezeta.atlassian.net/browse/WPB-10119

# What's new in this PR?

### Issues

All clients need to align on when they register an MLS client by only doing so when the following conditions are fulfilled:

- GET /mls/public-keys contains an entry with the key removal.
- The mls feature config is enabled (status = enabled)
- The configuration will indicate which cipher suite to use

### Solutions

- Add check for the key before doing update of protocols

### Testing

#### How to Test

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
