### PR TITLE
feat: Delete group as admin [WPB-11559]

### DIFF
--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -299,7 +299,7 @@ sealed class ConversationDetails(open val conversation: Conversation) {
         override val conversation: Conversation,
         val hasOngoingCall: Boolean = false,
         val isSelfUserMember: Boolean,
-        val isSelfUserCreator: Boolean,
+        val selfUserTeamId: TeamId?,
         val selfRole: Conversation.Member.Role?
 //         val isTeamAdmin: Boolean, TODO kubaz
     ) : ConversationDetails(conversation)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryExtensions.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryExtensions.kt
@@ -20,6 +20,8 @@ package com.wire.kalium.logic.data.conversation
 import app.cash.paging.PagingConfig
 import app.cash.paging.PagingData
 import app.cash.paging.map
+import com.wire.kalium.logic.data.id.SelfTeamIdProvider
+import com.wire.kalium.logic.functional.getOrNull
 import com.wire.kalium.persistence.dao.conversation.ConversationDAO
 import com.wire.kalium.persistence.dao.conversation.ConversationDetailsWithEventsEntity
 import com.wire.kalium.persistence.dao.conversation.ConversationExtensions.QueryConfig
@@ -37,7 +39,8 @@ interface ConversationRepositoryExtensions {
 
 class ConversationRepositoryExtensionsImpl internal constructor(
     private val conversationDAO: ConversationDAO,
-    private val conversationMapper: ConversationMapper
+    private val conversationMapper: ConversationMapper,
+    private val selfTeamIdProvider: SelfTeamIdProvider
 ) : ConversationRepositoryExtensions {
     override suspend fun getPaginatedConversationDetailsWithEventsBySearchQuery(
         queryConfig: ConversationQueryConfig,
@@ -61,7 +64,8 @@ class ConversationRepositoryExtensionsImpl internal constructor(
             pagingData
                 .map { conversationDetailsWithEventsEntity ->
                     conversationMapper.fromDaoModelToDetailsWithEvents(
-                        conversationDetailsWithEventsEntity
+                        daoModel = conversationDetailsWithEventsEntity,
+                        selfUserTeamId = selfTeamIdProvider().getOrNull()
                     )
                 }
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/folders/ConversationFolderRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/folders/ConversationFolderRepository.kt
@@ -27,9 +27,11 @@ import com.wire.kalium.logic.data.conversation.ConversationMapper
 import com.wire.kalium.logic.data.conversation.FolderType
 import com.wire.kalium.logic.data.conversation.FolderWithConversations
 import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.id.SelfTeamIdProvider
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMapLeft
+import com.wire.kalium.logic.functional.getOrNull
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
@@ -57,6 +59,7 @@ internal class ConversationFolderDataSource internal constructor(
     private val conversationFolderDAO: ConversationFolderDAO,
     private val userPropertiesApi: PropertiesApi,
     private val selfUserId: QualifiedID,
+    private val selfTeamIdProvider: SelfTeamIdProvider,
     private val conversationMapper: ConversationMapper = MapperProvider.conversationMapper(selfUserId)
 ) : ConversationFolderRepository {
 
@@ -72,7 +75,7 @@ internal class ConversationFolderDataSource internal constructor(
     override suspend fun observeConversationsFromFolder(folderId: String): Flow<List<ConversationDetailsWithEvents>> =
         conversationFolderDAO.observeConversationListFromFolder(folderId).map { conversationDetailsWithEventsEntityList ->
             conversationDetailsWithEventsEntityList.map {
-                conversationMapper.fromDaoModelToDetailsWithEvents(it)
+                conversationMapper.fromDaoModelToDetailsWithEvents(it, selfTeamIdProvider().getOrNull())
             }
         }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -720,9 +720,10 @@ class UserSessionScope internal constructor(
 
     private val conversationFolderRepository: ConversationFolderRepository
         get() = ConversationFolderDataSource(
-            userStorage.database.conversationFolderDAO,
-            authenticatedNetworkContainer.propertiesApi,
-            userId
+            conversationFolderDAO = userStorage.database.conversationFolderDAO,
+            userPropertiesApi = authenticatedNetworkContainer.propertiesApi,
+            selfUserId = userId,
+            selfTeamIdProvider = selfTeamId
         )
 
     private val conversationGroupRepository: ConversationGroupRepository

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
@@ -174,7 +174,7 @@ class CallRepositoryTest {
                             Arrangement.groupConversation,
                             false,
                             isSelfUserMember = true,
-                            isSelfUserCreator = true,
+                            selfUserTeamId = null,
                             selfRole = Conversation.Member.Role.Member
                         )
                     )
@@ -212,7 +212,7 @@ class CallRepositoryTest {
                         ConversationDetails.Group(
                             Arrangement.groupConversation,
                             isSelfUserMember = true,
-                            isSelfUserCreator = true,
+                            selfUserTeamId = null,
                             selfRole = Conversation.Member.Role.Member
                         )
                     )
@@ -266,7 +266,7 @@ class CallRepositoryTest {
                         ConversationDetails.Group(
                             Arrangement.groupConversation,
                             isSelfUserMember = true,
-                            isSelfUserCreator = true,
+                            selfUserTeamId = null,
                             selfRole = Conversation.Member.Role.Member
                         )
                     )
@@ -309,7 +309,7 @@ class CallRepositoryTest {
                         ConversationDetails.Group(
                             Arrangement.groupConversation,
                             isSelfUserMember = true,
-                            isSelfUserCreator = true,
+                            selfUserTeamId = null,
                             selfRole = Conversation.Member.Role.Member
                         )
                     )
@@ -366,7 +366,7 @@ class CallRepositoryTest {
                         ConversationDetails.Group(
                             Arrangement.groupConversation,
                             isSelfUserMember = true,
-                            isSelfUserCreator = true,
+                            selfUserTeamId = null,
                             selfRole = Conversation.Member.Role.Member
                         )
                     )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
@@ -385,7 +385,7 @@ class ConversationMapperTest {
             messageDraft = messageDraft,
             unreadEvents = ConversationUnreadEventEntity(TestConversation.VIEW_ENTITY.id, mapOf()),
         )
-        assertion(conversationMapper.fromDaoModelToDetailsWithEvents(conversation).lastMessage)
+        assertion(conversationMapper.fromDaoModelToDetailsWithEvents(conversation, selfUserTeamId = null).lastMessage)
     }
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryExtensionsTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryExtensionsTest.kt
@@ -22,6 +22,7 @@ import app.cash.paging.Pager
 import app.cash.paging.PagingConfig
 import app.cash.paging.PagingSource
 import app.cash.paging.PagingState
+import com.wire.kalium.logic.data.id.SelfTeamIdProvider
 import com.wire.kalium.logic.data.message.MessageMapper
 import com.wire.kalium.logic.framework.TestConversationDetails
 import com.wire.kalium.logic.framework.TestMessage
@@ -91,9 +92,12 @@ class ConversationRepositoryExtensionsTest {
         private val conversationMapper: ConversationMapper = mock(ConversationMapper::class)
 
         @Mock
+        private val selfTeamIdProvider: SelfTeamIdProvider = mock(SelfTeamIdProvider::class)
+
+        @Mock
         private val messageMapper: MessageMapper = mock(MessageMapper::class)
         private val conversationRepositoryExtensions: ConversationRepositoryExtensions by lazy {
-            ConversationRepositoryExtensionsImpl(conversationDAO, conversationMapper)
+            ConversationRepositoryExtensionsImpl(conversationDAO, conversationMapper, selfTeamIdProvider)
         }
 
         init {
@@ -101,7 +105,7 @@ class ConversationRepositoryExtensionsTest {
                 messageMapper.fromEntityToMessage(any())
             }.returns(TestMessage.TEXT_MESSAGE)
             every {
-                conversationMapper.fromDaoModelToDetails(any())
+                conversationMapper.fromDaoModelToDetails(any(), any())
             }.returns(TestConversationDetails.CONVERSATION_GROUP)
             every {
                 conversationDAO.platformExtensions

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnConversationChangeUseCaseTest.kt
@@ -249,7 +249,7 @@ class EndCallOnConversationChangeUseCaseTest {
             conversation = conversation,
             hasOngoingCall = true,
             isSelfUserMember = false,
-            isSelfUserCreator = false,
+            selfUserTeamId = null,
             selfRole = null
         )
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationDetailsUseCaseTest.kt
@@ -81,7 +81,7 @@ class ObserveConversationDetailsUseCaseTest {
                     ConversationDetails.Group(
                         conversation,
                         isSelfUserMember = true,
-                        isSelfUserCreator = true,
+                        selfUserTeamId = null,
                         selfRole = Conversation.Member.Role.Member
                     )
                 ),
@@ -89,7 +89,7 @@ class ObserveConversationDetailsUseCaseTest {
                     ConversationDetails.Group(
                         conversation.copy(name = "New Name"),
                         isSelfUserMember = true,
-                        isSelfUserCreator = true,
+                        selfUserTeamId = null,
                         selfRole = Conversation.Member.Role.Member
                     )
                 )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationListDetailsUseCaseTest.kt
@@ -65,7 +65,7 @@ class ObserveConversationListDetailsUseCaseTest {
             ConversationDetails.Group(
                 groupConversation,
                 isSelfUserMember = true,
-                isSelfUserCreator = true,
+                selfUserTeamId = null,
                 selfRole = Conversation.Member.Role.Member
             )
 
@@ -100,14 +100,14 @@ class ObserveConversationListDetailsUseCaseTest {
             ConversationDetails.Group(
                 groupConversation1,
                 isSelfUserMember = true,
-                isSelfUserCreator = true,
+                selfUserTeamId = null,
                 selfRole = Conversation.Member.Role.Member
             )
         val groupConversationDetails2 =
             ConversationDetails.Group(
                 groupConversation2,
                 isSelfUserMember = true,
-                isSelfUserCreator = true,
+                selfUserTeamId = null,
                 selfRole = Conversation.Member.Role.Member
             )
 
@@ -141,7 +141,7 @@ class ObserveConversationListDetailsUseCaseTest {
         val groupConversationDetails = ConversationDetails.Group(
             conversation = groupConversation,
             isSelfUserMember = true,
-            isSelfUserCreator = true,
+            selfUserTeamId = null,
             selfRole = Conversation.Member.Role.Member
         )
 
@@ -175,7 +175,7 @@ class ObserveConversationListDetailsUseCaseTest {
             ConversationDetails.Group(
                 groupConversation,
                 isSelfUserMember = true,
-                isSelfUserCreator = true,
+                selfUserTeamId = null,
                 selfRole = Conversation.Member.Role.Member
             )
         )
@@ -223,7 +223,7 @@ class ObserveConversationListDetailsUseCaseTest {
         val groupConversationDetails = ConversationDetails.Group(
             groupConversation,
             isSelfUserMember = true,
-            isSelfUserCreator = true,
+            selfUserTeamId = null,
             selfRole = Conversation.Member.Role.Member
         )
 
@@ -258,7 +258,7 @@ class ObserveConversationListDetailsUseCaseTest {
         val groupConversationDetails = ConversationDetails.Group(
             groupConversation,
             isSelfUserMember = true,
-            isSelfUserCreator = true,
+            selfUserTeamId = null,
             selfRole = Conversation.Member.Role.Member
         )
 
@@ -287,7 +287,7 @@ class ObserveConversationListDetailsUseCaseTest {
         val groupConversationDetails = ConversationDetails.Group(
             groupConversation,
             isSelfUserMember = true,
-            isSelfUserCreator = true,
+            selfUserTeamId = null,
             selfRole = Conversation.Member.Role.Member
         )
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversationDetails.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversationDetails.kt
@@ -45,8 +45,8 @@ object TestConversationDetails {
 
     val CONVERSATION_GROUP = ConversationDetails.Group(
         conversation = TestConversation.GROUP(),
-        isSelfUserCreator = true,
         isSelfUserMember = true,
+        selfUserTeamId = null,
         selfRole = Conversation.Member.Role.Member
     )
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11559" title="WPB-11559" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-11559</a>  [Android] Delete a group as admin
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-11559

# What's new in this PR?

### Issues

We want to allow admins to delete group conversations

### Solutions

In order to delete group as an admin, we have to be in the same team, so we need to know our own team id, to later
check in the client if were matching the team

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
