### PR TITLE
fix: delay outgoing message before sync is finished [#WPB-15141]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
@@ -199,7 +199,8 @@ class DebugScope internal constructor(
             currentClientIdProvider = currentClientIdProvider,
             messageSender = messageSender,
             selfUserId = userId,
-            selfConversationIdProvider = selfConversationIdProvider
+            selfConversationIdProvider = selfConversationIdProvider,
+            syncManager = syncManager,
         )
 
     private val deleteEphemeralMessageForSelfUserAsSender: DeleteEphemeralMessageForSelfUserAsSenderUseCaseImpl

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -435,7 +435,8 @@ class MessageScope internal constructor(
             currentClientIdProvider = currentClientIdProvider,
             messageSender = messageSender,
             selfUserId = selfUserId,
-            selfConversationIdProvider = selfConversationIdProvider
+            selfConversationIdProvider = selfConversationIdProvider,
+            syncManager = syncManager,
         )
 
     val getSearchedConversationMessagePosition: GetSearchedConversationMessagePositionUseCase

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ephemeral/DeleteEphemeralMessageForSelfUserAsReceiverUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ephemeral/DeleteEphemeralMessageForSelfUserAsReceiverUseCaseTest.kt
@@ -23,8 +23,8 @@ import com.wire.kalium.logic.data.message.AssetContent
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageEncryptionAlgorithm
-import com.wire.kalium.logic.data.message.MessageTarget
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.data.message.MessageTarget
 import com.wire.kalium.logic.feature.message.ephemeral.DeleteEphemeralMessageForSelfUserAsReceiverUseCase
 import com.wire.kalium.logic.feature.message.ephemeral.DeleteEphemeralMessageForSelfUserAsReceiverUseCaseImpl
 import com.wire.kalium.logic.functional.Either
@@ -32,6 +32,8 @@ import com.wire.kalium.logic.util.arrangement.MessageSenderArrangement
 import com.wire.kalium.logic.util.arrangement.MessageSenderArrangementImpl
 import com.wire.kalium.logic.util.arrangement.SelfConversationIdProviderArrangement
 import com.wire.kalium.logic.util.arrangement.SelfConversationIdProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.SyncManagerArrangement
+import com.wire.kalium.logic.util.arrangement.SyncManagerArrangementImpl
 import com.wire.kalium.logic.util.arrangement.provider.CurrentClientIdProviderArrangement
 import com.wire.kalium.logic.util.arrangement.provider.CurrentClientIdProviderArrangementImpl
 import com.wire.kalium.logic.util.arrangement.repository.AssetRepositoryArrangement
@@ -163,7 +165,8 @@ class DeleteEphemeralMessageForSelfUserAsReceiverUseCaseTest {
         MessageRepositoryArrangement by MessageRepositoryArrangementImpl(),
         MessageSenderArrangement by MessageSenderArrangementImpl(),
         SelfConversationIdProviderArrangement by SelfConversationIdProviderArrangementImpl(),
-        AssetRepositoryArrangement by AssetRepositoryArrangementImpl() {
+        AssetRepositoryArrangement by AssetRepositoryArrangementImpl(),
+        SyncManagerArrangement by SyncManagerArrangementImpl() {
 
         private val useCase: DeleteEphemeralMessageForSelfUserAsReceiverUseCase =
             DeleteEphemeralMessageForSelfUserAsReceiverUseCaseImpl(
@@ -172,7 +175,8 @@ class DeleteEphemeralMessageForSelfUserAsReceiverUseCaseTest {
                 selfUserId = SELF_USER_ID,
                 selfConversationIdProvider = selfConversationIdProvider,
                 assetRepository = assetRepository,
-                currentClientIdProvider = currentClientIdProvider
+                currentClientIdProvider = currentClientIdProvider,
+                syncManager = syncManager,
             )
 
         suspend fun arrange(block: suspend Arrangement.() -> Unit): Pair<Arrangement, DeleteEphemeralMessageForSelfUserAsReceiverUseCase> {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15141" title="WPB-15141" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15141</a>  [Android] After playtest, coming back to the app, getting a lot of "Cannot decrypt" system messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-15141
----
# What's new in this PR?

### Issues
Preconditions:
- Client was offline for a long time and has a lot of messages to sync.
- Conversation has self deleting messages with short expiration.

User opens the app, sync is started and user see some messages that cannot be decrypted in the conversation.

### Causes 
- Client receives a self delete message that expires before the sync is complete
- Client sends delete message to sender to confirm message deletion before sync is finished.
- Delete message is sent with old epoch value.
- Client receives 'mls-stale-message' error and re-joins conversation.
- All subsequent messages cannot be decrypted after re-join.

### Solutions

Delay sending delete message until sync is complete. This ensures that message is sent with correct epoch value.

The issue has a broader context. Any message a client sends before sync is complete can cause re-join and break decryption. This should be covered as a part of: https://wearezeta.atlassian.net/browse/WPB-15262
