### PR TITLE
refactor: remove the fetch of self user when only the ID is used [WPB-3726]

### DIFF
--- a/logic/src/androidInstrumentedTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
+++ b/logic/src/androidInstrumentedTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
@@ -63,9 +63,6 @@ class CallManagerTest {
     private val callRepository = mock(CallRepository::class)
 
     @Mock
-    private val userRepository = mock(UserRepository::class)
-
-    @Mock
     private val messageSender = mock(MessageSender::class)
 
     @Mock
@@ -120,7 +117,6 @@ class CallManagerTest {
         callManagerImpl = CallManagerImpl(
             calling = calling,
             callRepository = callRepository,
-            userRepository = userRepository,
             currentClientIdProvider = currentClientIdProvider,
             selfConversationIdProvider = selfConversationIdProvider,
             conversationRepository = conversationRepository,
@@ -137,7 +133,8 @@ class CallManagerTest {
             kaliumConfigs = kaliumConfigs,
             mediaManagerService = mediaManagerService,
             flowManagerService = flowManagerService,
-            createAndPersistRecentlyEndedCallMetadata = createAndPersistRecentlyEndedCallMetadata
+            createAndPersistRecentlyEndedCallMetadata = createAndPersistRecentlyEndedCallMetadata,
+            selfUserId = UserId
         )
     }
 

--- a/logic/src/androidInstrumentedTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
+++ b/logic/src/androidInstrumentedTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
@@ -58,6 +58,8 @@ class CallManagerTest {
     @Mock
     private val calling = mock(Calling::class)
 
+    private val selfUserId = UserId(value = "selfUserId", domain = "selfDomain")
+
     @Mock
     private val callRepository = mock(CallRepository::class)
 
@@ -133,7 +135,7 @@ class CallManagerTest {
             mediaManagerService = mediaManagerService,
             flowManagerService = flowManagerService,
             createAndPersistRecentlyEndedCallMetadata = createAndPersistRecentlyEndedCallMetadata,
-            selfUserId = UserId
+            selfUserId = selfUserId
         )
     }
 

--- a/logic/src/androidInstrumentedTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
+++ b/logic/src/androidInstrumentedTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
@@ -34,7 +34,6 @@ import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.call.usecase.ConversationClientsInCallUpdater
 import com.wire.kalium.logic.feature.call.usecase.CreateAndPersistRecentlyEndedCallMetadataUseCase
 import com.wire.kalium.logic.feature.call.usecase.GetCallConversationTypeProvider

--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -31,7 +31,6 @@ import com.wire.kalium.logic.data.id.FederatedIdMapper
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.call.usecase.ConversationClientsInCallUpdater
 import com.wire.kalium.logic.feature.call.usecase.GetCallConversationTypeProvider
 import com.wire.kalium.logic.feature.call.usecase.CreateAndPersistRecentlyEndedCallMetadataUseCase

--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -44,7 +44,6 @@ actual class GlobalCallManager {
     internal actual fun getCallManagerForClient(
         userId: QualifiedID,
         callRepository: CallRepository,
-        userRepository: UserRepository,
         currentClientIdProvider: CurrentClientIdProvider,
         selfConversationIdProvider: SelfConversationIdProvider,
         conversationRepository: ConversationRepository,

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -56,7 +56,6 @@ import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.call.scenario.CallingMessageSender
 import com.wire.kalium.logic.feature.call.scenario.OnActiveSpeakers
 import com.wire.kalium.logic.feature.call.scenario.OnAnsweredCall

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -104,7 +104,6 @@ import java.util.Collections
 class CallManagerImpl internal constructor(
     private val calling: Calling,
     private val callRepository: CallRepository,
-    private val userRepository: UserRepository,
     private val currentClientIdProvider: CurrentClientIdProvider,
     selfConversationIdProvider: SelfConversationIdProvider,
     private val conversationRepository: ConversationRepository,
@@ -121,6 +120,7 @@ class CallManagerImpl internal constructor(
     private val mediaManagerService: MediaManagerService,
     private val flowManagerService: FlowManagerService,
     private val createAndPersistRecentlyEndedCallMetadata: CreateAndPersistRecentlyEndedCallMetadataUseCase,
+    private val selfUserId: UserId,
     private val json: Json = Json { ignoreUnknownKeys = true },
     private val shouldRemoteMuteChecker: ShouldRemoteMuteChecker = ShouldRemoteMuteCheckerImpl(),
     private val serverTimeHandler: ServerTimeHandler = ServerTimeHandlerImpl(),
@@ -153,11 +153,6 @@ class CallManagerImpl internal constructor(
             it
         })
     }
-    private val userId: Deferred<UserId> = scope.async(start = CoroutineStart.LAZY) {
-        userRepository.observeSelfUser().first().id.also {
-            callingLogger.d("$TAG - userId ${it.toLogString()}")
-        }
-    }
 
     @Suppress("UNUSED_ANONYMOUS_PARAMETER")
     private val metricsHandler = MetricsHandler { conversationId: String, metricsJson: String, arg: Pointer? ->
@@ -186,7 +181,7 @@ class CallManagerImpl internal constructor(
             }
             joinAll(flowManagerStartJob, mediaManagerStartJob)
             callingLogger.i("$TAG: Creating Handle")
-            val selfUserId = federatedIdMapper.parseToFederatedId(userId.await())
+            val selfUserId = federatedIdMapper.parseToFederatedId(selfUserId)
             val selfClientId = clientId.await().value
 
             val waitInitializationJob = Job()
@@ -254,7 +249,7 @@ class CallManagerImpl internal constructor(
         val conversationMembers = conversationRepository.observeConversationMembers(message.conversationId).first()
         val shouldRemoteMute = shouldRemoteMuteChecker.check(
             senderUserId = message.senderUserId,
-            selfUserId = userId.await(),
+            selfUserId = selfUserId,
             selfClientId = clientId.await().value,
             targets = callingValue.targets,
             conversationMembers = conversationMembers
@@ -306,7 +301,7 @@ class CallManagerImpl internal constructor(
             isMuted = false,
             isCameraOn = isCameraOn,
             isCbrEnabled = isAudioCbr,
-            callerId = userId.await()
+            callerId = selfUserId
         )
 
         withCalling {
@@ -401,7 +396,7 @@ class CallManagerImpl internal constructor(
         }
         callingLogger.d("$TAG -> set test video to $logString")
 
-        val selfUserId = federatedIdMapper.parseToFederatedId(userId.await())
+        val selfUserId = federatedIdMapper.parseToFederatedId(selfUserId)
         val selfClientId = clientId.await().value
         val handle = deferredHandle.await()
 

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -36,7 +36,6 @@ import com.wire.kalium.logic.data.id.FederatedIdMapper
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.call.usecase.ConversationClientsInCallUpdater
 import com.wire.kalium.logic.feature.call.usecase.GetCallConversationTypeProvider
 import com.wire.kalium.logic.feature.call.usecase.CreateAndPersistRecentlyEndedCallMetadataUseCase

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -82,7 +82,6 @@ actual class GlobalCallManager(
     internal actual fun getCallManagerForClient(
         userId: QualifiedID,
         callRepository: CallRepository,
-        userRepository: UserRepository,
         currentClientIdProvider: CurrentClientIdProvider,
         selfConversationIdProvider: SelfConversationIdProvider,
         conversationRepository: ConversationRepository,
@@ -103,7 +102,7 @@ actual class GlobalCallManager(
                 CallManagerImpl(
                     calling = calling,
                     callRepository = callRepository,
-                    userRepository = userRepository,
+                    selfUserId = userId,
                     currentClientIdProvider = currentClientIdProvider,
                     selfConversationIdProvider = selfConversationIdProvider,
                     callMapper = callMapper,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallingParticipantsOrder.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallingParticipantsOrder.kt
@@ -18,8 +18,8 @@
 
 package com.wire.kalium.logic.data.call
 
-import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.fold
 
 internal interface CallingParticipantsOrder {
@@ -27,10 +27,10 @@ internal interface CallingParticipantsOrder {
 }
 
 internal class CallingParticipantsOrderImpl(
-    private val userRepository: UserRepository,
     private val currentClientIdProvider: CurrentClientIdProvider,
     private val participantsFilter: ParticipantsFilter,
     private val participantsOrderByName: ParticipantsOrderByName,
+    private val selfUserId: UserId
 ) : CallingParticipantsOrder {
 
     override suspend fun reorderItems(participants: List<Participant>): List<Participant> {
@@ -38,7 +38,6 @@ internal class CallingParticipantsOrderImpl(
             currentClientIdProvider().fold({
                 participants
             }, { selfClientId ->
-                val selfUserId = userRepository.getSelfUser()?.id!!
 
                 val selfParticipant = participantsFilter.selfParticipant(participants, selfUserId, selfClientId.value)
                 val otherParticipants = participantsFilter.otherParticipants(participants, selfClientId.value)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -439,28 +439,6 @@ internal class UserDataSource internal constructor(
                 .map(userMapper::fromUserDetailsEntityToSelfUser)
         }
     }
-//         return metadataDAO.valueByKeyFlow(SELF_USER_ID_KEY).onEach {
-//             // If the self user is not in the database, proactively fetch it.
-//             if (it == null) {
-//                 val logPrefix = "Observing self user before insertion"
-//                 kaliumLogger.w("cccc: $logPrefix: Triggering a fetch.")
-//                 fetchSelfUser().fold({ failure ->
-//                     kaliumLogger.e("""$logPrefix failed: {"failure":"$failure"}""")
-//                 }, {
-//                     kaliumLogger.i("$logPrefix: Succeeded")
-//                     userDetailsRefreshInstantCache[selfUserId] = DateTimeUtil.currentInstant()
-//                 })
-//             } else {
-//                 kaliumLogger.d("cccc: Self user found in metadata")
-//                 refreshUserDetailsIfNeeded(selfUserId)
-//             }
-//         }.filterNotNull().flatMapMerge { encodedValue ->
-//             val selfUserID: QualifiedIDEntity = Json.decodeFromString(encodedValue)
-//             userDAO.observeUserDetailsByQualifiedID(selfUserID)
-//                 .filterNotNull()
-//                 .map(userMapper::fromUserDetailsEntityToSelfUser)
-//         }
-//     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     override suspend fun observeSelfUserWithTeam(): Flow<Pair<SelfUser, Team?>> {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -470,7 +470,6 @@ internal class UserDataSource internal constructor(
 
     // TODO: replace the flow with selfUser and cache it
     override suspend fun getSelfUser(): SelfUser? {
-        kaliumLogger.d("cccc: Getting self user")
         return observeSelfUser().firstOrNull()
     }
 
@@ -660,7 +659,6 @@ internal class UserDataSource internal constructor(
             CreateUserTeam(dto.teamId, dto.teamName)
         }
             .onSuccess {
-                kaliumLogger.d("cccc: Migrated user to team")
                 fetchSelfUser()
             }
             .onFailure { failure ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -229,13 +229,13 @@ internal class UserDataSource internal constructor(
     private suspend fun updateSelfUserProviderAccountInfo(userDTO: SelfUserDTO): Either<StorageFailure, Unit> =
         sessionRepository.updateSsoIdAndScimInfo(userDTO.id.toModel(), idMapper.toSsoId(userDTO.ssoID), userDTO.managedByDTO)
 
+    // TODO: race condition, if we request the same user (can happen for self) multiple times, we will fetch it multiple times
     override suspend fun getKnownUser(userId: UserId): Flow<OtherUser?> =
         userDAO.observeUserDetailsByQualifiedID(qualifiedID = userId.toDao())
             .map { userEntity ->
                 userEntity?.let { userMapper.fromUserDetailsEntityToOtherUser(userEntity) }
             }.onEach { otherUser ->
                 if (otherUser != null) {
-//                     TODO: reuse TCP connection aka update in parallel
                     refreshUserDetailsIfNeeded(userId)
                 }
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -235,6 +235,7 @@ internal class UserDataSource internal constructor(
                 userEntity?.let { userMapper.fromUserDetailsEntityToOtherUser(userEntity) }
             }.onEach { otherUser ->
                 if (otherUser != null) {
+//                     TODO: reuse TCP connection aka update in parallel
                     refreshUserDetailsIfNeeded(userId)
                 }
             }
@@ -414,6 +415,7 @@ internal class UserDataSource internal constructor(
         else fetchUsersByIds(missingIds.map { it.toModel() }.toSet()).map { }
     }
 
+    // TODO: this can cause many issues since it will
     @OptIn(ExperimentalCoroutinesApi::class)
     override suspend fun observeSelfUser(): Flow<SelfUser> {
         return metadataDAO.valueByKeyFlow(SELF_USER_ID_KEY).onEach {
@@ -437,6 +439,28 @@ internal class UserDataSource internal constructor(
                 .map(userMapper::fromUserDetailsEntityToSelfUser)
         }
     }
+//         return metadataDAO.valueByKeyFlow(SELF_USER_ID_KEY).onEach {
+//             // If the self user is not in the database, proactively fetch it.
+//             if (it == null) {
+//                 val logPrefix = "Observing self user before insertion"
+//                 kaliumLogger.w("cccc: $logPrefix: Triggering a fetch.")
+//                 fetchSelfUser().fold({ failure ->
+//                     kaliumLogger.e("""$logPrefix failed: {"failure":"$failure"}""")
+//                 }, {
+//                     kaliumLogger.i("$logPrefix: Succeeded")
+//                     userDetailsRefreshInstantCache[selfUserId] = DateTimeUtil.currentInstant()
+//                 })
+//             } else {
+//                 kaliumLogger.d("cccc: Self user found in metadata")
+//                 refreshUserDetailsIfNeeded(selfUserId)
+//             }
+//         }.filterNotNull().flatMapMerge { encodedValue ->
+//             val selfUserID: QualifiedIDEntity = Json.decodeFromString(encodedValue)
+//             userDAO.observeUserDetailsByQualifiedID(selfUserID)
+//                 .filterNotNull()
+//                 .map(userMapper::fromUserDetailsEntityToSelfUser)
+//         }
+//     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     override suspend fun observeSelfUserWithTeam(): Flow<Pair<SelfUser, Team?>> {
@@ -467,8 +491,10 @@ internal class UserDataSource internal constructor(
     }
 
     // TODO: replace the flow with selfUser and cache it
-    override suspend fun getSelfUser(): SelfUser? =
-        observeSelfUser().firstOrNull()
+    override suspend fun getSelfUser(): SelfUser? {
+        kaliumLogger.d("cccc: Getting self user")
+        return observeSelfUser().firstOrNull()
+    }
 
     override suspend fun observeAllKnownUsers(): Flow<Either<StorageFailure, List<OtherUser>>> {
         val selfUserId = selfUserId.toDao()
@@ -656,7 +682,7 @@ internal class UserDataSource internal constructor(
             CreateUserTeam(dto.teamId, dto.teamName)
         }
             .onSuccess {
-                kaliumLogger.d("Migrated user to team")
+                kaliumLogger.d("cccc: Migrated user to team")
                 fetchSelfUser()
             }
             .onFailure { failure ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1264,7 +1264,6 @@ class UserSessionScope internal constructor(
         globalCallManager.getCallManagerForClient(
             userId = userId,
             callRepository = callRepository,
-            userRepository = userRepository,
             currentClientIdProvider = clientIdProvider,
             conversationRepository = conversationRepository,
             userConfigRepository = userConfigRepository,
@@ -2060,7 +2059,6 @@ class UserSessionScope internal constructor(
             callManager = callManager,
             callRepository = callRepository,
             conversationRepository = conversationRepository,
-            userRepository = userRepository,
             flowManagerService = flowManagerService,
             mediaManagerService = mediaManagerService,
             syncManager = syncManager,
@@ -2071,6 +2069,8 @@ class UserSessionScope internal constructor(
             conversationClientsInCallUpdater = conversationClientsInCallUpdater,
             kaliumConfigs = kaliumConfigs,
             inCallReactionsRepository = inCallReactionsRepository,
+            selfUserId = userId,
+            userRepository = userRepository
         )
 
     val connection: ConnectionScope

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
@@ -28,6 +28,7 @@ import com.wire.kalium.logic.data.call.ParticipantsOrderByNameImpl
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.call.usecase.AnswerCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.AnswerCallUseCaseImpl
@@ -107,6 +108,7 @@ class CallsScope internal constructor(
     private val getCallConversationType: GetCallConversationTypeProvider,
     private val kaliumConfigs: KaliumConfigs,
     private val inCallReactionsRepository: InCallReactionsRepository,
+    private val selfUserId: UserId,
     internal val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) {
 
@@ -122,7 +124,7 @@ class CallsScope internal constructor(
         get() = GetIncomingCallsUseCaseImpl(
             callRepository = callRepository,
             conversationRepository = conversationRepository,
-            userRepository = userRepository
+            userRepository = userRepository,
         )
     val observeOutgoingCall: ObserveOutgoingCallUseCase
         get() = ObserveOutgoingCallUseCaseImpl(
@@ -211,10 +213,10 @@ class CallsScope internal constructor(
 
     private val callingParticipantsOrder: CallingParticipantsOrder
         get() = CallingParticipantsOrderImpl(
-            userRepository = userRepository,
             currentClientIdProvider = currentClientIdProvider,
             participantsFilter = ParticipantsFilterImpl(qualifiedIdMapper),
-            participantsOrderByName = ParticipantsOrderByNameImpl()
+            participantsOrderByName = ParticipantsOrderByNameImpl(),
+            selfUserId = selfUserId
         )
 
     val isLastCallClosed: IsLastCallClosedUseCase get() = IsLastCallClosedUseCaseImpl(callRepository)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -30,7 +30,6 @@ import com.wire.kalium.logic.data.id.FederatedIdMapper
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.call.usecase.ConversationClientsInCallUpdater
 import com.wire.kalium.logic.feature.call.usecase.GetCallConversationTypeProvider

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -45,7 +45,6 @@ expect class GlobalCallManager {
     internal fun getCallManagerForClient(
         userId: QualifiedID,
         callRepository: CallRepository,
-        userRepository: UserRepository,
         currentClientIdProvider: CurrentClientIdProvider,
         selfConversationIdProvider: SelfConversationIdProvider,
         conversationRepository: ConversationRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetIncomingCallsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetIncomingCallsUseCase.kt
@@ -70,9 +70,9 @@ internal class GetIncomingCallsUseCaseImpl internal constructor(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private suspend fun observeIncomingCallsIfUserStatusAllows(): Flow<List<Call>> =
+        // TODO: do not refresh self form remote in this case and just get status from local
         userRepository.observeSelfUser()
             .flatMapLatest {
-
                 // if user is AWAY we don't show any IncomingCalls
                 if (it.availabilityStatus == UserAvailabilityStatus.AWAY) {
                     logger.d("$TAG; Ignoring possible calls based user's status")

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -137,7 +137,7 @@ class ConversationScope internal constructor(
         get() = ObserveConversationMembersUseCaseImpl(conversationRepository, userRepository)
 
     val getMembersToMention: MembersToMentionUseCase
-        get() = MembersToMentionUseCase(observeConversationMembers, userRepository)
+        get() = MembersToMentionUseCase(observeConversationMembers = observeConversationMembers, selfUserId = selfUserId)
 
     val observeUserListById: ObserveUserListByIdUseCase
         get() = ObserveUserListByIdUseCase(userRepository)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/MembersToMentionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/MembersToMentionUseCase.kt
@@ -20,7 +20,7 @@ package com.wire.kalium.logic.feature.conversation
 
 import com.wire.kalium.logic.data.conversation.MemberDetails
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.flow.first
@@ -42,7 +42,7 @@ import kotlinx.coroutines.withContext
 @Suppress("ReturnCount")
 class MembersToMentionUseCase internal constructor(
     private val observeConversationMembers: ObserveConversationMembersUseCase,
-    private val userRepository: UserRepository,
+    private val selfUserId: UserId,
     private val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) {
     /**
@@ -57,7 +57,7 @@ class MembersToMentionUseCase internal constructor(
         // TODO apply normalization techniques that are used for other searches to the name (e.g. ö -> oe)
 
         val usersToSearch = conversationMembers.filter {
-            it.user.id != userRepository.getSelfUser()?.id
+            it.user.id != selfUserId
         }
         if (searchQuery.isEmpty())
             return@withContext usersToSearch

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
@@ -116,10 +116,10 @@ class DebugScope internal constructor(
 
     val sendConfirmation: SendConfirmationUseCase
         get() = SendConfirmationUseCase(
-            userRepository,
-            currentClientIdProvider,
-            slowSyncRepository,
-            messageSender
+            currentClientIdProvider = currentClientIdProvider,
+            slowSyncRepository = slowSyncRepository,
+            messageSender = messageSender,
+            selfUserId = userId,
         )
 
     val disableEventProcessing: DisableEventProcessingUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/SendConfirmationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/SendConfirmationUseCase.kt
@@ -26,8 +26,8 @@ import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.receipt.ReceiptType
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
-import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.message.MessageSender
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
@@ -41,10 +41,10 @@ import kotlinx.datetime.Clock
  * client behaviour. It should not be used by clients itself.
  */
 class SendConfirmationUseCase internal constructor(
-    private val userRepository: UserRepository,
     private val currentClientIdProvider: CurrentClientIdProvider,
     private val slowSyncRepository: SlowSyncRepository,
-    private val messageSender: MessageSender
+    private val messageSender: MessageSender,
+    private val selfUserId: UserId
 ) {
 
     suspend operator fun invoke(
@@ -57,8 +57,6 @@ class SendConfirmationUseCase internal constructor(
             it is SlowSyncStatus.Complete
         }
 
-        val selfUser = userRepository.observeSelfUser().first()
-
         val generatedMessageUuid = uuid4().toString()
 
         return currentClientIdProvider().flatMap { currentClientId ->
@@ -67,7 +65,7 @@ class SendConfirmationUseCase internal constructor(
                 content = MessageContent.Receipt(type, listOf(firstMessageId) + moreMessageIds),
                 conversationId = conversationId,
                 date = Clock.System.now(),
-                senderUserId = selfUser.id,
+                senderUserId = selfUserId,
                 senderClientId = currentClientId,
                 status = Message.Status.Pending,
                 isSelfMessage = true,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallingParticipantsOrderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallingParticipantsOrderTest.kt
@@ -45,10 +45,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class CallingParticipantsOrderTest {
-
-    @Mock
-    private val userRepository = mock(UserRepository::class)
-
     @Mock
     private val participantsFilter = mock(ParticipantsFilter::class)
 
@@ -63,7 +59,12 @@ class CallingParticipantsOrderTest {
     @BeforeTest
     fun setup() {
         callingParticipantsOrder =
-            CallingParticipantsOrderImpl(userRepository, currentClientIdProvider, participantsFilter, participantsOrderByName)
+            CallingParticipantsOrderImpl(
+                currentClientIdProvider,
+                participantsFilter,
+                selfUserId = selfUserId,
+                participantsOrderByName = participantsOrderByName
+            )
     }
 
     @Test
@@ -92,10 +93,6 @@ class CallingParticipantsOrderTest {
         coEvery {
             currentClientIdProvider.invoke()
         }.returns(Either.Right(ClientId(selfClientId)))
-
-        coEvery {
-            userRepository.getSelfUser()
-        }.returns(selfUser)
 
         every {
             participantsFilter.otherParticipants(participants, selfClientId)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/MembersToMentionUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/MembersToMentionUseCaseTest.kt
@@ -44,8 +44,7 @@ import kotlin.test.assertEquals
 
 class MembersToMentionUseCaseTest {
 
-    @Mock
-    private val userRepository: UserRepository = mock(UserRepository::class)
+    private val selfUserId = SELF_USER.id
 
     @Mock
     private val observeConversationMembers = mock(ObserveConversationMembersUseCase::class)
@@ -54,10 +53,7 @@ class MembersToMentionUseCaseTest {
 
     @BeforeTest
     fun setup() = runBlocking {
-        membersToMention = MembersToMentionUseCase(observeConversationMembers, userRepository, TestKaliumDispatcher)
-        coEvery {
-            userRepository.getSelfUser()
-        }.returns(SELF_USER)
+        membersToMention = MembersToMentionUseCase(observeConversationMembers, selfUserId = selfUserId, TestKaliumDispatcher)
         coEvery {
             observeConversationMembers.invoke(any())
         }.returns(flowOf(members))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3726" title="WPB-3726" target="_blank"><img alt="Epic" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10807?size=medium" />WPB-3726</a>  [Android] Performance
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

i many places the calling code is fetching self user from remote when it does not needs to and it can get the id from cache

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
