### PR TITLE
feat: remove conversation from folder [WPB-14630]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/folders/ConversationFolderRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/folders/ConversationFolderRepository.kt
@@ -57,6 +57,7 @@ internal interface ConversationFolderRepository {
     suspend fun fetchConversationFolders(): Either<CoreFailure, Unit>
     suspend fun addConversationToFolder(conversationId: QualifiedID, folderId: String): Either<CoreFailure, Unit>
     suspend fun removeConversationFromFolder(conversationId: QualifiedID, folderId: String): Either<CoreFailure, Unit>
+    suspend fun removeFolder(folderId: String): Either<CoreFailure, Unit>
     suspend fun syncConversationFoldersFromLocal(): Either<CoreFailure, Unit>
     suspend fun observeFolders(): Flow<Either<CoreFailure, List<ConversationFolder>>>
 }
@@ -141,6 +142,10 @@ internal class ConversationFolderDataSource internal constructor(
         return wrapStorageRequest {
             conversationFolderDAO.removeConversationFromFolder(conversationId.toDao(), folderId)
         }
+    }
+
+    override suspend fun removeFolder(folderId: String): Either<CoreFailure, Unit> = wrapStorageRequest {
+        conversationFolderDAO.removeFolder(folderId)
     }
 
     override suspend fun syncConversationFoldersFromLocal(): Either<CoreFailure, Unit> {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -63,6 +63,8 @@ import com.wire.kalium.logic.feature.conversation.folder.ObserveUserFoldersUseCa
 import com.wire.kalium.logic.feature.conversation.folder.ObserveUserFoldersUseCaseImpl
 import com.wire.kalium.logic.feature.conversation.folder.RemoveConversationFromFavoritesUseCase
 import com.wire.kalium.logic.feature.conversation.folder.RemoveConversationFromFavoritesUseCaseImpl
+import com.wire.kalium.logic.feature.conversation.folder.RemoveConversationFromFolderUseCase
+import com.wire.kalium.logic.feature.conversation.folder.RemoveConversationFromFolderUseCaseImpl
 import com.wire.kalium.logic.feature.conversation.guestroomlink.CanCreatePasswordProtectedLinksUseCase
 import com.wire.kalium.logic.feature.conversation.guestroomlink.GenerateGuestRoomLinkUseCase
 import com.wire.kalium.logic.feature.conversation.guestroomlink.GenerateGuestRoomLinkUseCaseImpl
@@ -390,4 +392,6 @@ class ConversationScope internal constructor(
         get() = ObserveUserFoldersUseCaseImpl(conversationFolderRepository)
     val moveConversationToFolder: MoveConversationToFolderUseCase
         get() = MoveConversationToFolderUseCaseImpl(conversationFolderRepository)
+    val removeConversationFromFolder: RemoveConversationFromFolderUseCase
+        get() = RemoveConversationFromFolderUseCaseImpl(conversationFolderRepository)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/folder/RemoveConversationFromFolderUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/folder/RemoveConversationFromFolderUseCase.kt
@@ -1,0 +1,74 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.conversation.folder
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.conversation.folders.ConversationFolderRepository
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+
+/**
+ * This use case will remove a conversation from the selected folder and if the folder is empty, it will remove the folder.
+ */
+interface RemoveConversationFromFolderUseCase {
+    /**
+     * @param conversationId the id of the conversation
+     * @param folderId the id of the folder
+     * @return the [Result] indicating a successful operation, otherwise a [CoreFailure]
+     */
+    suspend operator fun invoke(conversationId: ConversationId, folderId: String): Result
+
+    sealed interface Result {
+        data object Success : Result
+        data class Failure(val cause: CoreFailure) : Result
+    }
+}
+
+internal class RemoveConversationFromFolderUseCaseImpl(
+    private val conversationFolderRepository: ConversationFolderRepository,
+    private val dispatchers: KaliumDispatcher = KaliumDispatcherImpl
+) : RemoveConversationFromFolderUseCase {
+    override suspend fun invoke(
+        conversationId: ConversationId,
+        folderId: String
+    ): RemoveConversationFromFolderUseCase.Result = withContext(dispatchers.io) {
+        conversationFolderRepository.removeConversationFromFolder(conversationId, folderId)
+            .flatMap {
+                if (conversationFolderRepository.observeConversationsFromFolder(folderId).first().isEmpty()) {
+                    conversationFolderRepository.removeFolder(folderId)
+                } else {
+                    Either.Right(Unit)
+                }
+            }
+            .flatMap {
+                conversationFolderRepository.syncConversationFoldersFromLocal()
+            }
+            .fold({
+                RemoveConversationFromFolderUseCase.Result.Failure(it)
+            }, {
+                RemoveConversationFromFolderUseCase.Result.Success
+            })
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/folders/ConversationFolderRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/folders/ConversationFolderRepositoryTest.kt
@@ -216,6 +216,20 @@ class ConversationFolderRepositoryTest {
         coVerify { arrangement.conversationFolderDAO.getFoldersWithConversations() }.wasInvoked()
     }
 
+    @Test
+    fun givenValidFolderIdWhenRemovingFolderThenShouldRemoveSuccessfully() = runTest {
+        // given
+        val folderId = "folder1"
+        val arrangement = Arrangement().withSuccessfulFolderRemoval()
+
+        // when
+        val result = arrangement.repository.removeFolder(folderId)
+
+        // then
+        result.shouldSucceed()
+        coVerify { arrangement.conversationFolderDAO.removeFolder(eq(folderId)) }.wasInvoked()
+    }
+
     private class Arrangement {
 
         @Mock
@@ -276,6 +290,11 @@ class ConversationFolderRepositoryTest {
 
         suspend fun withRemoveConversationFromFolder(): Arrangement {
             coEvery { conversationFolderDAO.removeConversationFromFolder(any(), any()) }.returns(Unit)
+            return this
+        }
+
+        suspend fun withSuccessfulFolderRemoval(): Arrangement {
+            coEvery { conversationFolderDAO.removeFolder(any()) }.returns(Unit)
             return this
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/folder/RemoveConversationFromFolderUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/folder/RemoveConversationFromFolderUseCaseTest.kt
@@ -1,0 +1,180 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.conversation.folder
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.conversation.ConversationDetailsWithEvents
+import com.wire.kalium.logic.data.conversation.folders.ConversationFolderRepository
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.feature.conversation.folder.RemoveConversationFromFolderUseCase.Result
+import com.wire.kalium.logic.framework.TestConversationDetails
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.coEvery
+import io.mockative.coVerify
+import io.mockative.mock
+import io.mockative.once
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertIs
+
+class RemoveConversationFromFolderUseCaseTest {
+
+    @Test
+    fun givenValidConversationAndFolder_WhenRemoveAndSyncSuccessful_ThenReturnSuccess() = runTest {
+        val testConversationId = ConversationId("conversation-value", "conversation-domain")
+        val testFolderId = "test-folder-id"
+
+        val (arrangement, removeConversationUseCase) = Arrangement()
+            .withRemoveConversationFromFolder(testConversationId, testFolderId, Either.Right(Unit))
+            .withObserveConversationsFromFolder(testFolderId, flowOf(emptyList()))
+            .withRemoveFolder(testFolderId, Either.Right(Unit))
+            .withSyncFolders(Either.Right(Unit))
+            .arrange()
+
+        val result = removeConversationUseCase(testConversationId, testFolderId)
+
+        assertIs<Result.Success>(result)
+
+        coVerify {
+            arrangement.conversationFolderRepository.removeConversationFromFolder(testConversationId, testFolderId)
+        }.wasInvoked(exactly = once)
+
+        coVerify {
+            arrangement.conversationFolderRepository.observeConversationsFromFolder(testFolderId)
+        }.wasInvoked(exactly = once)
+
+        coVerify {
+            arrangement.conversationFolderRepository.removeFolder(testFolderId)
+        }.wasInvoked(exactly = once)
+
+        coVerify {
+            arrangement.conversationFolderRepository.syncConversationFoldersFromLocal()
+        }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenFolderNotEmpty_WhenRemoveAndSyncSuccessful_ThenReturnSuccessWithoutFolderRemoval() = runTest {
+        val testConversationId = ConversationId("conversation-value", "conversation-domain")
+        val testFolderId = "test-folder-id"
+
+        val (arrangement, removeConversationUseCase) = Arrangement()
+            .withRemoveConversationFromFolder(testConversationId, testFolderId, Either.Right(Unit))
+            .withObserveConversationsFromFolder(
+                testFolderId,
+                flowOf(listOf(ConversationDetailsWithEvents(TestConversationDetails.CONVERSATION_GROUP)))
+            )
+            .withSyncFolders(Either.Right(Unit))
+            .arrange()
+
+        val result = removeConversationUseCase(testConversationId, testFolderId)
+
+        assertIs<Result.Success>(result)
+
+        coVerify {
+            arrangement.conversationFolderRepository.removeConversationFromFolder(testConversationId, testFolderId)
+        }.wasInvoked(exactly = once)
+
+        coVerify {
+            arrangement.conversationFolderRepository.observeConversationsFromFolder(testFolderId)
+        }.wasInvoked(exactly = once)
+
+        coVerify {
+            arrangement.conversationFolderRepository.removeFolder(testFolderId)
+        }.wasNotInvoked()
+
+        coVerify {
+            arrangement.conversationFolderRepository.syncConversationFoldersFromLocal()
+        }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenErrorDuringFolderRemoval_WhenObservedEmpty_ThenReturnFailure() = runTest {
+        val testConversationId = ConversationId("conversation-value", "conversation-domain")
+        val testFolderId = "test-folder-id"
+
+        val (arrangement, removeConversationUseCase) = Arrangement()
+            .withRemoveConversationFromFolder(testConversationId, testFolderId, Either.Right(Unit))
+            .withObserveConversationsFromFolder(testFolderId, flowOf(emptyList()))
+            .withRemoveFolder(testFolderId, Either.Left(CoreFailure.Unknown(null)))
+            .arrange()
+
+        val result = removeConversationUseCase(testConversationId, testFolderId)
+
+        assertIs<Result.Failure>(result)
+
+        coVerify {
+            arrangement.conversationFolderRepository.removeConversationFromFolder(testConversationId, testFolderId)
+        }.wasInvoked(exactly = once)
+
+        coVerify {
+            arrangement.conversationFolderRepository.observeConversationsFromFolder(testFolderId)
+        }.wasInvoked(exactly = once)
+
+        coVerify {
+            arrangement.conversationFolderRepository.removeFolder(testFolderId)
+        }.wasInvoked(exactly = once)
+    }
+
+    private class Arrangement {
+        @Mock
+        val conversationFolderRepository = mock(ConversationFolderRepository::class)
+
+        private val removeConversationFromFolderUseCase = RemoveConversationFromFolderUseCaseImpl(
+            conversationFolderRepository
+        )
+
+        suspend fun withRemoveConversationFromFolder(
+            conversationId: ConversationId,
+            folderId: String,
+            either: Either<CoreFailure, Unit>
+        ) = apply {
+            coEvery {
+                conversationFolderRepository.removeConversationFromFolder(conversationId, folderId)
+            }.returns(either)
+        }
+
+        suspend fun withObserveConversationsFromFolder(
+            folderId: String,
+            flow: Flow<List<ConversationDetailsWithEvents>>
+        ) = apply {
+            coEvery {
+                conversationFolderRepository.observeConversationsFromFolder(folderId)
+            }.returns(flow)
+        }
+
+        suspend fun withRemoveFolder(
+            folderId: String,
+            either: Either<CoreFailure, Unit>
+        ) = apply {
+            coEvery {
+                conversationFolderRepository.removeFolder(folderId)
+            }.returns(either)
+        }
+
+        suspend fun withSyncFolders(either: Either<CoreFailure, Unit>) = apply {
+            coEvery {
+                conversationFolderRepository.syncConversationFoldersFromLocal()
+            }.returns(either)
+        }
+
+        fun arrange(block: Arrangement.() -> Unit = { }) = apply(block).let { this to removeConversationFromFolderUseCase }
+    }
+}

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationFolders.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationFolders.sq
@@ -11,7 +11,6 @@ CREATE TABLE LabeledConversation (
       conversation_id TEXT AS QualifiedIDEntity NOT NULL,
       folder_id TEXT NOT NULL,
 
-      FOREIGN KEY (conversation_id) REFERENCES Conversation(qualified_id) ON DELETE CASCADE ON UPDATE CASCADE,
       FOREIGN KEY (folder_id) REFERENCES ConversationFolder(id) ON DELETE CASCADE ON UPDATE CASCADE,
 
       PRIMARY KEY (folder_id, conversation_id)
@@ -68,3 +67,6 @@ DELETE FROM LabeledConversation;
 
 clearFolders:
 DELETE FROM ConversationFolder;
+
+deleteFolder:
+DELETE FROM ConversationFolder WHERE id = ?;

--- a/persistence/src/commonMain/db_user/migrations/96.sqm
+++ b/persistence/src/commonMain/db_user/migrations/96.sqm
@@ -1,4 +1,6 @@
-CREATE TABLE LabeledConversation_New (
+DROP TABLE LabeledConversation;
+
+CREATE TABLE LabeledConversation (
       conversation_id TEXT AS QualifiedIDEntity NOT NULL,
       folder_id TEXT NOT NULL,
 
@@ -6,10 +8,3 @@ CREATE TABLE LabeledConversation_New (
 
       PRIMARY KEY (folder_id, conversation_id)
 );
-
-INSERT INTO LabeledConversation_New (conversation_id, folder_id)
-SELECT conversation_id, folder_id FROM LabeledConversation;
-
-DROP TABLE LabeledConversation;
-
-ALTER TABLE LabeledConversation_New RENAME TO LabeledConversation;

--- a/persistence/src/commonMain/db_user/migrations/96.sqm
+++ b/persistence/src/commonMain/db_user/migrations/96.sqm
@@ -1,0 +1,19 @@
+PRAGMA foreign_keys=off;
+
+CREATE TABLE LabeledConversation_New (
+      conversation_id TEXT AS QualifiedIDEntity NOT NULL,
+      folder_id TEXT NOT NULL,
+
+      FOREIGN KEY (folder_id) REFERENCES ConversationFolder(id) ON DELETE CASCADE ON UPDATE CASCADE,
+
+      PRIMARY KEY (folder_id, conversation_id)
+);
+
+INSERT INTO LabeledConversation_New (conversation_id, folder_id)
+SELECT conversation_id, folder_id FROM LabeledConversation;
+
+DROP TABLE LabeledConversation;
+
+ALTER TABLE LabeledConversation_New RENAME TO LabeledConversation;
+
+PRAGMA foreign_keys=on;

--- a/persistence/src/commonMain/db_user/migrations/96.sqm
+++ b/persistence/src/commonMain/db_user/migrations/96.sqm
@@ -1,5 +1,3 @@
-PRAGMA foreign_keys=off;
-
 CREATE TABLE LabeledConversation_New (
       conversation_id TEXT AS QualifiedIDEntity NOT NULL,
       folder_id TEXT NOT NULL,
@@ -15,5 +13,3 @@ SELECT conversation_id, folder_id FROM LabeledConversation;
 DROP TABLE LabeledConversation;
 
 ALTER TABLE LabeledConversation_New RENAME TO LabeledConversation;
-
-PRAGMA foreign_keys=on;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/folder/ConversationFolderDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/folder/ConversationFolderDAO.kt
@@ -29,4 +29,5 @@ interface ConversationFolderDAO {
     suspend fun addConversationToFolder(conversationId: QualifiedIDEntity, folderId: String)
     suspend fun removeConversationFromFolder(conversationId: QualifiedIDEntity, folderId: String)
     suspend fun observeFolders(): Flow<List<ConversationFolderEntity>>
+    suspend fun removeFolder(folderId: String)
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/folder/ConversationFolderDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/folder/ConversationFolderDAOImpl.kt
@@ -21,6 +21,7 @@ import app.cash.sqldelight.coroutines.asFlow
 import com.wire.kalium.persistence.ConversationFolder
 import com.wire.kalium.persistence.ConversationFoldersQueries
 import com.wire.kalium.persistence.GetAllFoldersWithConversations
+import com.wire.kalium.persistence.LabeledConversation
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.conversation.ConversationDetailsWithEventsEntity
 import com.wire.kalium.persistence.dao.conversation.ConversationDetailsWithEventsMapper
@@ -45,6 +46,10 @@ class ConversationFolderDAOImpl internal constructor(
             .flowOn(coroutineContext)
     }
 
+    override suspend fun removeFolder(folderId: String) = withContext(coroutineContext) {
+        conversationFoldersQueries.deleteFolder(folderId)
+    }
+
     override suspend fun getFoldersWithConversations(): List<FolderWithConversationsEntity> = withContext(coroutineContext) {
         val labeledConversationList = conversationFoldersQueries.getAllFoldersWithConversations().executeAsList().map(::toEntity)
 
@@ -66,6 +71,11 @@ class ConversationFolderDAOImpl internal constructor(
         folderId = row.label_id,
         folderName = row.label_name,
         folderType = row.label_type,
+        conversationId = row.conversation_id
+    )
+
+    private fun toEntity(row: LabeledConversation) = ConversationLabelEntity(
+        folderId = row.folder_id,
         conversationId = row.conversation_id
     )
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/folder/ConversationFolderEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/folder/ConversationFolderEntity.kt
@@ -39,6 +39,11 @@ data class LabeledConversationEntity(
     val conversationId: QualifiedIDEntity?
 )
 
+data class ConversationLabelEntity(
+    val conversationId: QualifiedIDEntity,
+    val folderId: String
+)
+
 enum class ConversationFolderTypeEntity {
     USER,
     FAVORITE


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14630" title="WPB-14630" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14630</a>  [Android] Conversation folder - Remove from folder
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- remove conversation from folder
- migrated `LabeledConversation` to not use `Conversation` foreign key to fix issue with syncing labeled conversations with not existing conversation