### PR TITLE
fix: 1:1s end up at the bottom of the list after migration [WPB-15452]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneMigrator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneMigrator.kt
@@ -55,6 +55,7 @@ interface OneOnOneMigrator {
     suspend fun migrateToMLS(user: OtherUser): Either<CoreFailure, ConversationId>
 }
 
+@Suppress("LongParameterList")
 internal class OneOnOneMigratorImpl(
     private val getResolvedMLSOneOnOne: MLSOneOnOneConversationResolver,
     private val conversationGroupRepository: ConversationGroupRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneMigrator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneMigrator.kt
@@ -32,8 +32,11 @@ import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.foldToEitherWhileRight
+import com.wire.kalium.logic.functional.getOrNull
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.kaliumLogger
+import com.wire.kalium.util.DateTimeUtil
+import kotlinx.datetime.Instant
 
 interface OneOnOneMigrator {
     /**
@@ -58,7 +61,8 @@ internal class OneOnOneMigratorImpl(
     private val conversationRepository: ConversationRepository,
     private val messageRepository: MessageRepository,
     private val userRepository: UserRepository,
-    private val systemMessageInserter: SystemMessageInserter
+    private val systemMessageInserter: SystemMessageInserter,
+    private val currentInstant: CurrentInstantProvider = CurrentInstantProvider { DateTimeUtil.currentInstant() },
 ) : OneOnOneMigrator {
 
     override suspend fun migrateToProteus(user: OtherUser): Either<CoreFailure, ConversationId> =
@@ -140,16 +144,26 @@ internal class OneOnOneMigratorImpl(
         ).flatMap { proteusOneOnOneConversations ->
             // We can theoretically have more than one proteus 1-1 conversation with
             // team members since there was no backend safeguards against this
-            proteusOneOnOneConversations.foldToEitherWhileRight(Unit) { proteusOneOnOneConversation, _ ->
-                kaliumLogger.d(
-                    "migrating proteus ${proteusOneOnOneConversation.toLogString()} " +
-                            "to MLS conv ${targetConversation.toLogString()}"
-                )
+            proteusOneOnOneConversations.foldToEitherWhileRight(null as Instant?) { proteusOneOnOneConversation, lastModifiedDate ->
                 messageRepository.moveMessagesToAnotherConversation(
                     originalConversation = proteusOneOnOneConversation,
                     targetConversation = targetConversation
-                )
+                ).map {
+                    // Emit most recent last modified date of the proteus conversations to pass it to the target conversation
+                    conversationRepository.getConversationById(proteusOneOnOneConversation).getOrNull()?.lastModifiedDate.let {
+                        listOfNotNull(lastModifiedDate, it).maxOrNull()
+                    }
+                }
+            }.map { lastModifiedDate ->
+                // Fallback to current time if not found as it means that it's completely new conversation without any history
+                lastModifiedDate ?: currentInstant()
             }
+        }.flatMap { lastModifiedDate ->
+            conversationRepository.updateConversationModifiedDate(targetConversation, lastModifiedDate)
         }
     }
+}
+
+fun interface CurrentInstantProvider {
+    operator fun invoke(): Instant
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15452" title="WPB-15452" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15452</a>  [Android] 1:1s end up at the bottom of the list after migration
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1:1 conversations, after MLS migration, are moved to the bottom of the conversation list, even if the conversation has some messages sent or received in the meantime. 

### Causes (Optional)

This is due to the fact that when migrating 1:1, a new conversation with different id is created, so in theory this new one doesn’t have any events thus `lastEventTime` and `last_modified_date` are empty (01.01.1970) - that’s why it’s moved to the bottom of the list as the query. It creates confusion and inconsistency in sorting as now, even if a conversation had some messages, which are migrated to the new one.

### Solutions

Update `last_modified_date` when migrating history (messages) - take the value from previous proteus conversation or set a current time otherwise (if there's no previous proteus conversation then it means it's a completely new one so it should be at the top anyway).

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Have proteus 1:1, send and receive some messages, migrate to MLS, check whether the conversation is still on the proper position on a list.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
