### PR TITLE
fix: wrong migrations order between 4.9 and 4.10 [WPB-15157]

### DIFF
--- a/persistence/src/commonMain/db_user/migrations/96.sqm
+++ b/persistence/src/commonMain/db_user/migrations/96.sqm
@@ -1,0 +1,19 @@
+import com.wire.kalium.persistence.dao.QualifiedIDEntity;
+import com.wire.kalium.persistence.dao.conversation.folder.ConversationFolderTypeEntity;
+
+CREATE TABLE IF NOT EXISTS ConversationFolder (
+    id TEXT NOT NULL PRIMARY KEY,
+    name TEXT NOT NULL,
+    folder_type TEXT AS ConversationFolderTypeEntity NOT NULL
+);
+
+
+CREATE TABLE IF NOT EXISTS LabeledConversation (
+      conversation_id TEXT AS QualifiedIDEntity NOT NULL,
+      folder_id TEXT NOT NULL,
+
+      FOREIGN KEY (conversation_id) REFERENCES Conversation(qualified_id) ON DELETE CASCADE ON UPDATE CASCADE,
+      FOREIGN KEY (folder_id) REFERENCES ConversationFolder(id) ON DELETE CASCADE ON UPDATE CASCADE,
+
+      PRIMARY KEY (folder_id, conversation_id)
+);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15157" title="WPB-15157" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15157</a>  App crashes after receiving links in a group chat
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When [cherry-picking the fix for multiple mentions from 4.9 to RC 4.10](https://github.com/wireapp/kalium/pull/3224), the order of migrations were changed - in 4.9 migration related to this fix was added as `91.sqm` but in 4.10 as `95.sqm`, so it means that when updating the app from 4.9 to 4.10, the app will lose migration that's implemented in 4.10 as `91.sqm` because migration with number 91 has already been executed in 4.9. 

### Solutions

Migration from `91.sqm` is about creating `ConversationFolder` and `LabeledConversation`, so to fix it, additional migration `96.sqm` was created in order to add these tables if they don't yet exist.
Note: this new migration also needs to be added to dev (4.11) to maintain the order there.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
