### PR TITLE
fix: extremely slow paginated conversation list query [WPB-11808]

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Calls.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Calls.sq
@@ -15,6 +15,7 @@ CREATE TABLE Call (
 CREATE INDEX call_date_index ON Call(created_at);
 CREATE INDEX call_conversation_index ON Call(conversation_id);
 CREATE INDEX call_caller_index ON Call(caller_id);
+CREATE INDEX call_status ON Call(status);
 
 insertCall:
 INSERT INTO Call(conversation_id, id, status, caller_id, conversation_type, created_at, type)

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationDetailsWithEvents.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationDetailsWithEvents.sq
@@ -31,7 +31,7 @@ SELECT
     -- last message
     Message.id AS lastMessageId,
     Message.content_type AS lastMessageContentType,
-    Message.creation_date AS lastMessageDatfe,
+    Message.creation_date AS lastMessageDate,
     Message.visibility AS lastMessageVisibility,
     Message.sender_user_id AS lastMessageSenderUserId,
     (Message.expire_after_millis IS NOT NULL) AS lastMessageIsEphemeral,

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/LastMessage.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/LastMessage.sq
@@ -1,0 +1,82 @@
+import com.wire.kalium.persistence.dao.QualifiedIDEntity;
+import com.wire.kalium.persistence.dao.conversation.ConversationEntity;
+import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType;
+import com.wire.kalium.persistence.dao.message.MessageEntity.FederationType;
+import com.wire.kalium.persistence.dao.message.MessageEntity.LegalHoldType;
+import com.wire.kalium.persistence.dao.message.MessageEntity.MemberChangeType;
+import com.wire.kalium.persistence.dao.message.MessageEntity;
+import com.wire.kalium.persistence.dao.message.RecipientFailureTypeEntity;
+import kotlin.Boolean;
+import kotlin.Float;
+import kotlin.Int;
+import kotlin.String;
+import kotlin.collections.List;
+import kotlinx.datetime.Instant;
+
+CREATE TABLE LastMessage (
+      conversation_id TEXT AS QualifiedIDEntity NOT NULL,
+      message_id TEXT NOT NULL,
+      creation_date INTEGER AS Instant NOT NULL,
+
+      FOREIGN KEY (conversation_id) REFERENCES Conversation(qualified_id) ON DELETE CASCADE ON UPDATE CASCADE,
+      FOREIGN KEY (message_id, conversation_id) REFERENCES Message(id, conversation_id) ON DELETE CASCADE ON UPDATE CASCADE,
+      PRIMARY KEY (conversation_id)
+);
+
+CREATE TRIGGER updateLastMessageAfterInsertingNewMessage
+AFTER INSERT ON Message
+WHEN
+    new.visibility IN ('VISIBLE', 'DELETED')
+    OR new.content_type IN ('TEXT', 'ASSET', 'KNOCK', 'MISSED_CALL', 'CONVERSATION_RENAMED', 'MEMBER_CHANGE', 'COMPOSITE', 'CONVERSATION_DEGRADED_MLS', 'CONVERSATION_DEGRADED_PROTEUS', 'CONVERSATION_VERIFIED_MLS', 'CONVERSATION_VERIFIED_PROTEUS', 'LOCATION')
+BEGIN
+    INSERT INTO LastMessage(conversation_id, message_id, creation_date)
+    VALUES (new.conversation_id, new.id, new.creation_date)
+    ON CONFLICT(conversation_id)
+        DO UPDATE SET
+            message_id = excluded.message_id,
+            creation_date = excluded.creation_date
+        WHERE
+            excluded.creation_date > LastMessage.creation_date;
+END;
+
+CREATE TRIGGER updateLastMessageAfterDeletingLastMessage
+AFTER DELETE ON LastMessage
+BEGIN
+    INSERT INTO LastMessage(conversation_id, message_id, creation_date)
+    SELECT conversation_id, id, creation_date
+    FROM Message
+    WHERE
+        old.conversation_id = Message.conversation_id
+		AND Message.visibility IN ('VISIBLE', 'DELETED')
+		AND Message.content_type IN ('TEXT', 'ASSET', 'KNOCK', 'MISSED_CALL', 'CONVERSATION_RENAMED', 'MEMBER_CHANGE', 'COMPOSITE', 'CONVERSATION_DEGRADED_MLS', 'CONVERSATION_DEGRADED_PROTEUS', 'CONVERSATION_VERIFIED_MLS', 'CONVERSATION_VERIFIED_PROTEUS', 'LOCATION')
+    ORDER BY creation_date DESC
+    LIMIT 1
+    ON CONFLICT(conversation_id)
+        DO UPDATE SET
+            message_id = excluded.message_id,
+            creation_date = excluded.creation_date
+        WHERE
+            excluded.creation_date > LastMessage.creation_date;
+END;
+
+CREATE TRIGGER updateLastMessageAfterUpdatingLastMessage
+AFTER UPDATE OF visibility, content_type, creation_date ON Message
+WHEN
+    new.creation_date >= (SELECT creation_date FROM LastMessage WHERE conversation_id = new.conversation_id LIMIT 1)
+BEGIN
+    INSERT INTO LastMessage(conversation_id, message_id, creation_date)
+    SELECT conversation_id, id, creation_date
+    FROM Message
+    WHERE
+        old.conversation_id = Message.conversation_id
+		AND Message.visibility IN ('VISIBLE', 'DELETED')
+		AND Message.content_type IN ('TEXT', 'ASSET', 'KNOCK', 'MISSED_CALL', 'CONVERSATION_RENAMED', 'MEMBER_CHANGE', 'COMPOSITE', 'CONVERSATION_DEGRADED_MLS', 'CONVERSATION_DEGRADED_PROTEUS', 'CONVERSATION_VERIFIED_MLS', 'CONVERSATION_VERIFIED_PROTEUS', 'LOCATION')
+    ORDER BY creation_date DESC
+    LIMIT 1
+    ON CONFLICT(conversation_id)
+        DO UPDATE SET
+            message_id = excluded.message_id,
+            creation_date = excluded.creation_date
+        WHERE
+            excluded.creation_date > LastMessage.creation_date;
+END;

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/LastMessage.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/LastMessage.sq
@@ -14,20 +14,21 @@ import kotlin.collections.List;
 import kotlinx.datetime.Instant;
 
 CREATE TABLE LastMessage (
-      conversation_id TEXT AS QualifiedIDEntity NOT NULL,
-      message_id TEXT NOT NULL,
-      creation_date INTEGER AS Instant NOT NULL,
+      conversation_id TEXT AS QualifiedIDEntity,
+      message_id TEXT,
+      creation_date INTEGER AS Instant,
 
-      FOREIGN KEY (conversation_id) REFERENCES Conversation(qualified_id) ON DELETE CASCADE ON UPDATE CASCADE,
-      FOREIGN KEY (message_id, conversation_id) REFERENCES Message(id, conversation_id) ON DELETE CASCADE ON UPDATE CASCADE,
+      FOREIGN KEY (conversation_id) REFERENCES Conversation(qualified_id) ON DELETE CASCADE ON UPDATE SET NULL, -- there is a trigger to handle null values
+      FOREIGN KEY (message_id, conversation_id) REFERENCES Message(id, conversation_id) ON DELETE CASCADE ON UPDATE SET NULL, -- there is a trigger to handle null values
       PRIMARY KEY (conversation_id)
 );
 
+-- update last message when newly inserted message is newer than the current last message
 CREATE TRIGGER updateLastMessageAfterInsertingNewMessage
 AFTER INSERT ON Message
 WHEN
     new.visibility IN ('VISIBLE', 'DELETED')
-    OR new.content_type IN ('TEXT', 'ASSET', 'KNOCK', 'MISSED_CALL', 'CONVERSATION_RENAMED', 'MEMBER_CHANGE', 'COMPOSITE', 'CONVERSATION_DEGRADED_MLS', 'CONVERSATION_DEGRADED_PROTEUS', 'CONVERSATION_VERIFIED_MLS', 'CONVERSATION_VERIFIED_PROTEUS', 'LOCATION')
+    AND new.content_type IN ('TEXT', 'ASSET', 'KNOCK', 'MISSED_CALL', 'CONVERSATION_RENAMED', 'MEMBER_CHANGE', 'COMPOSITE', 'CONVERSATION_DEGRADED_MLS', 'CONVERSATION_DEGRADED_PROTEUS', 'CONVERSATION_VERIFIED_MLS', 'CONVERSATION_VERIFIED_PROTEUS', 'LOCATION')
 BEGIN
     INSERT INTO LastMessage(conversation_id, message_id, creation_date)
     VALUES (new.conversation_id, new.id, new.creation_date)
@@ -39,6 +40,7 @@ BEGIN
             excluded.creation_date > LastMessage.creation_date;
 END;
 
+-- update last message after deleting the current last message by finding new last message for the conversation
 CREATE TRIGGER updateLastMessageAfterDeletingLastMessage
 AFTER DELETE ON LastMessage
 BEGIN
@@ -59,10 +61,36 @@ BEGIN
             excluded.creation_date > LastMessage.creation_date;
 END;
 
-CREATE TRIGGER updateLastMessageAfterUpdatingLastMessage
-AFTER UPDATE OF visibility, content_type, creation_date ON Message
+-- update last message after a message got updated and now this one should be the new last message
+-- or if the current last message shouldn't be the last message anymore because of the visibility update for instance
+CREATE TRIGGER updateLastMessageAfterUpdatingMessage
+AFTER UPDATE OF id, conversation_id, visibility, content_type, creation_date ON Message
 WHEN
     new.creation_date >= (SELECT creation_date FROM LastMessage WHERE conversation_id = new.conversation_id LIMIT 1)
+BEGIN
+    INSERT INTO LastMessage(conversation_id, message_id, creation_date)
+    SELECT conversation_id, id, creation_date
+    FROM Message
+    WHERE
+        new.conversation_id = Message.conversation_id
+		AND Message.visibility IN ('VISIBLE', 'DELETED')
+		AND Message.content_type IN ('TEXT', 'ASSET', 'KNOCK', 'MISSED_CALL', 'CONVERSATION_RENAMED', 'MEMBER_CHANGE', 'COMPOSITE', 'CONVERSATION_DEGRADED_MLS', 'CONVERSATION_DEGRADED_PROTEUS', 'CONVERSATION_VERIFIED_MLS', 'CONVERSATION_VERIFIED_PROTEUS', 'LOCATION')
+    ORDER BY creation_date DESC
+    LIMIT 1
+    ON CONFLICT(conversation_id)
+        DO UPDATE SET
+            message_id = excluded.message_id,
+            creation_date = excluded.creation_date
+        WHERE
+            excluded.creation_date > LastMessage.creation_date;
+END;
+
+-- update last message after there was a foreign key updated to null by finding new last message for that conversation
+-- this happens when last message is moved to another conversation or id of last message is changed
+CREATE TRIGGER updateLastMessageAfterForeignKeyUpdatedToNull
+AFTER UPDATE OF conversation_id ON LastMessage
+WHEN
+    new.conversation_id IS NULL
 BEGIN
     INSERT INTO LastMessage(conversation_id, message_id, creation_date)
     SELECT conversation_id, id, creation_date
@@ -79,4 +107,5 @@ BEGIN
             creation_date = excluded.creation_date
         WHERE
             excluded.creation_date > LastMessage.creation_date;
+    DELETE FROM LastMessage WHERE conversation_id IS NULL;
 END;

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -501,14 +501,11 @@ selectByConversationIdAndVisibility:
 SELECT * FROM MessageDetailsView WHERE conversationId = :conversationId AND visibility IN :visibility ORDER BY date DESC LIMIT :limit OFFSET :offset;
 
 selectLastMessagesByConversationIds:
-SELECT MessageDetailsView.* FROM MessageDetailsView
-JOIN (
-    SELECT conversationId, MAX(date) AS latest_date
-    FROM MessageDetailsView
-    WHERE conversationId IN :conversationIds
-    GROUP BY conversationId
-) AS lastMessage
-ON MessageDetailsView.conversationId = lastMessage.conversationId AND MessageDetailsView.date = lastMessage.latest_date;
+SELECT MessageDetailsView.*
+FROM LastMessage
+INNER JOIN MessageDetailsView
+ON MessageDetailsView.conversationId = LastMessage.conversation_id AND MessageDetailsView.id = LastMessage.message_id
+WHERE LastMessage.conversation_id IN :conversationIds;
 
 selectMessagesByConversationIdAndVisibilityAfterDate:
 SELECT * FROM MessageDetailsView WHERE MessageDetailsView.conversationId = ? AND visibility IN ? AND date > ? ORDER BY date DESC;

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/UnreadEvents.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/UnreadEvents.sq
@@ -11,6 +11,9 @@ CREATE TABLE UnreadEvent (
     FOREIGN KEY (id, conversation_id) REFERENCES Message(id, conversation_id) ON DELETE CASCADE ON UPDATE CASCADE,
     PRIMARY KEY (id, conversation_id)
 );
+CREATE INDEX unread_event_conversation ON UnreadEvent(conversation_id);
+CREATE INDEX unread_event_date ON UnreadEvent(creation_date);
+CREATE INDEX unread_event_type ON UnreadEvent(type);
 
 deleteUnreadEvent:
 DELETE FROM UnreadEvent WHERE id = ? AND conversation_id = ?;

--- a/persistence/src/commonMain/db_user/migrations/90.sqm
+++ b/persistence/src/commonMain/db_user/migrations/90.sqm
@@ -91,7 +91,7 @@ BEGIN
 END;
 
 -- update last message after there was a foreign key updated to null by finding new last message for that conversation
--- this happens when a message is moved to another conversation or id of a message is changed
+-- this happens when last message is moved to another conversation or id of last message is changed
 CREATE TRIGGER updateLastMessageAfterForeignKeyUpdatedToNull
 AFTER UPDATE OF conversation_id ON LastMessage
 WHEN

--- a/persistence/src/commonMain/db_user/migrations/90.sqm
+++ b/persistence/src/commonMain/db_user/migrations/90.sqm
@@ -1,3 +1,103 @@
+import com.wire.kalium.persistence.dao.QualifiedIDEntity;
+import com.wire.kalium.persistence.dao.conversation.ConversationEntity;
+import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType;
+import com.wire.kalium.persistence.dao.message.MessageEntity.FederationType;
+import com.wire.kalium.persistence.dao.message.MessageEntity.LegalHoldType;
+import com.wire.kalium.persistence.dao.message.MessageEntity.MemberChangeType;
+import com.wire.kalium.persistence.dao.message.MessageEntity;
+import com.wire.kalium.persistence.dao.message.RecipientFailureTypeEntity;
+import kotlin.Boolean;
+import kotlin.Float;
+import kotlin.Int;
+import kotlin.String;
+import kotlin.collections.List;
+import kotlinx.datetime.Instant;
+
+CREATE INDEX call_status ON Call(status);
+CREATE INDEX unread_event_conversation ON UnreadEvent(conversation_id);
+CREATE INDEX unread_event_date ON UnreadEvent(creation_date);
+CREATE INDEX unread_event_type ON UnreadEvent(type);
+
+CREATE TABLE LastMessage (
+      conversation_id TEXT AS QualifiedIDEntity NOT NULL,
+      message_id TEXT NOT NULL,
+      creation_date INTEGER AS Instant NOT NULL,
+
+      FOREIGN KEY (conversation_id) REFERENCES Conversation(qualified_id) ON DELETE CASCADE ON UPDATE CASCADE,
+      FOREIGN KEY (message_id, conversation_id) REFERENCES Message(id, conversation_id) ON DELETE CASCADE ON UPDATE CASCADE,
+      PRIMARY KEY (conversation_id)
+);
+
+CREATE TRIGGER updateLastMessageAfterInsertingNewMessage
+AFTER INSERT ON Message
+WHEN
+    new.visibility IN ('VISIBLE', 'DELETED')
+    OR new.content_type IN ('TEXT', 'ASSET', 'KNOCK', 'MISSED_CALL', 'CONVERSATION_RENAMED', 'MEMBER_CHANGE', 'COMPOSITE', 'CONVERSATION_DEGRADED_MLS', 'CONVERSATION_DEGRADED_PROTEUS', 'CONVERSATION_VERIFIED_MLS', 'CONVERSATION_VERIFIED_PROTEUS', 'LOCATION')
+BEGIN
+    INSERT INTO LastMessage(conversation_id, message_id, creation_date)
+    VALUES (new.conversation_id, new.id, new.creation_date)
+    ON CONFLICT(conversation_id)
+        DO UPDATE SET
+            message_id = excluded.message_id,
+            creation_date = excluded.creation_date
+        WHERE
+            excluded.creation_date > LastMessage.creation_date;
+END;
+
+CREATE TRIGGER updateLastMessageAfterDeletingLastMessage
+AFTER DELETE ON LastMessage
+BEGIN
+    INSERT INTO LastMessage(conversation_id, message_id, creation_date)
+    SELECT conversation_id, id, creation_date
+    FROM Message
+    WHERE
+        old.conversation_id = Message.conversation_id
+		AND Message.visibility IN ('VISIBLE', 'DELETED')
+		AND Message.content_type IN ('TEXT', 'ASSET', 'KNOCK', 'MISSED_CALL', 'CONVERSATION_RENAMED', 'MEMBER_CHANGE', 'COMPOSITE', 'CONVERSATION_DEGRADED_MLS', 'CONVERSATION_DEGRADED_PROTEUS', 'CONVERSATION_VERIFIED_MLS', 'CONVERSATION_VERIFIED_PROTEUS', 'LOCATION')
+    ORDER BY creation_date DESC
+    LIMIT 1
+    ON CONFLICT(conversation_id)
+        DO UPDATE SET
+            message_id = excluded.message_id,
+            creation_date = excluded.creation_date
+        WHERE
+            excluded.creation_date > LastMessage.creation_date;
+END;
+
+CREATE TRIGGER updateLastMessageAfterUpdatingLastMessage
+AFTER UPDATE OF visibility, content_type, creation_date ON Message
+WHEN
+    new.creation_date >= (SELECT creation_date FROM LastMessage WHERE conversation_id = new.conversation_id LIMIT 1)
+BEGIN
+    INSERT INTO LastMessage(conversation_id, message_id, creation_date)
+    SELECT conversation_id, id, creation_date
+    FROM Message
+    WHERE
+        old.conversation_id = Message.conversation_id
+		AND Message.visibility IN ('VISIBLE', 'DELETED')
+		AND Message.content_type IN ('TEXT', 'ASSET', 'KNOCK', 'MISSED_CALL', 'CONVERSATION_RENAMED', 'MEMBER_CHANGE', 'COMPOSITE', 'CONVERSATION_DEGRADED_MLS', 'CONVERSATION_DEGRADED_PROTEUS', 'CONVERSATION_VERIFIED_MLS', 'CONVERSATION_VERIFIED_PROTEUS', 'LOCATION')
+    ORDER BY creation_date DESC
+    LIMIT 1
+    ON CONFLICT(conversation_id)
+        DO UPDATE SET
+            message_id = excluded.message_id,
+            creation_date = excluded.creation_date
+        WHERE
+            excluded.creation_date > LastMessage.creation_date;
+END;
+
+-- populate LastMessage table with the last message of each conversation
+INSERT INTO LastMessage(conversation_id, message_id, creation_date)
+SELECT conversation_id, id, creation_date
+FROM Message
+WHERE
+    visibility IN ('VISIBLE', 'DELETED')
+    AND content_type IN ('TEXT', 'ASSET', 'KNOCK', 'MISSED_CALL', 'CONVERSATION_RENAMED', 'MEMBER_CHANGE', 'COMPOSITE', 'CONVERSATION_DEGRADED_MLS', 'CONVERSATION_DEGRADED_PROTEUS', 'CONVERSATION_VERIFIED_MLS', 'CONVERSATION_VERIFIED_PROTEUS', 'LOCATION')
+GROUP BY conversation_id
+HAVING creation_date = MAX(creation_date);
+
+DROP VIEW IF EXISTS ConversationDetailsWithEvents;
+
 CREATE VIEW IF NOT EXISTS ConversationDetailsWithEvents AS
 SELECT
     ConversationDetails.*,
@@ -77,71 +177,3 @@ WHERE
     )
     AND (ConversationDetails.protocol IS 'PROTEUS' OR ConversationDetails.protocol IS 'MIXED' OR (ConversationDetails.protocol IS 'MLS' AND ConversationDetails.mls_group_state IS 'ESTABLISHED'))
     AND ConversationDetails.isActive;
