### PR TITLE
feat: Move API V6 to supported #WPB-14528

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/BackendMetaDataUtil.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/BackendMetaDataUtil.kt
@@ -23,11 +23,11 @@ import com.wire.kalium.network.api.unbound.versioning.VersionInfoDTO
 
 // They are not truly constants as set is not a primitive type, yet are treated as one in this context
 @Suppress("MagicNumber")
-val SupportedApiVersions = setOf(0, 1, 2, 4, 5)
+val SupportedApiVersions = setOf(0, 1, 2, 4, 5, 6)
 
 // They are not truly constants as set is not a primitive type, yet are treated as one in this context
 @Suppress("MagicNumber")
-val DevelopmentApiVersions = setOf(6, 7)
+val DevelopmentApiVersions = setOf(7)
 
 // You can use scripts/generate_new_api_version.sh or gradle task network:generateNewApiVersion to
 // bump API version and generate all needed classes


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14528" title="WPB-14528" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14528</a>  [Android] Not possible to create MLS 1:1 conversations across backends
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

Not possible to create MLS 1:1 conversations across backends

### Causes (Optional)

creating 1o1 MLS conversation available in API v6 +

### Solutions

Move API v6 to supported (it's stable already)
