### PR TITLE
feat(backup): support file peeking [WPB-10575]

### DIFF
--- a/backup/src/commonMain/kotlin/com/wire/backup/envelope/BackupHeader.kt
+++ b/backup/src/commonMain/kotlin/com/wire/backup/envelope/BackupHeader.kt
@@ -22,6 +22,8 @@ package com.wire.backup.envelope
 import com.ionspin.kotlin.crypto.pwhash.crypto_pwhash_MEMLIMIT_MIN
 import com.wire.backup.data.BackupQualifiedId
 import com.wire.backup.encryption.XChaChaPoly1305AuthenticationData
+import com.wire.backup.envelope.HashData.Companion.HASHED_USER_ID_SIZE_IN_BYTES
+import com.wire.backup.envelope.HashData.Companion.SALT_SIZE_IN_BYTES
 import com.wire.backup.hash.HASH_MEM_LIMIT
 import com.wire.backup.hash.HASH_OPS_LIMIT
 import com.wire.backup.hash.hashUserId

--- a/backup/src/commonMain/kotlin/com/wire/backup/ingest/BackupPeekResult.kt
+++ b/backup/src/commonMain/kotlin/com/wire/backup/ingest/BackupPeekResult.kt
@@ -21,9 +21,15 @@ import kotlin.js.JsExport
 
 @JsExport
 public sealed class BackupPeekResult {
+    /**
+     * The provided data corresponds to a compatible backup artifact.
+     *
+     * @property isCreatedBySameUser - true if the provided UserId matches the UserId that created the backup.
+     */
     public data class Success(
         val version: String,
         val isEncrypted: Boolean,
+        val isCreatedBySameUser: Boolean,
         /** TODO: Add more info about the backup */
     ) : BackupPeekResult()
 

--- a/backup/src/commonTest/kotlin/com/wire/backup/ingest/BackupPeekResultTest.kt
+++ b/backup/src/commonTest/kotlin/com/wire/backup/ingest/BackupPeekResultTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.backup.ingest
+
+import com.wire.backup.data.BackupQualifiedId
+import com.wire.backup.envelope.HashData
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class BackupPeekResultTest {
+
+    @Test
+    fun givenResultWasCreatedBySameUserId_whenComparingResult_thenShouldReturnTrue() = runTest {
+        val creatorUserId = BackupQualifiedId("123", "456")
+        val subject = BackupPeekResult.Success("42", false, HashData.defaultFromUserId(creatorUserId))
+        assertTrue { subject.isCreatedBySameUser(creatorUserId) }
+    }
+
+    @Test
+    fun givenResultWasCreatedByUserIdWithDifferentDomain_whenComparingResult_thenShouldReturnFalse() = runTest {
+        val creatorUserId = BackupQualifiedId("123", "456")
+        val otherUserId = BackupQualifiedId("123", "789")
+        val subject = BackupPeekResult.Success("42", false, HashData.defaultFromUserId(creatorUserId))
+        assertFalse { subject.isCreatedBySameUser(otherUserId) }
+    }
+
+    @Test
+    fun givenResultWasCreatedByDifferentUserId_whenComparingResult_thenShouldReturnFalse() = runTest {
+        val creatorUserId = BackupQualifiedId("123", "456")
+        val otherUserId = BackupQualifiedId("234", "456")
+        val subject = BackupPeekResult.Success("42", false, HashData.defaultFromUserId(creatorUserId))
+        assertFalse { subject.isCreatedBySameUser(otherUserId) }
+    }
+}

--- a/backup/src/commonTest/kotlin/com/wire/backup/ingest/MPBackupImporterTest.kt
+++ b/backup/src/commonTest/kotlin/com/wire/backup/ingest/MPBackupImporterTest.kt
@@ -34,9 +34,7 @@ import okio.Sink
 import okio.Source
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertIs
-import kotlin.test.assertTrue
 
 class MPBackupImporterTest {
 
@@ -140,31 +138,10 @@ class MPBackupImporterTest {
         buffer.write(data)
         val subject = createSubject()
 
-        val result = subject.peekBackup(buffer, userId)
+        val result = subject.peekBackup(buffer)
         assertIs<BackupPeekResult.Success>(result)
         assertEquals(header.version.toString(), result.version)
         assertEquals(header.isEncrypted, result.isEncrypted)
-        assertTrue { result.isCreatedBySameUser }
-    }
-
-    @Test
-    fun givenBackupWasNotCreatedBySameUserId_whenPeeking_thenCorrectDataIsReturned() = runTest {
-        val userId = BackupQualifiedId("user", "domain")
-        val header = BackupHeader(
-            version = BackupHeaderSerializer.Default.MAXIMUM_SUPPORTED_VERSION,
-            isEncrypted = true,
-            hashData = HashData.defaultFromUserId(userId)
-        )
-        val data = BackupHeaderSerializer.Default.headerToBytes(header)
-        val buffer = Buffer()
-        buffer.write(data)
-        val subject = createSubject()
-
-        val result = subject.peekBackup(buffer, userId.copy(id = "otherUser"))
-        assertIs<BackupPeekResult.Success>(result)
-        assertEquals(header.version.toString(), result.version)
-        assertEquals(header.isEncrypted, result.isEncrypted)
-        assertFalse { result.isCreatedBySameUser }
     }
 
     @Test
@@ -180,7 +157,7 @@ class MPBackupImporterTest {
         buffer.write(data)
         val subject = createSubject()
 
-        val result = subject.peekBackup(buffer, userId.copy(id = "otherUser"))
+        val result = subject.peekBackup(buffer)
         assertIs<BackupPeekResult.Failure.UnsupportedVersion>(result)
         assertEquals(header.version.toString(), result.backupVersion)
     }
@@ -192,7 +169,7 @@ class MPBackupImporterTest {
         buffer.write(data)
         val subject = createSubject()
 
-        val result = subject.peekBackup(buffer, BackupQualifiedId("user", "domain"))
+        val result = subject.peekBackup(buffer)
         assertIs<BackupPeekResult.Failure.UnknownFormat>(result)
     }
 }

--- a/backup/src/jsMain/kotlin/com/wire/backup/ingest/MPBackupImporter.kt
+++ b/backup/src/jsMain/kotlin/com/wire/backup/ingest/MPBackupImporter.kt
@@ -17,7 +17,6 @@
  */
 package com.wire.backup.ingest
 
-import com.wire.backup.data.BackupQualifiedId
 import com.wire.backup.dump.JSZip
 import com.wire.backup.filesystem.BackupEntry
 import com.wire.backup.filesystem.EntryStorage
@@ -36,10 +35,10 @@ import kotlin.js.Promise
 public actual class MPBackupImporter : CommonMPBackupImporter() {
     private val inMemoryUnencryptedBuffer = Buffer()
 
-    public fun peekFileData(data: ByteArray, selfUserId: BackupQualifiedId): Promise<BackupPeekResult> = GlobalScope.promise {
+    public fun peekFileData(data: ByteArray): Promise<BackupPeekResult> = GlobalScope.promise {
         val buffer = Buffer()
         buffer.write(data)
-        peekBackup(buffer, selfUserId)
+        peekBackup(buffer)
     }
 
     public fun importFromFileData(data: ByteArray, passphrase: String?): Promise<BackupImportResult> = GlobalScope.promise {

--- a/backup/src/jsMain/kotlin/com/wire/backup/ingest/MPBackupImporter.kt
+++ b/backup/src/jsMain/kotlin/com/wire/backup/ingest/MPBackupImporter.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.backup.ingest
 
+import com.wire.backup.data.BackupQualifiedId
 import com.wire.backup.dump.JSZip
 import com.wire.backup.filesystem.BackupEntry
 import com.wire.backup.filesystem.EntryStorage
@@ -34,6 +35,12 @@ import kotlin.js.Promise
 @JsExport
 public actual class MPBackupImporter : CommonMPBackupImporter() {
     private val inMemoryUnencryptedBuffer = Buffer()
+
+    public fun peekFileData(data: ByteArray, selfUserId: BackupQualifiedId): Promise<BackupPeekResult> = GlobalScope.promise {
+        val buffer = Buffer()
+        buffer.write(data)
+        peekBackup(buffer, selfUserId)
+    }
 
     public fun importFromFileData(data: ByteArray, passphrase: String?): Promise<BackupImportResult> = GlobalScope.promise {
         val buffer = Buffer()

--- a/backup/src/nonJsMain/kotlin/com/wire/backup/ingest/MPBackupImporter.kt
+++ b/backup/src/nonJsMain/kotlin/com/wire/backup/ingest/MPBackupImporter.kt
@@ -18,6 +18,7 @@
 package com.wire.backup.ingest
 
 import com.rickclephas.kmp.nativecoroutines.NativeCoroutines
+import com.wire.backup.data.BackupQualifiedId
 import com.wire.backup.filesystem.EntryStorage
 import com.wire.backup.filesystem.FileBasedEntryStorage
 import okio.FileSystem
@@ -39,6 +40,21 @@ public actual class MPBackupImporter(
             if (!FileSystem.SYSTEM.exists(it)) FileSystem.SYSTEM.createDirectories(it)
         }
     }
+
+    /**
+     * Peeks into the specified backup file and retrieves metadata about it.
+     *
+     * @param pathToBackupFile the path to the backup file to be inspected
+     * @param selfUserId the identifier of the user performing the inspection
+     * @return a [BackupPeekResult] that contains information about the backup,
+     * such as version, encryption status, and if it was created by the same [selfUserId]
+     */
+    @ObjCName("peek")
+    @NativeCoroutines
+    public suspend fun peekBackupFile(
+        pathToBackupFile: String,
+        selfUserId: BackupQualifiedId
+    ): BackupPeekResult = peekBackup(FileSystem.SYSTEM.source(pathToBackupFile.toPath()), selfUserId)
 
     /**
      * Imports a backup from the specified root path.

--- a/backup/src/nonJsMain/kotlin/com/wire/backup/ingest/MPBackupImporter.kt
+++ b/backup/src/nonJsMain/kotlin/com/wire/backup/ingest/MPBackupImporter.kt
@@ -18,7 +18,6 @@
 package com.wire.backup.ingest
 
 import com.rickclephas.kmp.nativecoroutines.NativeCoroutines
-import com.wire.backup.data.BackupQualifiedId
 import com.wire.backup.filesystem.EntryStorage
 import com.wire.backup.filesystem.FileBasedEntryStorage
 import okio.FileSystem
@@ -45,16 +44,14 @@ public actual class MPBackupImporter(
      * Peeks into the specified backup file and retrieves metadata about it.
      *
      * @param pathToBackupFile the path to the backup file to be inspected
-     * @param selfUserId the identifier of the user performing the inspection
      * @return a [BackupPeekResult] that contains information about the backup,
-     * such as version, encryption status, and if it was created by the same [selfUserId]
+     * such as version, encryption status, etc.
      */
     @ObjCName("peek")
     @NativeCoroutines
     public suspend fun peekBackupFile(
-        pathToBackupFile: String,
-        selfUserId: BackupQualifiedId
-    ): BackupPeekResult = peekBackup(FileSystem.SYSTEM.source(pathToBackupFile.toPath()), selfUserId)
+        pathToBackupFile: String
+    ): BackupPeekResult = peekBackup(FileSystem.SYSTEM.source(pathToBackupFile.toPath()))
 
     /**
      * Imports a backup from the specified root path.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10575" title="WPB-10575" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-10575</a>  Cross Platform Backup: Write common backup / restore library
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We need a way to peek into a file, to check if the file is using the new backup format or not, and learn more information about, like if it is encrypted or not.
This way the clients can decide which flow to follow, if falling back to older backup logic, asking the user for a password, etc.

### Solutions

Add a function to the backup importer, that will take in data, attempt to parse it and return the relevant header data.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
