### PR TITLE
fix: MLS groups are not usable if I have a proteus client registered to my account but have MLS on current client [WPB-15192]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.logger.obfuscateDomain
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.MemberMapper
 import com.wire.kalium.logic.data.conversation.Recipient
 import com.wire.kalium.logic.data.conversation.mls.NameAndHandle
@@ -167,6 +168,7 @@ interface UserRepository {
     suspend fun getNameAndHandle(userId: UserId): Either<StorageFailure, NameAndHandle>
     suspend fun migrateUserToTeam(teamName: String): Either<CoreFailure, CreateUserTeam>
     suspend fun updateTeamId(userId: UserId, teamId: TeamId): Either<StorageFailure, Unit>
+    suspend fun isClientMlsCapable(userId: UserId, clientId: ClientId): Either<StorageFailure, Boolean>
 }
 
 @Suppress("LongParameterList", "TooManyFunctions")
@@ -666,6 +668,10 @@ internal class UserDataSource internal constructor(
 
     override suspend fun updateTeamId(userId: UserId, teamId: TeamId): Either<StorageFailure, Unit> = wrapStorageRequest {
         userDAO.updateTeamId(userId.toDao(), teamId.value)
+    }
+
+    override suspend fun isClientMlsCapable(userId: UserId, clientId: ClientId): Either<StorageFailure, Boolean> = wrapStorageRequest {
+        clientDAO.isMLSCapable(userId.toDao(), clientId.value)
     }
 
     companion object {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -23,6 +23,8 @@ import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.configuration.server.ServerConfigRepository
+import com.wire.kalium.logic.data.client.ClientDataSource
+import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.conversation.ConversationGroupRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
@@ -158,7 +160,12 @@ class ConversationScope internal constructor(
         get() = ObserveIsSelfUserMemberUseCaseImpl(conversationRepository, selfUserId)
 
     val observeConversationInteractionAvailabilityUseCase: ObserveConversationInteractionAvailabilityUseCase
-        get() = ObserveConversationInteractionAvailabilityUseCase(conversationRepository, userRepository)
+        get() = ObserveConversationInteractionAvailabilityUseCase(
+            conversationRepository,
+            selfUserId = selfUserId,
+            selfClientIdProvider = currentClientIdProvider,
+            userRepository = userRepository
+        )
 
     val deleteTeamConversation: DeleteTeamConversationUseCase
         get() = DeleteTeamConversationUseCaseImpl(selfTeamIdProvider, teamRepository, conversationRepository)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -23,8 +23,6 @@ import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.configuration.server.ServerConfigRepository
-import com.wire.kalium.logic.data.client.ClientDataSource
-import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.conversation.ConversationGroupRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationInteractionAvailabilityUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationInteractionAvailabilityUseCase.kt
@@ -68,7 +68,7 @@ class ObserveConversationInteractionAvailabilityUseCase internal constructor(
             return@withContext flow { IsInteractionAvailableResult.Failure(it) }
         }
 
-        kaliumLogger.d("cccc: isSelfClientMlsCapable $isSelfClientMlsCapable")
+        kaliumLogger.withTextTag("ObserveConversationInteractionAvailabilityUseCase").d("isSelfClientMlsCapable $isSelfClientMlsCapable")
 
         conversationRepository.observeConversationDetailsById(conversationId).map { eitherConversation ->
             eitherConversation.fold({ failure -> IsInteractionAvailableResult.Failure(failure) }, { conversationDetails ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationInteractionAvailabilityUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationInteractionAvailabilityUseCase.kt
@@ -72,7 +72,10 @@ class ObserveConversationInteractionAvailabilityUseCase internal constructor(
 
         conversationRepository.observeConversationDetailsById(conversationId).map { eitherConversation ->
             eitherConversation.fold({ failure -> IsInteractionAvailableResult.Failure(failure) }, { conversationDetails ->
-                val isProtocolSupported = doesUserSupportConversationProtocol(conversationDetails, isSelfClientMlsCapable)
+                val isProtocolSupported = doesUserSupportConversationProtocol(
+                    conversationDetails = conversationDetails,
+                    isSelfClientMlsCapable = isSelfClientMlsCapable
+                )
                 if (!isProtocolSupported) { // short-circuit to Unsupported Protocol if it's the case
                     return@fold IsInteractionAvailableResult.Success(InteractionAvailability.UNSUPPORTED_PROTOCOL)
                 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationInteractionAvailabilityUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationInteractionAvailabilityUseCase.kt
@@ -62,7 +62,9 @@ class ObserveConversationInteractionAvailabilityUseCase internal constructor(
      */
     suspend operator fun invoke(conversationId: ConversationId): Flow<IsInteractionAvailableResult> = withContext(dispatcher.io) {
 
-        val isSelfClientMlsCapable = selfClientIdProvider().flatMap { userRepository.isClientMlsCapable(selfUserId, it) }.getOrElse {
+        val isSelfClientMlsCapable = selfClientIdProvider().flatMap {
+            userRepository.isClientMlsCapable(selfUserId, it)
+        }.getOrElse {
             return@withContext flow { IsInteractionAvailableResult.Failure(it) }
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationInteractionAvailabilityUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationInteractionAvailabilityUseCaseTest.kt
@@ -142,7 +142,6 @@ class ObserveConversationInteractionAvailabilityUseCaseTest {
 
             awaitComplete()
         }
-
     }
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationInteractionAvailabilityUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveConversationInteractionAvailabilityUseCaseTest.kt
@@ -20,16 +20,21 @@ package com.wire.kalium.logic.feature.conversation
 
 import app.cash.turbine.test
 import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.InteractionAvailability
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.SupportedProtocol
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestConversationDetails
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.right
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import com.wire.kalium.logic.test_util.testKaliumDispatcher
+import com.wire.kalium.logic.util.arrangement.provider.CurrentClientIdProviderArrangement
+import com.wire.kalium.logic.util.arrangement.provider.CurrentClientIdProviderArrangementImpl
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangement
@@ -41,6 +46,7 @@ import io.mockative.once
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -52,6 +58,7 @@ class ObserveConversationInteractionAvailabilityUseCaseTest {
         val conversationId = TestConversation.ID
 
         val (arrangement, observeConversationInteractionAvailability) = arrange {
+            withIsClientMlsCapable(false.right())
             dispatcher = testKaliumDispatcher
             withSelfUserBeingMemberOfConversation(isMember = true)
         }
@@ -76,6 +83,7 @@ class ObserveConversationInteractionAvailabilityUseCaseTest {
         val (arrangement, observeConversationInteractionAvailability) = arrange {
             dispatcher = testKaliumDispatcher
             withSelfUserBeingMemberOfConversation(isMember = false)
+            withIsClientMlsCapable(false.right())
         }
 
         observeConversationInteractionAvailability(conversationId).test {
@@ -96,6 +104,7 @@ class ObserveConversationInteractionAvailabilityUseCaseTest {
         val conversationId = TestConversation.ID
 
         val (arrangement, observeConversationInteractionAvailability) = arrange {
+            withIsClientMlsCapable(false.right())
             dispatcher = testKaliumDispatcher
             withGroupConversationError()
         }
@@ -118,6 +127,7 @@ class ObserveConversationInteractionAvailabilityUseCaseTest {
         val conversationId = TestConversation.ID
 
         val (arrangement, observeConversationInteractionAvailability) = arrange {
+            withIsClientMlsCapable(false.right())
             dispatcher = testKaliumDispatcher
             withBlockedUserConversation()
         }
@@ -140,6 +150,7 @@ class ObserveConversationInteractionAvailabilityUseCaseTest {
         val conversationId = TestConversation.ID
 
         val (arrangement, observeConversationInteractionAvailability) = arrange {
+            withIsClientMlsCapable(false.right())
             dispatcher = testKaliumDispatcher
             withDeletedUserConversation()
         }
@@ -156,11 +167,12 @@ class ObserveConversationInteractionAvailabilityUseCaseTest {
         }
     }
 
+    @Ignore // is this really a case that a client does not support Proteus
     @Test
     fun givenProteusConversationAndUserSupportsOnlyMLS_whenObserving_thenShouldReturnUnsupportedProtocol() = runTest {
         testProtocolSupport(
             conversationProtocolInfo = Conversation.ProtocolInfo.Proteus,
-            userSupportedProtocols = setOf(SupportedProtocol.MLS),
+            isMlsCapable = true.right(),
             expectedResult = InteractionAvailability.UNSUPPORTED_PROTOCOL
         )
     }
@@ -169,7 +181,7 @@ class ObserveConversationInteractionAvailabilityUseCaseTest {
     fun givenMLSConversationAndUserSupportsOnlyMLS_whenObserving_thenShouldReturnUnsupportedProtocol() = runTest {
         testProtocolSupport(
             conversationProtocolInfo = TestConversation.MLS_PROTOCOL_INFO,
-            userSupportedProtocols = setOf(SupportedProtocol.PROTEUS),
+            isMlsCapable = false.right(),
             expectedResult = InteractionAvailability.UNSUPPORTED_PROTOCOL
         )
     }
@@ -178,7 +190,7 @@ class ObserveConversationInteractionAvailabilityUseCaseTest {
     fun givenMixedConversationAndUserSupportsOnlyMLS_whenObserving_thenShouldReturnUnsupportedProtocol() = runTest {
         testProtocolSupport(
             conversationProtocolInfo = TestConversation.MIXED_PROTOCOL_INFO,
-            userSupportedProtocols = setOf(SupportedProtocol.PROTEUS),
+            isMlsCapable = false.right(),
             expectedResult = InteractionAvailability.ENABLED
         )
     }
@@ -187,7 +199,7 @@ class ObserveConversationInteractionAvailabilityUseCaseTest {
     fun givenMixedConversationAndUserSupportsProteus_whenObserving_thenShouldReturnEnabled() = runTest {
         testProtocolSupport(
             conversationProtocolInfo = TestConversation.MIXED_PROTOCOL_INFO,
-            userSupportedProtocols = setOf(SupportedProtocol.PROTEUS),
+            isMlsCapable = false.right(),
             expectedResult = InteractionAvailability.ENABLED
         )
     }
@@ -196,8 +208,8 @@ class ObserveConversationInteractionAvailabilityUseCaseTest {
     fun givenMLSConversationAndUserSupportsMLS_whenObserving_thenShouldReturnEnabled() = runTest {
         testProtocolSupport(
             conversationProtocolInfo = TestConversation.MLS_PROTOCOL_INFO,
-            userSupportedProtocols = setOf(SupportedProtocol.MLS),
-            expectedResult = InteractionAvailability.ENABLED
+            expectedResult = InteractionAvailability.ENABLED,
+            isMlsCapable = true.right()
         )
     }
 
@@ -205,18 +217,19 @@ class ObserveConversationInteractionAvailabilityUseCaseTest {
     fun givenProteusConversationAndUserSupportsProteus_whenObserving_thenShouldReturnEnabled() = runTest {
         testProtocolSupport(
             conversationProtocolInfo = TestConversation.PROTEUS_PROTOCOL_INFO,
-            userSupportedProtocols = setOf(SupportedProtocol.PROTEUS),
-            expectedResult = InteractionAvailability.ENABLED
+            expectedResult = InteractionAvailability.ENABLED,
+            isMlsCapable = false.right()
         )
     }
 
     private suspend fun CoroutineScope.testProtocolSupport(
         conversationProtocolInfo: Conversation.ProtocolInfo,
-        userSupportedProtocols: Set<SupportedProtocol>,
+        isMlsCapable: Either<StorageFailure, Boolean>,
         expectedResult: InteractionAvailability
     ) {
         val convId = TestConversationDetails.CONVERSATION_GROUP.conversation.id
         val (_, observeConversationInteractionAvailabilityUseCase) = arrange {
+            withIsClientMlsCapable(isMlsCapable)
             dispatcher = testKaliumDispatcher
             val proteusGroupDetails = TestConversationDetails.CONVERSATION_GROUP.copy(
                 conversation = TestConversationDetails.CONVERSATION_GROUP.conversation.copy(
@@ -224,7 +237,6 @@ class ObserveConversationInteractionAvailabilityUseCaseTest {
                 )
             )
             withObserveConversationDetailsByIdReturning(Either.Right(proteusGroupDetails))
-            withObservingSelfUserReturning(flowOf(TestUser.SELF.copy(supportedProtocols = userSupportedProtocols)))
         }
 
         observeConversationInteractionAvailabilityUseCase(convId).test {
@@ -241,6 +253,7 @@ class ObserveConversationInteractionAvailabilityUseCaseTest {
         val (_, observeConversationInteractionAvailability) = arrange {
             dispatcher = testKaliumDispatcher
             withLegalHoldOneOnOneConversation(Conversation.LegalHoldStatus.ENABLED)
+            withIsClientMlsCapable(false.right())
         }
         observeConversationInteractionAvailability(conversationId).test {
             val interactionResult = awaitItem()
@@ -253,6 +266,7 @@ class ObserveConversationInteractionAvailabilityUseCaseTest {
     fun givenConversationLegalHoldIsDegraded_whenInvokingInteractionForConversation_thenInteractionShouldBeLegalHold() = runTest {
         val conversationId = TestConversation.ID
         val (_, observeConversationInteractionAvailability) = arrange {
+            withIsClientMlsCapable(false.right())
             dispatcher = testKaliumDispatcher
             withLegalHoldOneOnOneConversation(Conversation.LegalHoldStatus.DEGRADED)
         }
@@ -266,10 +280,12 @@ class ObserveConversationInteractionAvailabilityUseCaseTest {
     private class Arrangement(
         private val configure: suspend Arrangement.() -> Unit
     ) : UserRepositoryArrangement by UserRepositoryArrangementImpl(),
-        ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl() {
+        ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
+        CurrentClientIdProviderArrangement by CurrentClientIdProviderArrangementImpl() {
 
         var dispatcher: KaliumDispatcher = TestKaliumDispatcher
 
+        val selfUser = UserId("self_value", "self_domain")
         suspend fun withSelfUserBeingMemberOfConversation(isMember: Boolean) = apply {
             withObserveConversationDetailsByIdReturning(
                 Either.Right(TestConversationDetails.CONVERSATION_GROUP.copy(isSelfUserMember = isMember))
@@ -315,17 +331,15 @@ class ObserveConversationInteractionAvailabilityUseCaseTest {
         }
 
         suspend fun arrange(): Pair<Arrangement, ObserveConversationInteractionAvailabilityUseCase> = run {
-            withObservingSelfUserReturning(
-                flowOf(
-                    TestUser.SELF.copy(supportedProtocols = setOf(SupportedProtocol.MLS, SupportedProtocol.PROTEUS))
-                )
-            )
+            withCurrentClientIdSuccess(ClientId("client_id"))
             configure()
             this@Arrangement to ObserveConversationInteractionAvailabilityUseCase(
                 conversationRepository = conversationRepository,
                 userRepository = userRepository,
-                dispatcher = dispatcher
-            )
+                dispatcher = dispatcher,
+                selfUserId = selfUser,
+                selfClientIdProvider = currentClientIdProvider
+                )
         }
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/UserRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/UserRepositoryArrangement.kt
@@ -19,6 +19,7 @@ package com.wire.kalium.logic.util.arrangement.repository
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.StorageFailure
+import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.mls.NameAndHandle
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
@@ -95,6 +96,12 @@ internal interface UserRepositoryArrangement {
     )
 
     suspend fun withNameAndHandle(result: Either<StorageFailure, NameAndHandle>, userId: Matcher<UserId> = AnyMatcher(valueOf()))
+
+    suspend fun withIsClientMlsCapable(
+        result: Either<StorageFailure, Boolean>,
+        userId: Matcher<UserId> = AnyMatcher(valueOf()),
+        clientId: Matcher<ClientId> = AnyMatcher(valueOf())
+    )
 }
 
 @Suppress("INAPPLICABLE_JVM_NAME")
@@ -232,5 +239,14 @@ internal open class UserRepositoryArrangementImpl : UserRepositoryArrangement {
 
     override suspend fun withNameAndHandle(result: Either<StorageFailure, NameAndHandle>, userId: Matcher<UserId>) {
         coEvery { userRepository.getNameAndHandle(matches { userId.matches(it) }) }.returns(result)
+    }
+
+    override suspend fun withIsClientMlsCapable(result: Either<StorageFailure, Boolean>, userId: Matcher<UserId>, clientId: Matcher<ClientId>) {
+        coEvery {
+            userRepository.isClientMlsCapable(
+                userId = matches { userId.matches(it) },
+                clientId = matches { clientId.matches(it) }
+            )
+        }.returns(result)
     }
 }

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Clients.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Clients.sq
@@ -87,6 +87,9 @@ SELECT * FROM Client WHERE user_id = :user_id AND id = :client_id;
 deleteClientsOfUserExcept:
 DELETE FROM Client WHERE user_id = :user_id AND id NOT IN :exception_ids;
 
+isClientMLSCapable:
+SELECT is_mls_capable FROM Client WHERE user_id = :user_id AND id = :client_id;
+
 tryMarkAsInvalid:
 UPDATE OR IGNORE Client SET is_valid = 0 WHERE user_id = :user_id AND  id IN :clientId_List;
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAO.kt
@@ -97,4 +97,5 @@ interface ClientDAO {
     ): Map<QualifiedIDEntity, List<Client>>
 
     suspend fun selectAllClients(): Map<QualifiedIDEntity, List<Client>>
+    suspend fun isMLSCapable(userId: QualifiedIDEntity, clientId: String): Boolean?
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOImpl.kt
@@ -173,6 +173,11 @@ internal class ClientDAOImpl internal constructor(
             .executeAsList()
             .groupBy { it.userId }
 
+    override suspend fun isMLSCapable(userId: QualifiedIDEntity, clientId: String): Boolean? = withContext(queriesContext) {
+        clientsQueries.isClientMLSCapable(userId, clientId)
+            .executeAsOneOrNull()
+    }
+
     override suspend fun getClientsOfUserByQualifiedIDFlow(qualifiedID: QualifiedIDEntity): Flow<List<Client>> =
         clientsQueries.selectAllClientsByUserId(qualifiedID, mapper::fromClient)
             .asFlow()

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOTest.kt
@@ -460,6 +460,31 @@ class ClientDAOTest : BaseDatabaseTest() {
     }
 
     @Test
+    fun givenClientIsNotMlsCapable_whenCallingIsMlsCapable_thenReturnFalse() = runTest {
+        val user = user
+        val client: InsertClientParam = insertedClient.copy(isMLSCapable = false)
+        userDAO.upsertUser(user)
+        clientDAO.insertClient(client)
+        assertFalse { clientDAO.isMLSCapable(userId, clientId = client.id)!! }
+    }
+
+    @Test
+    fun givenClientIsMlsCapable_whenCallingIsMlsCapable_thenReturnTrue() = runTest {
+        val user = user
+        val client: InsertClientParam = insertedClient.copy(isMLSCapable = true)
+        userDAO.upsertUser(user)
+        clientDAO.insertClient(client)
+        assertTrue { clientDAO.isMLSCapable(userId, clientId = client.id)!! }
+    }
+
+    @Test
+    fun givenNotFound_whenCallingIsMlsCapableForUser_thenReturnNull() = runTest {
+        val user = user
+        userDAO.upsertUser(user)
+        assertNull(clientDAO.isMLSCapable(userId, clientId = client.id))
+    }
+
+    @Test
     fun givenPersistedClient_whenUpsertingTheSameExactClient_thenItShouldIgnoreAndNotNotifyOtherQueries() = runTest {
         // Given
         userDAO.upsertUser(user)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15192" title="WPB-15192" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15192</a>  [Android] MLS groups are not usable if I have a proteus client registered to my account but have MLS on current client
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

the current client can be MLS capable but it did not announce it yet to the backend (migration is not forced yet)

### Solutions

instead of looking at the user in general to know if interactions are allowed only look at the current client 
this will result to the current client ignoring any Proteus self clients when sending but this is an acceptable case 

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