-
-selectAllConversationDetailsWithEvents:
-SELECT * FROM ConversationDetailsWithEvents
-WHERE archived = :fromArchive
-    AND CASE WHEN :onlyInteractionsEnabled THEN interactionEnabled = 1 ELSE 1 END
-ORDER BY
-    CASE WHEN :newActivitiesOnTop THEN hasNewActivitiesToShow ELSE 0 END DESC,
-    lastModifiedDate DESC,
-    name IS NULL,
-    name COLLATE NOCASE ASC;
-
-selectConversationDetailsWithEvents:
-    SELECT * FROM ConversationDetailsWithEvents
-    WHERE
-        archived = :fromArchive
-        AND CASE WHEN :onlyInteractionsEnabled THEN interactionEnabled = 1 ELSE 1 END
-    ORDER BY
-        CASE WHEN :newActivitiesOnTop THEN hasNewActivitiesToShow ELSE 0 END DESC,
-        lastModifiedDate DESC,
-        name IS NULL,
-        name COLLATE NOCASE ASC
-    LIMIT :limit
-    OFFSET :offset;
-
-selectConversationDetailsWithEventsFromSearch:
-SELECT * FROM ConversationDetailsWithEvents
-WHERE
-    archived = :fromArchive
-    AND CASE WHEN :onlyInteractionsEnabled THEN interactionEnabled = 1 ELSE 1 END
-    AND name LIKE ('%' || :searchQuery || '%')
-ORDER BY
-    CASE WHEN :newActivitiesOnTop THEN hasNewActivitiesToShow ELSE 0 END DESC,
-    lastModifiedDate DESC,
-    name IS NULL,
-    name COLLATE NOCASE ASC
-LIMIT :limit
-OFFSET :offset;
-
-countConversationDetailsWithEvents:
-SELECT COUNT(*) FROM ConversationDetails
-WHERE
-    ConversationDetails.type IS NOT 'SELF'
-    AND (
-        ConversationDetails.type IS 'GROUP'
-        OR (ConversationDetails.type IS 'ONE_ON_ONE' AND (ConversationDetails.name IS NOT NULL AND ConversationDetails.otherUserId IS NOT NULL)) -- show 1:1 convos if they have user metadata
-        OR (ConversationDetails.type IS 'ONE_ON_ONE' AND ConversationDetails.userDeleted = 1) -- show deleted 1:1 convos to maintain prev, logic
-        OR (ConversationDetails.type IS 'CONNECTION_PENDING' AND ConversationDetails.otherUserId IS NOT NULL) -- show connection requests even without metadata
-    )
-    AND (ConversationDetails.protocol IS 'PROTEUS' OR ConversationDetails.protocol IS 'MIXED' OR (ConversationDetails.protocol IS 'MLS' AND ConversationDetails.mls_group_state IS 'ESTABLISHED'))
-    AND ConversationDetails.isActive
-    AND archived = :fromArchive
-    AND CASE WHEN :onlyInteractionsEnabled THEN interactionEnabled = 1 ELSE 1 END;
-
-countConversationDetailsWithEventsFromSearch:
-SELECT COUNT(*) FROM ConversationDetails
-WHERE
-    ConversationDetails.type IS NOT 'SELF'
-    AND (
-        ConversationDetails.type IS 'GROUP'
-        OR (ConversationDetails.type IS 'ONE_ON_ONE' AND (ConversationDetails.name IS NOT NULL AND ConversationDetails.otherUserId IS NOT NULL)) -- show 1:1 convos if they have user metadata
-        OR (ConversationDetails.type IS 'ONE_ON_ONE' AND ConversationDetails.userDeleted = 1) -- show deleted 1:1 convos to maintain prev, logic
-        OR (ConversationDetails.type IS 'CONNECTION_PENDING' AND ConversationDetails.otherUserId IS NOT NULL) -- show connection requests even without metadata
-    )
-    AND (ConversationDetails.protocol IS 'PROTEUS' OR ConversationDetails.protocol IS 'MIXED' OR (ConversationDetails.protocol IS 'MLS' AND ConversationDetails.mls_group_state IS 'ESTABLISHED'))
-    AND ConversationDetails.isActive
-    AND archived = :fromArchive
-    AND CASE WHEN :onlyInteractionsEnabled THEN interactionEnabled = 1 ELSE 1 END
-    AND name LIKE ('%' || :searchQuery || '%');

