### PR TITLE
chore: create backup protobuf models [WPB-10575]

### DIFF
--- a/protobuf-codegen/src/main/proto/backup.proto
+++ b/protobuf-codegen/src/main/proto/backup.proto
@@ -1,0 +1,68 @@
+/*
+ * Wire
+ * Copyright (C) 2021 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+syntax = "proto2";
+
+option java_package = "com.wire.kalium.protobuf.backup";
+
+message BackupData {
+    required BackupInfo info = 1;
+    repeated ExportedConversation conversations = 2;
+    repeated ExportedMessage messages = 3;
+    repeated ExportUser users = 4;
+}
+
+message BackupInfo {
+    required string platform = 1;
+    required string version = 2;
+    required ExportedQualifiedId userId = 3;
+    required int64 creation_time = 4;
+    required string clientId = 5;
+}
+
+message ExportUser {
+    required ExportedQualifiedId id = 1;
+    required string name = 2;
+    required string handle = 3;
+}
+
+message ExportedQualifiedId {
+    required string value = 1;
+    required string domain = 2;
+}
+
+message ExportedConversation {
+    required ExportedQualifiedId id = 1;
+    required string name = 2;
+}
+
+message ExportedMessage {
+    required string id = 1;
+    required int64 time_iso = 2;
+    required ExportedQualifiedId sender_user_id = 3;
+    required string sender_client_id = 4;
+    required ExportedQualifiedId conversation_id = 5;
+    oneof content {
+        ExportedText text = 6;
+    }
+}
+
+message ExportedText {
+    required string content = 1;
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10575" title="WPB-10575" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-10575</a>  Cross Platform Backup: Write common backup / restore library
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need to (de)serialize data when storing backups.

### Solutions

Use protobufs.
The idea here is to leverage the current protobuf generation and just build on top of it for backups.

When we upgrade to Kotlin 2.0+ we could replace PBandK and use KotlinX serialization for this. Unfortunately we're not there yet :'( 

### Notes

This is an initial / draft version that will be expanded in future PRs.

### Testing

N/A


----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
