### PR TITLE
feat: Consider team settings when registering mls device #WPB-10119

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1979,7 +1979,11 @@ class UserSessionScope internal constructor(
 
     @OptIn(DelicateKaliumApi::class)
     private val isAllowedToRegisterMLSClient: IsAllowedToRegisterMLSClientUseCase
-        get() = IsAllowedToRegisterMLSClientUseCaseImpl(featureSupport, mlsPublicKeysRepository)
+        get() = IsAllowedToRegisterMLSClientUseCaseImpl(
+            featureSupport,
+            mlsPublicKeysRepository,
+            userConfigRepository
+        )
 
     private val syncFeatureConfigsUseCase: SyncFeatureConfigsUseCase
         get() = SyncFeatureConfigsUseCaseImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -591,7 +591,6 @@ class UserSessionScope internal constructor(
         kaliumLogger = userScopedLogger
     )
     private val featureSupport: FeatureSupport = FeatureSupportImpl(
-        kaliumConfigs,
         sessionManager.serverConfig().metaData.commonApiVersion.version
     )
 
@@ -1225,7 +1224,6 @@ class UserSessionScope internal constructor(
 
     private val pendingProposalScheduler: PendingProposalScheduler =
         PendingProposalSchedulerImpl(
-            kaliumConfigs,
             incrementalSyncRepository,
             lazy { mlsConversationRepository },
             lazy { subconversationRepository }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/IsAllowedToRegisterMLSClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/IsAllowedToRegisterMLSClientUseCase.kt
@@ -23,7 +23,6 @@ import com.wire.kalium.logic.data.mlspublickeys.MLSPublicKeysRepository
 import com.wire.kalium.logic.featureFlags.FeatureSupport
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.isRight
-import com.wire.kalium.logic.functional.right
 import com.wire.kalium.util.DelicateKaliumApi
 
 /**

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/IsAllowedToRegisterMLSClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/IsAllowedToRegisterMLSClientUseCase.kt
@@ -18,9 +18,12 @@
 
 package com.wire.kalium.logic.feature.client
 
+import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.mlspublickeys.MLSPublicKeysRepository
 import com.wire.kalium.logic.featureFlags.FeatureSupport
+import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.isRight
+import com.wire.kalium.logic.functional.right
 import com.wire.kalium.util.DelicateKaliumApi
 
 /**
@@ -39,8 +42,12 @@ interface IsAllowedToRegisterMLSClientUseCase {
 internal class IsAllowedToRegisterMLSClientUseCaseImpl(
     private val featureSupport: FeatureSupport,
     private val mlsPublicKeysRepository: MLSPublicKeysRepository,
+    private val userConfigRepository: UserConfigRepository
 ) : IsAllowedToRegisterMLSClientUseCase {
 
-    override suspend operator fun invoke(): Boolean =
-        featureSupport.isMLSSupported && mlsPublicKeysRepository.getKeys().isRight()
+    override suspend operator fun invoke(): Boolean {
+        return featureSupport.isMLSSupported &&
+                mlsPublicKeysRepository.getKeys().isRight() &&
+                userConfigRepository.isMLSEnabled().fold({ false }, { isEnabled -> isEnabled })
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PendingProposalScheduler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PendingProposalScheduler.kt
@@ -24,7 +24,6 @@ import com.wire.kalium.logic.data.conversation.SubconversationRepository
 import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
-import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.functional.distinct
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.kaliumLogger

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PendingProposalScheduler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PendingProposalScheduler.kt
@@ -63,7 +63,6 @@ interface PendingProposalScheduler {
 }
 
 internal class PendingProposalSchedulerImpl(
-    private val kaliumConfigs: KaliumConfigs,
     private val incrementalSyncRepository: IncrementalSyncRepository,
     private val mlsConversationRepository: Lazy<MLSConversationRepository>,
     private val subconversationRepository: Lazy<SubconversationRepository>,
@@ -82,7 +81,7 @@ internal class PendingProposalSchedulerImpl(
         commitPendingProposalsScope.launch() {
             incrementalSyncRepository.incrementalSyncState.collectLatest { syncState ->
                 ensureActive()
-                if (syncState == IncrementalSyncStatus.Live && kaliumConfigs.isMLSSupportEnabled) {
+                if (syncState == IncrementalSyncStatus.Live) {
                     startCommittingPendingProposals()
                 }
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/FeatureSupportImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/FeatureSupportImpl.kt
@@ -24,9 +24,8 @@ interface FeatureSupport {
 
 @Suppress("MagicNumber")
 class FeatureSupportImpl(
-    kaliumConfigs: KaliumConfigs,
     apiVersion: Int
 ) : FeatureSupport {
 
-    override val isMLSSupported: Boolean = kaliumConfigs.isMLSSupportEnabled && apiVersion >= 5
+    override val isMLSSupported: Boolean = apiVersion >= 5
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/FeatureSupportImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/FeatureSupportImpl.kt
@@ -27,5 +27,5 @@ class FeatureSupportImpl(
     apiVersion: Int
 ) : FeatureSupport {
 
-    override val isMLSSupported: Boolean = apiVersion >= 5
+    override val isMLSSupported: Boolean = apiVersion >= 6
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/KaliumConfigs.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/featureFlags/KaliumConfigs.kt
@@ -26,7 +26,6 @@ import kotlin.time.Duration.Companion.hours
 data class KaliumConfigs(
     val forceConstantBitrateCalls: Boolean = false,
     val fileRestrictionState: BuildFileRestrictionState = BuildFileRestrictionState.NoRestriction,
-    var isMLSSupportEnabled: Boolean = true,
     // Disabling db-encryption will crash on android-api level below 30
     val shouldEncryptData: Boolean = true,
     val encryptProteusStorage: Boolean = false,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/IsAllowedToRegisterMLSClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/IsAllowedToRegisterMLSClientUseCaseTest.kt
@@ -1,0 +1,172 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.client
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.data.mls.MLSPublicKeys
+import com.wire.kalium.logic.data.mlspublickeys.MLSPublicKeysRepository
+import com.wire.kalium.logic.featureFlags.FeatureSupport
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.coEvery
+import io.mockative.every
+import io.mockative.mock
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class IsAllowedToRegisterMLSClientUseCaseTest {
+
+    @Test
+    fun givenAllMlsConditionsAreMet_whenUseCaseInvoked_returnsTrue() = runTest {
+        // given
+        val (_, isAllowedToRegisterMLSClientUseCase) = Arrangement()
+            .withMlsFeatureFlag(true)
+            .withUserConfigMlsEnabled(true)
+            .withGetPublicKeysSuccessful()
+            .arrange()
+
+        // when
+        val result = isAllowedToRegisterMLSClientUseCase()
+
+        // then
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun givenMlsFeatureFlagDisabled_whenUseCaseInvoked_returnsFalse() = runTest {
+        // given
+        val (_, isAllowedToRegisterMLSClientUseCase) = Arrangement()
+            .withMlsFeatureFlag(false)
+            .withUserConfigMlsEnabled(true)
+            .withGetPublicKeysSuccessful()
+            .arrange()
+
+        // when
+        val result = isAllowedToRegisterMLSClientUseCase()
+
+        // then
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun givenUserConfigMlsDisabled_whenUseCaseInvoked_returnsFalse() = runTest {
+        // given
+        val (_, isAllowedToRegisterMLSClientUseCase) = Arrangement()
+            .withMlsFeatureFlag(true)
+            .withUserConfigMlsEnabled(false)
+            .withGetPublicKeysSuccessful()
+            .arrange()
+
+        // when
+        val result = isAllowedToRegisterMLSClientUseCase()
+
+        // then
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun givenPublicKeysFailure_whenUseCaseInvoked_returnsFalse() = runTest {
+        // given
+        val (_, isAllowedToRegisterMLSClientUseCase) = Arrangement()
+            .withMlsFeatureFlag(true)
+            .withUserConfigMlsEnabled(true)
+            .withGetPublicKeysFailed()
+            .arrange()
+
+        // when
+        val result = isAllowedToRegisterMLSClientUseCase()
+
+        // then
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun givenUserConfigDataNotFound_whenUseCaseInvoked_returnsFalse() = runTest {
+        // given
+        val (_, isAllowedToRegisterMLSClientUseCase) = Arrangement()
+            .withMlsFeatureFlag(true)
+            .withUserConfigDataNotFound()
+            .withGetPublicKeysFailed()
+            .arrange()
+
+        // when
+        val result = isAllowedToRegisterMLSClientUseCase()
+
+        // then
+        assertEquals(false, result)
+    }
+
+
+    private class Arrangement {
+        @Mock
+        val featureSupport = mock(FeatureSupport::class)
+
+        @Mock
+        val mlsPublicKeysRepository = mock(MLSPublicKeysRepository::class)
+
+        @Mock
+        val userConfigRepository = mock(UserConfigRepository::class)
+
+        fun withMlsFeatureFlag(enabled: Boolean) = apply {
+            every {
+                featureSupport.isMLSSupported
+            }.returns(enabled)
+        }
+
+        fun withUserConfigMlsEnabled(enabled: Boolean) = apply {
+            every {
+                userConfigRepository.isMLSEnabled()
+            }.returns(Either.Right(enabled))
+        }
+
+        fun withUserConfigDataNotFound() = apply {
+            every {
+                userConfigRepository.isMLSEnabled()
+            }.returns(Either.Left(StorageFailure.DataNotFound))
+        }
+
+        suspend fun withGetPublicKeysSuccessful() = apply {
+            coEvery {
+                mlsPublicKeysRepository.getKeys()
+            }.returns(Either.Right(MLS_PUBLIC_KEY))
+        }
+
+        suspend fun withGetPublicKeysFailed() = apply {
+            coEvery {
+                mlsPublicKeysRepository.getKeys()
+            }.returns(Either.Left(CoreFailure.Unknown(Throwable("an error"))))
+        }
+
+        fun arrange() = this to IsAllowedToRegisterMLSClientUseCaseImpl(
+            featureSupport = featureSupport,
+            mlsPublicKeysRepository = mlsPublicKeysRepository,
+            userConfigRepository = userConfigRepository
+        )
+
+        companion object {
+            val MLS_PUBLIC_KEY = MLSPublicKeys(
+                removal = mapOf(
+                    "ed25519" to "gRNvFYReriXbzsGu7zXiPtS8kaTvhU1gUJEV9rdFHVw="
+                )
+            )
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/PendingProposalSchedulerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/PendingProposalSchedulerTest.kt
@@ -96,22 +96,6 @@ class PendingProposalSchedulerTest {
     }
 
     @Test
-    fun givenMLSSupportIsDisabled_whenSyncIsLive_thenPendingProposalIsNotCommitted() = runTest(TestKaliumDispatcher.default) {
-        val (arrangement, _) = Arrangement()
-            .withScheduledProposalTimers(listOf(ProposalTimer(TestConversation.GROUP_ID, Arrangement.INSTANT_PAST)))
-            .withCommitPendingProposalsSuccessful()
-            .arrange()
-
-        arrangement.kaliumConfigs.isMLSSupportEnabled = false
-        arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Live)
-        yield()
-
-        coVerify {
-            arrangement.mlsConversationRepository.commitPendingProposals(eq(TestConversation.GROUP_ID))
-        }.wasNotInvoked()
-    }
-
-    @Test
     fun givenNonExpiredProposalTimer_whenSyncFinishes_thenPendingProposalIsNotCommitted() = runTest(TestKaliumDispatcher.default) {
         val (arrangement, _) = Arrangement()
             .withScheduledProposalTimers(listOf(ProposalTimer(TestConversation.GROUP_ID, Arrangement.INSTANT_NEAR_FUTURE)))
@@ -182,8 +166,6 @@ class PendingProposalSchedulerTest {
 
     private class Arrangement {
 
-        val kaliumConfigs = KaliumConfigs()
-
         val incrementalSyncRepository = InMemoryIncrementalSyncRepository()
 
         @Mock
@@ -193,7 +175,6 @@ class PendingProposalSchedulerTest {
         val subconversationRepository = mock(SubconversationRepository::class)
 
         val pendingProposalScheduler = PendingProposalSchedulerImpl(
-            kaliumConfigs,
             incrementalSyncRepository,
             lazy { mlsConversationRepository },
             lazy { subconversationRepository },

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/homeDirectory.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/homeDirectory.kt
@@ -32,7 +32,6 @@ fun coreLogic(
         rootPath, kaliumConfigs = KaliumConfigs(
             developmentApiEnabled = true,
             encryptProteusStorage = true,
-            isMLSSupportEnabled = true,
             wipeOnDeviceRemoval = true,
         ), userAgent = "Wire Infinite Monkeys", useInMemoryStorage = true
     )

--- a/monkeys/src/main/kotlin/com/wire/kalium/monkeys/homeDirectory.kt
+++ b/monkeys/src/main/kotlin/com/wire/kalium/monkeys/homeDirectory.kt
@@ -29,11 +29,14 @@ fun coreLogic(
     rootPath: String,
 ): CoreLogic {
     val coreLogic = CoreLogic(
-        rootPath, kaliumConfigs = KaliumConfigs(
+        rootPath = rootPath,
+        kaliumConfigs = KaliumConfigs(
             developmentApiEnabled = true,
             encryptProteusStorage = true,
             wipeOnDeviceRemoval = true,
-        ), userAgent = "Wire Infinite Monkeys", useInMemoryStorage = true
+        ),
+        userAgent = "Wire Infinite Monkeys",
+        useInMemoryStorage = true
     )
     coreLogic.updateApiVersionsScheduler.scheduleImmediateApiVersionUpdate()
     return coreLogic

--- a/tango-tests/src/integrationTest/kotlin/PocIntegrationTest.kt
+++ b/tango-tests/src/integrationTest/kotlin/PocIntegrationTest.kt
@@ -231,7 +231,6 @@ class PocIntegrationTest {
             kaliumConfigs = KaliumConfigs(
                 developmentApiEnabled = true,
                 encryptProteusStorage = true,
-                isMLSSupportEnabled = true,
                 wipeOnDeviceRemoval = true,
                 mockedRequests = mockedRequests,
                 mockNetworkStateObserver = TestNetworkStateObserver.DEFAULT_TEST_NETWORK_STATE_OBSERVER,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10119" title="WPB-10119" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-10119</a>  [Android] Clients should initialize MLS clients according to backend feature flag
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

https://wearezeta.atlassian.net/browse/WPB-10119

# What's new in this PR?

### Issues

We now need to check team settings before registering a mls client

### Solutions

Add another check before mls device registration

### Testing

#### How to Test

Make sure registering device only when: feature flag is on, mls keys are present and team settings is enabled

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