--- a/persistence/src/commonMain/db_user/migrations/90.sqm
+++ b/persistence/src/commonMain/db_user/migrations/90.sqm
@@ -19,20 +19,21 @@ CREATE INDEX unread_event_date ON UnreadEvent(creation_date);
 CREATE INDEX unread_event_type ON UnreadEvent(type);
 
 CREATE TABLE LastMessage (
-      conversation_id TEXT AS QualifiedIDEntity NOT NULL,
-      message_id TEXT NOT NULL,
-      creation_date INTEGER AS Instant NOT NULL,
+      conversation_id TEXT AS QualifiedIDEntity,
+      message_id TEXT,
+      creation_date INTEGER AS Instant,
 
-      FOREIGN KEY (conversation_id) REFERENCES Conversation(qualified_id) ON DELETE CASCADE ON UPDATE CASCADE,
-      FOREIGN KEY (message_id, conversation_id) REFERENCES Message(id, conversation_id) ON DELETE CASCADE ON UPDATE CASCADE,
+      FOREIGN KEY (conversation_id) REFERENCES Conversation(qualified_id) ON DELETE CASCADE ON UPDATE SET NULL, -- there is a trigger to handle null values
+      FOREIGN KEY (message_id, conversation_id) REFERENCES Message(id, conversation_id) ON DELETE CASCADE ON UPDATE SET NULL, -- there is a trigger to handle null values
       PRIMARY KEY (conversation_id)
 );
 
