### PR TITLE
chore(backup): improve backup export error handling [WPB-10575]

### DIFF
--- a/backup/build.gradle.kts
+++ b/backup/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
     id(libs.plugins.kalium.library.get().pluginId)
+    alias(libs.plugins.kotlinNativeCoroutines)
 }
 
 kaliumLibrary {
@@ -59,6 +60,7 @@ kotlin {
         all {
             languageSettings.optIn("kotlin.ExperimentalUnsignedTypes")
             languageSettings.optIn("kotlin.experimental.ExperimentalObjCRefinement")
+            languageSettings.optIn("kotlin.experimental.ExperimentalObjCName")
             languageSettings.optIn("kotlin.js.ExperimentalJsExport")
         }
         val commonMain by getting {

--- a/backup/src/commonMain/kotlin/com/wire/backup/dump/ExportResult.kt
+++ b/backup/src/commonMain/kotlin/com/wire/backup/dump/ExportResult.kt
@@ -1,0 +1,28 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.backup.dump
+
+internal sealed interface ExportResult {
+
+    data object Success : ExportResult
+
+    sealed class Failure(val message: String) : ExportResult {
+        class IOError(message: String) : Failure(message)
+        class ZipError(message: String) : Failure(message)
+    }
+}

--- a/backup/src/commonTest/kotlin/com/wire/backup/dump/MPBackupExporterTest.kt
+++ b/backup/src/commonTest/kotlin/com/wire/backup/dump/MPBackupExporterTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.backup.dump
+
+import com.wire.backup.data.BackupQualifiedId
+import com.wire.backup.filesystem.BackupEntry
+import com.wire.backup.filesystem.EntryStorage
+import com.wire.backup.filesystem.InMemoryEntryStorage
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.test.runTest
+import okio.Buffer
+import okio.Source
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class MPBackupExporterTest {
+
+    @Test
+    fun givenZippingError_whenFinalizing_thenZipErrorShouldBeReturned() = runTest {
+        val thrownException = IllegalStateException("Zipping failed!")
+        val subject = object : CommonMPBackupExporter(
+            BackupQualifiedId("user", "domain")
+        ) {
+            override val storage: EntryStorage = InMemoryEntryStorage()
+
+            override fun zipEntries(data: List<BackupEntry>): Deferred<Source> {
+                throw thrownException
+            }
+        }
+
+        val result = subject.finalize(null, Buffer())
+        assertIs<ExportResult.Failure.ZipError>(result)
+        assertEquals(thrownException.message, result.message)
+    }
+
+}

--- a/backup/src/jsMain/kotlin/com/wire/backup/dump/BackupExportResult.kt
+++ b/backup/src/jsMain/kotlin/com/wire/backup/dump/BackupExportResult.kt
@@ -1,0 +1,36 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.backup.dump
+
+@JsExport
+public sealed class BackupExportResult {
+    public class Success(public val bytes: ByteArray) : BackupExportResult()
+    public sealed class Failure(public val message: String) : BackupExportResult() {
+        /**
+         * Represents an I/O error that occurs during an export process.
+         *
+         * It's unlikely for this to ever be thrown on JavaScript/Browser
+         */
+        public class IOError(message: String) : Failure(message)
+
+        /**
+         * An error happened during the zipping process.
+         */
+        public class ZipError(message: String) : Failure(message)
+    }
+}

--- a/backup/src/jsMain/kotlin/com/wire/backup/dump/MPBackupExporter.kt
+++ b/backup/src/jsMain/kotlin/com/wire/backup/dump/MPBackupExporter.kt
@@ -58,11 +58,12 @@ public actual class MPBackupExporter(
         return result.asDeferred()
     }
 
-    public fun finalize(password: String?): Promise<ByteArray> {
-        return GlobalScope.promise {
-            val output = Buffer()
-            finalize(password, output)
-            output.readByteArray()
+    public fun finalize(password: String?): Promise<BackupExportResult> = GlobalScope.promise {
+        val output = Buffer()
+        when (val result = finalize(password, output)) {
+            is ExportResult.Failure.IOError -> BackupExportResult.Failure.IOError(result.message)
+            is ExportResult.Failure.ZipError -> BackupExportResult.Failure.ZipError(result.message)
+            ExportResult.Success -> BackupExportResult.Success(output.readByteArray())
         }
     }
 }

--- a/backup/src/jsTest/kotlin/com/wire/backup/BackupEndToEndTest.kt
+++ b/backup/src/jsTest/kotlin/com/wire/backup/BackupEndToEndTest.kt
@@ -18,6 +18,7 @@
 package com.wire.backup
 
 import com.wire.backup.data.BackupQualifiedId
+import com.wire.backup.dump.BackupExportResult
 import com.wire.backup.dump.CommonMPBackupExporter
 import com.wire.backup.dump.MPBackupExporter
 import com.wire.backup.ingest.BackupImportResult
@@ -34,7 +35,7 @@ actual fun endToEndTestSubjectProvider() = object : CommonBackupEndToEndTestSubj
         val exporter = MPBackupExporter(selfUserId)
         exporter.export()
         val artifactPath = exporter.finalize(passphrase)
-        val artifactData = artifactPath.await()
+        val artifactData = (artifactPath.await() as BackupExportResult.Success).bytes
         val importer = MPBackupImporter()
         return importer.importFromFileData(artifactData, passphrase).await()
     }

--- a/backup/src/nonJsMain/kotlin/com/wire/backup/dump/BackupExportResult.kt
+++ b/backup/src/nonJsMain/kotlin/com/wire/backup/dump/BackupExportResult.kt
@@ -1,0 +1,40 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.backup.dump
+
+public sealed interface BackupExportResult {
+    /**
+     * Represents a successful result of a backup export operation.
+     *
+     * @property pathToOutputFile The path to the resulting output file of the export.
+     */
+    public class Success(public val pathToOutputFile: String) : BackupExportResult
+    public sealed interface Failure : BackupExportResult {
+        public val message: String
+
+        /**
+         * Represents an I/O error that occurs during an export process.
+         */
+        public class IOError(override val message: String) : Failure
+
+        /**
+         * An error happened during the zipping process.
+         */
+        public class ZipError(override val message: String) : Failure
+    }
+}

--- a/backup/src/nonJsMain/kotlin/com/wire/backup/ingest/MPBackupImporter.kt
+++ b/backup/src/nonJsMain/kotlin/com/wire/backup/ingest/MPBackupImporter.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.backup.ingest
 
+import com.rickclephas.kmp.nativecoroutines.NativeCoroutines
 import com.wire.backup.filesystem.EntryStorage
 import com.wire.backup.filesystem.FileBasedEntryStorage
 import okio.FileSystem
@@ -45,6 +46,7 @@ public actual class MPBackupImporter(
      * @param multiplatformBackupFilePath the path to the decrypted, unzipped backup data file
      */
     @ObjCName("importFile")
+    @NativeCoroutines
     public suspend fun importFromFile(
         multiplatformBackupFilePath: String,
         passphrase: String?,

--- a/backup/src/nonJsTest/kotlin/com/wire/backup/BackupEndToEndTest.kt
+++ b/backup/src/nonJsTest/kotlin/com/wire/backup/BackupEndToEndTest.kt
@@ -18,6 +18,7 @@
 package com.wire.backup
 
 import com.wire.backup.data.BackupQualifiedId
+import com.wire.backup.dump.BackupExportResult
 import com.wire.backup.dump.CommonMPBackupExporter
 import com.wire.backup.dump.MPBackupExporter
 import com.wire.backup.ingest.BackupImportResult
@@ -51,7 +52,8 @@ actual fun endToEndTestSubjectProvider() = object : CommonBackupEndToEndTestSubj
             zipper
         )
         exporter.export()
-        val artifactPath = exporter.finalize(passphrase)
+        val artifactPath = (exporter.finalize(passphrase) as BackupExportResult.Success).pathToOutputFile
+
         val importer = MPBackupImporter(exportDirectory.toString(), zipper)
         return importer.importFromFile(artifactPath, passphrase)
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ cryptobox4j = "1.4.0"
 cryptobox-android = "1.1.5"
 android-security = "1.1.0-alpha06"
 ktor = "2.3.10"
+kotlinNativeCoroutines = "1.0.0-ALPHA-26"
 okio = "3.9.0"
 ok-http = "4.12.0"
 mockative = "2.2.0"
@@ -79,6 +80,7 @@ moduleGraph = { id = "dev.iurysouza.modulegraph", version.ref = "moduleGraph" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kotlinNativeCoroutines = { id = "com.rickclephas.kmp.nativecoroutines", version.ref = "kotlinNativeCoroutines"}
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 carthage = { id = "com.wire.carthage-gradle-plugin", version.ref = "carthage" }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10575" title="WPB-10575" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-10575</a>  Cross Platform Backup: Write common backup / restore library
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Follow-up on:
- #3248

but for exporting.

### Solutions

Encapsulate and catch failures during the exporting process. Either ZIP or IO Errors can happen at this stage.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
