### PR TITLE
fix: persist mls conversation when mls disabled [WPB-15149]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -477,11 +477,11 @@ internal class ConversationMapperImpl(
     private fun ConversationResponse.getProtocolInfo(mlsGroupState: GroupState?): ProtocolInfo {
         return when (protocol) {
             ConvProtocol.MLS -> ProtocolInfo.MLS(
-                groupId ?: "",
-                mlsGroupState ?: GroupState.PENDING_JOIN,
-                epoch ?: 0UL,
+                groupId = groupId ?: "",
+                groupState = mlsGroupState ?: GroupState.PENDING_JOIN,
+                epoch = epoch ?: 0UL,
                 keyingMaterialLastUpdate = DateTimeUtil.currentInstant(),
-                ConversationEntity.CipherSuite.fromTag(mlsCipherSuiteTag)
+                cipherSuite = ConversationEntity.CipherSuite.fromTag(mlsCipherSuiteTag)
             )
 
             ConvProtocol.MIXED -> ProtocolInfo.Mixed(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -430,21 +430,24 @@ internal class ConversationDataSource internal constructor(
         selfUserTeamId: String?,
         originatedFromEvent: Boolean
     ): Either<CoreFailure, Boolean> = wrapStorageRequest {
-        val isNewConversation = conversationDAO.getConversationById(conversation.id.toDao()) == null
+        val existingConversation = conversationDAO.getConversationById(conversation.id.toDao())
+        val isNewConversation = existingConversation?.let { conversationEntity ->
+            (conversationEntity.protocolInfo as? ConversationEntity.ProtocolInfo.MLSCapable)?.groupState?.let {
+                it != ConversationEntity.GroupState.ESTABLISHED
+            } ?: false
+        } ?: true
         if (isNewConversation) {
             val mlsGroupState = conversation.groupId?.let { mlsGroupState(idMapper.fromGroupIDEntity(it), originatedFromEvent) }
-            if (shouldPersistMLSConversation(mlsGroupState)) {
-                conversationDAO.insertConversation(
-                    conversationMapper.fromApiModelToDaoModel(
-                        conversation,
-                        mlsGroupState = mlsGroupState?.getOrNull(),
-                        selfTeamIdProvider().getOrNull(),
-                    )
+            conversationDAO.insertConversation(
+                conversationMapper.fromApiModelToDaoModel(
+                    conversation,
+                    mlsGroupState = mlsGroupState,
+                    selfTeamIdProvider().getOrNull(),
                 )
-                memberDAO.insertMembersWithQualifiedId(
-                    memberMapper.fromApiModelToDaoModel(conversation.members), idMapper.fromApiToDao(conversation.id)
-                )
-            }
+            )
+            memberDAO.insertMembersWithQualifiedId(
+                memberMapper.fromApiModelToDaoModel(conversation.members), idMapper.fromApiToDao(conversation.id)
+            )
         }
         isNewConversation
     }
@@ -456,19 +459,15 @@ internal class ConversationDataSource internal constructor(
         invalidateMembers: Boolean
     ) = wrapStorageRequest {
         val conversationEntities = conversations
-            .mapNotNull { conversationResponse ->
+            .map { conversationResponse ->
                 val mlsGroupState = conversationResponse.groupId?.let {
                     mlsGroupState(idMapper.fromGroupIDEntity(it), originatedFromEvent)
                 }
-                if (shouldPersistMLSConversation(mlsGroupState)) {
-                    conversationMapper.fromApiModelToDaoModel(
-                        conversationResponse,
-                        mlsGroupState = mlsGroupState?.getOrNull(),
-                        selfTeamIdProvider().getOrNull(),
-                    )
-                } else {
-                    null
-                }
+                conversationMapper.fromApiModelToDaoModel(
+                    conversationResponse,
+                    mlsGroupState = mlsGroupState,
+                    selfTeamIdProvider().getOrNull(),
+                )
             }
         conversationDAO.insertConversations(conversationEntities)
         conversations.forEach { conversationsResponse ->
@@ -491,8 +490,12 @@ internal class ConversationDataSource internal constructor(
     private suspend fun mlsGroupState(
         groupId: GroupID,
         originatedFromEvent: Boolean = false
-    ): Either<CoreFailure, ConversationEntity.GroupState> = hasEstablishedMLSGroup(groupId)
-        .map { exists ->
+    ): ConversationEntity.GroupState = hasEstablishedMLSGroup(groupId)
+        .fold({ failure ->
+            kaliumLogger.withFeatureId(CONVERSATIONS)
+                .w("Error checking MLS group state, setting to ${ConversationEntity.GroupState.PENDING_JOIN}")
+            ConversationEntity.GroupState.PENDING_JOIN
+        }, { exists ->
             if (exists) {
                 ConversationEntity.GroupState.ESTABLISHED
             } else {
@@ -502,7 +505,7 @@ internal class ConversationDataSource internal constructor(
                     ConversationEntity.GroupState.PENDING_JOIN
                 }
             }
-        }
+        })
 
     private suspend fun hasEstablishedMLSGroup(groupID: GroupID): Either<CoreFailure, Boolean> =
         mlsClientProvider.getMLSClient()
@@ -511,10 +514,6 @@ internal class ConversationDataSource internal constructor(
                     it.conversationExists(idMapper.toCryptoModel(groupID))
                 }
             }
-
-    // if group state is not null and is left, then we don't want to persist the MLS conversation
-    private fun shouldPersistMLSConversation(groupState: Either<CoreFailure, ConversationEntity.GroupState>?): Boolean =
-        groupState?.fold({ true }, { false }) != true
 
     @DelicateKaliumApi("This function does not get values from cache")
     override suspend fun getProteusSelfConversationId(): Either<StorageFailure, ConversationId> =

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationEntity.kt
@@ -75,7 +75,7 @@ data class ConversationEntity(
 
         companion object {
             fun fromTag(tag: Int?): CipherSuite =
-                if (tag != null) values().first { type -> type.cipherSuiteTag == tag } else UNKNOWN
+                if (tag != null) entries.first { type -> type.cipherSuiteTag == tag } else UNKNOWN
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15149" title="WPB-15149" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15149</a>  App is stuck after MLS migration
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

MLS conversations was not saved if MLS was disabled, causing further message migration fail.

### Solutions

Instead of not saving MLS conversations we save them but with `GroupState.PENDING_JOIN` state to trigger migration when MLS will be enabled
