### PR TITLE
fix: Remove unused conversation id [#WPB-14256]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/ObserveRecentlyEndedCallMetadataUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/ObserveRecentlyEndedCallMetadataUseCase.kt
@@ -27,13 +27,13 @@ import com.wire.kalium.logic.data.id.ConversationId
  * Used mainly for analytics.
  */
 interface ObserveRecentlyEndedCallMetadataUseCase {
-    suspend operator fun invoke(conversationId: ConversationId): Flow<RecentlyEndedCallMetadata>
+    suspend operator fun invoke(): Flow<RecentlyEndedCallMetadata>
 }
 
 class ObserveRecentlyEndedCallMetadataUseCaseImpl internal constructor(
     private val callRepository: CallRepository,
 ) : ObserveRecentlyEndedCallMetadataUseCase {
-    override suspend fun invoke(conversationId: ConversationId): Flow<RecentlyEndedCallMetadata> {
+    override suspend fun invoke(): Flow<RecentlyEndedCallMetadata> {
         return callRepository.observeRecentlyEndedCallMetadata()
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/ObserveRecentlyEndedCallMetadataUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/ObserveRecentlyEndedCallMetadataUseCase.kt
@@ -20,7 +20,6 @@ package com.wire.kalium.logic.feature.call.usecase
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.RecentlyEndedCallMetadata
 import kotlinx.coroutines.flow.Flow
-import com.wire.kalium.logic.data.id.ConversationId
 
 /**
  * Use case to observe recently ended call metadata. This gives us all metadata assigned to a call.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14256" title="WPB-14256" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-14256</a>  [Android] Call end - Event and segmentation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

I have left unused conversation id in the use case - which we have to clean up

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
