### PR TITLE
test: add tests for old format parser in capabilities (WPB-12022)

### DIFF
--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v0/user/client/ClientApiV0Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v0/user/client/ClientApiV0Test.kt
@@ -24,9 +24,9 @@ import com.wire.kalium.mocks.responses.ClientResponseJson
 import com.wire.kalium.mocks.responses.RegisterClientRequestJson
 import com.wire.kalium.mocks.responses.RegisterTokenJson
 import com.wire.kalium.mocks.responses.UpdateClientRequestJson
-import com.wire.kalium.network.api.base.authenticated.client.ClientApi
 import com.wire.kalium.network.api.authenticated.client.ClientCapabilityDTO
 import com.wire.kalium.network.api.authenticated.client.UpdateClientCapabilitiesRequest
+import com.wire.kalium.network.api.base.authenticated.client.ClientApi
 import com.wire.kalium.network.api.v0.authenticated.ClientApiV0
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
@@ -58,7 +58,26 @@ internal class ClientApiV0Test : ApiTest() {
             val clientApi: ClientApi = ClientApiV0(networkClient)
             val response = clientApi.registerClient(REGISTER_CLIENT_REQUEST.serializableData)
             assertTrue(response.isSuccessful())
-            assertEquals(response.value, VALID_REGISTER_CLIENT_RESPONSE.serializableData)
+            assertEquals(VALID_REGISTER_CLIENT_RESPONSE.serializableData, response.value)
+        }
+
+    @Test
+    fun givenAValidRegisterClientRequest_whenCallingTheRegisterClientEndpointWithOldFormat_theRequestShouldBeConfiguredCorrectly() =
+        runTest {
+            val networkClient = mockAuthenticatedNetworkClient(
+                VALID_REGISTER_CLIENT_OLD_RESPONSE.rawJson,
+                statusCode = HttpStatusCode.Created,
+                assertion = {
+                    assertPost()
+                    assertJson()
+                    assertNoQueryParams()
+                    assertPathEqual(PATH_CLIENTS)
+                }
+            )
+            val clientApi: ClientApi = ClientApiV0(networkClient)
+            val response = clientApi.registerClient(REGISTER_CLIENT_REQUEST.serializableData)
+            assertTrue(response.isSuccessful())
+            assertEquals(VALID_REGISTER_CLIENT_OLD_RESPONSE.serializableData, response.value)
         }
 
     @Test
@@ -93,6 +112,7 @@ internal class ClientApiV0Test : ApiTest() {
 
             assertTrue(response.isSuccessful())
         }
+
     @Test
     fun givenAValidUpdateClientCapabilitiesRequest_whenCallingTheUpdateClientEndpoint_theRequestShouldBeConfiguredCorrectly() =
         runTest {
@@ -172,6 +192,7 @@ internal class ClientApiV0Test : ApiTest() {
         const val PATH_CLIENTS = "/clients"
         val REGISTER_CLIENT_REQUEST = RegisterClientRequestJson.valid
         val VALID_REGISTER_CLIENT_RESPONSE = ClientResponseJson.valid
+        val VALID_REGISTER_CLIENT_OLD_RESPONSE = ClientResponseJson.validCapabilitiesObject
         val UPDATE_CLIENT_REQUEST = UpdateClientRequestJson.valid
         val ERROR_RESPONSE = ErrorResponseJson.valid.serializableData
         val VALID_PUSH_TOKEN_REQUEST = RegisterTokenJson.validPushTokenRequest


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-12022" title="WPB-12022" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-12022</a>  [Android] API V7 related client ticket
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

V7 API changes in capabilities, add missing test to cover the retrocompat case.
Covering alternative (not modifying the serializer) for https://github.com/wireapp/kalium/pull/3151 with working tests

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