+-- update last message when newly inserted message is newer than the current last message
 CREATE TRIGGER updateLastMessageAfterInsertingNewMessage
 AFTER INSERT ON Message
 WHEN
     new.visibility IN ('VISIBLE', 'DELETED')
-    OR new.content_type IN ('TEXT', 'ASSET', 'KNOCK', 'MISSED_CALL', 'CONVERSATION_RENAMED', 'MEMBER_CHANGE', 'COMPOSITE', 'CONVERSATION_DEGRADED_MLS', 'CONVERSATION_DEGRADED_PROTEUS', 'CONVERSATION_VERIFIED_MLS', 'CONVERSATION_VERIFIED_PROTEUS', 'LOCATION')
+    AND new.content_type IN ('TEXT', 'ASSET', 'KNOCK', 'MISSED_CALL', 'CONVERSATION_RENAMED', 'MEMBER_CHANGE', 'COMPOSITE', 'CONVERSATION_DEGRADED_MLS', 'CONVERSATION_DEGRADED_PROTEUS', 'CONVERSATION_VERIFIED_MLS', 'CONVERSATION_VERIFIED_PROTEUS', 'LOCATION')
 BEGIN
     INSERT INTO LastMessage(conversation_id, message_id, creation_date)
     VALUES (new.conversation_id, new.id, new.creation_date)
