### PR TITLE
fix: Login to second device does not have MLS capabilities RC #WPB-14906

### DIFF
--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/conversation/ConversationResponse.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/conversation/ConversationResponse.kt
@@ -114,7 +114,7 @@ data class ConversationResponse(
 @Serializable
 data class ConversationResponseV3(
     @SerialName("creator")
-    val creator: String,
+    val creator: String?,
 
     @SerialName("members")
     val members: ConversationMembersResponse,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14906" title="WPB-14906" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14906</a>  [Android] Login to second device does not have MLS capabilities
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

When a user logs in to a second device after logging in to an MLS capable client, he does not have MLS capabilities on the second device: no previously created conversations and not MLS thumbprints in device details.

### Causes (Optional)

field `creator` in `ConversationResponseDTOV3` suppose to be nullable.
Looks like we just forgot to add "?" to the field.
So when backend sends conversations with `creator = null` parser on android side fails.

### Solutions

Make `creator` filed nullable. Later `ConversationResponseDTOV3` mapped into `ConversationResponse` which has `val creator: String?`, so it should not add any problems :)
