### PR TITLE
chore: improve logging for backups (WPB-12113)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/RestoreBackupUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/RestoreBackupUseCase.kt
@@ -96,7 +96,7 @@ internal class RestoreBackupUseCaseImpl(
                     }
                 }
                 .fold({ error ->
-                    kaliumLogger.e("$TAG Failed to restore the backup, reason: ${error.failure.cause}")
+                    kaliumLogger.e("$TAG Failed to restore the backup, reason: ${error.failure}")
                     error
                 }, {
                     kaliumLogger.i("$TAG Backup restored successfully")

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/RestoreBackupUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/RestoreBackupUseCase.kt
@@ -95,7 +95,13 @@ internal class RestoreBackupUseCaseImpl(
                         importEncryptedBackup(extractedBackupRootPath, password)
                     }
                 }
-                .fold({ it }, { RestoreBackupResult.Success })
+                .fold({ error ->
+                    kaliumLogger.e("$TAG Failed to restore the backup, reason: ${error.failure.cause}")
+                    error
+                }, {
+                    kaliumLogger.i("$TAG Backup restored successfully")
+                    RestoreBackupResult.Success
+                })
         }
 
     private suspend fun importUnencryptedBackup(
@@ -140,7 +146,7 @@ internal class RestoreBackupUseCaseImpl(
         val extractedFilesRootPath = createExtractedFilesRootPath()
         return extractFiles(tempCompressedFileSource, extractedFilesRootPath)
             .fold({
-                kaliumLogger.e("Failed to extract backup files")
+                kaliumLogger.e("$TAG Failed to extract backup files")
                 Either.Left(Failure(BackupIOFailure("Failed to extract backup files")))
             }, {
                 Either.Right(extractedFilesRootPath)
@@ -176,7 +182,7 @@ internal class RestoreBackupUseCaseImpl(
         return if (backupSize > 0) {
             // On successful decryption, we still need to extract the zip file to do sanity checks and get the database file
             extractFiles(kaliumFileSystem.source(extractedBackupPath), extractedBackupRootPath).fold({
-                kaliumLogger.e("Failed to extract encrypted backup files")
+                kaliumLogger.e("$TAG Failed to extract encrypted backup files")
                 Either.Left(Failure(BackupIOFailure("Failed to extract encrypted backup files")))
             }, {
                 kaliumFileSystem.delete(extractedBackupPath)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/RestoreWebBackupUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/RestoreWebBackupUseCase.kt
@@ -80,7 +80,7 @@ internal class RestoreWebBackupUseCaseImpl(
             } else {
                 Either.Left(IncompatibleBackup("invoke: The provided backup format is not supported"))
             }.fold({ error ->
-                kaliumLogger.e("$TAG Failed to restore the backup, reason: ${error}")
+                kaliumLogger.e("$TAG Failed to restore the backup, reason: $error")
                 RestoreBackupResult.Failure(error)
             }, {
                 kaliumLogger.i("$TAG Successfully restored the backup")

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/RestoreWebBackupUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/RestoreWebBackupUseCase.kt
@@ -80,7 +80,7 @@ internal class RestoreWebBackupUseCaseImpl(
             } else {
                 Either.Left(IncompatibleBackup("invoke: The provided backup format is not supported"))
             }.fold({ error ->
-                kaliumLogger.e("$TAG Failed to restore the backup, reason: ${error.cause}")
+                kaliumLogger.e("$TAG Failed to restore the backup, reason: ${error}")
                 RestoreBackupResult.Failure(error)
             }, {
                 kaliumLogger.i("$TAG Successfully restored the backup")

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/RestoreWebBackupUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/RestoreWebBackupUseCase.kt
@@ -79,7 +79,13 @@ internal class RestoreWebBackupUseCaseImpl(
                 importWebBackup(backupRootPath, this)
             } else {
                 Either.Left(IncompatibleBackup("invoke: The provided backup format is not supported"))
-            }.fold({ RestoreBackupResult.Failure(it) }, { RestoreBackupResult.Success })
+            }.fold({ error ->
+                kaliumLogger.e("$TAG Failed to restore the backup, reason: ${error.cause}")
+                RestoreBackupResult.Failure(error)
+            }, {
+                kaliumLogger.i("$TAG Successfully restored the backup")
+                RestoreBackupResult.Success
+            })
         }
 
     private suspend fun importWebBackup(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-12113" title="WPB-12113" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-12113</a>  [Android] Improve logging for backups
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Logging was not being performed for importing backups

### Causes (Optional)

Difficulty to troubleshoot problems related to it

### Solutions

Implement logging, to add more info about failures.

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

Fail to import a backup, you should see more info related to the failure.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