@@ -44,6 +45,7 @@ BEGIN
             excluded.creation_date > LastMessage.creation_date;
 END;
 
+-- update last message after deleting the current last message by finding new last message for the conversation
 CREATE TRIGGER updateLastMessageAfterDeletingLastMessage
 AFTER DELETE ON LastMessage
 BEGIN
@@ -64,10 +66,36 @@ BEGIN
             excluded.creation_date > LastMessage.creation_date;
 END;
 
-CREATE TRIGGER updateLastMessageAfterUpdatingLastMessage
-AFTER UPDATE OF visibility, content_type, creation_date ON Message
+-- update last message after a message got updated and now this one should be the new last message
+-- or if the current last message shouldn't be the last message anymore because of the visibility update for instance
+CREATE TRIGGER updateLastMessageAfterUpdatingMessage
+AFTER UPDATE OF id, conversation_id, visibility, content_type, creation_date ON Message
 WHEN
     new.creation_date >= (SELECT creation_date FROM LastMessage WHERE conversation_id = new.conversation_id LIMIT 1)
+BEGIN
+    INSERT INTO LastMessage(conversation_id, message_id, creation_date)
+    SELECT conversation_id, id, creation_date
+    FROM Message
+    WHERE
+        new.conversation_id = Message.conversation_id
+		AND Message.visibility IN ('VISIBLE', 'DELETED')
+		AND Message.content_type IN ('TEXT', 'ASSET', 'KNOCK', 'MISSED_CALL', 'CONVERSATION_RENAMED', 'MEMBER_CHANGE', 'COMPOSITE', 'CONVERSATION_DEGRADED_MLS', 'CONVERSATION_DEGRADED_PROTEUS', 'CONVERSATION_VERIFIED_MLS', 'CONVERSATION_VERIFIED_PROTEUS', 'LOCATION')
+    ORDER BY creation_date DESC
+    LIMIT 1
+    ON CONFLICT(conversation_id)
+        DO UPDATE SET
+            message_id = excluded.message_id,
+            creation_date = excluded.creation_date
+        WHERE
+            excluded.creation_date > LastMessage.creation_date;
+END;
+
+-- update last message after there was a foreign key updated to null by finding new last message for that conversation
+-- this happens when a message is moved to another conversation or id of a message is changed
+CREATE TRIGGER updateLastMessageAfterForeignKeyUpdatedToNull
+AFTER UPDATE OF conversation_id ON LastMessage
+WHEN
+    new.conversation_id IS NULL
 BEGIN
     INSERT INTO LastMessage(conversation_id, message_id, creation_date)
     SELECT conversation_id, id, creation_date
