### PR TITLE
refactor(backup): enhance error handling and test coverage [WPB-10575]

### DIFF
--- a/backup/src/commonMain/kotlin/com/wire/backup/encryption/EncryptedStream.kt
+++ b/backup/src/commonMain/kotlin/com/wire/backup/encryption/EncryptedStream.kt
@@ -161,12 +161,12 @@ internal interface EncryptedStream<AuthenticationData> {
 
 internal sealed interface DecryptionResult {
     data object Success : DecryptionResult
-    data object Failure : DecryptionResult {
+    sealed interface Failure : DecryptionResult {
         /**
          * Wrong passphrase, salt, header, or additional data
          */
-        data object AuthenticationFailure : DecryptionResult
-        data class Unknown(val message: String) : DecryptionResult
+        data object AuthenticationFailure : Failure
+        data class Unknown(val message: String) : Failure
     }
 }
 

--- a/backup/src/commonMain/kotlin/com/wire/backup/filesystem/InMemoryEntryStorage.kt
+++ b/backup/src/commonMain/kotlin/com/wire/backup/filesystem/InMemoryEntryStorage.kt
@@ -22,6 +22,7 @@ import okio.buffer
 
 /**
  * As JS on a browser doesn't have access to files, we just write stuff in memory.
+ * It is also useful for tests.
  */
 internal class InMemoryEntryStorage : EntryStorage {
 

--- a/backup/src/commonMain/kotlin/com/wire/backup/ingest/BackupImportResult.kt
+++ b/backup/src/commonMain/kotlin/com/wire/backup/ingest/BackupImportResult.kt
@@ -23,7 +23,17 @@ import kotlin.js.JsExport
 public sealed class BackupImportResult {
     public class Success(public val pager: BackupImportPager) : BackupImportResult()
     public sealed class Failure : BackupImportResult() {
+        /**
+         * The file has an incompatible format.
+         * _i.e._ it isn't a Wire Backup file, or it is from an unsupported version.
+         */
         public data object ParsingFailure : Failure()
         public data object MissingOrWrongPassphrase : Failure()
+
+        /**
+         * Error thrown during unzipping.
+         */
+        public data class UnzippingError(public val message: String) : Failure()
+        public data class UnknownError(public val message: String) : Failure()
     }
 }

--- a/backup/src/commonTest/kotlin/com/wire/backup/envelope/header/FakeHeaderSerializer.kt
+++ b/backup/src/commonTest/kotlin/com/wire/backup/envelope/header/FakeHeaderSerializer.kt
@@ -1,0 +1,48 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.backup.envelope.header
+
+import com.wire.backup.envelope.BackupHeader
+import com.wire.backup.envelope.BackupHeaderSerializer
+import com.wire.backup.envelope.HashData
+import com.wire.backup.envelope.HeaderParseResult
+import okio.Source
+
+internal class FakeHeaderSerializer(
+    private val bytes: ByteArray = byteArrayOf(),
+    private val parseResult: HeaderParseResult = HeaderParseResult.Success(fakeBackupHeader())
+) : BackupHeaderSerializer {
+    override fun headerToBytes(header: BackupHeader): ByteArray {
+        return bytes
+    }
+
+    override fun parseHeader(source: Source): HeaderParseResult {
+        return parseResult
+    }
+}
+
+internal fun fakeBackupHeader() = BackupHeader(
+    version = 1,
+    isEncrypted = true,
+    hashData = HashData(
+        hashedUserId = UByteArray(HashData.HASHED_USER_ID_SIZE_IN_BYTES),
+        salt = UByteArray(HashData.SALT_SIZE_IN_BYTES),
+        operationsLimit = 4UL,
+        hashingMemoryLimit = HashData.MINIMUM_MEMORY_LIMIT
+    )
+)

--- a/backup/src/commonTest/kotlin/com/wire/backup/ingest/MPBackupImporterTest.kt
+++ b/backup/src/commonTest/kotlin/com/wire/backup/ingest/MPBackupImporterTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.backup.ingest
+
+import com.wire.backup.encryption.DecryptionResult
+import com.wire.backup.encryption.EncryptedStream
+import com.wire.backup.encryption.XChaChaPoly1305AuthenticationData
+import com.wire.backup.envelope.BackupHeaderSerializer
+import com.wire.backup.envelope.HeaderParseResult
+import com.wire.backup.envelope.header.FakeHeaderSerializer
+import com.wire.backup.filesystem.EntryStorage
+import com.wire.backup.filesystem.InMemoryEntryStorage
+import kotlinx.coroutines.test.runTest
+import okio.Buffer
+import okio.Sink
+import okio.Source
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class MPBackupImporterTest {
+
+    private fun createSubject(
+        unzipEntries: () -> EntryStorage = { InMemoryEntryStorage() },
+        encryptedStream: EncryptedStream<XChaChaPoly1305AuthenticationData> = EncryptedStream.XChaCha20Poly1305,
+        headerSerializer: BackupHeaderSerializer = BackupHeaderSerializer.Default,
+    ): CommonMPBackupImporter = object : CommonMPBackupImporter(encryptedStream, headerSerializer) {
+        override fun getUnencryptedArchiveSink(): Sink = Buffer()
+
+        override suspend fun unzipAllEntries() = unzipEntries()
+    }
+
+    @Test
+    fun givenFailureToParseHeader_whenImporting_thenFailureIsReturned() = runTest {
+        val subject = createSubject(
+            headerSerializer = FakeHeaderSerializer(parseResult = HeaderParseResult.Failure.UnknownFormat)
+        )
+        val result = subject.importBackup(Buffer(), null)
+
+        assertEquals(BackupImportResult.Failure.ParsingFailure, result)
+    }
+
+    @Test
+    fun givenNoPasswordAndBackupIsEncrypted_whenImporting_thenMissingPasswordIsReturned() = runTest {
+        val subject = createSubject(
+            headerSerializer = FakeHeaderSerializer()
+        )
+        val result = subject.importBackup(Buffer(), null)
+
+        assertEquals(BackupImportResult.Failure.MissingOrWrongPassphrase, result)
+    }
+
+    @Test
+    fun givenDecryptionFailsForUnknownReason_whenImporting_thenFailureIsReturned() = runTest {
+        val decryptionResult = DecryptionResult.Failure.Unknown("Oopsie")
+        val subject = createSubject(
+            headerSerializer = FakeHeaderSerializer(),
+            encryptedStream = object : EncryptedStream<XChaChaPoly1305AuthenticationData> by EncryptedStream.XChaCha20Poly1305 {
+                override suspend fun decrypt(
+                    source: Source,
+                    outputSink: Sink,
+                    authenticationData: XChaChaPoly1305AuthenticationData
+                ): DecryptionResult = decryptionResult
+            }
+        )
+        val result = subject.importBackup(Buffer(), "pass")
+
+        assertIs<BackupImportResult.Failure.UnknownError>(result)
+        assertEquals(decryptionResult.message, result.message)
+    }
+
+    @Test
+    fun givenDecryptionFailsDueToWrongPassword_whenImporting_thenFailureIsReturned() = runTest {
+        val decryptionResult = DecryptionResult.Failure.AuthenticationFailure
+        val subject = createSubject(
+            headerSerializer = FakeHeaderSerializer(),
+            encryptedStream = object : EncryptedStream<XChaChaPoly1305AuthenticationData> by EncryptedStream.XChaCha20Poly1305 {
+                override suspend fun decrypt(
+                    source: Source,
+                    outputSink: Sink,
+                    authenticationData: XChaChaPoly1305AuthenticationData
+                ): DecryptionResult = decryptionResult
+            }
+        )
+        val result = subject.importBackup(Buffer(), "pass")
+
+        assertIs<BackupImportResult.Failure.MissingOrWrongPassphrase>(result)
+    }
+
+    @Test
+    fun givenUnzippingThrows_whenImporting_thenFailureIsReturned() = runTest {
+        val throwable = IllegalStateException("something went wrong")
+        val subject = createSubject(
+            unzipEntries = { throw throwable },
+            encryptedStream = object : EncryptedStream<XChaChaPoly1305AuthenticationData> by EncryptedStream.XChaCha20Poly1305 {
+                override suspend fun decrypt(
+                    source: Source,
+                    outputSink: Sink,
+                    authenticationData: XChaChaPoly1305AuthenticationData
+                ): DecryptionResult = DecryptionResult.Success
+            },
+            headerSerializer = FakeHeaderSerializer()
+        )
+        val result = subject.importBackup(Buffer(), "pass")
+
+        assertIs<BackupImportResult.Failure.UnzippingError>(result)
+        assertEquals(throwable.message, result.message)
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10575" title="WPB-10575" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-10575</a>  Cross Platform Backup: Write common backup / restore library
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some possible errors (mainly IO) during unzipping and decryption are not being handled.

### Solutions

Refactored the backup import process to improve error handling by introducing more granular failure types. Added comprehensive test coverage, including tests for edge cases in decryption, parsing, and unzipping.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

Other than the current End-To-End test for the happy paths, a new test suite for the failures was introduced.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
