### PR TITLE
fix: slow conversation list queries [WPB-11808]

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationDetailsWithEvents.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationDetailsWithEvents.sq
@@ -100,6 +100,20 @@ selectConversationDetailsWithEvents:
     LIMIT :limit
     OFFSET :offset;
 
+selectConversationDetailsWithEventsFromSearch:
+SELECT * FROM ConversationDetailsWithEvents
+WHERE
+    archived = :fromArchive
+    AND CASE WHEN :onlyInteractionsEnabled THEN interactionEnabled = 1 ELSE 1 END
+    AND name LIKE ('%' || :searchQuery || '%')
+ORDER BY
+    CASE WHEN :newActivitiesOnTop THEN hasNewActivitiesToShow ELSE 0 END DESC,
+    lastModifiedDate DESC,
+    name IS NULL,
+    name COLLATE NOCASE ASC
+LIMIT :limit
+OFFSET :offset;
+
 countConversationDetailsWithEvents:
 SELECT COUNT(*) FROM ConversationDetails
 WHERE

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationDetailsWithEvents.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationDetailsWithEvents.sq
@@ -100,29 +100,33 @@ selectConversationDetailsWithEvents:
     LIMIT :limit
     OFFSET :offset;
 
-selectConversationDetailsWithEventsFromSearch:
-SELECT * FROM ConversationDetailsWithEvents
-WHERE
-    archived = :fromArchive
-    AND CASE WHEN :onlyInteractionsEnabled THEN interactionEnabled = 1 ELSE 1 END
-    AND name LIKE ('%' || :searchQuery || '%')
-ORDER BY
-    CASE WHEN :newActivitiesOnTop THEN hasNewActivitiesToShow ELSE 0 END DESC,
-    lastModifiedDate DESC,
-    name IS NULL,
-    name COLLATE NOCASE ASC
-LIMIT :limit
-OFFSET :offset;
-
 countConversationDetailsWithEvents:
 SELECT COUNT(*) FROM ConversationDetails
 WHERE
-    archived = :fromArchive
+    ConversationDetails.type IS NOT 'SELF'
+    AND (
+        ConversationDetails.type IS 'GROUP'
+        OR (ConversationDetails.type IS 'ONE_ON_ONE' AND (ConversationDetails.name IS NOT NULL AND ConversationDetails.otherUserId IS NOT NULL)) -- show 1:1 convos if they have user metadata
+        OR (ConversationDetails.type IS 'ONE_ON_ONE' AND ConversationDetails.userDeleted = 1) -- show deleted 1:1 convos to maintain prev, logic
+        OR (ConversationDetails.type IS 'CONNECTION_PENDING' AND ConversationDetails.otherUserId IS NOT NULL) -- show connection requests even without metadata
+    )
+    AND (ConversationDetails.protocol IS 'PROTEUS' OR ConversationDetails.protocol IS 'MIXED' OR (ConversationDetails.protocol IS 'MLS' AND ConversationDetails.mls_group_state IS 'ESTABLISHED'))
+    AND ConversationDetails.isActive
+    AND archived = :fromArchive
     AND CASE WHEN :onlyInteractionsEnabled THEN interactionEnabled = 1 ELSE 1 END;
 
 countConversationDetailsWithEventsFromSearch:
 SELECT COUNT(*) FROM ConversationDetails
 WHERE
-    archived = :fromArchive
+    ConversationDetails.type IS NOT 'SELF'
+    AND (
+        ConversationDetails.type IS 'GROUP'
+        OR (ConversationDetails.type IS 'ONE_ON_ONE' AND (ConversationDetails.name IS NOT NULL AND ConversationDetails.otherUserId IS NOT NULL)) -- show 1:1 convos if they have user metadata
+        OR (ConversationDetails.type IS 'ONE_ON_ONE' AND ConversationDetails.userDeleted = 1) -- show deleted 1:1 convos to maintain prev, logic
+        OR (ConversationDetails.type IS 'CONNECTION_PENDING' AND ConversationDetails.otherUserId IS NOT NULL) -- show connection requests even without metadata
+    )
+    AND (ConversationDetails.protocol IS 'PROTEUS' OR ConversationDetails.protocol IS 'MIXED' OR (ConversationDetails.protocol IS 'MLS' AND ConversationDetails.mls_group_state IS 'ESTABLISHED'))
+    AND ConversationDetails.isActive
+    AND archived = :fromArchive
     AND CASE WHEN :onlyInteractionsEnabled THEN interactionEnabled = 1 ELSE 1 END
     AND name LIKE ('%' || :searchQuery || '%');

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationDetailsWithEvents.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationDetailsWithEvents.sq
@@ -52,7 +52,7 @@ LEFT JOIN UnreadEvent
 LEFT JOIN MessageDraft
     ON ConversationDetails.qualifiedId = MessageDraft.conversation_id AND ConversationDetails.archived = 0 -- only return message draft for non-archived conversations
 LEFT JOIN Message AS LastMessage
