### PR TITLE
fix: sub conversation epoch verification [WPB-15647]

### DIFF
--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/SubConversation.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/SubConversation.kt
@@ -1,0 +1,39 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.conversation
+
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.GroupID
+import com.wire.kalium.logic.data.id.SubconversationId
+
+data class SubConversation(
+    val id: SubconversationId,
+    val parentId: ConversationId,
+    val groupId: GroupID,
+    val epoch: ULong,
+    val epochTimestamp: String?,
+    val mlsCipherSuiteTag: Int?,
+
+    val members: List<SubconversationMember>,
+)
+
+data class SubconversationMember(
+     val clientId: String,
+     val userId: String,
+     val domain: String
+)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/LeaveSubconversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/LeaveSubconversationUseCase.kt
@@ -31,7 +31,7 @@ import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.logic.wrapMLSRequest
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
-import com.wire.kalium.network.api.authenticated.conversation.SubconversationMember
+import com.wire.kalium.network.api.authenticated.conversation.SubconversationMemberDTO
 
 /**
  * Leave a sub-conversation you've previously joined
@@ -71,7 +71,7 @@ internal class LeaveSubconversationUseCaseImpl(
             subconversationRepository.getSubconversationInfo(conversationId, subconversationId)?.let {
                 Either.Right(it)
             } ?: wrapApiRequest { conversationApi.fetchSubconversationDetails(conversationId.toApi(), subconversationId.toApi()) }.flatMap {
-                if (it.members.contains(SubconversationMember(selfClientId.value, selfUserId.value, selfUserId.domain))) {
+                if (it.members.contains(SubconversationMemberDTO(selfClientId.value, selfUserId.value, selfUserId.domain))) {
                     Either.Right(GroupID(it.groupId))
                 } else {
                     Either.Right(null)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/SubConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/SubConversationMapper.kt
@@ -1,0 +1,43 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.conversation
+
+import com.wire.kalium.logic.data.id.GroupID
+import com.wire.kalium.logic.data.id.toModel
+import com.wire.kalium.network.api.authenticated.conversation.SubconversationMemberDTO
+import com.wire.kalium.network.api.authenticated.conversation.SubconversationResponse
+
+fun SubconversationResponse.toModel(): SubConversation {
+    return SubConversation(
+        id = id.toModel(),
+        parentId = parentId.toModel(),
+        groupId = GroupID(groupId),
+        epoch = epoch,
+        epochTimestamp = epochTimestamp,
+        mlsCipherSuiteTag = mlsCipherSuiteTag,
+        members = members.map { it.toModel() }
+    )
+}
+
+fun SubconversationMemberDTO.toModel(): SubconversationMember {
+    return SubconversationMember(
+        clientId = clientId,
+        userId = userId,
+        domain = domain
+    )
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/SubconversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/SubconversationRepository.kt
@@ -24,12 +24,12 @@ import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.SubconversationId
 import com.wire.kalium.logic.data.id.toApi
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onFailure
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.wrapApiRequest
 import com.wire.kalium.network.api.authenticated.conversation.SubconversationDeleteRequest
-import com.wire.kalium.network.api.authenticated.conversation.SubconversationResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
 import io.ktor.util.collections.ConcurrentMap
 import kotlinx.coroutines.sync.Mutex
@@ -68,7 +68,7 @@ interface SubconversationRepository {
     suspend fun fetchRemoteSubConversationDetails(
         conversationId: ConversationId,
         subConversationId: SubconversationId
-    ): Either<NetworkFailure, SubconversationResponse>
+    ): Either<NetworkFailure, SubConversation>
 }
 
 class SubconversationRepositoryImpl(
@@ -139,14 +139,15 @@ class SubconversationRepositoryImpl(
         )
     }
 
-    // TODO: Replace SubconversationResponse with a domain model
     override suspend fun fetchRemoteSubConversationDetails(
         conversationId: ConversationId,
         subConversationId: SubconversationId
-    ): Either<NetworkFailure, SubconversationResponse> = wrapApiRequest {
+    ): Either<NetworkFailure, SubConversation> = wrapApiRequest {
         conversationApi.fetchSubconversationDetails(
             conversationId.toApi(),
             subConversationId.toApi()
         )
+    }.map {
+        it.toModel()
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/IdMappers.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/id/IdMappers.kt
@@ -26,6 +26,7 @@ import com.wire.kalium.cryptography.MLSGroupId
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.network.api.model.UserAssetDTO
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.network.api.model.SubconversationId as NetworkSubConversationId
 
 internal typealias NetworkQualifiedId = com.wire.kalium.network.api.model.QualifiedID
 internal typealias PersistenceQualifiedId = QualifiedIDEntity
@@ -53,3 +54,5 @@ internal fun SubconversationId.toApi(): String = value
 internal fun GroupID.toCrypto(): MLSGroupId = value
 
 internal fun CryptoQualifiedClientId.toModel() = QualifiedClientID(ClientId(value), userId.toModel())
+
+internal fun NetworkSubConversationId.toModel() = SubconversationId(this)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1392,7 +1392,8 @@ class UserSessionScope internal constructor(
             systemMessageInserter = systemMessageInserter,
             conversationRepository = conversationRepository,
             mlsConversationRepository = mlsConversationRepository,
-            joinExistingMLSConversation = joinExistingMLSConversationUseCase
+            joinExistingMLSConversation = joinExistingMLSConversationUseCase,
+            subconversationRepository = subconversationRepository
         )
 
     private val newMessageHandler: NewMessageEventHandler

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
@@ -129,6 +129,7 @@ internal class NewMessageEventHandlerImpl(
                         eventLogger.logFailure(it, "protocol" to "MLS", "mlsOutcome" to "OUT_OF_SYNC")
                         staleEpochVerifier.verifyEpoch(
                             event.conversationId,
+                            event.subconversationId,
                             event.messageInstant
                         )
                     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
@@ -64,7 +64,6 @@ import com.wire.kalium.logic.util.thenReturnSequentially
 import com.wire.kalium.network.api.base.authenticated.message.MLSMessageApi
 import com.wire.kalium.network.api.model.ErrorResponse
 import com.wire.kalium.network.exceptions.KaliumException
-import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.time.UNIX_FIRST_DATE
 import io.ktor.utils.io.core.toByteArray
 import io.mockative.Mock

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
@@ -323,7 +323,7 @@ class MessageSenderTest {
             // then
             result.shouldSucceed()
             coVerify {
-                arrangement.staleEpochVerifier.verifyEpoch(eq(Arrangement.TEST_CONVERSATION_ID), any())
+                arrangement.staleEpochVerifier.verifyEpoch(eq(Arrangement.TEST_CONVERSATION_ID), any(), any())
             }.wasInvoked(once)
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifierTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifierTest.kt
@@ -17,7 +17,12 @@
  */
 package com.wire.kalium.logic.feature.message
 
