### PR TITLE
chore: add extra indexes to calls and unread events tables [WPB-11808]

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Calls.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Calls.sq
@@ -15,6 +15,7 @@ CREATE TABLE Call (
 CREATE INDEX call_date_index ON Call(created_at);
 CREATE INDEX call_conversation_index ON Call(conversation_id);
 CREATE INDEX call_caller_index ON Call(caller_id);
+CREATE INDEX call_status ON Call(status);
 
 insertCall:
 INSERT INTO Call(conversation_id, id, status, caller_id, conversation_type, created_at, type)

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/UnreadEvents.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/UnreadEvents.sq
@@ -11,6 +11,9 @@ CREATE TABLE UnreadEvent (
     FOREIGN KEY (id, conversation_id) REFERENCES Message(id, conversation_id) ON DELETE CASCADE ON UPDATE CASCADE,
     PRIMARY KEY (id, conversation_id)
 );
+CREATE INDEX unread_event_conversation ON UnreadEvent(conversation_id);
+CREATE INDEX unread_event_date ON UnreadEvent(creation_date);
+CREATE INDEX unread_event_type ON UnreadEvent(type);
 
 deleteUnreadEvent:
 DELETE FROM UnreadEvent WHERE id = ? AND conversation_id = ?;

--- a/persistence/src/commonMain/db_user/migrations/89.sqm
+++ b/persistence/src/commonMain/db_user/migrations/89.sqm
@@ -1,0 +1,4 @@
+CREATE INDEX call_status ON Call(status);
+CREATE INDEX unread_event_conversation ON UnreadEvent(conversation_id);
+CREATE INDEX unread_event_date ON UnreadEvent(creation_date);
+CREATE INDEX unread_event_type ON UnreadEvent(type);


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We are executing queries on UnreadEvents and Calls that result in full table scans.

### Causes

Missing indexes.

### Solutions

Add indexes :)

### Dependencies 

Needs releases with:

- #3083

I've created `89.sqm`, as the PR #3083 creates `88.sqm`

### Testing

N/A

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
