### PR TITLE
fix: make some conversation models serializable, add serializer for Any primitive type [WPB-14433]

### DIFF
--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -38,6 +38,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.util.serialization.toJsonElement
 import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
 import kotlin.time.Duration
 
 /**
@@ -258,10 +259,19 @@ data class Conversation(
         fun toLogMap(): Map<String, Any?>
     }
 
+    @Serializable
     data class Member(val id: UserId, val role: Role) {
+
+        @Serializable
         sealed class Role {
+
+            @Serializable
             data object Member : Role()
+
+            @Serializable
             data object Admin : Role()
+
+            @Serializable
             data class Unknown(val name: String) : Role()
 
             override fun toString(): String =

--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -38,6 +38,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.util.serialization.toJsonElement
 import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.time.Duration
 
@@ -260,7 +261,10 @@ data class Conversation(
     }
 
     @Serializable
-    data class Member(val id: UserId, val role: Role) {
+    data class Member(
+        @SerialName("id") val id: UserId,
+        @SerialName("role") val role: Role
+    ) {
 
         @Serializable
         sealed class Role {
@@ -272,7 +276,7 @@ data class Conversation(
             data object Admin : Role()
 
             @Serializable
-            data class Unknown(val name: String) : Role()
+            data class Unknown(@SerialName("name") val name: String) : Role()
 
             override fun toString(): String =
                 when (this) {

--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatus.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatus.kt
@@ -18,13 +18,14 @@
 
 package com.wire.kalium.logic.data.conversation
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
  * Conversation muting settings type
  */
 @Serializable
