### PR TITLE
fix: infinite profile loading screen when user cannot be added (WPB-14842)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSendFailureHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSendFailureHandler.kt
@@ -111,7 +111,7 @@ class MessageSendFailureHandlerImpl internal constructor(
 
     private suspend fun syncUserIds(userId: Set<UserId>): Either<CoreFailure, Unit> {
         return if (userId.isEmpty()) Either.Right(Unit)
-        else userRepository.fetchUsersByIds(userId)
+        else userRepository.fetchUsersByIds(userId).map { }
     }
 
     private suspend fun addMissingClients(missingClients: Map<UserId, List<ClientId>>): Either<CoreFailure, Unit> =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveUserInfoUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveUserInfoUseCase.kt
@@ -77,7 +77,15 @@ internal class ObserveUserInfoUseCaseImpl(
                 either.fold({ storageFailure ->
                     if (storageFailure is StorageFailure.DataNotFound) {
                         userRepository.fetchUsersByIds(setOf(userId))
-                            .fold({ ObserveOtherUserResult(fetchUserError = it) }) { ObserveOtherUserResult() }
+                            .fold({ ObserveOtherUserResult(fetchUserError = it) }) { usersFound ->
+                                if (usersFound) {
+                                    // Fetched users are persisted
+                                    ObserveOtherUserResult()
+                                } else {
+                                    // Users cannot be found
+                                    ObserveOtherUserResult(fetchUserError = StorageFailure.DataNotFound)
+                                }
+                            }
                     } else {
                         ObserveOtherUserResult(getKnownUserError = storageFailure)
                     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/prekey/MessageSendFailureHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/prekey/MessageSendFailureHandlerTest.kt
@@ -400,7 +400,7 @@ class MessageSendFailureHandlerTest {
         suspend fun withFetchUsersByIdSuccess() = apply {
             coEvery {
                 userRepository.fetchUsersByIds(any())
-            }.returns(Either.Right(Unit))
+            }.returns(Either.Right(true))
         }
 
         suspend fun withFetchUsersByIdFailure(failure: CoreFailure) = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolverTest.kt
@@ -101,7 +101,7 @@ class OneOnOneResolverTest {
         // given
         val oneOnOneUser = TestUser.OTHER.copy(id = TestUser.OTHER_USER_ID)
         val (arrangement, resolver) = arrange {
-            withFetchUsersByIdReturning(Either.Right(Unit))
+            withFetchUsersByIdReturning(Either.Right(true))
             withGetProtocolForUser(Either.Right(SupportedProtocol.MLS))
             withMigrateToMLSReturns(Either.Right(TestConversation.ID))
         }
@@ -128,7 +128,7 @@ class OneOnOneResolverTest {
         // given
         val oneOnOneUser = TestUser.OTHER.copy(id = TestUser.OTHER_USER_ID)
         val (arrangement, resolver) = arrange {
-            withFetchUsersByIdReturning(Either.Right(Unit))
+            withFetchUsersByIdReturning(Either.Right(true))
             withGetProtocolForUser(Either.Right(SupportedProtocol.MLS))
             withMigrateToMLSReturns(Either.Right(TestConversation.ID))
         }
@@ -149,7 +149,7 @@ class OneOnOneResolverTest {
         val oneOnOneUser = TestUser.OTHER.copy(id = TestUser.OTHER_USER_ID)
         val (arrangement, resolver) = arrange {
             withGetKnownUserReturning(flowOf(oneOnOneUser))
-            withFetchUsersByIdReturning(Either.Right(Unit))
+            withFetchUsersByIdReturning(Either.Right(true))
             withGetProtocolForUser(Either.Right(SupportedProtocol.MLS))
             withMigrateToMLSReturns(Either.Right(TestConversation.ID))
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/UserRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/UserRepositoryArrangement.kt
@@ -72,7 +72,7 @@ internal interface UserRepositoryArrangement {
     suspend fun withFetchUserInfoReturning(result: Either<CoreFailure, Unit>)
 
     suspend fun withFetchUsersByIdReturning(
-        result: Either<CoreFailure, Unit>,
+        result: Either<CoreFailure, Boolean>,
         userIdList: Matcher<Set<UserId>> = AnyMatcher(valueOf())
     )
 
@@ -186,7 +186,7 @@ internal open class UserRepositoryArrangementImpl : UserRepositoryArrangement {
     }
 
     override suspend fun withFetchUsersByIdReturning(
-        result: Either<CoreFailure, Unit>,
+        result: Either<CoreFailure, Boolean>,
         userIdList: Matcher<Set<UserId>>
     ) {
         coEvery {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14842" title="WPB-14842" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14842</a>  [Android] User profile loading indefinitely when trying to connect to a user with QR code when I am not allowed to connect
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-14842
----
# What's new in this PR?

### Issues

When trying to add user via QR code and this user cannot be added (e.g. anta user to beta app) then profile screen is showing infinite loading progress.

### Causes (Optional)

The scenario when user is not found locally and network fetch returns success result with no users is not handled. The repository is storing fetched users in the database and UI will get user from the database. In this flow no users are saved in the database and UI keeps showing progress because no error was returned.

### Solutions

Add a boolean flag (instead of Unit) to indicate if actual users were found. Use this flag to return error if no users were found on server.

#### How to Test

Try to add an anta user to beta app via QR code.