-    ON LastMessage.conversation_id = ConversationDetails.qualifiedId
+    ON LastMessage.conversation_id = ConversationDetails.qualifiedId AND ConversationDetails.archived = 0 -- only return message draft for non-archived conversations
 LEFT JOIN User
     ON LastMessage.sender_user_id = User.qualified_id
 LEFT JOIN MessageMemberChangeContent AS MemberChangeContent

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationDetailsWithEvents.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationDetailsWithEvents.sq
@@ -52,7 +52,7 @@ LEFT JOIN UnreadEvent
 LEFT JOIN MessageDraft
     ON ConversationDetails.qualifiedId = MessageDraft.conversation_id AND ConversationDetails.archived = 0 -- only return message draft for non-archived conversations
 LEFT JOIN Message AS LastMessage
-    ON LastMessage.conversation_id = ConversationDetails.qualifiedId AND ConversationDetails.archived = 0 -- only return message draft for non-archived conversations
+    ON LastMessage.conversation_id = ConversationDetails.qualifiedId AND ConversationDetails.archived = 0 -- only return last message for non-archived conversations
 LEFT JOIN User
     ON LastMessage.sender_user_id = User.qualified_id
 LEFT JOIN MessageMemberChangeContent AS MemberChangeContent

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/MessageDrafts.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/MessageDrafts.sq
@@ -22,13 +22,21 @@ upsertDraft:
 INSERT INTO MessageDraft(conversation_id, text, edit_message_id, quoted_message_id, mention_list)
 VALUES( ?, ?, ?, ?, ?)
 ON CONFLICT(conversation_id) DO UPDATE SET
-text = excluded.text,
-edit_message_id = excluded.edit_message_id,
-quoted_message_id = excluded.quoted_message_id,
-mention_list = excluded.mention_list;
+    text = excluded.text,
+    edit_message_id = excluded.edit_message_id,
+    quoted_message_id = excluded.quoted_message_id,
+    mention_list = excluded.mention_list
+WHERE -- execute the update only if any of the fields changed
+    MessageDraft.text != excluded.text
+    OR MessageDraft.edit_message_id != excluded.edit_message_id
+    OR MessageDraft.quoted_message_id != excluded.quoted_message_id
+    OR MessageDraft.mention_list != excluded.mention_list;
 
 getDraft:
 SELECT * FROM MessageDraft WHERE conversation_id = ?;
 
 getDrafts:
 SELECT * FROM MessageDraft;
+
+selectChanges:
+SELECT changes();

--- a/persistence/src/commonMain/db_user/migrations/89.sqm
+++ b/persistence/src/commonMain/db_user/migrations/89.sqm
@@ -54,7 +54,7 @@ LEFT JOIN UnreadEvent
 LEFT JOIN MessageDraft
     ON ConversationDetails.qualifiedId = MessageDraft.conversation_id AND ConversationDetails.archived = 0 -- only return message draft for non-archived conversations
 LEFT JOIN Message AS LastMessage
-    ON LastMessage.conversation_id = ConversationDetails.qualifiedId
+    ON LastMessage.conversation_id = ConversationDetails.qualifiedId AND ConversationDetails.archived = 0 -- only return message draft for non-archived conversations
 LEFT JOIN User
     ON LastMessage.sender_user_id = User.qualified_id
 LEFT JOIN MessageMemberChangeContent AS MemberChangeContent

--- a/persistence/src/commonMain/db_user/migrations/89.sqm
+++ b/persistence/src/commonMain/db_user/migrations/89.sqm
@@ -54,7 +54,7 @@ LEFT JOIN UnreadEvent
 LEFT JOIN MessageDraft
     ON ConversationDetails.qualifiedId = MessageDraft.conversation_id AND ConversationDetails.archived = 0 -- only return message draft for non-archived conversations
 LEFT JOIN Message AS LastMessage
