### PR TITLE
feat: support Proteus federation if MLS not supported by backend (WPB-14250)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1879,6 +1879,9 @@ class UserSessionScope internal constructor(
 
     val search: SearchScope by lazy {
         SearchScope(
+            mlsPublicKeysRepository = mlsPublicKeysRepository,
+            getDefaultProtocol = getDefaultProtocol,
+            getConversationProtocolInfo = conversations.getConversationProtocolInfo,
             searchUserRepository = searchUserRepository,
             selfUserId = userId,
             sessionRepository = globalScope.sessionRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/search/IsFederationSearchAllowedUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/search/IsFederationSearchAllowedUseCase.kt
@@ -40,16 +40,21 @@ internal fun IsFederationSearchAllowedUseCase(
     dispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) = object : IsFederationSearchAllowedUseCase {
 
+    /**
+     * Check if FederatedSearchIsAllowed according to MLS configuration and protocol if a conversation is provided.
+     */
     override suspend operator fun invoke(conversationId: ConversationId?): Boolean = withContext(dispatcher.io) {
-        val isMLSConfigured = mlsPublicKeysRepository.getKeys().isRight()
-
-//         when ()
-
-
-        true
+        val isMlsConfiguredForBackend = mlsPublicKeysRepository.getKeys().isRight()
+        when (isMlsConfiguredForBackend) {
+            true -> isConversationProtocolAbleToFederate(conversationId)
+            false -> true
+        }
     }
 
-    private suspend fun isProtocolAbleToFederate(conversationId: ConversationId?): Boolean {
+    /**
+     * Check if the protocol for the conversation is able to federate.
+     */
+    private suspend fun isConversationProtocolAbleToFederate(conversationId: ConversationId?): Boolean {
         val isProteusTeam = getDefaultProtocol() == SupportedProtocol.PROTEUS
         val isOtherDomainAllowed: Boolean = conversationId?.let {
             when (val result = getConversationProtocolInfo(it)) {
@@ -59,7 +64,6 @@ internal fun IsFederationSearchAllowedUseCase(
                     !isProteusTeam && result.protocolInfo !is Conversation.ProtocolInfo.Proteus
             }
         } ?: !isProteusTeam
-
         return isOtherDomainAllowed
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/search/IsFederationSearchAllowedUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/search/IsFederationSearchAllowedUseCase.kt
@@ -28,6 +28,10 @@ import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.withContext
 
+/**
+ * Check if FederatedSearchIsAllowed according to MLS configuration of the backend
+ * and the conversation  protocol if a [ConversationId] is provided.
+ */
 interface IsFederationSearchAllowedUseCase {
     suspend operator fun invoke(conversationId: ConversationId?): Boolean
 }
@@ -40,9 +44,6 @@ internal fun IsFederationSearchAllowedUseCase(
     dispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) = object : IsFederationSearchAllowedUseCase {
 
-    /**
-     * Check if FederatedSearchIsAllowed according to MLS configuration and protocol if a conversation is provided.
-     */
     override suspend operator fun invoke(conversationId: ConversationId?): Boolean = withContext(dispatcher.io) {
         val isMlsConfiguredForBackend = mlsPublicKeysRepository.getKeys().isRight()
         when (isMlsConfiguredForBackend) {
@@ -52,7 +53,7 @@ internal fun IsFederationSearchAllowedUseCase(
     }
 
     /**
-     * Check if the protocol for the conversation is able to federate.
+     * MLS is enabled, then we need to check if the protocol for the conversation is able to federate.
      */
     private suspend fun isConversationProtocolAbleToFederate(conversationId: ConversationId?): Boolean {
         val isProteusTeam = getDefaultProtocol() == SupportedProtocol.PROTEUS

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/search/IsFederationSearchAllowedUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/search/IsFederationSearchAllowedUseCase.kt
@@ -1,0 +1,66 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.search
+
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.mlspublickeys.MLSPublicKeysRepository
+import com.wire.kalium.logic.data.user.SupportedProtocol
+import com.wire.kalium.logic.feature.conversation.GetConversationProtocolInfoUseCase
+import com.wire.kalium.logic.feature.user.GetDefaultProtocolUseCase
+import com.wire.kalium.logic.functional.isRight
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
+import kotlinx.coroutines.withContext
+
+interface IsFederationSearchAllowedUseCase {
+    suspend operator fun invoke(conversationId: ConversationId?): Boolean
+}
+
+@Suppress("FunctionNaming")
+internal fun IsFederationSearchAllowedUseCase(
+    mlsPublicKeysRepository: MLSPublicKeysRepository,
+    getDefaultProtocol: GetDefaultProtocolUseCase,
+    getConversationProtocolInfo: GetConversationProtocolInfoUseCase,
+    dispatcher: KaliumDispatcher = KaliumDispatcherImpl
+) = object : IsFederationSearchAllowedUseCase {
+
+    override suspend operator fun invoke(conversationId: ConversationId?): Boolean = withContext(dispatcher.io) {
+        val isMLSConfigured = mlsPublicKeysRepository.getKeys().isRight()
+
+//         when ()
+
+
+        true
+    }
+
+    private suspend fun isProtocolAbleToFederate(conversationId: ConversationId?): Boolean {
+        val isProteusTeam = getDefaultProtocol() == SupportedProtocol.PROTEUS
+        val isOtherDomainAllowed: Boolean = conversationId?.let {
+            when (val result = getConversationProtocolInfo(it)) {
+                is GetConversationProtocolInfoUseCase.Result.Failure -> !isProteusTeam
+
+                is GetConversationProtocolInfoUseCase.Result.Success ->
+                    !isProteusTeam && result.protocolInfo !is Conversation.ProtocolInfo.Proteus
+            }
+        } ?: !isProteusTeam
+
+        return isOtherDomainAllowed
+    }
+
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/search/SearchScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/search/SearchScope.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.logic.feature.conversation.GetConversationProtocolInfoUse
 import com.wire.kalium.logic.feature.user.GetDefaultProtocolUseCase
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 
+@Suppress("LongParameterList")
 class SearchScope internal constructor(
     private val mlsPublicKeysRepository: MLSPublicKeysRepository,
     private val getDefaultProtocol: GetDefaultProtocolUseCase,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/search/SearchScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/search/SearchScope.kt
@@ -17,12 +17,18 @@
  */
 package com.wire.kalium.logic.feature.search
 
+import com.wire.kalium.logic.data.mlspublickeys.MLSPublicKeysRepository
 import com.wire.kalium.logic.data.publicuser.SearchUserRepository
 import com.wire.kalium.logic.data.session.SessionRepository
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.conversation.GetConversationProtocolInfoUseCase
+import com.wire.kalium.logic.feature.user.GetDefaultProtocolUseCase
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 
 class SearchScope internal constructor(
+    private val mlsPublicKeysRepository: MLSPublicKeysRepository,
+    private val getDefaultProtocol: GetDefaultProtocolUseCase,
+    private val getConversationProtocolInfo: GetConversationProtocolInfoUseCase,
     private val searchUserRepository: SearchUserRepository,
     private val sessionRepository: SessionRepository,
     private val selfUserId: UserId,
@@ -42,4 +48,7 @@ class SearchScope internal constructor(
             kaliumConfigs.maxRemoteSearchResultCount
         )
     val federatedSearchParser: FederatedSearchParser get() = FederatedSearchParser(sessionRepository, selfUserId)
+
+    val isFederationSearchAllowedUseCase: IsFederationSearchAllowedUseCase
+        get() = IsFederationSearchAllowedUseCase(mlsPublicKeysRepository, getDefaultProtocol, getConversationProtocolInfo)
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/search/IsFederationSearchAllowedUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/search/IsFederationSearchAllowedUseCaseTest.kt
@@ -98,41 +98,43 @@ class IsFederationSearchAllowedUseCaseTest {
         coVerify { arrangement.getDefaultProtocol.invoke() }.wasInvoked(once)
         coVerify { arrangement.getConversationProtocolInfo.invoke(any()) }.wasInvoked(once)
     }
-}
 
-private class Arrangement {
+    private class Arrangement {
 
-    @Mock
-    val mlsPublicKeysRepository = mock(MLSPublicKeysRepository::class)
+        @Mock
+        val mlsPublicKeysRepository = mock(MLSPublicKeysRepository::class)
 
-    @Mock
-    val getDefaultProtocol = mock(GetDefaultProtocolUseCase::class)
+        @Mock
+        val getDefaultProtocol = mock(GetDefaultProtocolUseCase::class)
 
-    @Mock
-    val getConversationProtocolInfo = mock(GetConversationProtocolInfoUseCase::class)
+        @Mock
+        val getConversationProtocolInfo = mock(GetConversationProtocolInfoUseCase::class)
 
-    fun withDefaultProtocol(protocol: SupportedProtocol) = apply {
-        every { getDefaultProtocol.invoke() }.returns(protocol)
-    }
+        fun withDefaultProtocol(protocol: SupportedProtocol) = apply {
+            every { getDefaultProtocol.invoke() }.returns(protocol)
+        }
 
-    suspend fun withConversationProtocolInfo(protocolInfo: GetConversationProtocolInfoUseCase.Result) = apply {
-        coEvery { getConversationProtocolInfo(any()) }.returns(protocolInfo)
-    }
+        suspend fun withConversationProtocolInfo(protocolInfo: GetConversationProtocolInfoUseCase.Result) = apply {
+            coEvery { getConversationProtocolInfo(any()) }.returns(protocolInfo)
+        }
 
-    suspend fun withMLSConfiguredForBackend(isConfigured: Boolean = true) = apply {
-        coEvery { mlsPublicKeysRepository.getKeys() }.returns(
-            if (isConfigured) {
-                Either.Right(MLSPublicKeys(emptyMap()))
-            } else {
-                Either.Left(CoreFailure.Unknown(RuntimeException("MLS is not configured")))
-            }
+        suspend fun withMLSConfiguredForBackend(isConfigured: Boolean = true) = apply {
+            coEvery { mlsPublicKeysRepository.getKeys() }.returns(
+                if (isConfigured) {
+                    Either.Right(MLSPublicKeys(emptyMap()))
+                } else {
+                    Either.Left(CoreFailure.Unknown(RuntimeException("MLS is not configured")))
+                }
+            )
+        }
+
+        fun arrange() = this to IsFederationSearchAllowedUseCase(
+            mlsPublicKeysRepository = mlsPublicKeysRepository,
+            getDefaultProtocol = getDefaultProtocol,
+            getConversationProtocolInfo = getConversationProtocolInfo,
+            dispatcher = KaliumDispatcherImpl
         )
     }
-
-    fun arrange() = this to IsFederationSearchAllowedUseCase(
-        mlsPublicKeysRepository = mlsPublicKeysRepository,
-        getDefaultProtocol = getDefaultProtocol,
-        getConversationProtocolInfo = getConversationProtocolInfo,
-        dispatcher = KaliumDispatcherImpl
-    )
 }
+
+

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/search/IsFederationSearchAllowedUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/search/IsFederationSearchAllowedUseCaseTest.kt
@@ -55,6 +55,20 @@ class IsFederationSearchAllowedUseCaseTest {
     }
 
     @Test
+    fun givenMLSIsConfiguredAndAMLSTeamWithEmptyKeys_whenInvokingIsFederationSearchAllowed_thenReturnTrue() = runTest {
+        val (arrangement, isFederationSearchAllowedUseCase) = Arrangement()
+            .withEmptyMlsKeys()
+            .arrange()
+
+        val isAllowed = isFederationSearchAllowedUseCase(conversationId = null)
+
+        assertEquals(true, isAllowed)
+        coVerify { arrangement.mlsPublicKeysRepository.getKeys() }.wasInvoked(once)
+        coVerify { arrangement.getDefaultProtocol.invoke() }.wasNotInvoked()
+        coVerify { arrangement.getConversationProtocolInfo.invoke(any()) }.wasNotInvoked()
+    }
+
+    @Test
     fun givenMLSIsConfiguredAndAMLSTeam_whenInvokingIsFederationSearchAllowed_thenReturnTrue() = runTest {
         val (arrangement, isFederationSearchAllowedUseCase) = Arrangement()
             .withMLSConfiguredForBackend(isConfigured = true)
@@ -66,21 +80,6 @@ class IsFederationSearchAllowedUseCaseTest {
         assertEquals(true, isAllowed)
         coVerify { arrangement.mlsPublicKeysRepository.getKeys() }.wasInvoked(once)
         coVerify { arrangement.getDefaultProtocol.invoke() }.wasInvoked(once)
-        coVerify { arrangement.getConversationProtocolInfo.invoke(any()) }.wasNotInvoked()
-    }
-
-    @Test
-    fun givenMLSIsConfiguredAndAMLSTeamWithEmptyKeys_whenInvokingIsFederationSearchAllowed_thenReturnTrue() = runTest {
-        val (arrangement, isFederationSearchAllowedUseCase) = Arrangement()
-            .withEmptyMlsKeys()
-            .withDefaultProtocol(SupportedProtocol.MLS)
-            .arrange()
-
-        val isAllowed = isFederationSearchAllowedUseCase(conversationId = null)
-
-        assertEquals(true, isAllowed)
-        coVerify { arrangement.mlsPublicKeysRepository.getKeys() }.wasInvoked(once)
-        coVerify { arrangement.getDefaultProtocol.invoke() }.wasNotInvoked()
         coVerify { arrangement.getConversationProtocolInfo.invoke(any()) }.wasNotInvoked()
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/search/IsFederationSearchAllowedUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/search/IsFederationSearchAllowedUseCaseTest.kt
@@ -1,0 +1,138 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.search
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.mls.MLSPublicKeys
+import com.wire.kalium.logic.data.mlspublickeys.MLSPublicKeysRepository
+import com.wire.kalium.logic.data.user.SupportedProtocol
+import com.wire.kalium.logic.feature.conversation.GetConversationProtocolInfoUseCase
+import com.wire.kalium.logic.feature.user.GetDefaultProtocolUseCase
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestConversation.PROTEUS_PROTOCOL_INFO
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.util.KaliumDispatcherImpl
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.coEvery
+import io.mockative.coVerify
+import io.mockative.every
+import io.mockative.mock
+import io.mockative.once
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class IsFederationSearchAllowedUseCaseTest {
+
+    @Test
+    fun givenMLSIsNotConfigured_whenInvokingIsFederationSearchAllowed_thenReturnTrue() = runTest {
+        val (arrangement, isFederationSearchAllowedUseCase) = Arrangement()
+            .withMLSConfiguredForBackend(isConfigured = false)
+            .arrange()
+
+        val isAllowed = isFederationSearchAllowedUseCase(conversationId = null)
+
+        assertEquals(true, isAllowed)
+        coVerify { arrangement.mlsPublicKeysRepository.getKeys() }.wasInvoked(once)
+    }
+
+    @Test
+    fun givenMLSIsConfiguredAndAMLSTeam_whenInvokingIsFederationSearchAllowed_thenReturnTrue() = runTest {
+        val (arrangement, isFederationSearchAllowedUseCase) = Arrangement()
+            .withMLSConfiguredForBackend(isConfigured = true)
+            .withDefaultProtocol(SupportedProtocol.MLS)
+            .arrange()
+
+        val isAllowed = isFederationSearchAllowedUseCase(conversationId = null)
+
+        assertEquals(true, isAllowed)
+        coVerify { arrangement.mlsPublicKeysRepository.getKeys() }.wasInvoked(once)
+        coVerify { arrangement.getDefaultProtocol.invoke() }.wasInvoked(once)
+        coVerify { arrangement.getConversationProtocolInfo.invoke(any()) }.wasNotInvoked()
+    }
+
+    @Test
+    fun givenMLSIsConfiguredAndAMLSTeamAndProteusProtocol_whenInvokingIsFederationSearchAllowed_thenReturnFalse() = runTest {
+        val (arrangement, isFederationSearchAllowedUseCase) = Arrangement()
+            .withMLSConfiguredForBackend(isConfigured = true)
+            .withDefaultProtocol(SupportedProtocol.MLS)
+            .withConversationProtocolInfo(GetConversationProtocolInfoUseCase.Result.Success(PROTEUS_PROTOCOL_INFO))
+            .arrange()
+
+        val isAllowed = isFederationSearchAllowedUseCase(conversationId = TestConversation.ID)
+
+        assertEquals(false, isAllowed)
+        coVerify { arrangement.mlsPublicKeysRepository.getKeys() }.wasInvoked(once)
+        coVerify { arrangement.getDefaultProtocol.invoke() }.wasInvoked(once)
+        coVerify { arrangement.getConversationProtocolInfo.invoke(any()) }.wasInvoked(once)
+    }
+
+    @Test
+    fun givenMLSIsConfiguredAndAProteusTeamAndProteusProtocol_whenInvokingIsFederationSearchAllowed_thenReturnFalse() = runTest {
+        val (arrangement, isFederationSearchAllowedUseCase) = Arrangement()
+            .withMLSConfiguredForBackend(isConfigured = true)
+            .withDefaultProtocol(SupportedProtocol.PROTEUS)
+            .withConversationProtocolInfo(GetConversationProtocolInfoUseCase.Result.Success(PROTEUS_PROTOCOL_INFO))
+            .arrange()
+
+        val isAllowed = isFederationSearchAllowedUseCase(conversationId = TestConversation.ID)
+
+        assertEquals(false, isAllowed)
+        coVerify { arrangement.mlsPublicKeysRepository.getKeys() }.wasInvoked(once)
+        coVerify { arrangement.getDefaultProtocol.invoke() }.wasInvoked(once)
+        coVerify { arrangement.getConversationProtocolInfo.invoke(any()) }.wasInvoked(once)
+    }
+}
+
+private class Arrangement {
+
+    @Mock
+    val mlsPublicKeysRepository = mock(MLSPublicKeysRepository::class)
+
+    @Mock
+    val getDefaultProtocol = mock(GetDefaultProtocolUseCase::class)
+
+    @Mock
+    val getConversationProtocolInfo = mock(GetConversationProtocolInfoUseCase::class)
+
+    fun withDefaultProtocol(protocol: SupportedProtocol) = apply {
+        every { getDefaultProtocol.invoke() }.returns(protocol)
+    }
+
+    suspend fun withConversationProtocolInfo(protocolInfo: GetConversationProtocolInfoUseCase.Result) = apply {
+        coEvery { getConversationProtocolInfo(any()) }.returns(protocolInfo)
+    }
+
+    suspend fun withMLSConfiguredForBackend(isConfigured: Boolean = true) = apply {
+        coEvery { mlsPublicKeysRepository.getKeys() }.returns(
+            if (isConfigured) {
+                Either.Right(MLSPublicKeys(emptyMap()))
+            } else {
+                Either.Left(CoreFailure.Unknown(RuntimeException("MLS is not configured")))
+            }
+        )
+    }
+
+    fun arrange() = this to IsFederationSearchAllowedUseCase(
+        mlsPublicKeysRepository = mlsPublicKeysRepository,
+        getDefaultProtocol = getDefaultProtocol,
+        getConversationProtocolInfo = getConversationProtocolInfo,
+        dispatcher = KaliumDispatcherImpl
+    )
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14250" title="WPB-14250" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-14250</a>  [Android] implement fall guards for CC migration
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need to support federation search, according to if MLS is enabled, or if it is configured or not in the backend.

### Solutions

Create a new use case centralizing the logic to decide if we need to support federation or not for this: team/conversation/backend.

Before the logic was in the view model in AR, but here is centralized and we can test all the cases for it, therefore now the view model just calls this use case to decide if we need to enable cross domain search.

### Dependencies (Optional)

- https://github.com/wireapp/wire-android/pull/3668

Needs releases with:

- [x] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