@@ -84,6 +112,7 @@ BEGIN
             creation_date = excluded.creation_date
         WHERE
             excluded.creation_date > LastMessage.creation_date;
+    DELETE FROM LastMessage WHERE conversation_id IS NULL;
 END;
 
 -- populate LastMessage table with the last message of each conversation

--- a/persistence/src/commonMain/db_user/migrations/90.sqm
+++ b/persistence/src/commonMain/db_user/migrations/90.sqm
@@ -131,7 +131,7 @@ SELECT
     -- last message
     Message.id AS lastMessageId,
     Message.content_type AS lastMessageContentType,
-    Message.creation_date AS lastMessageDatfe,
+    Message.creation_date AS lastMessageDate,
     Message.visibility AS lastMessageVisibility,
     Message.sender_user_id AS lastMessageSenderUserId,
     (Message.expire_after_millis IS NOT NULL) AS lastMessageIsEphemeral,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/TableMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/TableMapper.kt
@@ -26,6 +26,7 @@ import com.wire.kalium.persistence.Client
 import com.wire.kalium.persistence.Connection
 import com.wire.kalium.persistence.Conversation
 import com.wire.kalium.persistence.ConversationLegalHoldStatusChangeNotified
+import com.wire.kalium.persistence.LastMessage
 import com.wire.kalium.persistence.Member
 import com.wire.kalium.persistence.Message
 import com.wire.kalium.persistence.MessageAssetContent
