### PR TITLE
feat: Call sharing metadata [WPB-14605]

### DIFF
--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallMetadataProfile.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallMetadataProfile.kt
@@ -48,7 +48,7 @@ data class CallMetadata(
     val protocol: Conversation.ProtocolInfo,
     val activeSpeakers: Map<UserId, List<String>> = mapOf(),
     val users: List<OtherUserMinimized> = listOf(),
-    val sharingScreenMetadata: CallSharingScreenMetadata = CallSharingScreenMetadata()
+    val screenShareMetadata: CallScreenSharingMetadata = CallScreenSharingMetadata()
 ) {
     fun getFullParticipants(): List<Participant> = participants.map { participant ->
         val user = users.firstOrNull { it.id == participant.userId }
@@ -74,7 +74,7 @@ data class CallMetadata(
  * [completedScreenShareDurationInMillis] - total time of already ended screen shares in milliseconds
  * [uniqueSharingUsers] - set of users that were sharing a screen at least once
  */
-data class CallSharingScreenMetadata(
+data class CallScreenSharingMetadata(
     val activeScreenShares: Map<QualifiedID, Instant> = emptyMap(),
     val completedScreenShareDurationInMillis: Long = 0L,
     val uniqueSharingUsers: Set<String> = emptySet()

--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallMetadataProfile.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallMetadataProfile.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.OtherUserMinimized
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
+import kotlinx.datetime.Instant
 
 data class CallMetadataProfile(
     val data: Map<ConversationId, CallMetadata>
@@ -46,7 +47,8 @@ data class CallMetadata(
     val maxParticipants: Int = 0, // Was used for tracking
     val protocol: Conversation.ProtocolInfo,
     val activeSpeakers: Map<UserId, List<String>> = mapOf(),
-    val users: List<OtherUserMinimized> = listOf()
+    val users: List<OtherUserMinimized> = listOf(),
+    val sharingScreenMetadata: CallSharingScreenMetadata = CallSharingScreenMetadata()
 ) {
     fun getFullParticipants(): List<Participant> = participants.map { participant ->
         val user = users.firstOrNull { it.id == participant.userId }
@@ -66,3 +68,14 @@ data class CallMetadata(
         )
     }
 }
+
+/**
+ * [activeScreenShares] - map of user ids that share screen with the start timestamp
+ * [completedScreenShareDurationInMillis] - total time of already ended screen shares in milliseconds
+ * [uniqueSharingUsers] - set of users that were sharing a screen at least once
+ */
+data class CallSharingScreenMetadata(
+    val activeScreenShares: Map<QualifiedID, Instant> = emptyMap(),
+    val completedScreenShareDurationInMillis: Long = 0L,
+    val uniqueSharingUsers: Set<String> = emptySet()
+)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
@@ -460,8 +460,8 @@ internal class CallDataSource(
                         participants = participants,
                         maxParticipants = max(call.maxParticipants, participants.size + 1),
                         users = updatedUsers,
-                        sharingScreenMetadata = updateSharingScreenMetadata(
-                            metadata = call.sharingScreenMetadata,
+                        screenShareMetadata = updateScreenSharingMetadata(
+                            metadata = call.screenShareMetadata,
                             usersCurrentlySharingScreen = sharingScreenParticipantIds
                         )
                     )
@@ -497,10 +497,10 @@ internal class CallDataSource(
      * 2. **Update Active Shares**: Filter out inactive shares and add any new ones, associating them with the current start time.
      * 3. **Track Unique Users**: Append ids to current set in order to keep track of unique users.
      */
-    private fun updateSharingScreenMetadata(
-        metadata: CallSharingScreenMetadata,
+    private fun updateScreenSharingMetadata(
+        metadata: CallScreenSharingMetadata,
         usersCurrentlySharingScreen: List<QualifiedID>
-    ): CallSharingScreenMetadata {
+    ): CallScreenSharingMetadata {
         val now = DateTimeUtil.currentInstant()
 
         val alreadyEndedScreenSharesTimeInMillis = metadata.activeScreenShares

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
@@ -40,6 +40,7 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.FederatedIdMapper
 import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.QualifiedClientID
+import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.id.SubconversationId
 import com.wire.kalium.logic.data.id.toCrypto
@@ -441,6 +442,8 @@ internal class CallDataSource(
 
                 val currentParticipantIds = call.participants.map { it.userId }.toSet()
                 val newParticipantIds = participants.map { it.userId }.toSet()
+                val sharingScreenParticipantIds = participants.filter { it.isSharingScreen }
+                    .map { participant -> participant.id }
 
                 val updatedUsers = call.users.toMutableList()
 
@@ -456,7 +459,11 @@ internal class CallDataSource(
                     this[conversationId] = call.copy(
                         participants = participants,
                         maxParticipants = max(call.maxParticipants, participants.size + 1),
-                        users = updatedUsers
+                        users = updatedUsers,
+                        sharingScreenMetadata = updateSharingScreenMetadata(
+                            metadata = call.sharingScreenMetadata,
+                            usersCurrentlySharingScreen = sharingScreenParticipantIds
+                        )
                     )
                 }
 
@@ -477,6 +484,43 @@ internal class CallDataSource(
                 }
             }
         }
+    }
+
+    /**
+     * Manages call sharing metadata for analytical purposes by tracking the following:
+     * - **Active Screen Shares**: Maintains a record of currently active screen shares with their start times (local to the device).
+     * - **Completed Screen Share Duration**: Accumulates the total duration of screen shares that have already ended.
+     * - **Unique Sharing Users**: Keeps a unique list of all users who have shared their screen during the call.
+     *
+     * To update the metadata, the following steps are performed:
+     * 1. **Calculate Ended Screen Share Time**: Determine the total time for users who stopped sharing since the last update.
+     * 2. **Update Active Shares**: Filter out inactive shares and add any new ones, associating them with the current start time.
+     * 3. **Track Unique Users**: Append ids to current set in order to keep track of unique users.
+     */
+    private fun updateSharingScreenMetadata(
+        metadata: CallSharingScreenMetadata,
+        usersCurrentlySharingScreen: List<QualifiedID>
+    ): CallSharingScreenMetadata {
+        val now = DateTimeUtil.currentInstant()
+
+        val alreadyEndedScreenSharesTimeInMillis = metadata.activeScreenShares
+            .filterKeys { id -> id !in usersCurrentlySharingScreen }
+            .values
+            .sumOf { startTime -> DateTimeUtil.calculateMillisDifference(startTime, now) }
+
+        val updatedShares = metadata.activeScreenShares
+            .filterKeys { id -> id in usersCurrentlySharingScreen }
+            .plus(
+                usersCurrentlySharingScreen
+                    .filterNot { id -> metadata.activeScreenShares.containsKey(id) }
+                    .associateWith { now }
+            )
+
+        return metadata.copy(
+            activeScreenShares = updatedShares,
+            completedScreenShareDurationInMillis = metadata.completedScreenShareDurationInMillis + alreadyEndedScreenSharesTimeInMillis,
+            uniqueSharingUsers = metadata.uniqueSharingUsers.plus(usersCurrentlySharingScreen.map { id -> id.toString() })
+        )
     }
 
     private fun clearStaleParticipantTimeout(participant: ParticipantMinimized) {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
@@ -1534,8 +1534,8 @@ class CallRepositoryTest {
 
         // then
         assertNotNull(callMetadata)
-        assertEquals(0L, callMetadata.sharingScreenMetadata.completedScreenShareDurationInMillis)
-        assertTrue(callMetadata.sharingScreenMetadata.activeScreenShares.containsKey(otherParticipant.id))
+        assertEquals(0L, callMetadata.screenShareMetadata.completedScreenShareDurationInMillis)
+        assertTrue(callMetadata.screenShareMetadata.activeScreenShares.containsKey(otherParticipant.id))
     }
 
     @Test
@@ -1565,8 +1565,8 @@ class CallRepositoryTest {
 
         // then
         assertNotNull(callMetadata)
-        assertTrue(callMetadata.sharingScreenMetadata.activeScreenShares.size == 1)
-        assertTrue(callMetadata.sharingScreenMetadata.activeScreenShares.containsKey(thirdParticipant.id))
+        assertTrue(callMetadata.screenShareMetadata.activeScreenShares.size == 1)
+        assertTrue(callMetadata.screenShareMetadata.activeScreenShares.containsKey(thirdParticipant.id))
     }
 
     @Test
@@ -1595,7 +1595,7 @@ class CallRepositoryTest {
 
         // then
         assertNotNull(callMetadata)
-        assertTrue(callMetadata.sharingScreenMetadata.activeScreenShares.isEmpty())
+        assertTrue(callMetadata.screenShareMetadata.activeScreenShares.isEmpty())
     }
 
     @Test
@@ -1629,8 +1629,8 @@ class CallRepositoryTest {
 
             // then
             assertNotNull(callMetadata)
-            assertTrue(callMetadata.sharingScreenMetadata.uniqueSharingUsers.size == 1)
-            assertTrue(callMetadata.sharingScreenMetadata.uniqueSharingUsers.contains(otherParticipant.id.toString()))
+            assertTrue(callMetadata.screenShareMetadata.uniqueSharingUsers.size == 1)
+            assertTrue(callMetadata.screenShareMetadata.uniqueSharingUsers.contains(otherParticipant.id.toString()))
         }
 
     @Test
@@ -1656,10 +1656,10 @@ class CallRepositoryTest {
 
         // then
         assertNotNull(callMetadata)
-        assertTrue(callMetadata.sharingScreenMetadata.uniqueSharingUsers.size == 2)
+        assertTrue(callMetadata.screenShareMetadata.uniqueSharingUsers.size == 2)
         assertEquals(
             setOf(secondParticipant.id.toString(), thirdParticipant.id.toString()),
-            callMetadata.sharingScreenMetadata.uniqueSharingUsers
+            callMetadata.screenShareMetadata.uniqueSharingUsers
         )
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.cryptography.CryptoQualifiedClientId
 import com.wire.kalium.cryptography.MLSClient
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.call.CallRepositoryTest.Arrangement.Companion.callerId
+import com.wire.kalium.logic.data.call.CallRepositoryTest.Arrangement.Companion.participant
 import com.wire.kalium.logic.data.call.mapper.CallMapperImpl
 import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.data.conversation.ClientId
@@ -84,6 +85,7 @@ import kotlinx.datetime.Clock
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
@@ -1506,6 +1508,158 @@ class CallRepositoryTest {
         assertEquals(
             true,
             fullParticipants?.first { it.id == unMutedParticipant.id && it.clientId == unMutedParticipant.clientId }?.isSpeaking
+        )
+    }
+
+    @Test
+    fun givenCallWithParticipantsNotSharingScreen_whenOneStartsToShare_thenSharingMetadataHasProperValues() = runTest {
+        // given
+        val otherParticipant = participant.copy(id = QualifiedID("anotherParticipantId", "participantDomain"))
+        val participantsList = listOf(participant, otherParticipant)
+        val (_, callRepository) = Arrangement()
+            .givenGetKnownUserMinimizedSucceeds()
+            .arrange()
+        callRepository.updateCallMetadataProfileFlow(
+            callMetadataProfile = CallMetadataProfile(
+                data = mapOf(Arrangement.conversationId to createCallMetadata().copy(participants = participantsList))
+            )
+        )
+
+        // when
+        callRepository.updateCallParticipants(
+            Arrangement.conversationId,
+            listOf(participant, otherParticipant.copy(isSharingScreen = true))
+        )
+        val callMetadata = callRepository.getCallMetadataProfile()[Arrangement.conversationId]
+
+        // then
+        assertNotNull(callMetadata)
+        assertEquals(0L, callMetadata.sharingScreenMetadata.completedScreenShareDurationInMillis)
+        assertTrue(callMetadata.sharingScreenMetadata.activeScreenShares.containsKey(otherParticipant.id))
+    }
+
+    @Test
+    fun givenCallWithParticipantsNotSharingScreen_whenTwoStartsAndOneStops_thenSharingMetadataHasProperValues() = runTest {
+        // given
+        val (_, callRepository) = Arrangement()
+            .arrange()
+        val secondParticipant = participant.copy(id = QualifiedID("secondParticipantId", "participantDomain"))
+        val thirdParticipant = participant.copy(id = QualifiedID("thirdParticipantId", "participantDomain"))
+        val participantsList = listOf(participant, secondParticipant, thirdParticipant)
+        callRepository.updateCallMetadataProfileFlow(
+            callMetadataProfile = CallMetadataProfile(
+                data = mapOf(Arrangement.conversationId to createCallMetadata().copy(participants = participantsList))
+            )
+        )
+
+        // when
+        callRepository.updateCallParticipants(
+            Arrangement.conversationId,
+            listOf(participant, secondParticipant.copy(isSharingScreen = true), thirdParticipant.copy(isSharingScreen = true))
+        )
+        callRepository.updateCallParticipants(
+            Arrangement.conversationId,
+            listOf(participant, secondParticipant, thirdParticipant.copy(isSharingScreen = true))
+        )
+        val callMetadata = callRepository.getCallMetadataProfile()[Arrangement.conversationId]
+
+        // then
+        assertNotNull(callMetadata)
+        assertTrue(callMetadata.sharingScreenMetadata.activeScreenShares.size == 1)
+        assertTrue(callMetadata.sharingScreenMetadata.activeScreenShares.containsKey(thirdParticipant.id))
+    }
+
+    @Test
+    fun givenCallWithParticipantsSharingScreen_whenOneStopsToShare_thenSharingMetadataHasProperValues() = runTest {
+        // given
+        val (_, callRepository) = Arrangement()
+            .arrange()
+        val otherParticipant = participant.copy(id = QualifiedID("anotherParticipantId", "participantDomain"))
+        val participantsList = listOf(participant, otherParticipant)
+        callRepository.updateCallMetadataProfileFlow(
+            callMetadataProfile = CallMetadataProfile(
+                data = mapOf(Arrangement.conversationId to createCallMetadata().copy(participants = participantsList))
+            )
+        )
+        callRepository.updateCallParticipants(
+            Arrangement.conversationId,
+            listOf(participant, otherParticipant.copy(isSharingScreen = true))
+        )
+
+        // when
+        callRepository.updateCallParticipants(
+            Arrangement.conversationId,
+            listOf(participant, otherParticipant.copy(isSharingScreen = false))
+        )
+        val callMetadata = callRepository.getCallMetadataProfile()[Arrangement.conversationId]
+
+        // then
+        assertNotNull(callMetadata)
+        assertTrue(callMetadata.sharingScreenMetadata.activeScreenShares.isEmpty())
+    }
+
+    @Test
+    fun givenCallWithParticipantsSharingScreen_whenTheSameParticipantIsSharingMultipleTime_thenSharingMetadataHasUserIdOnlyOnce() =
+        runTest {
+            // given
+            val (_, callRepository) = Arrangement()
+                .arrange()
+            val otherParticipant = participant.copy(id = QualifiedID("anotherParticipantId", "participantDomain"))
+            val participantsList = listOf(participant, otherParticipant)
+            callRepository.updateCallMetadataProfileFlow(
+                callMetadataProfile = CallMetadataProfile(
+                    data = mapOf(Arrangement.conversationId to createCallMetadata().copy(participants = participantsList))
+                )
+            )
+
+            // when
+            callRepository.updateCallParticipants(
+                Arrangement.conversationId,
+                listOf(participant, otherParticipant.copy(isSharingScreen = true))
+            )
+            callRepository.updateCallParticipants(
+                Arrangement.conversationId,
+                listOf(participant, otherParticipant.copy(isSharingScreen = false))
+            )
+            callRepository.updateCallParticipants(
+                Arrangement.conversationId,
+                listOf(participant, otherParticipant.copy(isSharingScreen = true))
+            )
+            val callMetadata = callRepository.getCallMetadataProfile()[Arrangement.conversationId]
+
+            // then
+            assertNotNull(callMetadata)
+            assertTrue(callMetadata.sharingScreenMetadata.uniqueSharingUsers.size == 1)
+            assertTrue(callMetadata.sharingScreenMetadata.uniqueSharingUsers.contains(otherParticipant.id.toString()))
+        }
+
+    @Test
+    fun givenCallWithParticipantsSharingScreen_whenTwoParticipantsAreSharing_thenSharingMetadataHasBothOfUsersIds() = runTest {
+        // given
+        val (_, callRepository) = Arrangement()
+            .arrange()
+        val secondParticipant = participant.copy(id = QualifiedID("secondParticipantId", "participantDomain"))
+        val thirdParticipant = participant.copy(id = QualifiedID("thirdParticipantId", "participantDomain"))
+        val participantsList = listOf(participant, secondParticipant, thirdParticipant)
+        callRepository.updateCallMetadataProfileFlow(
+            callMetadataProfile = CallMetadataProfile(
+                data = mapOf(Arrangement.conversationId to createCallMetadata().copy(participants = participantsList))
+            )
+        )
+
+        // when
+        callRepository.updateCallParticipants(
+            Arrangement.conversationId,
+            listOf(participant, secondParticipant.copy(isSharingScreen = true), thirdParticipant.copy(isSharingScreen = true))
+        )
+        val callMetadata = callRepository.getCallMetadataProfile()[Arrangement.conversationId]
+
+        // then
+        assertNotNull(callMetadata)
+        assertTrue(callMetadata.sharingScreenMetadata.uniqueSharingUsers.size == 2)
+        assertEquals(
+            setOf(secondParticipant.id.toString(), thirdParticipant.id.toString()),
+            callMetadata.sharingScreenMetadata.uniqueSharingUsers
         )
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14605" title="WPB-14605" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14605</a>  [Android] Count share screen duration for end call segmentation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

https://wearezeta.atlassian.net/browse/WPB-14605

# What's new in this PR?

### Issues

For analytic purposes we need to gather screen sharing metadata:
- Total time screenshare was on during a call (local to phone, we dont have the ability to know after joining a call for how long the sharing was previously on)
- Total number of unique people that shared the screen

### Solutions

Call metadata have additional object `CallSharingScreenMetadata` which stores all of the data.
On each participant update we also update the sharing screen metadata

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
