### PR TITLE
feat: send and receive in-call reactions [#WPB-14254]

### DIFF
--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/call/InCallReactionMessage.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/call/InCallReactionMessage.kt
@@ -1,0 +1,27 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.call
+
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.QualifiedID
+
+data class InCallReactionMessage(
+    val conversationId: ConversationId,
+    val senderUserId: QualifiedID,
+    val emojis: Set<String>,
+)

--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
@@ -248,6 +248,11 @@ sealed interface Message {
                     typeKey to "dataTransfer",
                     "content" to content.toLogMap(),
                 )
+
+                is MessageContent.InCallEmoji -> mutableMapOf(
+                    typeKey to "inCallEmoji",
+                    "content" to content.emojis
+                )
             }
 
             val standardProperties = mapOf(

--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
@@ -395,6 +395,10 @@ sealed interface MessageContent {
             data object Disabled : ForConversation()
         }
     }
+
+    data class InCallEmoji(
+        val emojis: Map<String, Int>
+    ) : Signaling
 }
 
 /**
@@ -455,6 +459,7 @@ fun MessageContent?.getType() = when (this) {
     is MessageContent.LegalHold.ForMembers.Disabled -> "LegalHold.ForMembers.Disabled"
     is MessageContent.LegalHold.ForMembers.Enabled -> "LegalHold.ForMembers.Enabled"
     is MessageContent.DataTransfer -> "DataTransfer"
+    is MessageContent.InCallEmoji -> "InCallEmoji"
     null -> "null"
 }
 

--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContentLogging.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContentLogging.kt
@@ -41,4 +41,5 @@ inline fun MessageContent.FromProto.typeDescription(): String = when (this) {
     is MessageContent.Receipt -> "Receipt"
     is MessageContent.TextEdited -> "TextEdited"
     is MessageContent.DataTransfer -> "DataTransfer"
+    is MessageContent.InCallEmoji -> "InCallEmoji"
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/InCallReactionsRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/InCallReactionsRepository.kt
@@ -1,0 +1,48 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.call
+
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.user.UserId
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.filter
+
+internal interface InCallReactionsRepository {
+    suspend fun addInCallReaction(conversationId: ConversationId, senderUserId: UserId, emojis: Set<String>)
+    fun observeInCallReactions(conversationId: ConversationId): Flow<InCallReactionMessage>
+}
+
+internal class InCallReactionsDataSource : InCallReactionsRepository {
+
+    private val inCallReactionsFlow: MutableSharedFlow<InCallReactionMessage> =
+        MutableSharedFlow(extraBufferCapacity = BUFFER_SIZE, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+
+    override suspend fun addInCallReaction(conversationId: ConversationId, senderUserId: UserId, emojis: Set<String>) {
+        inCallReactionsFlow.emit(InCallReactionMessage(conversationId, senderUserId, emojis))
+    }
+
+    override fun observeInCallReactions(conversationId: ConversationId): Flow<InCallReactionMessage> = inCallReactionsFlow.asSharedFlow()
+        .filter { it.conversationId == conversationId }
+
+    private companion object {
+        const val BUFFER_SIZE = 32 // drop after this threshold
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/PersistMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/PersistMessageUseCase.kt
@@ -126,6 +126,7 @@ internal class PersistMessageUseCaseImpl(
             is MessageContent.MemberChange.RemovedFromTeam -> false
             is MessageContent.TeamMemberRemoved -> false
             is MessageContent.DataTransfer -> false
+            is MessageContent.InCallEmoji -> false
         }
 
     @Suppress("ComplexMethod")
@@ -180,6 +181,7 @@ internal class PersistMessageUseCaseImpl(
             is MessageContent.LegalHold,
             is MessageContent.MemberChange.RemovedFromTeam,
             is MessageContent.TeamMemberRemoved,
-            is MessageContent.DataTransfer -> false
+            is MessageContent.DataTransfer,
+            is MessageContent.InCallEmoji -> false
         }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -40,6 +40,8 @@ import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.data.asset.KaliumFileSystemImpl
 import com.wire.kalium.logic.data.call.CallDataSource
 import com.wire.kalium.logic.data.call.CallRepository
+import com.wire.kalium.logic.data.call.InCallReactionsDataSource
+import com.wire.kalium.logic.data.call.InCallReactionsRepository
 import com.wire.kalium.logic.data.call.VideoStateChecker
 import com.wire.kalium.logic.data.call.VideoStateCheckerImpl
 import com.wire.kalium.logic.data.call.mapper.CallMapper
@@ -1387,7 +1389,8 @@ class UserSessionScope internal constructor(
             receiptMessageHandler,
             buttonActionConfirmationHandler,
             dataTransferEventHandler,
-            userId
+            inCallReactionsRepository,
+            userId,
         )
 
     private val staleEpochVerifier: StaleEpochVerifier
@@ -2066,7 +2069,8 @@ class UserSessionScope internal constructor(
             userConfigRepository = userConfigRepository,
             getCallConversationType = getCallConversationType,
             conversationClientsInCallUpdater = conversationClientsInCallUpdater,
-            kaliumConfigs = kaliumConfigs
+            kaliumConfigs = kaliumConfigs,
+            inCallReactionsRepository = inCallReactionsRepository,
         )
 
     val connection: ConnectionScope
@@ -2164,6 +2168,8 @@ class UserSessionScope internal constructor(
             authenticationScope.serverConfigRepository,
         )
     }
+
+    private val inCallReactionsRepository: InCallReactionsRepository = InCallReactionsDataSource()
 
     /**
      * This will start subscribers of observable work per user session, as long as the user is logged in.

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.CallingParticipantsOrder
 import com.wire.kalium.logic.data.call.CallingParticipantsOrderImpl
+import com.wire.kalium.logic.data.call.InCallReactionsRepository
 import com.wire.kalium.logic.data.call.ParticipantsFilterImpl
 import com.wire.kalium.logic.data.call.ParticipantsOrderByNameImpl
 import com.wire.kalium.logic.data.conversation.ConversationRepository
@@ -43,8 +44,6 @@ import com.wire.kalium.logic.feature.call.usecase.GetAllCallsWithSortedParticipa
 import com.wire.kalium.logic.feature.call.usecase.GetCallConversationTypeProvider
 import com.wire.kalium.logic.feature.call.usecase.GetIncomingCallsUseCase
 import com.wire.kalium.logic.feature.call.usecase.GetIncomingCallsUseCaseImpl
-import com.wire.kalium.logic.feature.call.usecase.ObserveConferenceCallingEnabledUseCase
-import com.wire.kalium.logic.feature.call.usecase.ObserveConferenceCallingEnabledUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.IsCallRunningUseCase
 import com.wire.kalium.logic.feature.call.usecase.IsEligibleToStartCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.IsEligibleToStartCallUseCaseImpl
@@ -53,12 +52,16 @@ import com.wire.kalium.logic.feature.call.usecase.IsLastCallClosedUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.MuteCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.MuteCallUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.ObserveAskCallFeedbackUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveConferenceCallingEnabledUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveConferenceCallingEnabledUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.ObserveEndCallDueToConversationDegradationUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveEndCallDueToConversationDegradationUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallWithSortedParticipantsUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallWithSortedParticipantsUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCaseImpl
+import com.wire.kalium.logic.feature.call.usecase.ObserveInCallReactionsUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveInCallReactionsUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.ObserveOngoingCallsUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveOngoingCallsUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.ObserveOutgoingCallUseCase
@@ -103,6 +106,7 @@ class CallsScope internal constructor(
     private val conversationClientsInCallUpdater: ConversationClientsInCallUpdater,
     private val getCallConversationType: GetCallConversationTypeProvider,
     private val kaliumConfigs: KaliumConfigs,
+    private val inCallReactionsRepository: InCallReactionsRepository,
     internal val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) {
 
@@ -239,4 +243,7 @@ class CallsScope internal constructor(
         get() = ObserveRecentlyEndedCallMetadataUseCaseImpl(
             callRepository = callRepository
         )
+
+    val observeInCallReactions: ObserveInCallReactionsUseCase
+        get() = ObserveInCallReactionsUseCaseImpl(inCallReactionsRepository)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/ObserveInCallReactionsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/ObserveInCallReactionsUseCase.kt
@@ -1,0 +1,39 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.call.usecase
+
+import com.wire.kalium.logic.data.call.InCallReactionMessage
+import com.wire.kalium.logic.data.call.InCallReactionsRepository
+import com.wire.kalium.logic.data.id.ConversationId
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Observe incoming in-call reactions
+ */
+interface ObserveInCallReactionsUseCase {
+    operator fun invoke(conversationId: ConversationId): Flow<InCallReactionMessage>
+}
+
+internal class ObserveInCallReactionsUseCaseImpl(
+    private val inCallReactionsRepository: InCallReactionsRepository,
+) : ObserveInCallReactionsUseCase {
+
+    override fun invoke(conversationId: ConversationId): Flow<InCallReactionMessage> {
+        return inCallReactionsRepository.observeInCallReactions(conversationId)
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/incallreaction/SendInCallReactionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/incallreaction/SendInCallReactionUseCase.kt
@@ -1,0 +1,70 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.incallreaction
+
+import com.benasher44.uuid.uuid4
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.CurrentClientIdProvider
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.feature.message.MessageSender
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.datetime.Clock
+
+/**
+ * Sends in-call reaction to the call with the conversationId
+ */
+class SendInCallReactionUseCase(
+    private val selfUserId: QualifiedID,
+    private val provideClientId: CurrentClientIdProvider,
+    private val messageSender: MessageSender,
+    private val dispatchers: KaliumDispatcher = KaliumDispatcherImpl,
+    private val scope: CoroutineScope
+) {
+
+    suspend operator fun invoke(conversationId: ConversationId, reaction: String): Either<CoreFailure, Unit> =
+        scope.async(dispatchers.io) {
+
+            val generatedMessageUuid = uuid4().toString()
+
+            provideClientId().flatMap { clientId ->
+                val message = Message.Signaling(
+                    id = generatedMessageUuid,
+                    content = MessageContent.InCallEmoji(
+                        emojis = mapOf(reaction to 1)
+                    ),
+                    conversationId = conversationId,
+                    date = Clock.System.now(),
+                    senderUserId = selfUserId,
+                    senderClientId = clientId,
+                    status = Message.Status.Pending,
+                    isSelfMessage = true,
+                    expirationData = null,
+                )
+
+                messageSender.sendMessage(message)
+            }
+        }.await()
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -62,6 +62,7 @@ import com.wire.kalium.logic.feature.asset.UpdateAssetMessageTransferStatusUseCa
 import com.wire.kalium.logic.feature.asset.UpdateAssetMessageTransferStatusUseCaseImpl
 import com.wire.kalium.logic.feature.asset.ValidateAssetFileTypeUseCase
 import com.wire.kalium.logic.feature.asset.ValidateAssetFileTypeUseCaseImpl
+import com.wire.kalium.logic.feature.incallreaction.SendInCallReactionUseCase
 import com.wire.kalium.logic.feature.message.composite.SendButtonActionConfirmationMessageUseCase
 import com.wire.kalium.logic.feature.message.composite.SendButtonActionMessageUseCase
 import com.wire.kalium.logic.feature.message.composite.SendButtonMessageUseCase
@@ -453,4 +454,13 @@ class MessageScope internal constructor(
 
     val removeMessageDraftUseCase: RemoveMessageDraftUseCase
         get() = RemoveMessageDraftUseCaseImpl(messageDraftRepository)
+
+    val sendInCallReactionUseCase: SendInCallReactionUseCase
+        get() = SendInCallReactionUseCase(
+            selfUserId = selfUserId,
+            provideClientId = currentClientIdProvider,
+            messageSender = messageSender,
+            dispatchers = dispatcher,
+            scope = scope,
+        )
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PersistMigratedMessagesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PersistMigratedMessagesUseCase.kt
@@ -212,5 +212,6 @@ internal class PersistMigratedMessagesUseCaseImpl(
         is MessageContent.ButtonActionConfirmation -> MessageEntity.Visibility.HIDDEN
         is MessageContent.Location -> MessageEntity.Visibility.VISIBLE
         is MessageContent.DataTransfer -> MessageEntity.Visibility.HIDDEN
+        is MessageContent.InCallEmoji -> MessageEntity.Visibility.HIDDEN
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/InCallReactionsRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/InCallReactionsRepositoryTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.call
+
+import app.cash.turbine.test
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class InCallReactionsRepositoryTest {
+    @Test
+    fun whenNewReactionIsAdded_thenRepositoryEmitsNewReactionMessage() = runBlocking {
+
+        // given
+        val repository: InCallReactionsRepository = InCallReactionsDataSource()
+
+        repository.observeInCallReactions(TestConversation.id()).test {
+
+            // when
+            repository.addInCallReaction(TestConversation.id(), TestUser.USER_ID, setOf("1"))
+
+            // then
+            assertEquals(InCallReactionMessage(TestConversation.id(), TestUser.USER_ID, setOf("1")), awaitItem())
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
@@ -29,9 +29,9 @@ import com.wire.kalium.protobuf.encodeToByteArray
 import com.wire.kalium.protobuf.messages.Asset
 import com.wire.kalium.protobuf.messages.Confirmation
 import com.wire.kalium.protobuf.messages.GenericMessage
+import com.wire.kalium.protobuf.messages.GenericMessage.UnknownStrategy
 import com.wire.kalium.protobuf.messages.MessageEdit
 import com.wire.kalium.protobuf.messages.Text
-import com.wire.kalium.protobuf.messages.UnknownStrategy
 import io.ktor.utils.io.core.toByteArray
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -502,6 +502,24 @@ class ProtoContentMapperTest {
             MessageContent.DataTransfer.TrackingIdentifier(
                 "abcd-1234"
             )
+        )
+        val protoContent = ProtoContent.Readable(
+            TEST_MESSAGE_UUID,
+            messageContent,
+            false,
+            legalHoldStatus = Conversation.LegalHoldStatus.UNKNOWN
+        )
+
+        val encoded = protoContentMapper.encodeToProtobuf(protoContent)
+        val decoded = protoContentMapper.decodeFromProtobuf(encoded)
+
+        assertEquals(decoded, protoContent)
+    }
+
+    @Test
+    fun givenInCallEmojiContent_whenMappingToProtoDataAndBack_thenTheContentsShouldMatchTheOriginal() {
+        val messageContent = MessageContent.InCallEmoji(
+            emojis = mapOf("emoji" to 999)
         )
         val protoContent = ProtoContent.Readable(
             TEST_MESSAGE_UUID,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/incallreaction/SendInCallReactionUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/incallreaction/SendInCallReactionUseCaseTest.kt
@@ -1,0 +1,119 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.incallreaction
+
+import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.CurrentClientIdProvider
+import com.wire.kalium.logic.feature.message.MessageSender
+import com.wire.kalium.logic.framework.TestClient
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.test_util.testKaliumDispatcher
+import com.wire.kalium.logic.util.shouldFail
+import com.wire.kalium.logic.util.shouldSucceed
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.coEvery
+import io.mockative.coVerify
+import io.mockative.mock
+import io.mockative.once
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class SendInCallReactionUseCaseTest {
+
+    @Mock
+    val messageSender = mock(MessageSender::class)
+
+    @Test
+    fun givenEstablishedConnection_WhenSending_ShouldReturnSuccess() = runTest {
+
+        // Given
+        val (arrangement, sendReactionUseCase) = Arrangement(this)
+            .withCurrentClientProviderSuccess()
+            .withSendMessageSuccess()
+            .arrange()
+
+        // When
+        val result = sendReactionUseCase(ConversationId("id", "domain"), "reaction")
+
+        // Then
+        result.shouldSucceed()
+
+        coVerify {
+            arrangement.messageSender.sendMessage(any(), any())
+        }.wasInvoked(once)
+    }
+
+    @Test
+    fun givenNoConnectionWhenSendingShouldFail() = runTest {
+
+        // Given
+        val (arrangement, sendReactionUseCase) = Arrangement(this)
+            .withCurrentClientProviderSuccess()
+            .withSendMessageFailure()
+            .arrange()
+
+        // When
+        val result = sendReactionUseCase(ConversationId("id", "domain"), "reaction")
+
+        // Then
+        result.shouldFail()
+
+        coVerify {
+            arrangement.messageSender.sendMessage(any(), any())
+        }.wasInvoked(once)
+    }
+
+    private class Arrangement(private val coroutineScope: CoroutineScope) {
+        @Mock
+        val messageSender = mock(MessageSender::class)
+
+        @Mock
+        val currentClientIdProvider = mock(CurrentClientIdProvider::class)
+
+        suspend fun withSendMessageSuccess() = apply {
+            coEvery {
+                messageSender.sendMessage(any(), any())
+            }.returns(Either.Right(Unit))
+        }
+
+        suspend fun withSendMessageFailure() = apply {
+            coEvery {
+                messageSender.sendMessage(any(), any())
+            }.returns(Either.Left(NetworkFailure.NoNetworkConnection(null)))
+        }
+
+        suspend fun withCurrentClientProviderSuccess(clientId: ClientId = TestClient.CLIENT_ID) = apply {
+            coEvery {
+                currentClientIdProvider.invoke()
+            }.returns(Either.Right(clientId))
+        }
+
+        fun arrange() = this to SendInCallReactionUseCase(
+            selfUserId = TestUser.SELF.id,
+            provideClientId = currentClientIdProvider,
+            messageSender = messageSender,
+            dispatchers = coroutineScope.testKaliumDispatcher,
+            scope = coroutineScope,
+        )
+    }
+}

--- a/protobuf-codegen/src/main/proto/messages.proto
+++ b/protobuf-codegen/src/main/proto/messages.proto
@@ -45,8 +45,19 @@ message GenericMessage {
         ButtonAction buttonAction = 21;
         ButtonActionConfirmation buttonActionConfirmation = 22;
         DataTransfer dataTransfer = 23; // client-side synchronization across devices of the same user
+        InCallEmoji inCallEmoji = 24;
+        // UnknownStrategy unknownStrategy = 25; -- Defined outside the oneof
+        // Next field should be 26 ↓
+        InCallHandRaise inCallHandRaise = 26;
     }
-    optional UnknownStrategy unknownStrategy = 24 [default = IGNORE];
+    optional UnknownStrategy unknownStrategy = 25 [default = IGNORE];
+
+    // See internal RFC: "2024-07-18 RFC Improve future-proofing for new OTR message types"
+    enum UnknownStrategy {
+        IGNORE = 0;                 // Ignore the message completely. Trash. Bye
+        DISCARD_AND_WARN = 1;       // Warn the user, but discard the message, as it won't be helpful in the future.
+        WARN_USER_ALLOW_RETRY = 2;  // Warn the user. Client has freedom to store it and retry in the future.
+    }
 }
 
 message QualifiedUserId {
@@ -332,6 +343,14 @@ message Reaction {
     optional LegalHoldStatus legal_hold_status = 3 [default = UNKNOWN]; // whether this message was sent to legal hold
 }
 
+message InCallEmoji {
+    map<string, int32> emojis = 1;
+}
+
+message InCallHandRaise {
+    required bool is_hand_up = 1; // true if the hand is raised, false if lowered
+}
+
 message Calling {
     required string content = 1;
     optional QualifiedConversationId qualified_conversation_id = 2;
@@ -361,10 +380,4 @@ enum LegalHoldStatus {
     UNKNOWN = 0;
     DISABLED = 1;
     ENABLED = 2;
-}
-
-enum UnknownStrategy {
-    IGNORE = 0;                 // Ignore the message completely.
-    DISCARD_AND_WARN = 1;       // Warn the user, but discard the message, as it may not be helpful in the future
-    WARN_USER_ALLOW_RETRY = 2;  // Warn the user. Client has freedom to store it and retry in the future.
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14254" title="WPB-14254" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-14254</a>  [Android] In-Call Reactions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

https://wearezeta.atlassian.net/browse/WPB-14254
----
# What's new in this PR?

Support for new In-call reaction messages.
- Handling new type of message content
- Repository and use case for observing incoming reactions
- Use case for sending in-call reactions