### PR TITLE
fix: Properly updating draft message [WPB-14271]

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/MessageDrafts.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/MessageDrafts.sq
@@ -28,8 +28,8 @@ ON CONFLICT(conversation_id) DO UPDATE SET
     mention_list = excluded.mention_list
 WHERE -- execute the update only if any of the fields changed
     MessageDraft.text != excluded.text
-    OR MessageDraft.edit_message_id != excluded.edit_message_id
-    OR MessageDraft.quoted_message_id != excluded.quoted_message_id
+    OR MessageDraft.edit_message_id IS NOT excluded.edit_message_id
+    OR MessageDraft.quoted_message_id IS NOT excluded.quoted_message_id
     OR MessageDraft.mention_list != excluded.mention_list;
 
 getDraft:

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/draft/MessageDraftDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/draft/MessageDraftDAOTest.kt
@@ -33,6 +33,8 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 @Suppress("LargeClass")
 class MessageDraftDAOTest : BaseDatabaseTest() {
@@ -69,7 +71,7 @@ class MessageDraftDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenAlreadyExistingMessageDraft_whenUpserting_thenItShouldBeProperlyUpdatedInDb() = runTest {
+    fun givenAlreadyExistingMessageDraft_whenUpsertingTextChange_thenItShouldBeProperlyUpdatedInDb() = runTest {
         // Given
         insertInitialData()
         messageDraftDAO.upsertMessageDraft(MESSAGE_DRAFT.copy(text = "@John I need"))
@@ -80,6 +82,98 @@ class MessageDraftDAOTest : BaseDatabaseTest() {
         // Then
         val result = messageDraftDAO.getMessageDraft(conversationEntity1.id)
         assertEquals(MESSAGE_DRAFT, result)
+    }
+
+    @Test
+    fun givenAlreadyExistingMessageDraft_whenUpsertingDifferentQuotedMessageId_thenItShouldBeProperlyUpdatedInDb() = runTest {
+        // given
+        val newQuotedMessageId = "newQuotedMessageId"
+        insertInitialData()
+        messageDraftDAO.upsertMessageDraft(MESSAGE_DRAFT)
+
+        // when
+        messageDraftDAO.upsertMessageDraft(MESSAGE_DRAFT.copy(quotedMessageId = newQuotedMessageId))
+
+        // then
+        val result = messageDraftDAO.getMessageDraft(conversationEntity1.id)
+        assertNotNull(result)
+        assertEquals(newQuotedMessageId, result.quotedMessageId)
+    }
+
+    @Test
+    fun givenAlreadyExistingMessageDraft_whenUpsertingNullQuotedMessageId_thenItShouldBeProperlyUpdatedInDb() = runTest {
+        // given
+        insertInitialData()
+        messageDraftDAO.upsertMessageDraft(MESSAGE_DRAFT)
+
+        // when
+        messageDraftDAO.upsertMessageDraft(MESSAGE_DRAFT.copy(quotedMessageId = null))
+
+        // then
+        val result = messageDraftDAO.getMessageDraft(conversationEntity1.id)
+        assertNotNull(result)
+        assertNull(result.quotedMessageId)
+    }
+
+    @Test
+    fun givenAlreadyExistingMessageDraftWithoutQuotedMessageId_whenUpsertingQuotedMessageId_thenItShouldBeProperlyUpdatedInDb() = runTest{
+        // given
+        insertInitialData()
+        messageDraftDAO.upsertMessageDraft(MESSAGE_DRAFT.copy(quotedMessageId = null))
+
+        // when
+        messageDraftDAO.upsertMessageDraft(MESSAGE_DRAFT)
+
+        // then
+        val result = messageDraftDAO.getMessageDraft(conversationEntity1.id)
+        assertNotNull(result)
+        assertEquals(MESSAGE_DRAFT.quotedMessageId, result.quotedMessageId)
+    }
+
+    @Test
+    fun givenAlreadyExistingMessageDraft_whenUpsertingDifferentEditMessageId_thenItShouldBeProperlyUpdatedInDb() = runTest {
+        // given
+        val newEditMessageId = "newEditMessageId"
+        insertInitialData()
+        messageDraftDAO.upsertMessageDraft(MESSAGE_DRAFT)
+
+        // when
+        messageDraftDAO.upsertMessageDraft(MESSAGE_DRAFT.copy(editMessageId = newEditMessageId))
+
+        // then
+        val result = messageDraftDAO.getMessageDraft(conversationEntity1.id)
+        assertNotNull(result)
+        assertEquals(newEditMessageId, result.editMessageId)
+    }
+
+    @Test
+    fun givenAlreadyExistingMessageDraft_whenUpsertingNullEditMessageId_thenItShouldBeProperlyUpdatedInDb() = runTest {
+        // given
+        insertInitialData()
+        messageDraftDAO.upsertMessageDraft(MESSAGE_DRAFT)
+
+        // when
+        messageDraftDAO.upsertMessageDraft(MESSAGE_DRAFT.copy(editMessageId = null))
+
+        // then
+        val result = messageDraftDAO.getMessageDraft(conversationEntity1.id)
+        assertNotNull(result)
+        assertNull(result.editMessageId)
+    }
+
+    @Test
+    fun givenAlreadyExistingMessageDraft_whenUpsertingEmptyMentionList_thenItShouldBeProperlyUpdatedInDb() = runTest {
+        // given
+        insertInitialData()
+        messageDraftDAO.upsertMessageDraft(MESSAGE_DRAFT)
+
+        // when
+        messageDraftDAO.upsertMessageDraft(MESSAGE_DRAFT.copy(selectedMentionList = emptyList()))
+
+        // then
+        val result = messageDraftDAO.getMessageDraft(conversationEntity1.id)
+        assertNotNull(result)
+        assertEquals(emptyList(), result.selectedMentionList)
     }
 
     @Test
@@ -209,7 +303,21 @@ class MessageDraftDAOTest : BaseDatabaseTest() {
         )
         messageDAO.insertOrIgnoreMessage(
             newRegularMessageEntity(
+                id = "newEditMessageId",
+                conversationId = conversationEntity1.id,
+                senderUserId = userEntity1.id
+            )
+        )
+        messageDAO.insertOrIgnoreMessage(
+            newRegularMessageEntity(
                 id = "quotedMessageId",
+                conversationId = conversationEntity1.id,
+                senderUserId = userEntity1.id
+            )
+        )
+        messageDAO.insertOrIgnoreMessage(
+            newRegularMessageEntity(
+                id = "newQuotedMessageId",
                 conversationId = conversationEntity1.id,
                 senderUserId = userEntity1.id
             )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14271" title="WPB-14271" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14271</a>  [Android] reply draft is not cleared when clicking the x icon
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-14271

# What's new in this PR?

### Issues

We could not get rid of quoted or edited message from draft

### Causes (Optional)

We were trying to update draft values to null when removing quoted or edited messages which was failing on the database query check, so in fact we're never updating actual value to a default null one

### Solutions

Changed `!=` check in database to `IS NOT` - comparing value and `null` with `!=` is returning `NULL` not `true` or `false` if Im not mistaken. I've also added tests to cover other draft fields update

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
