### PR TITLE
fix: Adjust used JDK name for deployment of testservice (WPB-14267)

### DIFF
--- a/testservice/Jenkinsfile
+++ b/testservice/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
                 }
             }
             steps {
-                withMaven(jdk: 'AdoptiumJDK17', maven: 'M3', mavenLocalRepo: '.repository') {
+                withMaven(jdk: 'JDK17', maven: 'M3', mavenLocalRepo: '.repository') {
                     sh 'PATH=$HOME/.cargo/bin:$PATH make'
                     sh 'sudo cp $WORKSPACE/native/libs/lib* /usr/lib/'
                     sh './gradlew clean'
@@ -25,7 +25,7 @@ pipeline {
         }
         stage('Build') {
             steps {
-                withMaven(jdk: 'AdoptiumJDK17', maven: 'M3', mavenLocalRepo: '.repository') {
+                withMaven(jdk: 'JDK17', maven: 'M3', mavenLocalRepo: '.repository') {
                     withCredentials([usernamePassword(credentialsId: 'READ_PACKAGES_GITHUB_TOKEN', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USER')]) {
                         sh './gradlew :testservice:shadowJar'
                     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14267" title="WPB-14267" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14267</a>  Kalium testservice fails to deploy
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We currently cannot deploy kalium testservice anymore.

### Causes (Optional)

I renamed the tool name from AdoptiumJDK17 to JDK17 in Jenkins to streamline settings.

### Solutions

Renamed it in the Jenkinsfile

