### PR TITLE
refactor(backup): visibility modifier [WPB-10575]

### DIFF
--- a/backup/build.gradle.kts
+++ b/backup/build.gradle.kts
@@ -31,6 +31,10 @@ kaliumLibrary {
 
 @Suppress("UnusedPrivateProperty")
 kotlin {
+    // Makes visibility modifiers mandatory
+    // Useful for a library that will be called by other clients
+    // This way we need to think before putting "public" in things, and we can be reminded by the compiler to use "internal" more often
+    explicitApi()
     val xcf = XCFramework()
     val appleTargets = listOf(iosX64(), iosArm64(), iosSimulatorArm64(), macosArm64(), macosX64())
     appleTargets.forEach {

--- a/backup/src/commonMain/kotlin/com/wire/backup/MPBackup.kt
+++ b/backup/src/commonMain/kotlin/com/wire/backup/MPBackup.kt
@@ -20,6 +20,6 @@ package com.wire.backup
 import kotlin.js.JsExport
 
 @JsExport
-object MPBackup {
-    const val ZIP_ENTRY_DATA = "data.wmbu"
+public object MPBackup {
+    public const val ZIP_ENTRY_DATA: String = "data.wmbu"
 }

--- a/backup/src/commonMain/kotlin/com/wire/backup/data/BackupData.kt
+++ b/backup/src/commonMain/kotlin/com/wire/backup/data/BackupData.kt
@@ -28,39 +28,39 @@ import kotlin.native.ObjCName
 import kotlin.native.ShouldRefineInSwift
 
 @JsExport
-class BackupData(
-    val metadata: BackupMetadata,
+public class BackupData(
+    public val metadata: BackupMetadata,
     @ShouldRefineInSwift
-    val users: Array<BackupUser>,
+    public val users: Array<BackupUser>,
     @ShouldRefineInSwift
-    val conversations: Array<BackupConversation>,
+    public val conversations: Array<BackupConversation>,
     @ShouldRefineInSwift
-    val messages: Array<BackupMessage>
+    public val messages: Array<BackupMessage>
 ) {
     @ObjCName("users")
-    val userList: List<BackupUser> get() = users.toList()
+    public val userList: List<BackupUser> get() = users.toList()
 
     @ObjCName("conversations")
-    val conversationList: List<BackupConversation> get() = conversations.toList()
+    public val conversationList: List<BackupConversation> get() = conversations.toList()
 
     @ObjCName("messages")
-    val messageList: List<BackupMessage> get() = messages.toList()
+    public val messageList: List<BackupMessage> get() = messages.toList()
 }
 
 @JsExport
 @Serializable
-data class BackupQualifiedId(
+public data class BackupQualifiedId(
     @SerialName("id")
     val id: String,
     @SerialName("domain")
     val domain: String,
 ) {
-    override fun toString() = "$id@$domain"
+    override fun toString(): String = "$id@$domain"
 
-    companion object {
+    public companion object {
         private const val QUALIFIED_ID_COMPONENT_COUNT = 2
 
-        fun fromEncodedString(id: String): BackupQualifiedId? {
+        public fun fromEncodedString(id: String): BackupQualifiedId? {
             val components = id.split("@")
             if (components.size != QUALIFIED_ID_COMPONENT_COUNT) return null
             return BackupQualifiedId(components[0], components[1])
@@ -69,20 +69,20 @@ data class BackupQualifiedId(
 }
 
 @JsExport
-data class BackupUser(
+public data class BackupUser(
     val id: BackupQualifiedId,
     val name: String,
     val handle: String,
 )
 
 @JsExport
-data class BackupConversation(
+public data class BackupConversation(
     val id: BackupQualifiedId,
     val name: String,
 )
 
 @JsExport
-data class BackupMessage(
+public data class BackupMessage(
     val id: String,
     val conversationId: BackupQualifiedId,
     val senderUserId: BackupQualifiedId,
@@ -93,16 +93,16 @@ data class BackupMessage(
     val webPrimaryKey: Int? = null,
 )
 
-expect class BackupDateTime
+public expect class BackupDateTime
 
-expect fun BackupDateTime(timestampMillis: Long): BackupDateTime
-expect fun BackupDateTime.toLongMilliseconds(): Long
+public expect fun BackupDateTime(timestampMillis: Long): BackupDateTime
+public expect fun BackupDateTime.toLongMilliseconds(): Long
 
 @JsExport
-sealed class BackupMessageContent {
-    data class Text(val text: String) : BackupMessageContent()
+public sealed class BackupMessageContent {
+    public data class Text(val text: String) : BackupMessageContent()
 
-    data class Asset(
+    public data class Asset(
         val mimeType: String,
         val size: Int,
         val name: String?,
@@ -114,29 +114,29 @@ sealed class BackupMessageContent {
         val encryption: EncryptionAlgorithm?,
         val metaData: AssetMetadata?,
     ) : BackupMessageContent() {
-        enum class EncryptionAlgorithm {
+        public enum class EncryptionAlgorithm {
             AES_GCM, AES_CBC
         }
 
-        sealed class AssetMetadata {
-            data class Image(
+        public sealed class AssetMetadata {
+            public data class Image(
                 val width: Int,
                 val height: Int,
                 val tag: String?
             ) : AssetMetadata()
 
-            data class Video(
+            public data class Video(
                 val width: Int?,
                 val height: Int?,
                 val duration: Long?,
             ) : AssetMetadata()
 
-            data class Audio(
+            public data class Audio(
                 val normalization: ByteArray?,
                 val duration: Long?,
             ) : AssetMetadata()
 
-            data class Generic(
+            public data class Generic(
                 val name: String?,
             ) : AssetMetadata()
         }
@@ -170,7 +170,7 @@ sealed class BackupMessageContent {
         }
     }
 
-    data class Location(
+    public data class Location(
         val longitude: Float,
         val latitude: Float,
         val name: String?,

--- a/backup/src/commonMain/kotlin/com/wire/backup/data/BackupMetadata.kt
+++ b/backup/src/commonMain/kotlin/com/wire/backup/data/BackupMetadata.kt
@@ -21,7 +21,7 @@ package com.wire.backup.data
 import kotlin.js.JsExport
 
 @JsExport
-data class BackupMetadata(
+public data class BackupMetadata(
     val version: String,
     val userId: BackupQualifiedId,
     val creationTime: BackupDateTime,

--- a/backup/src/commonMain/kotlin/com/wire/backup/dump/MPBackupExporter.kt
+++ b/backup/src/commonMain/kotlin/com/wire/backup/dump/MPBackupExporter.kt
@@ -39,7 +39,7 @@ import kotlin.native.ShouldRefineInSwift
  */
 @OptIn(ExperimentalObjCName::class, ExperimentalObjCRefinement::class)
 @JsExport
-abstract class CommonMPBackupExporter(
+public abstract class CommonMPBackupExporter(
     private val selfUserId: BackupQualifiedId
 ) {
     private val mapper = MPBackupMapper()
@@ -51,23 +51,23 @@ abstract class CommonMPBackupExporter(
     //       Unfortunately the IDE doesn't understand this right now and
     //       keeps complaining if making the other way around
     @ObjCName("add")
-    fun addUser(user: BackupUser) {
+    public fun addUser(user: BackupUser) {
         allUsers.add(user)
     }
 
     @ObjCName("add")
-    fun addConversation(conversation: BackupConversation) {
+    public fun addConversation(conversation: BackupConversation) {
         allConversations.add(conversation)
     }
 
     @ObjCName("add")
-    fun addMessage(message: BackupMessage) {
+    public fun addMessage(message: BackupMessage) {
         allMessages.add(message)
     }
 
     @OptIn(ExperimentalStdlibApi::class)
     @ShouldRefineInSwift // Hidden in Swift
-    fun serialize(): ByteArray {
+    public fun serialize(): ByteArray {
         val backupData = BackupData(
             BackupInfo(
                 platform = "Common",
@@ -92,4 +92,4 @@ abstract class CommonMPBackupExporter(
     }
 }
 
-expect class MPBackupExporter : CommonMPBackupExporter
+public expect class MPBackupExporter : CommonMPBackupExporter

--- a/backup/src/commonMain/kotlin/com/wire/backup/ingest/BackupImportResult.kt
+++ b/backup/src/commonMain/kotlin/com/wire/backup/ingest/BackupImportResult.kt
@@ -21,7 +21,7 @@ import com.wire.backup.data.BackupData
 import kotlin.js.JsExport
 
 @JsExport
-sealed class BackupImportResult {
-    data object ParsingFailure : BackupImportResult()
-    data class Success(val backupData: BackupData) : BackupImportResult()
+public sealed class BackupImportResult {
+    public data object ParsingFailure : BackupImportResult()
+    public data class Success(val backupData: BackupData) : BackupImportResult()
 }

--- a/backup/src/commonMain/kotlin/com/wire/backup/ingest/MPBackupImporter.kt
+++ b/backup/src/commonMain/kotlin/com/wire/backup/ingest/MPBackupImporter.kt
@@ -30,7 +30,7 @@ import kotlin.native.ShouldRefineInSwift
  */
 @OptIn(ExperimentalObjCRefinement::class)
 @JsExport
-abstract class CommonMPBackupImporter {
+public abstract class CommonMPBackupImporter {
     private val mapper = MPBackupMapper()
 
     /**
@@ -39,7 +39,7 @@ abstract class CommonMPBackupImporter {
     @OptIn(ExperimentalStdlibApi::class)
     @ShouldRefineInSwift // Function not visible in Swift
     @Suppress("TooGenericExceptionCaught")
-    fun importBackup(data: ByteArray): BackupImportResult = try {
+    public fun importBackup(data: ByteArray): BackupImportResult = try {
         println("XPlatform Backup POC. Imported data bytes: ${data.toHexString()}")
         BackupImportResult.Success(
             mapper.fromProtoToBackupModel(ProtoBackupData.decodeFromByteArray(data))
@@ -51,4 +51,4 @@ abstract class CommonMPBackupImporter {
     }
 }
 
-expect class MPBackupImporter : CommonMPBackupImporter
+public expect class MPBackupImporter : CommonMPBackupImporter

--- a/backup/src/jsMain/kotlin/com/wire/backup/data/BackupDateTime.kt
+++ b/backup/src/jsMain/kotlin/com/wire/backup/data/BackupDateTime.kt
@@ -20,7 +20,7 @@ package com.wire.backup.data
 import kotlin.js.Date
 
 @JsExport
-actual data class BackupDateTime(val date: Date) {
+public actual data class BackupDateTime(val date: Date) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other == null || this::class.js != other::class.js) return false
@@ -35,10 +35,10 @@ actual data class BackupDateTime(val date: Date) {
     }
 }
 
-actual fun BackupDateTime(timestampMillis: Long): BackupDateTime {
+public actual fun BackupDateTime(timestampMillis: Long): BackupDateTime {
     return BackupDateTime(Date(timestampMillis))
 }
 
-actual fun BackupDateTime.toLongMilliseconds(): Long {
+public actual fun BackupDateTime.toLongMilliseconds(): Long {
     return date.getTime().toLong()
 }

--- a/backup/src/jsMain/kotlin/com/wire/backup/dump/MPBackupExporter.kt
+++ b/backup/src/jsMain/kotlin/com/wire/backup/dump/MPBackupExporter.kt
@@ -21,4 +21,4 @@ import com.wire.backup.data.BackupQualifiedId
 
 // JS uses the common one. Only handles Bytes / ByteArrays.
 @JsExport
-actual class MPBackupExporter(selfUserId: BackupQualifiedId) : CommonMPBackupExporter(selfUserId)
+public actual class MPBackupExporter(selfUserId: BackupQualifiedId) : CommonMPBackupExporter(selfUserId)

--- a/backup/src/jsMain/kotlin/com/wire/backup/ingest/MPBackupImporter.kt
+++ b/backup/src/jsMain/kotlin/com/wire/backup/ingest/MPBackupImporter.kt
@@ -18,4 +18,4 @@
 package com.wire.backup.ingest
 
 @JsExport
-actual class MPBackupImporter : CommonMPBackupImporter()
+public actual class MPBackupImporter : CommonMPBackupImporter()

--- a/backup/src/nonJsMain/kotlin/com/wire/backup/data/BackupDateTime.kt
+++ b/backup/src/nonJsMain/kotlin/com/wire/backup/data/BackupDateTime.kt
@@ -19,12 +19,12 @@ package com.wire.backup.data
 
 import kotlinx.datetime.Instant
 
-actual data class BackupDateTime(val instant: Instant)
+public actual data class BackupDateTime(val instant: Instant)
 
-actual fun BackupDateTime(timestampMillis: Long): BackupDateTime {
+public actual fun BackupDateTime(timestampMillis: Long): BackupDateTime {
     return BackupDateTime(Instant.fromEpochMilliseconds(timestampMillis))
 }
 
-actual fun BackupDateTime.toLongMilliseconds(): Long {
+public actual fun BackupDateTime.toLongMilliseconds(): Long {
     return this.instant.toEpochMilliseconds()
 }

--- a/backup/src/nonJsMain/kotlin/com/wire/backup/dump/MPBackupExporter.kt
+++ b/backup/src/nonJsMain/kotlin/com/wire/backup/dump/MPBackupExporter.kt
@@ -19,4 +19,4 @@ package com.wire.backup.dump
 
 import com.wire.backup.data.BackupQualifiedId
 
-actual class MPBackupExporter(selfUserId: BackupQualifiedId) : CommonMPBackupExporter(selfUserId)
+public actual class MPBackupExporter(selfUserId: BackupQualifiedId) : CommonMPBackupExporter(selfUserId)

--- a/backup/src/nonJsMain/kotlin/com/wire/backup/ingest/MPBackupImporter.kt
+++ b/backup/src/nonJsMain/kotlin/com/wire/backup/ingest/MPBackupImporter.kt
@@ -24,7 +24,7 @@ import kotlin.experimental.ExperimentalObjCName
 import kotlin.native.ObjCName
 
 @OptIn(ExperimentalObjCName::class)
-actual class MPBackupImporter : CommonMPBackupImporter() {
+public actual class MPBackupImporter : CommonMPBackupImporter() {
 
     /**
      * Imports a backup from the specified root path.
@@ -32,7 +32,7 @@ actual class MPBackupImporter : CommonMPBackupImporter() {
      * @param multiplatformBackupFilePath the path to the decrypted, unzipped backup data file
      */
     @ObjCName("importFile")
-    fun importFromFile(multiplatformBackupFilePath: String): BackupImportResult {
+    public fun importFromFile(multiplatformBackupFilePath: String): BackupImportResult {
         return FileSystem.SYSTEM.read(multiplatformBackupFilePath.toPath()) {
             importBackup(readByteArray())
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10575" title="WPB-10575" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-10575</a>  Cross Platform Backup: Write common backup / restore library
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

As a library that will be consumed by other clients, we should be very careful to not expose unnecessary internals to consumers.

### Solutions

Make visibility modifiers mandatory, so that we do not have accidental `public` entities.

### Testing

N/A

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
