### PR TITLE
fix: fallback to proteus if conversation already present but MLS is default (WPB-15191)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCase.kt
@@ -33,10 +33,6 @@ import kotlinx.coroutines.flow.first
 /**
  * Operation that creates one-to-one Conversation with specific [UserId] (only if it is absent in local DB)
  * and returns [Conversation] data.
- *
- * @param otherUserId [UserId] private conversation with which we are interested in.
- * @return Result with [Conversation] in case of success, or [CoreFailure] if something went wrong:
- * can't get data from local DB, or can't create a conversation.
  */
 interface GetOrCreateOneToOneConversationUseCase {
     suspend operator fun invoke(otherUserId: UserId): CreateConversationResult
@@ -47,6 +43,14 @@ internal class GetOrCreateOneToOneConversationUseCaseImpl(
     private val userRepository: UserRepository,
     private val oneOnOneResolver: OneOnOneResolver
 ) : GetOrCreateOneToOneConversationUseCase {
+
+    /**
+     * The use case operation operation params and return type.
+     *
+     * @param otherUserId [UserId] private conversation with which we are interested in.
+     * @return Result with [Conversation] in case of success, or [CoreFailure] if something went wrong:
+     * can't get data from local DB, or can't create a conversation.
+     */
     override suspend operator fun invoke(otherUserId: UserId): CreateConversationResult {
         // TODO periodically re-resolve one-on-one
         return conversationRepository.observeOneToOneConversationWithOtherUser(otherUserId)
@@ -66,6 +70,18 @@ internal class GetOrCreateOneToOneConversationUseCaseImpl(
             })
     }
 
+    /**
+     * Resolves one-on-one conversation with the user.
+     * Resolving conversations is the process of:
+     *
+     * - Intersecting the supported protocols of the self user and the other user.
+     * - Selecting the common protocol, based on the team settings with the highest priority.
+     * - Get or create a conversation with the other user.
+     * - If the protocol now is MLS, migrate the existing Proteus conversation to MLS.
+     * - Mark the conversation as active.
+     *
+     * If no common protocol is found, and we have existing Proteus conversations, we do best effort to use them as fallback.
+     */
     private suspend fun resolveOneOnOneConversationWithUser(otherUserId: UserId): Either<CoreFailure, Conversation> =
         userRepository.userById(otherUserId).flatMap { otherUser ->
             // TODO support lazily establishing mls group for team 1-1

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneMigrator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneMigrator.kt
@@ -36,7 +36,19 @@ import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.kaliumLogger
 
 interface OneOnOneMigrator {
+    /**
+     * Migrates the user's one-on-one Proteus. Without creating a new one since MLS is the default, marking it as active.
+     */
+    suspend fun migrateExistingProteus(user: OtherUser): Either<CoreFailure, ConversationId>
+
+    /**
+     * Get one-on-one conversation with the user, if not found, create a new one (Proteus still default) and mark it as active.
+     */
     suspend fun migrateToProteus(user: OtherUser): Either<CoreFailure, ConversationId>
+
+    /**
+     * Perform migration of Proteus to MLS keeping history and marking the new conversation as active.
+     */
     suspend fun migrateToMLS(user: OtherUser): Either<CoreFailure, ConversationId>
 }
 
@@ -100,19 +112,35 @@ internal class OneOnOneMigratorImpl(
             }
     }
 
-    private suspend fun migrateOneOnOneHistory(user: OtherUser, targetConversation: ConversationId): Either<CoreFailure, Unit> {
-            return conversationRepository.getOneOnOneConversationsWithOtherUser(
-                otherUserId = user.id,
-                protocol = Conversation.Protocol.PROTEUS
-            ).flatMap { proteusOneOnOneConversations ->
-                // We can theoretically have more than one proteus 1-1 conversation with
-                // team members since there was no backend safeguards against this
-                proteusOneOnOneConversations.foldToEitherWhileRight(Unit) { proteusOneOnOneConversation, _ ->
-                    messageRepository.moveMessagesToAnotherConversation(
-                        originalConversation = proteusOneOnOneConversation,
-                        targetConversation = targetConversation
-                    )
-                }
+    override suspend fun migrateExistingProteus(user: OtherUser): Either<CoreFailure, ConversationId> =
+        conversationRepository.getOneOnOneConversationsWithOtherUser(user.id, Conversation.Protocol.PROTEUS).flatMap { conversationIds ->
+            if (conversationIds.isNotEmpty()) {
+                val conversationId = conversationIds.first()
+                Either.Right(conversationId)
+            } else {
+                Either.Left(StorageFailure.DataNotFound)
             }
+        }.flatMap { conversationId ->
+            if (user.activeOneOnOneConversationId != conversationId) {
+                kaliumLogger.d("resolved existing one-on-one to proteus, user = ${user.id.toLogString()}")
+                userRepository.updateActiveOneOnOneConversation(user.id, conversationId)
+            }
+            Either.Right(conversationId)
+        }
+
+    private suspend fun migrateOneOnOneHistory(user: OtherUser, targetConversation: ConversationId): Either<CoreFailure, Unit> {
+        return conversationRepository.getOneOnOneConversationsWithOtherUser(
+            otherUserId = user.id,
+            protocol = Conversation.Protocol.PROTEUS
+        ).flatMap { proteusOneOnOneConversations ->
+            // We can theoretically have more than one proteus 1-1 conversation with
+            // team members since there was no backend safeguards against this
+            proteusOneOnOneConversations.foldToEitherWhileRight(Unit) { proteusOneOnOneConversation, _ ->
+                messageRepository.moveMessagesToAnotherConversation(
+                    originalConversation = proteusOneOnOneConversation,
+                    targetConversation = targetConversation
+                )
+            }
+        }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolverTest.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.left
 import com.wire.kalium.logic.util.arrangement.IncrementalSyncRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.IncrementalSyncRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.mls.OneOnOneMigratorArrangement
@@ -241,6 +242,23 @@ class OneOnOneResolverTest {
         // then
         coVerify {
             arrangement.oneOnOneMigrator.migrateToProteus(eq(OTHER_USER))
+        }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenProtocolResolvesToOtherNeedToUpdate_whenResolveOneOnOneConversationWithUser_thenMigrateExistingToProteus() = runTest {
+        // given
+        val (arrangement, resolver) = arrange {
+            withGetProtocolForUser(CoreFailure.NoCommonProtocolFound.OtherNeedToUpdate.left())
+            withMigrateExistingToProteusReturns(Either.Right(TestConversation.ID))
+        }
+
+        // when
+        resolver.resolveOneOnOneConversationWithUser(OTHER_USER, false).shouldSucceed()
+
+        // then
+        coVerify {
+            arrangement.oneOnOneMigrator.migrateExistingProteus(eq(OTHER_USER))
         }.wasInvoked(exactly = once)
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolverTest.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.left
+import com.wire.kalium.logic.functional.right
 import com.wire.kalium.logic.util.arrangement.IncrementalSyncRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.IncrementalSyncRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.mls.OneOnOneMigratorArrangement
@@ -250,7 +251,7 @@ class OneOnOneResolverTest {
         // given
         val (arrangement, resolver) = arrange {
             withGetProtocolForUser(CoreFailure.NoCommonProtocolFound.OtherNeedToUpdate.left())
-            withMigrateExistingToProteusReturns(Either.Right(TestConversation.ID))
+            withMigrateExistingToProteusReturns(TestConversation.ID.right())
         }
 
         // when

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/mls/OneOnOneMigratorArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/mls/OneOnOneMigratorArrangement.kt
@@ -33,6 +33,8 @@ interface OneOnOneMigratorArrangement {
     suspend fun withMigrateToMLSReturns(result: Either<CoreFailure, ConversationId>)
 
     suspend fun withMigrateToProteusReturns(result: Either<CoreFailure, ConversationId>)
+
+    suspend fun withMigrateExistingToProteusReturns(result: Either<CoreFailure, ConversationId>)
 }
 
 class OneOnOneMigratorArrangementImpl : OneOnOneMigratorArrangement {
@@ -49,6 +51,12 @@ class OneOnOneMigratorArrangementImpl : OneOnOneMigratorArrangement {
     override suspend fun withMigrateToProteusReturns(result: Either<CoreFailure, ConversationId>) {
         coEvery {
             oneOnOneMigrator.migrateToProteus(any())
+        }.returns(result)
+    }
+
+    override suspend fun withMigrateExistingToProteusReturns(result: Either<CoreFailure, ConversationId>) {
+        coEvery {
+            oneOnOneMigrator.migrateExistingProteus(any())
         }.returns(result)
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15191" title="WPB-15191" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15191</a>  [Android] User can not create or see MLS conversations, when they still have a proteus client registered to their account
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There is case when two users on different teams (team A and team B) have already Proteus conversations.
They get lost if:

- user A PROTEUS & MLS, user B PROTEUS, team MLS - no common protocol → 1:1 not shown
- user A PROTEUS, user B PROTEUS, team MLS - no common protocol  → 1:1 not shown

### Causes (Optional)

When performing the creation of 1:1, we introduced a check for validating the team default protocol. #2787
Also when resolving 1:1 conversation protocol, we introduced the concept of `active_one_to_one_id` #2010 this runs on migration of Proteus to MLS conversations as well.

Long story short, the checks for these cases triggers that when enabling MLS as the protocol for the team, and no matching protocols between user A and B, those conversations won't be shown, and cannot interact, even though, the conversation is a valid Proteus one from the BE perspective, as WEB also shows double-checked with the DB.

### Solutions

Since we introduced on #2841 the error type `CoreFailure.NoCommonProtocolFound.OtherNeedToUpdate` for cases when the other users are still on Proteus, we take advantage of this case and for existing Proteus conversations, we get them and update the `active_one_on_one_id`. A new function was introduced that does not create Proteus conversations in this case.

### More notes

https://wearezeta.atlassian.net/wiki/x/lwIPYQ

### Testing

#### Test Coverage (Optional) 

WIP. (will add)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