+import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.data.conversation.SubConversation
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.GroupID
+import com.wire.kalium.logic.data.id.SubconversationId
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.util.arrangement.SystemMessageInserterArrangement
@@ -26,6 +31,8 @@ import com.wire.kalium.logic.util.arrangement.mls.MLSConversationRepositoryArran
 import com.wire.kalium.logic.util.arrangement.mls.MLSConversationRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangementImpl
+import com.wire.kalium.logic.util.arrangement.repository.SubconversationRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.repository.SubconversationRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.usecase.JoinExistingMLSConversationUseCaseArrangement
 import com.wire.kalium.logic.util.arrangement.usecase.JoinExistingMLSConversationUseCaseArrangementImpl
 import com.wire.kalium.logic.util.shouldFail
@@ -133,18 +140,134 @@ class StaleEpochVerifierTest {
         }.wasInvoked(once)
     }
 
+    @Test
+    fun givenSubconversationIdAndValidEpoch_WhenVerified_ThenShouldSucceed() = runTest {
+        val subConversationId = SubconversationId("subconversation-id")
+        val (arrangement, staleEpochHandler) = arrange {
+            withFetchRemoteSubConversationDetails(CONVERSATION_ID, subConversationId, Either.Right(TestSubConversationDetails))
+            withIsGroupOutOfSync(Either.Right(false))
+        }
+
+        val result = staleEpochHandler.verifyEpoch(CONVERSATION_ID, subConversationId, null)
+
+        result.shouldSucceed()
+
+        coVerify {
+            arrangement.subconversationRepository.fetchRemoteSubConversationDetails(CONVERSATION_ID, subConversationId)
+        }.wasInvoked(once)
+
+        coVerify {
+            arrangement.mlsConversationRepository.isGroupOutOfSync(
+                TestSubConversationDetails.groupId,
+                TestSubConversationDetails.epoch
+            )
+        }.wasInvoked(once)
+    }
+
+    @Test
+    fun givenSubconversationIdAndStaleEpoch_WhenVerified_ThenShouldJoinUsingExternalCommit() = runTest {
+        val subConversationId = SubconversationId("subconversation-id")
+        val (arrangement, staleEpochHandler) = arrange {
+            withFetchRemoteSubConversationDetails(CONVERSATION_ID, subConversationId, Either.Right(TestSubConversationDetails))
+            withIsGroupOutOfSync(Either.Right(true))
+            withFetchRemoteSubConversationGroupInfo(CONVERSATION_ID, subConversationId, Either.Right(TestGroupInfo))
+            withJoinGroupByExternalCommit(TestSubConversationDetails.groupId, TestGroupInfo, Either.Right(Unit))
+        }
+
+        val result = staleEpochHandler.verifyEpoch(CONVERSATION_ID, subConversationId, null)
+
+        result.shouldSucceed()
+
+        coVerify {
+            arrangement.subconversationRepository.fetchRemoteSubConversationDetails(CONVERSATION_ID, subConversationId)
+        }.wasInvoked(once)
+
+        coVerify {
+            arrangement.mlsConversationRepository.joinGroupByExternalCommit(TestSubConversationDetails.groupId, TestGroupInfo)
+        }.wasInvoked(once)
+    }
+
+    @Test
+    fun givenSubconversationIdAndFetchDetailsFails_WhenVerified_ThenShouldFail() = runTest {
+        val subConversationId = SubconversationId("subconversation-id")
+        val (arrangement, staleEpochHandler) = arrange {
+            withFetchRemoteSubConversationDetails(
+                CONVERSATION_ID,
+                subConversationId,
+                Either.Left(NetworkFailure.NoNetworkConnection(null))
+            )
+        }
+
+        val result = staleEpochHandler.verifyEpoch(CONVERSATION_ID, subConversationId, null)
+
+        result.shouldFail()
+
+        coVerify {
+            arrangement.subconversationRepository.fetchRemoteSubConversationDetails(CONVERSATION_ID, subConversationId)
+        }.wasInvoked(once)
+    }
+
+    @Test
+    fun givenSubconversationIdAndExternalCommitFails_WhenVerified_ThenShouldFail() = runTest {
+        val subConversationId = SubconversationId("subconversation-id")
+        val (arrangement, staleEpochHandler) = arrange {
+            withFetchRemoteSubConversationDetails(CONVERSATION_ID, subConversationId, Either.Right(TestSubConversationDetails))
+            withIsGroupOutOfSync(Either.Right(true))
+            withFetchRemoteSubConversationGroupInfo(CONVERSATION_ID, subConversationId, Either.Right(TestGroupInfo))
+            withJoinGroupByExternalCommit(
+                TestSubConversationDetails.groupId,
+                TestGroupInfo,
+                Either.Left(CoreFailure.Unknown(null))
+            )
+        }
+
+        val result = staleEpochHandler.verifyEpoch(CONVERSATION_ID, subConversationId, null)
+
+        result.shouldFail()
+
+        coVerify {
+            arrangement.subconversationRepository.fetchRemoteSubConversationDetails(CONVERSATION_ID, subConversationId)
+        }.wasInvoked(once)
+
+        coVerify {
+            arrangement.mlsConversationRepository.joinGroupByExternalCommit(TestSubConversationDetails.groupId, TestGroupInfo)
+        }.wasInvoked(once)
+    }
+
+    @Test
+    fun givenSubconversationId_WhenVerified_ThenShouldNotCallFetchConversation() = runTest {
+        val subConversationId = SubconversationId("subconversation-id")
+        val (arrangement, staleEpochHandler) = arrange {
+            withFetchRemoteSubConversationDetails(CONVERSATION_ID, subConversationId, Either.Right(TestSubConversationDetails))
+            withIsGroupOutOfSync(Either.Right(false))
+        }
+
+        val result = staleEpochHandler.verifyEpoch(CONVERSATION_ID, subConversationId, null)
+
+        result.shouldSucceed()
+
+        coVerify {
+            arrangement.subconversationRepository.fetchRemoteSubConversationDetails(CONVERSATION_ID, subConversationId)
+        }.wasInvoked(once)
+
+        coVerify {
+            arrangement.conversationRepository.fetchConversation(any())
+        }.wasNotInvoked()
+    }
+
 
     private class Arrangement(private val block: suspend Arrangement.() -> Unit) :
         SystemMessageInserterArrangement by SystemMessageInserterArrangementImpl(),
         ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
         MLSConversationRepositoryArrangement by MLSConversationRepositoryArrangementImpl(),
