### PR TITLE
feat: Implement message unknown strategy #WPB-11913

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/PersistMigratedMessagesUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/PersistMigratedMessagesUseCaseTest.kt
@@ -58,7 +58,10 @@ class PersistMigratedMessagesUseCaseTest {
         @Mock
         val migrationDAO: MigrationDAO = mock(MigrationDAO::class)
 
-        val genericMessage = GenericMessage("uuid", GenericMessage.Content.Text(Text("some_text")))
+        val genericMessage = GenericMessage(
+            messageId = "uuid",
+            content = GenericMessage.Content.Text(Text("some_text"))
+        )
 
         fun fakeMigratedMessage() = MigratedMessage(
             conversationId = TestConversation.ID,

--- a/protobuf-codegen/src/main/proto/messages.proto
+++ b/protobuf-codegen/src/main/proto/messages.proto
@@ -46,6 +46,7 @@ message GenericMessage {
         ButtonActionConfirmation buttonActionConfirmation = 22;
         DataTransfer dataTransfer = 23; // client-side synchronization across devices of the same user
     }
+    optional UnknownStrategy unknownStrategy = 24 [default = IGNORE];
 }
 
 message QualifiedUserId {
@@ -359,4 +360,10 @@ enum LegalHoldStatus {
     UNKNOWN = 0;
     DISABLED = 1;
     ENABLED = 2;
+}
+
+enum UnknownStrategy {
+    IGNORE = 0;                 // Ignore the message completely.
+    DISCARD_AND_WARN = 1;       // Warn the user, but discard the message, as it may not be helpful in the future
+    WARN_USER_ALLOW_RETRY = 2;  // Warn the user. Client has freedom to store it and retry in the future.
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11913" title="WPB-11913" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-11913</a>  [Android] - Implement RFC - Message handling - Incall reactions / Hand raising
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-11913

# What's new in this PR?

### Issues

Implement Unknown messages RFC 

### Solutions

Add a new optional proto field for GenericMessage.
Basically right now we're handling incoming messages that will support `UnknownStrategy` 
Unless we know the type of added message we cant really implement a strategy to bring back the stored byte data into real content.
Also I did not implement adding the `UnknownStrategy` for current messages as stated in the rfc document.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