@@ -264,5 +265,10 @@ internal object TableMapper {
     val messageDraftsAdapter = MessageDraft.Adapter(
         conversation_idAdapter = QualifiedIDAdapter,
         mention_listAdapter = MentionListAdapter()
+    )
+
+    val lastMessageAdapter = LastMessage.Adapter(
+        conversation_idAdapter = QualifiedIDAdapter,
+        creation_dateAdapter = InstantTypeAdapter,
     )
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
@@ -157,7 +157,8 @@ class UserDatabaseBuilder internal constructor(
         TableMapper.messageConversationProtocolChangedDuringACAllContentAdapter,
         ConversationLegalHoldStatusChangeNotifiedAdapter = TableMapper.conversationLegalHoldStatusChangeNotifiedAdapter,
         MessageAssetTransferStatusAdapter = TableMapper.messageAssetTransferStatusAdapter,
-        MessageDraftAdapter = TableMapper.messageDraftsAdapter
+        MessageDraftAdapter = TableMapper.messageDraftsAdapter,
+        LastMessageAdapter = TableMapper.lastMessageAdapter,
     )
 
     init {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11808" title="WPB-11808" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11808</a>  [Android] app stalls when fetching a page of conversations from the local DB
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The paginated conversation list query is unable to show the list in a reasonable time, if someone has many conversations and messages then it can take multiple minutes.

### Causes (Optional)

Left joining messages with multiple columns from different content tables and left joining unread events to just get last message for each conversation and count of different unread events is too far from optimal. We have managed to reduce full table scans but there is still a lot of data to work on by this query.

### Solutions

To have a proper data to work on, I filled a database with ~1150 conversations and over 200 000 messages, biggest conversation had around 35 000 messages and 27 000 unread events.
With this DB, I waited more than 10 minutes using the current paginated query to get the result and eventually gave up. So I checked various ideas, below are the ones that looked most promising.

For unread events table, there are two ways: to left join all unread events into main query and calculate it or to make a subquery or view to first count events on just that table and then left join results of that calculations into the main query.

For message table, first idea was to match the solution implemented some time ago and to make a single subquery to get ids of last messages for each conversation and then left join it with all contents and other things - thanks to that it doesn't left join all messages and their contents first, but just the messages that it actually needs.
Second one was to create a dedicated table which contains ids of last message for each conversation, and just that, so it could replace this subquery and make the query even simpler. The main problem with that was to make sure this table is synced with the message table, so 3 triggers were created - when inserting new message, when updating visibility or type of a message (two parameters that are taken into account when selecting last message) and when deleting a last message (to find the one that from now on should be the last one). Another issue is whether this can affect the event handling times, so I checked that by executing 3000x `processApplicationMessage` using current code and with this additional table which needs to stay synced using triggers when new message is inserted:

<img width="744" alt="image" src="https://github.com/user-attachments/assets/3206c517-3bf8-48f3-a7aa-f83c47c5e114">

Results show that there is no difference, so it's safe to use.

To have a perspective, here are the times of three main queries used to fetch conversation list currently without the pagination:
<img width="516" alt="image" src="https://github.com/user-attachments/assets/08486694-52ee-466b-a626-be127492167c">

Around 175ms to get the list without pagination. 
As I said, with current paginated query I couldn't get a result in over 10 minutes, but with improvements explained above, it started to work in a very reasonable time:
  
<img width="506" alt="image" src="https://github.com/user-attachments/assets/e180114a-cac7-4b87-8848-cf255402ea3d">

A, B, C, D are just a combinations of these improvements for joining both message and unread event table, explained here (with average execution times):

<img width="864" alt="image" src="https://github.com/user-attachments/assets/b827894c-2b45-4a26-8e74-b390372cbe04">

It looks like the winner is D, and it's unbelievable that the execution of such complex query can take under 20ms, but so far it looks like everything is working correctly. 
So here in this PR, the D approach is implemented - with new dedicated table `LastMessage` and `UnreadEventCountsGrouped` view used in the main query which doesn't require anymore to be GROUPed BY.

### Testing

#### How to Test

Enable `paginated_conversation_list_enabled` feature flag and open the conversation list.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
