### PR TITLE
feat: add metrics for sync engine slow and incremental - RC (WPB-11199)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncManagerLogger.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncManagerLogger.kt
@@ -1,0 +1,99 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync
+
+import com.benasher44.uuid.uuid4
+import com.wire.kalium.logger.KaliumLogLevel
+import com.wire.kalium.logger.KaliumLogger
+import com.wire.kalium.logic.logStructuredJson
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.time.Duration
+
+/**
+ * Logs the sync process by providing structured logs.
+ * It logs the sync process start and completion with the syncId as a unique identifier.
+ */
+internal class SyncManagerLogger(
+    private val logger: KaliumLogger,
+    private val syncId: String,
+    private val syncType: SyncType,
+    private val syncStartedMoment: Instant
+) {
+
+    /**
+     * Logs the sync process start.
+     */
+    fun logSyncStarted() {
+        logger.withFeatureId(KaliumLogger.Companion.ApplicationFlow.SYNC).logStructuredJson(
+            level = KaliumLogLevel.INFO,
+            leadingMessage = "Started sync process",
+            jsonStringKeyValues = mapOf(
+                "syncMetadata" to mapOf(
+                    "id" to syncId,
+                    "status" to SyncStatus.STARTED.name,
+                    "type" to syncType.name
+                )
+            )
+        )
+    }
+
+    /**
+     * Logs the sync process completion.
+     * Optionally, it can pass the duration of the sync process,
+     * useful for incremental sync that can happen between collecting states.
+     *
+     * @param duration optional the duration of the sync process.
+     */
+    fun logSyncCompleted(duration: Duration = Clock.System.now() - syncStartedMoment) {
+        val logMap = mapOf(
+            "id" to syncId,
+            "status" to SyncStatus.COMPLETED.name,
+            "type" to syncType.name,
+            "performanceData" to mapOf("timeTakenInMillis" to duration.inWholeMilliseconds)
+        )
+
+        logger.withFeatureId(KaliumLogger.Companion.ApplicationFlow.SYNC).logStructuredJson(
+            level = KaliumLogLevel.INFO,
+            leadingMessage = "Completed sync process",
+            jsonStringKeyValues = mapOf("syncMetadata" to logMap)
+        )
+    }
+}
+
+internal enum class SyncStatus {
+    STARTED,
+    COMPLETED
+}
+
+internal enum class SyncType {
+    SLOW,
+    INCREMENTAL
+}
+
+/**
+ * Provides a new [SyncManagerLogger] instance with the given parameters.
+ * @param syncType the [SyncType] that will log.
+ * @param syncId the unique identifier for the sync process.
+ * @param syncStartedMoment the moment when the sync process started.
+ */
+internal fun KaliumLogger.provideNewSyncManagerLogger(
+    syncType: SyncType,
+    syncId: String = uuid4().toString(),
+    syncStartedMoment: Instant = Clock.System.now()
+) = SyncManagerLogger(this, syncId, syncType, syncStartedMoment)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.logic.sync.incremental
 
+import com.benasher44.uuid.uuid4
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.SYNC
 import com.wire.kalium.logic.data.event.Event
@@ -28,6 +29,8 @@ import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.SyncExceptionHandler
+import com.wire.kalium.logic.sync.SyncType
+import com.wire.kalium.logic.sync.provideNewSyncManagerLogger
 import com.wire.kalium.logic.sync.slow.SlowSyncManager
 import com.wire.kalium.logic.util.ExponentialDurationHelper
 import com.wire.kalium.logic.util.ExponentialDurationHelperImpl
@@ -41,12 +44,15 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.cancellable
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.runningFold
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
+import kotlinx.datetime.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -179,16 +185,25 @@ internal class IncrementalSyncManager(
         incrementalSyncWorker
             .processEventsWhilePolicyAllowsFlow()
             .cancellable()
-            .collect {
-                val newState = when (it) {
-                    EventSource.PENDING -> IncrementalSyncStatus.FetchingPendingEvents
+            .runningFold(uuid4().toString() to Clock.System.now()) { syncData, eventSource ->
+                val syncLogger = kaliumLogger.provideNewSyncManagerLogger(SyncType.INCREMENTAL, syncData.first)
+                val newState = when (eventSource) {
+                    EventSource.PENDING -> {
+                        syncLogger.logSyncStarted()
+                        IncrementalSyncStatus.FetchingPendingEvents
+                    }
+
                     EventSource.LIVE -> {
+                        syncLogger.logSyncCompleted(duration = Clock.System.now() - syncData.second)
                         exponentialDurationHelper.reset()
                         IncrementalSyncStatus.Live
                     }
                 }
                 incrementalSyncRepository.updateIncrementalSyncState(newState)
-            }
+
+                // when the source is LIVE, we need to generate a new syncId since it means the previous one is done
+                if (eventSource == EventSource.LIVE) uuid4().toString() to Clock.System.now() else syncData
+            }.collect()
         incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Pending)
         logger.i("$TAG IncrementalSync stopped.")
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11199" title="WPB-11199" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-11199</a>  [Android] add Datadog state for sync job start and stop and how much time it took
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Cherry-pick of:
- https://github.com/wireapp/kalium/pull/3086
----

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We are somehow blind in some places regarding sync

### Causes (Optional)

Difficulty to troubleshoot sync problems, and no metrics regarding this, like we have in other places for example for events.

### Solutions

- Create a wrapper class for handling formatted logs for sync manager
- Adds metrics handling data, like id and duration of sync jobs
- Call from Slow and Incremental sync to these logs
- Incremental sync needs to handle foreground case and background cases, that's why the state change handles the ids and started time of job across coroutine collections using `.runningFold`

### Testing

#### Test Coverage (Optional) 

- [ ] I have added automated test to this contribution

#### How to Test

Interact with the app and see logs formatted in Datadog (not available if you don't have local setup of credentials)

### Notes (Optional)

Dashboards in DD will follow.
https://app.datadoghq.eu/dashboard/crc-suh-fq6/android-sync-manager-performance?fromUser=false&refresh_mode=sliding&from_ts=1730463823807&to_ts=1730478223807&live=true

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