-    ON LastMessage.conversation_id = ConversationDetails.qualifiedId AND ConversationDetails.archived = 0 -- only return message draft for non-archived conversations
+    ON LastMessage.conversation_id = ConversationDetails.qualifiedId AND ConversationDetails.archived = 0 -- only return last message for non-archived conversations
 LEFT JOIN User
     ON LastMessage.sender_user_id = User.qualified_id
 LEFT JOIN MessageMemberChangeContent AS MemberChangeContent

--- a/persistence/src/commonMain/db_user/migrations/89.sqm
+++ b/persistence/src/commonMain/db_user/migrations/89.sqm
@@ -1,3 +1,5 @@
+DROP VIEW IF EXISTS ConversationDetailsWithEvents;
+
 CREATE VIEW IF NOT EXISTS ConversationDetailsWithEvents AS
 SELECT
     ConversationDetails.*,
@@ -76,53 +78,3 @@ WHERE
     AND (ConversationDetails.protocol IS 'PROTEUS' OR ConversationDetails.protocol IS 'MIXED' OR (ConversationDetails.protocol IS 'MLS' AND ConversationDetails.mls_group_state IS 'ESTABLISHED'))
     AND ConversationDetails.isActive
 GROUP BY ConversationDetails.qualifiedId;
-
-selectAllConversationDetailsWithEvents:
-SELECT * FROM ConversationDetailsWithEvents
-WHERE archived = :fromArchive
-    AND CASE WHEN :onlyInteractionsEnabled THEN interactionEnabled = 1 ELSE 1 END
-ORDER BY
-    CASE WHEN :newActivitiesOnTop THEN hasNewActivitiesToShow ELSE 0 END DESC,
-    lastModifiedDate DESC,
-    name IS NULL,
-    name COLLATE NOCASE ASC;
-
-selectConversationDetailsWithEvents:
-    SELECT * FROM ConversationDetailsWithEvents
-    WHERE
-        archived = :fromArchive
-        AND CASE WHEN :onlyInteractionsEnabled THEN interactionEnabled = 1 ELSE 1 END
-    ORDER BY
-        CASE WHEN :newActivitiesOnTop THEN hasNewActivitiesToShow ELSE 0 END DESC,
-        lastModifiedDate DESC,
-        name IS NULL,
-        name COLLATE NOCASE ASC
-    LIMIT :limit
-    OFFSET :offset;
-
-selectConversationDetailsWithEventsFromSearch:
-SELECT * FROM ConversationDetailsWithEvents
-WHERE
-    archived = :fromArchive
-    AND CASE WHEN :onlyInteractionsEnabled THEN interactionEnabled = 1 ELSE 1 END
-    AND name LIKE ('%' || :searchQuery || '%')
-ORDER BY
-    CASE WHEN :newActivitiesOnTop THEN hasNewActivitiesToShow ELSE 0 END DESC,
-    lastModifiedDate DESC,
-    name IS NULL,
-    name COLLATE NOCASE ASC
-LIMIT :limit
-OFFSET :offset;
-
-countConversationDetailsWithEvents:
-SELECT COUNT(*) FROM ConversationDetails
-WHERE
-    archived = :fromArchive
-    AND CASE WHEN :onlyInteractionsEnabled THEN interactionEnabled = 1 ELSE 1 END;
-
-countConversationDetailsWithEventsFromSearch:
-SELECT COUNT(*) FROM ConversationDetails
-WHERE
-    archived = :fromArchive
-    AND CASE WHEN :onlyInteractionsEnabled THEN interactionEnabled = 1 ELSE 1 END
-    AND name LIKE ('%' || :searchQuery || '%');


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11808" title="WPB-11808" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11808</a>  [Android] app stalls when fetching a page of conversations from the local DB
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Paginated conversation list queries are very slow when there are many conversations and/or messages in the database.

### Causes (Optional)

I noticed that the biggest impact on the execution time was the nested query to get last message id for the conversation.
Also, every time the draft message is upserted, even with the same value, then conversation list query is notified and reloads.

### Solutions

Replaced nested query with just using `MAX` - we already make `GROUP BY` so when using `MAX(LastMessage.creation_date)` it will left join the message with largest `creation_date` which is the last one, no need to make a nested query to get that.
For draft messages, do not make update query when nothing changed and make it inside the transaction to rollback it if nothing is changed - thanks to that no other query will be notified about this update unnecessarily.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
