### PR TITLE
fix: ignore subconversation message fail system message [WPB-15684]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
@@ -112,17 +112,20 @@ internal class NewMessageEventHandlerImpl(
 
                     is MLSMessageFailureResolution.InformUser -> {
                         eventLogger.logFailure(it, "protocol" to "MLS", "mlsOutcome" to "INFORM_USER")
-                        applicationMessageHandler.handleDecryptionError(
-                            eventId = event.id,
-                            conversationId = event.conversationId,
-                            messageInstant = event.messageInstant,
-                            senderUserId = event.senderUserId,
-                            senderClientId = ClientId(""), // TODO(mls): client ID not available for MLS messages
-                            content = MessageContent.FailedDecryption(
-                                isDecryptionResolved = false,
-                                senderUserId = event.senderUserId
+                        // messages from subconversations should not send a system message
+                        if (event.subconversationId == null) {
+                            applicationMessageHandler.handleDecryptionError(
+                                eventId = event.id,
+                                conversationId = event.conversationId,
+                                messageInstant = event.messageInstant,
+                                senderUserId = event.senderUserId,
+                                senderClientId = ClientId(""), // TODO(mls): client ID not available for MLS messages
+                                content = MessageContent.FailedDecryption(
+                                    isDecryptionResolved = false,
+                                    senderUserId = event.senderUserId
+                                )
                             )
-                        )
+                        }
                     }
 
                     is MLSMessageFailureResolution.OutOfSync -> {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.logic.data.event.EventEnvelope
 import com.wire.kalium.logic.data.event.MemberLeaveReason
 import com.wire.kalium.logic.data.featureConfig.AppLockModel
 import com.wire.kalium.logic.data.featureConfig.Status
+import com.wire.kalium.logic.data.id.SubconversationId
 import com.wire.kalium.logic.data.user.Connection
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
@@ -198,11 +199,12 @@ object TestEvent {
     )
 
     fun newMLSMessageEvent(
-        dateTime: Instant
+        dateTime: Instant,
+        subConversationId: SubconversationId? = null
     ) = Event.Conversation.NewMLSMessage(
         "eventId",
         TestConversation.ID,
-        null,
+        subConversationId,
         TestUser.USER_ID,
         dateTime,
         "content".encodeBase64(),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15684" title="WPB-15684" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15684</a>  [Android] SubConversation messages sends system messages when fails to decrypt
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Previously, system messages were being sent for MLS messages even when the `subConversationId` was present. This behavior was incorrect because sub-conversations should not trigger system messages for decryption errors.

### Solutions

1. **Sub-Conversation Check**: 
   - Updated the code to skip sending system messages if `subConversationId` is not null when handling `InformUser` failures.
   - This ensures that sub-conversation-specific events are handled correctly without unnecessary system messages.

2. **Comprehensive Testing**:
   - Added a new test case to verify that `handleDecryptionError` is not invoked when `subConversationId` is present.
   - Ensured that all related scenarios are covered to prevent regressions.