-sealed class MutedConversationStatus(open val status: Int = 0) {
+sealed class MutedConversationStatus(@SerialName("status") open val status: Int = 0) {
     /**
      * 0 -> All notifications are displayed
      */

--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatus.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatus.kt
@@ -18,22 +18,28 @@
 
 package com.wire.kalium.logic.data.conversation
 
+import kotlinx.serialization.Serializable
+
 /**
  * Conversation muting settings type
  */
+@Serializable
 sealed class MutedConversationStatus(open val status: Int = 0) {
     /**
      * 0 -> All notifications are displayed
      */
+    @Serializable
     data object AllAllowed : MutedConversationStatus(0)
 
     /**
      * 1 -> Only mentions and replies are displayed (normal messages muted)
      */
+    @Serializable
     data object OnlyMentionsAndRepliesAllowed : MutedConversationStatus(1)
 
     /**
      * 3 -> No notifications are displayed
      */
+    @Serializable
     data object AllMuted : MutedConversationStatus(3)
 }

--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import com.wire.kalium.util.serialization.toJsonElement
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlin.time.Duration
@@ -473,14 +474,19 @@ sealed interface Message {
         }
     }
 
+    @Serializable
     data class ExpirationData(
         val expireAfter: Duration,
         val selfDeletionStatus: SelfDeletionStatus = SelfDeletionStatus.NotStarted
     ) {
 
+        @Serializable
         sealed class SelfDeletionStatus {
+
+            @Serializable
             data object NotStarted : SelfDeletionStatus()
 
+            @Serializable
             data class Started(val selfDeletionEndDate: Instant) : SelfDeletionStatus()
 
             fun toLogMap(): Map<String, String> = when (this) {

--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import com.wire.kalium.util.serialization.toJsonElement
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -476,8 +477,8 @@ sealed interface Message {
 
     @Serializable
     data class ExpirationData(
-        val expireAfter: Duration,
-        val selfDeletionStatus: SelfDeletionStatus = SelfDeletionStatus.NotStarted
+        @SerialName("expire_after") val expireAfter: Duration,
+        @SerialName("self_deletion_status") val selfDeletionStatus: SelfDeletionStatus = SelfDeletionStatus.NotStarted
     ) {
 
         @Serializable
@@ -487,7 +488,7 @@ sealed interface Message {
             data object NotStarted : SelfDeletionStatus()
 
             @Serializable
-            data class Started(val selfDeletionEndDate: Instant) : SelfDeletionStatus()
+            data class Started(@SerialName("self_deletion_end_date") val selfDeletionEndDate: Instant) : SelfDeletionStatus()
 
             fun toLogMap(): Map<String, String> = when (this) {
                 is NotStarted -> mutableMapOf(

--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/mention/MessageMention.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/mention/MessageMention.kt
@@ -19,12 +19,13 @@
 package com.wire.kalium.logic.data.message.mention
 
 import com.wire.kalium.logic.data.user.UserId
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class MessageMention(
-    val start: Int,
-    val length: Int,
-    val userId: UserId,
-    val isSelfMention: Boolean
+    @SerialName("start") val start: Int,
+    @SerialName("length") val length: Int,
+    @SerialName("userId") val userId: UserId,
+    @SerialName("isSelfMention") val isSelfMention: Boolean
 )

--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/mention/MessageMention.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/mention/MessageMention.kt
@@ -19,7 +19,9 @@
 package com.wire.kalium.logic.data.message.mention
 
 import com.wire.kalium.logic.data.user.UserId
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class MessageMention(
     val start: Int,
     val length: Int,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -450,7 +450,7 @@ class EventMapper(
     }
 
     @Suppress("MagicNumber")
-    private fun mapConversationMutedStatus(status: Int?) = when (status) {
+    private fun mapConversationMutedStatus(status: Int?): MutedConversationStatus = when (status) {
         0 -> MutedConversationStatus.AllAllowed
         1 -> MutedConversationStatus.OnlyMentionsAndRepliesAllowed
         3 -> MutedConversationStatus.AllMuted

--- a/util/src/commonMain/kotlin/com.wire.kalium.util/serialization/SerializationUtils.kt
+++ b/util/src/commonMain/kotlin/com.wire.kalium.util/serialization/SerializationUtils.kt
@@ -95,4 +95,3 @@ object AnyPrimitiveValueSerializer : KSerializer<Any> {
         return requireNotNull(jsonPrimitive.toAnyOrNull()) { "value cannot be null" }
     }
 }
-

--- a/util/src/commonMain/kotlin/com.wire.kalium.util/serialization/SerializationUtils.kt
+++ b/util/src/commonMain/kotlin/com.wire.kalium.util/serialization/SerializationUtils.kt
@@ -18,11 +18,20 @@
 
 package com.wire.kalium.util.serialization
 
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.floatOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.longOrNull
 
 // See: https://github.com/Kotlin/kotlinx.serialization/issues/746#issuecomment-737000705
 
@@ -60,3 +69,30 @@ fun Map<*, *>.toJsonObject(): JsonObject {
     }
     return JsonObject(map)
 }
+
+private fun JsonElement.toAnyOrNull(): Any? {
+    return when (this) {
+        is JsonNull -> null
+        is JsonPrimitive -> toAnyValue()
+        is JsonObject -> this.map { it.key to it.value.toAnyOrNull() }.toMap()
+        is JsonArray -> this.map { it.toAnyOrNull() }
+    }
+}
+
+private fun JsonPrimitive.toAnyValue(): Any? {
+    return this.booleanOrNull ?: this.intOrNull ?: this.longOrNull ?: this.floatOrNull ?: this.doubleOrNull ?: this.contentOrNull
+}
+
+object AnyPrimitiveValueSerializer : KSerializer<Any> {
+    private val delegateSerializer = JsonElement.serializer()
+    override val descriptor = delegateSerializer.descriptor
+    override fun serialize(encoder: Encoder, value: Any) {
+        encoder.encodeSerializableValue(delegateSerializer, value.toJsonElement())
+    }
+
+    override fun deserialize(decoder: Decoder): Any {
+        val jsonPrimitive = decoder.decodeSerializableValue(delegateSerializer)
+        return requireNotNull(jsonPrimitive.toAnyOrNull()) { "value cannot be null" }
+    }
+}
+


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14433" title="WPB-14433" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14433</a>  [Android] Crash after longtapping on a conversation and putting phone to sleep
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When saving conversation menu state, models cannot be saved into bundle resulting in a crash.

### Solutions

In order to save conversation menu state, models must be able to be saved, so the best way is to use kotlin serialization.
- added serializer for `Any` type representing primitive types like boolean, string, int, float, etc.
- added serialization for selected conversation-related models

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
