### PR TITLE
fix: update common protocol resolution (WPB-15191)

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/protocol/OneOnOneProtocolSelectorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/protocol/OneOnOneProtocolSelectorTest.kt
@@ -167,48 +167,6 @@ class OneOnOneProtocolSelectorTest {
     }
 
     @Test
-    fun givenUsersHaveProtocolInCommonButDiffersWithDefaultProtocol_thenShouldReturnNoCommonProtocol() = runTest {
-        val (_, oneOnOneProtocolSelector) = arrange {
-            withSelfUserReturning(TestUser.SELF.copy(supportedProtocols = setOf(SupportedProtocol.MLS)))
-            withUserByIdReturning(Either.Right(TestUser.OTHER.copy(supportedProtocols = setOf(SupportedProtocol.MLS))))
-            withGetDefaultProtocolReturning(SupportedProtocol.PROTEUS.right())
-        }
-
-        oneOnOneProtocolSelector.getProtocolForUser(TestUser.USER_ID)
-            .shouldFail {
-                assertIs<CoreFailure.NoCommonProtocolFound>(it)
-            }
-    }
-
-    @Test
-    fun givenSelfUserSupportsDefaultProtocolButOtherUserDoesnt_thenShouldReturnNoCommonProtocol() = runTest {
-        val (_, oneOnOneProtocolSelector) = arrange {
-            withSelfUserReturning(TestUser.SELF.copy(supportedProtocols = setOf(SupportedProtocol.MLS, SupportedProtocol.PROTEUS)))
-            withUserByIdReturning(Either.Right(TestUser.OTHER.copy(supportedProtocols = setOf(SupportedProtocol.MLS))))
-            withGetDefaultProtocolReturning(SupportedProtocol.PROTEUS.right())
-        }
-
-        oneOnOneProtocolSelector.getProtocolForUser(TestUser.USER_ID)
-            .shouldFail {
-                assertIs<CoreFailure.NoCommonProtocolFound>(it)
-            }
-    }
-
-    @Test
-    fun givenSelfUserDoesntSupportsDefaultProtocolButOtherUserDoes_thenShouldReturnNoCommonProtocol() = runTest {
-        val (_, oneOnOneProtocolSelector) = arrange {
-            withSelfUserReturning(TestUser.SELF.copy(supportedProtocols = setOf(SupportedProtocol.MLS)))
-            withUserByIdReturning(Either.Right(TestUser.OTHER.copy(supportedProtocols = setOf(SupportedProtocol.MLS, SupportedProtocol.PROTEUS))))
-            withGetDefaultProtocolReturning(SupportedProtocol.PROTEUS.right())
-        }
-
-        oneOnOneProtocolSelector.getProtocolForUser(TestUser.USER_ID)
-            .shouldFail {
-                assertIs<CoreFailure.NoCommonProtocolFound>(it)
-            }
-    }
-
-    @Test
     fun givenUsersHaveProtocolInCommonIncludingDefaultProtocol_thenShouldReturnDefaultProtocolAsCommonProtocol() = runTest {
         val (_, oneOnOneProtocolSelector) = arrange {
             withSelfUserReturning(TestUser.SELF.copy(supportedProtocols = setOf(SupportedProtocol.MLS, SupportedProtocol.PROTEUS)))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15191" title="WPB-15191" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15191</a>  [Android] User can not create or see MLS conversations, when they still have a proteus client registered to their account
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Resolving protocol for 1:1 was incorrectly taking in consideration teamDefault Protocol

### Causes (Optional)

When the migration to MLS is not completed, and I have still valid Proteus clients around. The resolution of these conversations, new or existing, was not possible.

### Solutions

Since this was introduced for another bug, that now we are taking care by creating the MLS client at the right moment.
We roll back those lines, see.
- https://github.com/wireapp/kalium/pull/2787

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
