### PR TITLE
fix: Sending of message in empty MLS group #WPB-14747

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -32,6 +32,7 @@ import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.data.conversation.mls.MLSAdditionResult
 import com.wire.kalium.logic.data.e2ei.CertificateRevocationListRepository
+import com.wire.kalium.logic.data.e2ei.RevocationListChecker
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.event.EventDeliveryInfo
 import com.wire.kalium.logic.data.id.ConversationId
@@ -45,12 +46,11 @@ import com.wire.kalium.logic.data.id.toModel
 import com.wire.kalium.logic.data.keypackage.KeyPackageLimitsProvider
 import com.wire.kalium.logic.data.keypackage.KeyPackageRepository
 import com.wire.kalium.logic.data.mls.CipherSuite
+import com.wire.kalium.logic.data.mls.MLSPublicKeys
 import com.wire.kalium.logic.data.mlspublickeys.MLSPublicKeysRepository
 import com.wire.kalium.logic.data.mlspublickeys.getRemovalKey
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider
-import com.wire.kalium.logic.data.e2ei.RevocationListChecker
-import com.wire.kalium.logic.data.mls.MLSPublicKeys
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.flatMapLeft
@@ -68,9 +68,9 @@ import com.wire.kalium.logic.sync.incremental.EventSource
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapMLSRequest
 import com.wire.kalium.logic.wrapStorageRequest
+import com.wire.kalium.network.api.authenticated.notification.EventContentDTO
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
 import com.wire.kalium.network.api.base.authenticated.message.MLSMessageApi
-import com.wire.kalium.network.api.authenticated.notification.EventContentDTO
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.exceptions.isMlsClientMismatch
 import com.wire.kalium.network.exceptions.isMlsCommitMissingReferences

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -656,7 +656,9 @@ internal class MLSConversationDataSource(
                 kaliumLogger.w("enrollment for existing client: upload new keypackages and drop old ones")
                 keyPackageRepository
                     .replaceKeyPackages(clientId, rotateBundle.newKeyPackages, CipherSuite.fromTag(mlsClient.getDefaultCipherSuite()))
-                    .flatMapLeft { E2EIFailure.RotationAndMigration(it).left() }
+                    .flatMapLeft {
+                        return E2EIFailure.RotationAndMigration(it).left()
+                    }
             }
             kaliumLogger.w("send migration commits after key rotations")
             kaliumLogger.w("rotate bundles: ${rotateBundle.commits.size}")

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -1512,7 +1512,7 @@ class MLSConversationRepositoryTest {
 
             val (arrangement, mlsConversationRepository) = Arrangement(testKaliumDispatcher)
                 .withCommitPendingProposalsReturningNothing()
-                .withClaimKeyPackagesSuccessful()
+                .withClaimKeyPackagesSuccessful(emptyList()) // empty cause members is empty in case of establishMLSSubConversationGroup
                 .withGetMLSClientSuccessful()
                 .withGetMLSGroupIdByConversationIdReturns(Arrangement.GROUP_ID.value)
                 .withGetExternalSenderKeySuccessful()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -99,7 +99,6 @@ import io.mockative.matches
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.twice
-import io.mockative.verify
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
@@ -304,13 +303,15 @@ class MLSConversationRepositoryTest {
         coVerify {
             arrangement.mlsClient.createConversation(
                 groupId = eq(Arrangement.RAW_GROUP_ID),
-                externalSenders = any())
+                externalSenders = any()
+            )
         }.wasInvoked(once)
 
         coVerify {
             arrangement.mlsClient.addMember(
                 groupId = eq(Arrangement.RAW_GROUP_ID),
-                membersKeyPackages = any())
+                membersKeyPackages = any()
+            )
         }.wasInvoked(once)
 
         coVerify {
@@ -1925,10 +1926,10 @@ class MLSConversationRepositoryTest {
                             "user_handle",
                             "wire.com"
                         ),
-                    "User Test",
-                    "domain.com",
-                    "certificate",
-                    serialNumber = "serialNumber",
+                        "User Test",
+                        "domain.com",
+                        "certificate",
+                        serialNumber = "serialNumber",
                         notAfter = 1899105093,
                         notBefore = 1899205093
                     )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14747" title="WPB-14747" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14747</a>  [Android] Sending of messages in EMPTY MLS groups not working with latest 4.10 build
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

When user creates empty MLS group (self user is the only member) and has only 1 client. Then sending messages always fails in such a group.

### Causes (Optional)

According to logs, send message error: `InvalidRequestError(errorResponse=ErrorResponse(code=400, message=Application messages at epoch 0 are not supported, label=mls-protocol-error, cause=null))`. 
Why `epoch = 0`? 

How it should work: when client creates MLS group `epoch` set 0, after that we suppose to add some users and when do that epoch is updated. But when the group is empty, no updating epoch. 
There is "workaround" for that case  calling `updateKeyingMaterial(idMapper.toCryptoModel(groupID))` but it didn't work because of `if(userIdList.isEmpty())` but it's always false, cause userIdList includes self userId.

### Solutions

Update `if` in `internalAddMemberToMLSGroup` to check not userIds but `clientKeyPackageList` if empty. 
In that case when client creates empty MLS group `clientKeyPackageList` will be empty and workaround works.
