### PR TITLE
fix: primary key of conversation folder [WPB-14309]

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationFolders.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationFolders.sq
@@ -14,7 +14,7 @@ CREATE TABLE LabeledConversation (
       FOREIGN KEY (conversation_id) REFERENCES Conversation(qualified_id) ON DELETE CASCADE ON UPDATE CASCADE,
       FOREIGN KEY (folder_id) REFERENCES ConversationFolder(id) ON DELETE CASCADE ON UPDATE CASCADE,
 
-      PRIMARY KEY (conversation_id, folder_id)
+      PRIMARY KEY (folder_id, conversation_id)
 );
 
 getConversationsFromFolder:

--- a/persistence/src/commonMain/db_user/migrations/91.sqm
+++ b/persistence/src/commonMain/db_user/migrations/91.sqm
@@ -15,5 +15,5 @@ CREATE TABLE LabeledConversation (
       FOREIGN KEY (conversation_id) REFERENCES Conversation(qualified_id) ON DELETE CASCADE ON UPDATE CASCADE,
       FOREIGN KEY (folder_id) REFERENCES ConversationFolder(id) ON DELETE CASCADE ON UPDATE CASCADE,
 
-      PRIMARY KEY (conversation_id, folder_id)
+      PRIMARY KEY (folder_id, conversation_id)
 );


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14309" title="WPB-14309" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14309</a>  Handle conversation folders and favorites from events
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- rearranged labeled conversation primary key 