### PR TITLE
chore: one on one conversation details [WPB-15479]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -319,6 +319,7 @@ interface ConversationRepository {
     suspend fun addConversationToDeleteQueue(conversationId: ConversationId)
     suspend fun removeConversationFromDeleteQueue(conversationId: ConversationId)
     suspend fun getConversationsDeleteQueue(): List<ConversationId>
+    suspend fun observeOneToOneConversationDetailsWithOtherUser(otherUserId: UserId): Flow<Either<StorageFailure, ConversationDetails.OneOne>>
 }
 
 @Suppress("LongParameterList", "TooManyFunctions", "LargeClass")
@@ -792,6 +793,16 @@ internal class ConversationDataSource internal constructor(
             .wrapStorageRequest()
             .mapRight { conversationMapper.fromDaoModel(it) }
     }
+
+    override suspend fun observeOneToOneConversationDetailsWithOtherUser(
+        otherUserId: UserId
+    ): Flow<Either<StorageFailure, ConversationDetails.OneOne>> {
+        println("KBX other user id $otherUserId")
+        return conversationDAO.observeOneOnOneConversationDetailsWithOtherUser(otherUserId.toDao())
+            .map { it?.let { conversationMapper.fromDaoModelToDetails(it) as? ConversationDetails.OneOne } }
+            .wrapStorageRequest()
+    }
+
 
     override suspend fun getOneOnOneConversationsWithOtherUser(
         otherUserId: UserId,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -319,7 +319,9 @@ interface ConversationRepository {
     suspend fun addConversationToDeleteQueue(conversationId: ConversationId)
     suspend fun removeConversationFromDeleteQueue(conversationId: ConversationId)
     suspend fun getConversationsDeleteQueue(): List<ConversationId>
-    suspend fun observeOneToOneConversationDetailsWithOtherUser(otherUserId: UserId): Flow<Either<StorageFailure, ConversationDetails.OneOne>>
+    suspend fun observeOneToOneConversationDetailsWithOtherUser(
+        otherUserId: UserId
+    ): Flow<Either<StorageFailure, ConversationDetails.OneOne>>
 }
 
 @Suppress("LongParameterList", "TooManyFunctions", "LargeClass")
@@ -797,12 +799,10 @@ internal class ConversationDataSource internal constructor(
     override suspend fun observeOneToOneConversationDetailsWithOtherUser(
         otherUserId: UserId
     ): Flow<Either<StorageFailure, ConversationDetails.OneOne>> {
-        println("KBX other user id $otherUserId")
         return conversationDAO.observeOneOnOneConversationDetailsWithOtherUser(otherUserId.toDao())
             .map { it?.let { conversationMapper.fromDaoModelToDetails(it) as? ConversationDetails.OneOne } }
             .wrapStorageRequest()
     }
-
 
     override suspend fun getOneOnOneConversationsWithOtherUser(
         otherUserId: UserId,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -136,8 +136,8 @@ class ConversationScope internal constructor(
     val getConversationDetails: GetConversationUseCase
         get() = GetConversationUseCase(conversationRepository)
 
-    val getOneToOneConversation: GetOneToOneConversationUseCase
-        get() = GetOneToOneConversationUseCase(conversationRepository)
+    val getOneToOneConversation: GetOneToOneConversationDetailsUseCase
+        get() = GetOneToOneConversationDetailsUseCase(conversationRepository)
 
     val observeConversationListDetails: ObserveConversationListDetailsUseCase
         get() = ObserveConversationListDetailsUseCaseImpl(conversationRepository)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetOneToOneConversationDetailsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetOneToOneConversationDetailsUseCase.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.logic.feature.conversation
 
 import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.functional.fold
@@ -35,18 +36,18 @@ import kotlinx.coroutines.flow.map
  * @return [Result.Success] with [Conversation] in case of success,
  * or [Result.Failure] if something went wrong - can't get data from local DB.
  */
-class GetOneToOneConversationUseCase internal constructor(
+class GetOneToOneConversationDetailsUseCase internal constructor(
     private val conversationRepository: ConversationRepository,
     private val dispatchers: KaliumDispatcher = KaliumDispatcherImpl
 ) {
 
     suspend operator fun invoke(otherUserId: UserId): Flow<Result> =
-        conversationRepository.observeOneToOneConversationWithOtherUser(otherUserId)
+        conversationRepository.observeOneToOneConversationDetailsWithOtherUser(otherUserId)
             .map { result -> result.fold({ Result.Failure }, { Result.Success(it) }) }
             .flowOn(dispatchers.io)
 
     sealed class Result {
-        data class Success(val conversation: Conversation) : Result()
+        data class Success(val conversation: ConversationDetails.OneOne) : Result()
         data object Failure : Result()
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -418,7 +418,7 @@ class ConversationRepositoryTest {
         }
 
     @Test
-    fun givenUserHasKnownContactAndConversation_WhenGettingConversationDetailsByExistingConversation_ReturnTheCorrectConversation() =
+    fun givenUserHasKnownContactAndConversation_WhenGettingConversationByExistingConversation_ReturnTheCorrectConversation() =
         runTest {
             // given
             val (_, conversationRepository) = Arrangement()
@@ -429,6 +429,25 @@ class ConversationRepositoryTest {
 
             // when
             conversationRepository.observeOneToOneConversationWithOtherUser(OTHER_USER_ID).test {
+                val result = awaitItem()
+                // then
+                assertIs<Either.Right<ConversationDetails.OneOne>>(result)
+                awaitComplete()
+            }
+        }
+
+    @Test
+    fun givenUserHasKnownContactAndConversation_WhenGettingConversationDetailsByExistingConversation_ReturnTheCorrectConversationDetails() =
+        runTest {
+            // given
+            val (_, conversationRepository) = Arrangement()
+                .withSelfUserFlow(flowOf(TestUser.SELF))
+                .withExpectedConversationDetailsWithOtherUser(TestConversation.VIEW_ONE_ON_ONE.copy(otherUserId = OTHER_USER_ID.toDao()))
+                .withExpectedOtherKnownUser(TestUser.OTHER)
+                .arrange()
+
+            // when
+            conversationRepository.observeOneToOneConversationDetailsWithOtherUser(OTHER_USER_ID).test {
                 val result = awaitItem()
                 // then
                 assertIs<Either.Right<ConversationDetails.OneOne>>(result)
@@ -1525,6 +1544,12 @@ class ConversationRepositoryTest {
         suspend fun withExpectedConversationWithOtherUser(conversation: ConversationEntity?) = apply {
             coEvery {
                 conversationDAO.observeOneOnOneConversationWithOtherUser(any())
+            }.returns(flowOf(conversation))
+        }
+
+        suspend fun withExpectedConversationDetailsWithOtherUser(conversation: ConversationViewEntity?) = apply {
+            coEvery {
+                conversationDAO.observeOneOnOneConversationDetailsWithOtherUser(any())
             }.returns(flowOf(conversation))
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -22,10 +22,12 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.Conversation.Member
 import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo
 import com.wire.kalium.logic.data.conversation.ConversationRepositoryTest
+import com.wire.kalium.logic.data.conversation.ConversationRepositoryTest.Companion.OTHER_USER_ID
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.toApi
+import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.mls.CipherSuite
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.network.api.authenticated.conversation.ConvProtocol
@@ -300,6 +302,7 @@ object TestConversation {
     val ENTITY_GROUP = ENTITY.copy(
         type = ConversationEntity.Type.GROUP
     )
+
     val VIEW_ENTITY = ConversationViewEntity(
         id = ENTITY_ID,
         name = "convo name",
@@ -346,6 +349,10 @@ object TestConversation {
         isFavorite = false,
         folderId = null,
         folderName = null
+    )
+
+    val VIEW_ONE_ON_ONE = VIEW_ENTITY.copy(
+        type = ConversationEntity.Type.ONE_ON_ONE,
     )
 
     val MLS_PROTOCOL_INFO = ProtocolInfo.MLS(

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationDetails.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationDetails.sq
@@ -158,3 +158,7 @@ SELECT * FROM ConversationDetails WHERE qualifiedId = ?;
 
 selectConversationDetailsByGroupId:
 SELECT * FROM ConversationDetails WHERE mls_group_id = ?;
+
+selectActiveOneOnOneConversationDetails:
+SELECT * FROM ConversationDetails
+WHERE qualifiedId = (SELECT active_one_on_one_conversation_id FROM User WHERE qualified_id = :user_id);

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
@@ -145,6 +145,7 @@ interface ConversationDAO {
     suspend fun getEstablishedSelfMLSGroupId(): String?
 
     suspend fun selectGroupStatusMembersNamesAndHandles(groupID: String): EpochChangesDataEntity?
+    suspend fun observeOneOnOneConversationDetailsWithOtherUser(userId: UserIDEntity): Flow<ConversationViewEntity?>
 }
 
 data class NameAndHandleEntity(

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
@@ -277,6 +277,13 @@ internal class ConversationDAOImpl internal constructor(
             .flowOn(coroutineContext)
     }
 
+    override suspend fun observeOneOnOneConversationDetailsWithOtherUser(userId: UserIDEntity): Flow<ConversationViewEntity?> {
+        return conversationDetailsQueries.selectActiveOneOnOneConversationDetails(userId, conversationMapper::fromViewToModel)
+            .asFlow()
+            .mapToOneOrNull()
+            .flowOn(coroutineContext)
+    }
+
     override suspend fun getConversationProtocolInfo(qualifiedID: QualifiedIDEntity): ConversationEntity.ProtocolInfo? =
         withContext(coroutineContext) {
             conversationQueries.selectProtocolInfoByQualifiedId(qualifiedID, conversationMapper::mapProtocolInfo).executeAsOneOrNull()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15479" title="WPB-15479" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15479</a>  [Android] Allow 1:1 conversations to be moved from user profile to folder
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- updated `GetOneToOneConversationUseCase` to `GetOneToOneConversationDetailsUseCase` which will return 
`ConversationDetails.OneOne` to have access to information about folders