-        JoinExistingMLSConversationUseCaseArrangement by JoinExistingMLSConversationUseCaseArrangementImpl()
-    {
+        SubconversationRepositoryArrangement by SubconversationRepositoryArrangementImpl(),
+        JoinExistingMLSConversationUseCaseArrangement by JoinExistingMLSConversationUseCaseArrangementImpl() {
         suspend fun arrange() = run {
             block()
             this@Arrangement to StaleEpochVerifierImpl(
                 systemMessageInserter = systemMessageInserter,
                 conversationRepository = conversationRepository,
+                subconversationRepository = subconversationRepository,
                 mlsConversationRepository = mlsConversationRepository,
                 joinExistingMLSConversation = joinExistingMLSConversationUseCase
             )
@@ -154,6 +277,18 @@ class StaleEpochVerifierTest {
     private companion object {
         suspend fun arrange(configuration: suspend Arrangement.() -> Unit) = Arrangement(configuration).arrange()
 
-        val CONVERSATION_ID = TestConversation.ID
+        val CONVERSATION_ID = ConversationId("conversation-value", "conversation-domain")
+
+        val TestSubConversationDetails = SubConversation(
+            id = SubconversationId("subconversation-value"),
+            parentId = CONVERSATION_ID,
+            groupId = GroupID("sub-group-id"),
+            epoch = 123UL,
+            epochTimestamp = null,
+            mlsCipherSuiteTag = null,
+            members = emptyList()
+        )
+
+        val TestGroupInfo = ByteArray(0)
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
@@ -493,7 +493,7 @@ class NewMessageEventHandlerTest {
 
         suspend fun withVerifyEpoch(result: Either<CoreFailure, Unit>) = apply {
             coEvery {
-                staleEpochVerifier.verifyEpoch(any(), any())
+                staleEpochVerifier.verifyEpoch(any(), any(), any())
             }.returns(result)
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
@@ -372,7 +372,11 @@ class NewMessageEventHandlerTest {
         newMessageEventHandler.handleNewMLSMessage(newMessageEvent, TestEvent.liveDeliveryInfo)
 
         coVerify {
-            arrangement.staleEpochVerifier.verifyEpoch(eq(newMessageEvent.conversationId), eq(newMessageEvent.messageInstant))
+            arrangement.staleEpochVerifier.verifyEpoch(
+                eq(newMessageEvent.conversationId),
+                any(),
+                eq(newMessageEvent.messageInstant)
+            )
         }.wasInvoked(exactly = once)
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/mls/MLSConversationRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/mls/MLSConversationRepositoryArrangement.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.logic.util.arrangement.mls
 import com.wire.kalium.cryptography.WireIdentity
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.Either
 import io.mockative.any
@@ -32,6 +33,11 @@ interface MLSConversationRepositoryArrangement {
     suspend fun withIsGroupOutOfSync(result: Either<CoreFailure, Boolean>)
     suspend fun withUserIdentity(result: Either<CoreFailure, List<WireIdentity>>)
     suspend fun withMembersIdentities(result: Either<CoreFailure, Map<UserId, List<WireIdentity>>>)
+    suspend fun withJoinGroupByExternalCommit(
+        groupId: GroupID,
+        groupInfo: ByteArray,
+        result: Either<CoreFailure, Unit>
+    ): MLSConversationRepositoryArrangementImpl
 }
 
 class MLSConversationRepositoryArrangementImpl : MLSConversationRepositoryArrangement {
@@ -52,6 +58,12 @@ class MLSConversationRepositoryArrangementImpl : MLSConversationRepositoryArrang
     override suspend fun withMembersIdentities(result: Either<CoreFailure, Map<UserId, List<WireIdentity>>>) {
         coEvery {
             mlsConversationRepository.getMembersIdentities(any(), any())
+        }.returns(result)
+    }
+
+    override suspend fun withJoinGroupByExternalCommit(groupId: GroupID, groupInfo: ByteArray, result: Either<CoreFailure, Unit>) = apply {
+        coEvery {
+            mlsConversationRepository.joinGroupByExternalCommit(groupId, groupInfo)
         }.returns(result)
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/mls/StaleEpochVerifierArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/mls/StaleEpochVerifierArrangement.kt
@@ -40,7 +40,7 @@ class StaleEpochVerifierArrangementImpl : StaleEpochVerifierArrangement {
 
     override suspend fun withVerifyEpoch(result: Either<CoreFailure, Unit>) {
         coEvery {
-            staleEpochVerifier.verifyEpoch(any(), any())
+            staleEpochVerifier.verifyEpoch(any(), any(), any())
         }.returns(result)
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/SubconversationRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/SubconversationRepositoryArrangement.kt
@@ -1,0 +1,137 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.util.arrangement.repository
+
+import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.data.conversation.SubConversation
+import com.wire.kalium.logic.data.conversation.SubconversationRepository
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.GroupID
+import com.wire.kalium.logic.data.id.SubconversationId
+import com.wire.kalium.logic.functional.Either
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.coEvery
+import io.mockative.mock
+
+internal interface SubconversationRepositoryArrangement {
+    val subconversationRepository: SubconversationRepository
+
+    suspend fun withInsertSubconversation(
+        conversationId: ConversationId,
+        subConversationId: SubconversationId,
+        groupId: GroupID
+    )
+
+    suspend fun withGetSubconversationInfo(
+        conversationId: ConversationId,
+        subConversationId: SubconversationId,
+        result: GroupID?
+    )
+
+    suspend fun withContainsSubconversation(groupId: GroupID, result: Boolean)
+
+    suspend fun withDeleteSubconversation(conversationId: ConversationId, subConversationId: SubconversationId)
+
+    suspend fun withDeleteRemoteSubConversation(
+        conversationId: ConversationId,
+        subConversationId: SubconversationId,
+        result: Either<CoreFailure, Unit>
+    )
+
+    suspend fun withFetchRemoteSubConversationGroupInfo(
+        conversationId: ConversationId,
+        subConversationId: SubconversationId,
+        result: Either<CoreFailure, ByteArray>
+    )
+
+    suspend fun withFetchRemoteSubConversationDetails(
+        conversationId: ConversationId,
+        subConversationId: SubconversationId,
+        result: Either<NetworkFailure, SubConversation>
+    )
+}
+
+internal class SubconversationRepositoryArrangementImpl : SubconversationRepositoryArrangement {
+
+    @Mock
+    override val subconversationRepository: SubconversationRepository = mock(SubconversationRepository::class)
+
+    override suspend fun withInsertSubconversation(
+        conversationId: ConversationId,
+        subConversationId: SubconversationId,
+        groupId: GroupID
+    ) {
+        coEvery {
+            subconversationRepository.insertSubconversation(conversationId, subConversationId, groupId)
+        }.returns(Unit)
+    }
+
+    override suspend fun withGetSubconversationInfo(
+        conversationId: ConversationId,
+        subConversationId: SubconversationId,
+        result: GroupID?
+    ) {
+        coEvery {
+            subconversationRepository.getSubconversationInfo(conversationId, subConversationId)
+        }.returns(result)
+    }
+
+    override suspend fun withContainsSubconversation(groupId: GroupID, result: Boolean) {
+        coEvery {
+            subconversationRepository.containsSubconversation(groupId)
+        }.returns(result)
+    }
+
+    override suspend fun withDeleteSubconversation(conversationId: ConversationId, subConversationId: SubconversationId) {
+        coEvery {
+            subconversationRepository.deleteSubconversation(conversationId, subConversationId)
+        }.returns(Unit)
+    }
+
+    override suspend fun withDeleteRemoteSubConversation(
+        conversationId: ConversationId,
+        subConversationId: SubconversationId,
+        result: Either<CoreFailure, Unit>
+    ) {
+        coEvery {
+            subconversationRepository.deleteRemoteSubConversation(conversationId, subConversationId, any())
+        }.returns(result)
+    }
+
+    override suspend fun withFetchRemoteSubConversationGroupInfo(
+        conversationId: ConversationId,
+        subConversationId: SubconversationId,
+        result: Either<CoreFailure, ByteArray>
+    ) {
+        coEvery {
+            subconversationRepository.fetchRemoteSubConversationGroupInfo(conversationId, subConversationId)
+        }.returns(result)
+    }
+
+    override suspend fun withFetchRemoteSubConversationDetails(
+        conversationId: ConversationId,
+        subConversationId: SubconversationId,
+        result: Either<NetworkFailure, SubConversation>
+    ) {
+        coEvery {
+            subconversationRepository.fetchRemoteSubConversationDetails(conversationId, subConversationId)
+        }.returns(result)
+    }
+}

--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/conversation/ConversationResponse.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/conversation/ConversationResponse.kt
@@ -255,11 +255,11 @@ data class SubconversationResponse(
     val mlsCipherSuiteTag: Int?,
 
     @SerialName("members")
-    val members: List<SubconversationMember>,
+    val members: List<SubconversationMemberDTO>,
 )
 
 @Serializable
-data class SubconversationMember(
+data class SubconversationMemberDTO(
     @SerialName("client_id") val clientId: String,
     @SerialName("user_id") val userId: String,
     @SerialName("domain") val domain: String


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15647" title="WPB-15647" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15647</a>  [Android] epoch check for sub conversations is verifying the main conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The previous implementation did not handle epoch verification for sub-conversations. As a result, the verification process always checked the parent conversation's epoch, leading to incorrect behavior when the sub-conversation epoch was out of sync while the parent conversation's epoch remained valid.

### Causes

1. **Lack of Sub-Conversation Handling**: Sub-conversations were not considered during epoch verification.
2. **Missing Models and Logic**: There were no models or logic in place to support sub-conversation-specific checks.
3. **Incorrect Parent Conversation Focus**: Epoch verification defaulted to the parent conversation, ignoring sub-conversations entirely.

### Solutions

1. **Added `verifySubConversationEpoch`**:
   - A dedicated method to verify epochs for sub-conversations, ensuring accurate context for verification.

2. **Sub-Conversation Repository Arrangement**:
   - Created `SubconversationRepositoryArrangement` to mock and test sub-conversation-related methods efficiently.

3. **Introduced Sub-Conversation Models**:
   - Added models in the `logic` module to handle sub-conversations as first-class entities.

4. **Updated Epoch Verification Logic**:
   - Refactored `NewMessageEventHandler` to call `verifySubConversationEpoch` when a `subConversationId` is provided.

5. **Added Comprehensive Tests**:
   - Verified that `fetchConversation` is not called when a `subConversationId` is present.
   - Ensured correct behavior for valid epochs, stale epochs, and failures.
