### PR TITLE
feature: connect to upgrade-personal-to-team API #WPB-11992

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -733,7 +733,7 @@ internal class UserDataSource internal constructor(
             .onSuccess {
                 kaliumLogger.d("Migrated user to team")
                 fetchSelfUser()
-                // TODO Invalidate team id in memory so UserSessionScope.selfTeamId got updated data
+                // TODO Invalidate team id in memory so UserSessionScope.selfTeamId got updated data WPB-12187
             }
             .onFailure { failure ->
                 kaliumLogger.e("Failed to migrate user to team: $failure")

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -298,6 +298,8 @@ import com.wire.kalium.logic.feature.session.token.AccessTokenRefresherImpl
 import com.wire.kalium.logic.feature.team.SyncSelfTeamUseCase
 import com.wire.kalium.logic.feature.team.SyncSelfTeamUseCaseImpl
 import com.wire.kalium.logic.feature.team.TeamScope
+import com.wire.kalium.logic.feature.team.migration.MigrateFromPersonalToTeamUseCase
+import com.wire.kalium.logic.feature.team.migration.MigrateFromPersonalToTeamUseCaseImpl
 import com.wire.kalium.logic.feature.user.GetDefaultProtocolUseCase
 import com.wire.kalium.logic.feature.user.GetDefaultProtocolUseCaseImpl
 import com.wire.kalium.logic.feature.user.IsE2EIEnabledUseCase
@@ -782,16 +784,17 @@ class UserSessionScope internal constructor(
     )
 
     private val userRepository: UserRepository = UserDataSource(
-        userStorage.database.userDAO,
-        userStorage.database.metadataDAO,
-        userStorage.database.clientDAO,
-        authenticatedNetworkContainer.selfApi,
-        authenticatedNetworkContainer.userDetailsApi,
-        authenticatedNetworkContainer.teamsApi,
-        globalScope.sessionRepository,
-        userId,
-        selfTeamId,
-        legalHoldHandler
+        userDAO = userStorage.database.userDAO,
+        metadataDAO = userStorage.database.metadataDAO,
+        clientDAO = userStorage.database.clientDAO,
+        selfApi = authenticatedNetworkContainer.selfApi,
+        userDetailsApi = authenticatedNetworkContainer.userDetailsApi,
+        upgradePersonalToTeamApi = authenticatedNetworkContainer.upgradePersonalToTeamApi,
+        teamsApi = authenticatedNetworkContainer.teamsApi,
+        sessionRepository = globalScope.sessionRepository,
+        selfUserId = userId,
+        selfTeamIdProvider = selfTeamId,
+        legalHoldHandler = legalHoldHandler,
     )
 
     private val accountRepository: AccountRepository
@@ -2073,6 +2076,9 @@ class UserSessionScope internal constructor(
             checkRevocationList,
             userScopedLogger
         )
+
+    val migrateFromPersonalToTeam: MigrateFromPersonalToTeamUseCase
+        get() = MigrateFromPersonalToTeamUseCaseImpl(userRepository)
 
     internal val getProxyCredentials: GetProxyCredentialsUseCase
         get() = GetProxyCredentialsUseCaseImpl(sessionManager)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/migration/MigrateFromPersonalToTeamUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/migration/MigrateFromPersonalToTeamUseCase.kt
@@ -1,0 +1,49 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.team.migration
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.functional.fold
+
+interface MigrateFromPersonalToTeamUseCase {
+    suspend operator fun invoke(teamName: String): MigrateFromPersonalToTeamResult
+}
+
+sealed class MigrateFromPersonalToTeamResult {
+    data class Success(val teamId: String, val teamName: String) : MigrateFromPersonalToTeamResult()
+    data class Error(val failure: CoreFailure) : MigrateFromPersonalToTeamResult()
+}
+
+internal class MigrateFromPersonalToTeamUseCaseImpl internal constructor(
+    private val userRepository: UserRepository,
+) : MigrateFromPersonalToTeamUseCase {
+    override suspend operator fun invoke(
+        teamName: String,
+    ): MigrateFromPersonalToTeamResult {
+        return userRepository.migrateUserToTeam(teamName)
+            .fold(
+                { error -> return MigrateFromPersonalToTeamResult.Error(error) },
+                { success ->
+                    MigrateFromPersonalToTeamResult.Success(
+                        teamId = success.teamId,
+                        teamName = success.teamName,
+                    )
+                })
+    }
+}

--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/UpgradePersonalToTeamDTO.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/UpgradePersonalToTeamDTO.kt
@@ -1,0 +1,27 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.authenticated
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CreateUserTeamDTO(
+    @SerialName("team_id") val teamId: String,
+    @SerialName("team_name") val teamName: String,
+)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/UpgradePersonalToTeamApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/UpgradePersonalToTeamApi.kt
@@ -1,0 +1,30 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.base.authenticated
+
+import com.wire.kalium.network.api.authenticated.CreateUserTeamDTO
+import com.wire.kalium.network.utils.NetworkResponse
+
+interface UpgradePersonalToTeamApi : BaseApi {
+
+    suspend fun migrateToTeam(teamName: String): NetworkResponse<CreateUserTeamDTO>
+
+    companion object {
+        const val MIN_API_VERSION = 7
+    }
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/ConversationApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/ConversationApiV0.kt
@@ -395,6 +395,7 @@ internal open class ConversationApiV0 internal constructor(
             httpClient.get("$PATH_CONVERSATIONS/${conversationId.value}/$PATH_CODE")
         }
 
+
     protected companion object {
         const val PATH_CONVERSATIONS = "conversations"
         const val PATH_SELF = "self"

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/UpgradePersonalToTeamApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/UpgradePersonalToTeamApiV0.kt
@@ -1,0 +1,33 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v0.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.authenticated.CreateUserTeamDTO
+import com.wire.kalium.network.api.base.authenticated.UpgradePersonalToTeamApi
+import com.wire.kalium.network.utils.NetworkResponse
+
+internal open class UpgradePersonalToTeamApiV0 internal constructor(
+    private val authenticatedNetworkClient: AuthenticatedNetworkClient,
+) : UpgradePersonalToTeamApi {
+
+    internal val httpClient get() = authenticatedNetworkClient.httpClient
+    override suspend fun migrateToTeam(teamName: String): NetworkResponse<CreateUserTeamDTO> =
+        getApiNotSupportedError(::migrateToTeam.name, UpgradePersonalToTeamApi.MIN_API_VERSION)
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/networkContainer/AuthenticatedNetworkContainerV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/networkContainer/AuthenticatedNetworkContainerV0.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.network.api.base.authenticated.AccessTokenApi
 import com.wire.kalium.network.api.base.authenticated.CallApi
 import com.wire.kalium.network.api.base.authenticated.TeamsApi
+import com.wire.kalium.network.api.base.authenticated.UpgradePersonalToTeamApi
 import com.wire.kalium.network.api.base.authenticated.WildCardApi
 import com.wire.kalium.network.api.base.authenticated.asset.AssetApi
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
@@ -59,6 +60,7 @@ import com.wire.kalium.network.api.v0.authenticated.PreKeyApiV0
 import com.wire.kalium.network.api.v0.authenticated.PropertiesApiV0
 import com.wire.kalium.network.api.v0.authenticated.SelfApiV0
 import com.wire.kalium.network.api.v0.authenticated.TeamsApiV0
+import com.wire.kalium.network.api.v0.authenticated.UpgradePersonalToTeamApiV0
 import com.wire.kalium.network.api.v0.authenticated.UserDetailsApiV0
 import com.wire.kalium.network.api.v0.authenticated.UserSearchApiV0
 import com.wire.kalium.network.api.vcommon.WildCardApiImpl
@@ -136,4 +138,9 @@ internal class AuthenticatedNetworkContainerV0 internal constructor(
     override val propertiesApi: PropertiesApi get() = PropertiesApiV0(networkClient)
 
     override val wildCardApi: WildCardApi get() = WildCardApiImpl(networkClient)
+
+    override val upgradePersonalToTeamApi: UpgradePersonalToTeamApi
+        get() = UpgradePersonalToTeamApiV0(
+            networkClient
+        )
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/authenticated/UpgradePersonalToTeamApiV2.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/authenticated/UpgradePersonalToTeamApiV2.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v2.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.v0.authenticated.UpgradePersonalToTeamApiV0
+
+internal open class UpgradePersonalToTeamApiV2 internal constructor(
+    authenticatedNetworkClient: AuthenticatedNetworkClient,
+) : UpgradePersonalToTeamApiV0(authenticatedNetworkClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/authenticated/networkContainer/AuthenticatedNetworkContainerV2.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/authenticated/networkContainer/AuthenticatedNetworkContainerV2.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.network.api.base.authenticated.AccessTokenApi
 import com.wire.kalium.network.api.base.authenticated.CallApi
 import com.wire.kalium.network.api.base.authenticated.TeamsApi
+import com.wire.kalium.network.api.base.authenticated.UpgradePersonalToTeamApi
 import com.wire.kalium.network.api.base.authenticated.WildCardApi
 import com.wire.kalium.network.api.base.authenticated.asset.AssetApi
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
@@ -60,6 +61,7 @@ import com.wire.kalium.network.api.v2.authenticated.PreKeyApiV2
 import com.wire.kalium.network.api.v2.authenticated.PropertiesApiV2
 import com.wire.kalium.network.api.v2.authenticated.SelfApiV2
 import com.wire.kalium.network.api.v2.authenticated.TeamsApiV2
+import com.wire.kalium.network.api.v2.authenticated.UpgradePersonalToTeamApiV2
 import com.wire.kalium.network.api.v2.authenticated.UserDetailsApiV2
 import com.wire.kalium.network.api.v2.authenticated.UserSearchApiV2
 import com.wire.kalium.network.api.vcommon.WildCardApiImpl
@@ -139,4 +141,9 @@ internal class AuthenticatedNetworkContainerV2 internal constructor(
     override val propertiesApi: PropertiesApi get() = PropertiesApiV2(networkClient)
 
     override val wildCardApi: WildCardApi get() = WildCardApiImpl(networkClient)
+
+    override val upgradePersonalToTeamApi: UpgradePersonalToTeamApi
+        get() = UpgradePersonalToTeamApiV2(
+            networkClient
+        )
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/authenticated/UpgradePersonalToTeamApiV3.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/authenticated/UpgradePersonalToTeamApiV3.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v3.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.v2.authenticated.UpgradePersonalToTeamApiV2
+
+internal open class UpgradePersonalToTeamApiV3 internal constructor(
+    authenticatedNetworkClient: AuthenticatedNetworkClient,
+) : UpgradePersonalToTeamApiV2(authenticatedNetworkClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/authenticated/networkContainer/AuthenticatedNetworkContainerV3.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/authenticated/networkContainer/AuthenticatedNetworkContainerV3.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.network.api.base.authenticated.AccessTokenApi
 import com.wire.kalium.network.api.base.authenticated.CallApi
 import com.wire.kalium.network.api.base.authenticated.TeamsApi
+import com.wire.kalium.network.api.base.authenticated.UpgradePersonalToTeamApi
 import com.wire.kalium.network.api.base.authenticated.WildCardApi
 import com.wire.kalium.network.api.base.authenticated.asset.AssetApi
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
@@ -61,6 +62,7 @@ import com.wire.kalium.network.api.v3.authenticated.PreKeyApiV3
 import com.wire.kalium.network.api.v3.authenticated.PropertiesApiV3
 import com.wire.kalium.network.api.v3.authenticated.SelfApiV3
 import com.wire.kalium.network.api.v3.authenticated.TeamsApiV3
+import com.wire.kalium.network.api.v3.authenticated.UpgradePersonalToTeamApiV3
 import com.wire.kalium.network.api.v3.authenticated.UserDetailsApiV3
 import com.wire.kalium.network.api.v3.authenticated.UserSearchApiV3
 import com.wire.kalium.network.api.vcommon.WildCardApiImpl
@@ -140,4 +142,9 @@ internal class AuthenticatedNetworkContainerV3 internal constructor(
     override val propertiesApi: PropertiesApi get() = PropertiesApiV3(networkClient)
 
     override val wildCardApi: WildCardApi get() = WildCardApiImpl(networkClient)
+
+    override val upgradePersonalToTeamApi: UpgradePersonalToTeamApi
+        get() = UpgradePersonalToTeamApiV3(
+            networkClient
+        )
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/UpgradePersonalToTeamApiV4.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/UpgradePersonalToTeamApiV4.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v4.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.v2.authenticated.UpgradePersonalToTeamApiV2
+
+internal open class UpgradePersonalToTeamApiV4 internal constructor(
+    authenticatedNetworkClient: AuthenticatedNetworkClient,
+) : UpgradePersonalToTeamApiV2(authenticatedNetworkClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/networkContainer/AuthenticatedNetworkContainerV4.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/networkContainer/AuthenticatedNetworkContainerV4.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.network.api.base.authenticated.AccessTokenApi
 import com.wire.kalium.network.api.base.authenticated.CallApi
 import com.wire.kalium.network.api.base.authenticated.TeamsApi
+import com.wire.kalium.network.api.base.authenticated.UpgradePersonalToTeamApi
 import com.wire.kalium.network.api.base.authenticated.WildCardApi
 import com.wire.kalium.network.api.base.authenticated.asset.AssetApi
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
@@ -60,6 +61,7 @@ import com.wire.kalium.network.api.v4.authenticated.PreKeyApiV4
 import com.wire.kalium.network.api.v4.authenticated.PropertiesApiV4
 import com.wire.kalium.network.api.v4.authenticated.SelfApiV4
 import com.wire.kalium.network.api.v4.authenticated.TeamsApiV4
+import com.wire.kalium.network.api.v4.authenticated.UpgradePersonalToTeamApiV4
 import com.wire.kalium.network.api.v4.authenticated.UserDetailsApiV4
 import com.wire.kalium.network.api.v4.authenticated.UserSearchApiV4
 import com.wire.kalium.network.api.vcommon.WildCardApiImpl
@@ -139,4 +141,9 @@ internal class AuthenticatedNetworkContainerV4 internal constructor(
     override val propertiesApi: PropertiesApi get() = PropertiesApiV4(networkClient)
 
     override val wildCardApi: WildCardApi get() = WildCardApiImpl(networkClient)
+
+    override val upgradePersonalToTeamApi: UpgradePersonalToTeamApi
+        get() = UpgradePersonalToTeamApiV4(
+            networkClient
+        )
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/UpgradePersonalToTeamApiV5.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/UpgradePersonalToTeamApiV5.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v5.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.v4.authenticated.UpgradePersonalToTeamApiV4
+
+internal open class UpgradePersonalToTeamApiV5 internal constructor(
+    authenticatedNetworkClient: AuthenticatedNetworkClient,
+) : UpgradePersonalToTeamApiV4(authenticatedNetworkClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/networkContainer/AuthenticatedNetworkContainerV5.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/networkContainer/AuthenticatedNetworkContainerV5.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.network.api.base.authenticated.AccessTokenApi
 import com.wire.kalium.network.api.base.authenticated.CallApi
 import com.wire.kalium.network.api.base.authenticated.TeamsApi
+import com.wire.kalium.network.api.base.authenticated.UpgradePersonalToTeamApi
 import com.wire.kalium.network.api.base.authenticated.WildCardApi
 import com.wire.kalium.network.api.base.authenticated.asset.AssetApi
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
@@ -60,6 +61,7 @@ import com.wire.kalium.network.api.v5.authenticated.PreKeyApiV5
 import com.wire.kalium.network.api.v5.authenticated.PropertiesApiV5
 import com.wire.kalium.network.api.v5.authenticated.SelfApiV5
 import com.wire.kalium.network.api.v5.authenticated.TeamsApiV5
+import com.wire.kalium.network.api.v5.authenticated.UpgradePersonalToTeamApiV5
 import com.wire.kalium.network.api.v5.authenticated.UserDetailsApiV5
 import com.wire.kalium.network.api.v5.authenticated.UserSearchApiV5
 import com.wire.kalium.network.api.vcommon.WildCardApiImpl
@@ -139,4 +141,9 @@ internal class AuthenticatedNetworkContainerV5 internal constructor(
     override val propertiesApi: PropertiesApi get() = PropertiesApiV5(networkClient)
 
     override val wildCardApi: WildCardApi get() = WildCardApiImpl(networkClient)
+
+    override val upgradePersonalToTeamApi: UpgradePersonalToTeamApi
+        get() = UpgradePersonalToTeamApiV5(
+            networkClient
+        )
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v6/authenticated/UpgradePersonalToTeamApiV6.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v6/authenticated/UpgradePersonalToTeamApiV6.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v6.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.v5.authenticated.UpgradePersonalToTeamApiV5
+
+internal open class UpgradePersonalToTeamApiV6 internal constructor(
+    authenticatedNetworkClient: AuthenticatedNetworkClient,
+) : UpgradePersonalToTeamApiV5(authenticatedNetworkClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v6/authenticated/networkContainer/AuthenticatedNetworkContainerV6.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v6/authenticated/networkContainer/AuthenticatedNetworkContainerV6.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.network.api.base.authenticated.AccessTokenApi
 import com.wire.kalium.network.api.base.authenticated.CallApi
 import com.wire.kalium.network.api.base.authenticated.TeamsApi
+import com.wire.kalium.network.api.base.authenticated.UpgradePersonalToTeamApi
 import com.wire.kalium.network.api.base.authenticated.WildCardApi
 import com.wire.kalium.network.api.base.authenticated.asset.AssetApi
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
@@ -60,6 +61,7 @@ import com.wire.kalium.network.api.v6.authenticated.PreKeyApiV6
 import com.wire.kalium.network.api.v6.authenticated.PropertiesApiV6
 import com.wire.kalium.network.api.v6.authenticated.SelfApiV6
 import com.wire.kalium.network.api.v6.authenticated.TeamsApiV6
+import com.wire.kalium.network.api.v6.authenticated.UpgradePersonalToTeamApiV6
 import com.wire.kalium.network.api.v6.authenticated.UserDetailsApiV6
 import com.wire.kalium.network.api.v6.authenticated.UserSearchApiV6
 import com.wire.kalium.network.api.vcommon.WildCardApiImpl
@@ -139,4 +141,10 @@ internal class AuthenticatedNetworkContainerV6 internal constructor(
     override val propertiesApi: PropertiesApi get() = PropertiesApiV6(networkClient)
 
     override val wildCardApi: WildCardApi get() = WildCardApiImpl(networkClient)
+
+    override val upgradePersonalToTeamApi: UpgradePersonalToTeamApi
+        get() = UpgradePersonalToTeamApiV6(
+            networkClient
+        )
+
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v7/authenticated/UpgradePersonalToTeamApiV7.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v7/authenticated/UpgradePersonalToTeamApiV7.kt
@@ -1,0 +1,54 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v7.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.authenticated.CreateUserTeamDTO
+import com.wire.kalium.network.api.unauthenticated.register.NewBindingTeamDTO
+import com.wire.kalium.network.api.v6.authenticated.UpgradePersonalToTeamApiV6
+import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.wrapKaliumResponse
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+
+internal open class UpgradePersonalToTeamApiV7 internal constructor(
+    authenticatedNetworkClient: AuthenticatedNetworkClient,
+) : UpgradePersonalToTeamApiV6(authenticatedNetworkClient) {
+
+    override suspend fun migrateToTeam(teamName: String): NetworkResponse<CreateUserTeamDTO> {
+        return wrapKaliumResponse {
+
+            httpClient.post(PATH_MIGRATE_TO_TEAM) {
+                // We do not ask user for icon at this point, so we use hardcoded values from the backend
+                setBody(
+                    NewBindingTeamDTO(
+                        name = teamName,
+                        iconAssetId = "default",
+                        iconKey = "abc",
+                        currency = null,//TODO is this ok?
+                    )
+                )
+            }
+        }
+    }
+
+    companion object {
+        const val PATH_MIGRATE_TO_TEAM = "upgrade-personal-to-team"
+    }
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v7/authenticated/UpgradePersonalToTeamApiV7.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v7/authenticated/UpgradePersonalToTeamApiV7.kt
@@ -41,7 +41,7 @@ internal open class UpgradePersonalToTeamApiV7 internal constructor(
                         name = teamName,
                         iconAssetId = "default",
                         iconKey = "abc",
-                        currency = null,//TODO is this ok?
+                        currency = null,
                     )
                 )
             }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v7/authenticated/networkContainer/AuthenticatedNetworkContainerV7.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v7/authenticated/networkContainer/AuthenticatedNetworkContainerV7.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.network.api.base.authenticated.AccessTokenApi
 import com.wire.kalium.network.api.base.authenticated.CallApi
 import com.wire.kalium.network.api.base.authenticated.TeamsApi
+import com.wire.kalium.network.api.base.authenticated.UpgradePersonalToTeamApi
 import com.wire.kalium.network.api.base.authenticated.WildCardApi
 import com.wire.kalium.network.api.base.authenticated.asset.AssetApi
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
@@ -60,6 +61,7 @@ import com.wire.kalium.network.api.v7.authenticated.PreKeyApiV7
 import com.wire.kalium.network.api.v7.authenticated.PropertiesApiV7
 import com.wire.kalium.network.api.v7.authenticated.SelfApiV7
 import com.wire.kalium.network.api.v7.authenticated.TeamsApiV7
+import com.wire.kalium.network.api.v7.authenticated.UpgradePersonalToTeamApiV7
 import com.wire.kalium.network.api.v7.authenticated.UserDetailsApiV7
 import com.wire.kalium.network.api.v7.authenticated.UserSearchApiV7
 import com.wire.kalium.network.api.vcommon.WildCardApiImpl
@@ -148,4 +150,9 @@ internal class AuthenticatedNetworkContainerV7 internal constructor(
     override val propertiesApi: PropertiesApi get() = PropertiesApiV7(networkClient)
 
     override val wildCardApi: WildCardApi get() = WildCardApiImpl(networkClient)
+
+    override val upgradePersonalToTeamApi: UpgradePersonalToTeamApi
+        get() = UpgradePersonalToTeamApiV7(
+            networkClient
+        )
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/networkContainer/AuthenticatedNetworkContainer.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/networkContainer/AuthenticatedNetworkContainer.kt
@@ -49,6 +49,7 @@ import com.wire.kalium.network.api.v0.authenticated.networkContainer.Authenticat
 import com.wire.kalium.network.api.v2.authenticated.networkContainer.AuthenticatedNetworkContainerV2
 import com.wire.kalium.network.api.v4.authenticated.networkContainer.AuthenticatedNetworkContainerV4
 import com.wire.kalium.network.api.v5.authenticated.networkContainer.AuthenticatedNetworkContainerV5
+import com.wire.kalium.network.api.v6.authenticated.networkContainer.AuthenticatedNetworkContainerV6
 import com.wire.kalium.network.api.v7.authenticated.networkContainer.AuthenticatedNetworkContainerV7
 import com.wire.kalium.network.session.CertificatePinning
 import com.wire.kalium.network.session.SessionManager
@@ -182,9 +183,7 @@ interface AuthenticatedNetworkContainer {
                     kaliumLogger
                 )
 
-
-                //TODO revert object to v6
-                6 -> AuthenticatedNetworkContainerV7(
+                6 -> AuthenticatedNetworkContainerV6(
                     sessionManager,
                     selfUserId,
                     certificatePinning,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/networkContainer/AuthenticatedNetworkContainer.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/networkContainer/AuthenticatedNetworkContainer.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.network.AuthenticatedWebSocketClient
 import com.wire.kalium.network.api.base.authenticated.AccessTokenApi
 import com.wire.kalium.network.api.base.authenticated.CallApi
 import com.wire.kalium.network.api.base.authenticated.TeamsApi
+import com.wire.kalium.network.api.base.authenticated.UpgradePersonalToTeamApi
 import com.wire.kalium.network.api.base.authenticated.WildCardApi
 import com.wire.kalium.network.api.base.authenticated.asset.AssetApi
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
@@ -48,7 +49,6 @@ import com.wire.kalium.network.api.v0.authenticated.networkContainer.Authenticat
 import com.wire.kalium.network.api.v2.authenticated.networkContainer.AuthenticatedNetworkContainerV2
 import com.wire.kalium.network.api.v4.authenticated.networkContainer.AuthenticatedNetworkContainerV4
 import com.wire.kalium.network.api.v5.authenticated.networkContainer.AuthenticatedNetworkContainerV5
-import com.wire.kalium.network.api.v6.authenticated.networkContainer.AuthenticatedNetworkContainerV6
 import com.wire.kalium.network.api.v7.authenticated.networkContainer.AuthenticatedNetworkContainerV7
 import com.wire.kalium.network.session.CertificatePinning
 import com.wire.kalium.network.session.SessionManager
@@ -109,6 +109,8 @@ interface AuthenticatedNetworkContainer {
     val propertiesApi: PropertiesApi
 
     val wildCardApi: WildCardApi
+
+    val upgradePersonalToTeamApi: UpgradePersonalToTeamApi
 
     companion object {
 
@@ -180,7 +182,18 @@ interface AuthenticatedNetworkContainer {
                     kaliumLogger
                 )
 
-                6 -> AuthenticatedNetworkContainerV6(
+
+                //TODO revert object to v6
+                6 -> AuthenticatedNetworkContainerV7(
+                    sessionManager,
+                    selfUserId,
+                    certificatePinning,
+                    mockEngine,
+                    mockWebSocketSession,
+                    kaliumLogger
+                )
+
+                7 -> AuthenticatedNetworkContainerV7(
                     sessionManager,
                     selfUserId,
                     certificatePinning,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Adds calls to the API when migrating from personal to team account.

Needs releases with:

- [api v7](https://github.com/wireapp/kalium/pull/3099)

### Testing

#### Test Coverage (Optional)

Work in Progress

- [ ] I have added automated test to this contribution

#### How to Test

To test you need to switch to anta 
https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/300351887/Testing+environments+for+federation#anta

The html with deeplinks switching can be downloaded here. You must logout first before switching. https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/300351887/Testing+environments+for+federation#anta

To get signup code you must read the email from [inbucket](https://inbucket.anta.wire.link/monitor). 
Password is on [1password](https://start.1password.com/open/i?a=FOQLGGWZU5EQXEJO3V3A5HI3DU&v=nqjxjxdabagisaqjlyfym4kye4&i=gprcgudpieokefbatxqlxctu2m&h=wire.1password.eu).

Then:
- create personal account
- go to you profile page, at the top you will see migration banner
- go through the process
- at the you should see success screen
- currently you will only see changes to your account after app restart, WIP: https://wearezeta.atlassian.net/browse/WPB-12187


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
