### PR TITLE
feat: adopt get domain registration endpoint (WPB-15721)

### DIFF
--- a/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/requests/DomainRegistrationRequestJson.kt
+++ b/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/requests/DomainRegistrationRequestJson.kt
@@ -15,16 +15,21 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-package com.wire.kalium.network.api.base.unauthenticated.domainregistration
+package com.wire.kalium.mocks.requests
 
-import com.wire.kalium.network.api.base.authenticated.BaseApi
-import com.wire.kalium.network.api.unauthenticated.domainregistration.DomainRegistrationDTO
-import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.mocks.responses.ValidJsonProvider
+import com.wire.kalium.network.api.unauthenticated.domainregistration.DomainRegistrationRequest
 
-interface GetDomainRegistrationApi : BaseApi {
-    suspend fun getDomainRegistration(email: String): NetworkResponse<DomainRegistrationDTO>
+object DomainRegistrationRequestJson {
 
-    companion object {
-        const val MIN_API_VERSION = 8
+    val jsonProvider = { serializable: DomainRegistrationRequest ->
+        """
+            {
+                "email": "${serializable.email}"
+            }
+            """.trimIndent()
     }
+
+    fun createValid(email: String) = ValidJsonProvider(DomainRegistrationRequest(email), jsonProvider)
+
 }

--- a/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/DomainRegistrationResponseJson.kt
+++ b/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/DomainRegistrationResponseJson.kt
@@ -15,16 +15,28 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-package com.wire.kalium.network.api.base.unauthenticated.domainregistration
+package com.wire.kalium.mocks.responses
 
-import com.wire.kalium.network.api.base.authenticated.BaseApi
+import com.wire.kalium.network.api.unauthenticated.domainregistration.DomainRedirect
 import com.wire.kalium.network.api.unauthenticated.domainregistration.DomainRegistrationDTO
-import com.wire.kalium.network.utils.NetworkResponse
 
-interface GetDomainRegistrationApi : BaseApi {
-    suspend fun getDomainRegistration(email: String): NetworkResponse<DomainRegistrationDTO>
+object DomainRegistrationResponseJson {
 
-    companion object {
-        const val MIN_API_VERSION = 8
-    }
+    val success = ValidJsonProvider(
+        serializableData = DomainRegistrationDTO(
+            backendUrl = null,
+            domainRedirect = DomainRedirect.NO_REGISTRATION,
+            ssoCode = null
+        ),
+        jsonProvider = { serializable ->
+            """
+            {
+                "backend_url": "${serializable.backendUrl}",
+                "domain_redirect": "${serializable.domainRedirect}",
+                "sso_code": "${serializable.ssoCode}"
+            }
+            """.trimIndent()
+        }
+    )
+
 }

--- a/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/DomainRegistrationResponseJson.kt
+++ b/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/DomainRegistrationResponseJson.kt
@@ -17,8 +17,11 @@
  */
 package com.wire.kalium.mocks.responses
 
+import com.wire.kalium.network.api.model.ErrorResponse
 import com.wire.kalium.network.api.unauthenticated.domainregistration.DomainRedirect
 import com.wire.kalium.network.api.unauthenticated.domainregistration.DomainRegistrationDTO
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 object DomainRegistrationResponseJson {
 
@@ -36,6 +39,21 @@ object DomainRegistrationResponseJson {
                 "sso_code": "${serializable.ssoCode}"
             }
             """.trimIndent()
+        }
+    )
+
+    val invalidDomain = ValidJsonProvider(
+        serializableData = ErrorResponse(
+            code = 400,
+            label = "invalid-domain",
+            message = "invalid-domain"
+        ),
+        jsonProvider = { serializable ->
+            buildJsonObject {
+                put("code", serializable.code)
+                put("label", serializable.label)
+                put("message", serializable.message)
+            }.toString()
         }
     )
 

--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/unauthenticated/domainregistration/DomainRegistrationDTO.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/unauthenticated/domainregistration/DomainRegistrationDTO.kt
@@ -1,0 +1,30 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.unauthenticated.domainregistration
+
+// todo(ym). validate optional and required fields
+data class DomainRegistrationDTO(
+    val backendUrl: String,
+    val domainRedirect: DomainRedirect,
+    val ssoCode: String?
+)
+
+
+enum class DomainRedirect {
+    NONE, LOCKED, SSO, BACKEND, NO_REGISTRATION, PRE_AUTHORIZED
+}

--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/unauthenticated/domainregistration/DomainRegistrationDTO.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/unauthenticated/domainregistration/DomainRegistrationDTO.kt
@@ -17,14 +17,47 @@
  */
 package com.wire.kalium.network.api.unauthenticated.domainregistration
 
-// todo(ym). validate optional and required fields
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class DomainRegistrationDTO(
-    val backendUrl: String,
+    @SerialName("backend_url")
+    val backendUrl: String?,
+    @SerialName("domain_redirect")
     val domainRedirect: DomainRedirect,
+    @SerialName("sso_code")
     val ssoCode: String?
 )
 
-
+@Serializable
 enum class DomainRedirect {
-    NONE, LOCKED, SSO, BACKEND, NO_REGISTRATION, PRE_AUTHORIZED
+    @SerialName("none")
+    NONE,
+
+    @SerialName("locked")
+    LOCKED,
+
+    @SerialName("sso")
+    SSO,
+
+    @SerialName("backend")
+    BACKEND,
+
+    @SerialName("no-registration")
+    NO_REGISTRATION,
+
+    @SerialName("pre-authorized")
+    PRE_AUTHORIZED;
+
+    override fun toString(): String {
+        return when (this) {
+            NONE -> "none"
+            LOCKED -> "locked"
+            SSO -> "sso"
+            BACKEND -> "backend"
+            NO_REGISTRATION -> "no-registration"
+            PRE_AUTHORIZED -> "pre-authorized"
+        }
+    }
 }

--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/unauthenticated/domainregistration/DomainRegistrationRequest.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/unauthenticated/domainregistration/DomainRegistrationRequest.kt
@@ -15,16 +15,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-package com.wire.kalium.network.api.base.unauthenticated.domainregistration
+package com.wire.kalium.network.api.unauthenticated.domainregistration
 
-import com.wire.kalium.network.api.base.authenticated.BaseApi
-import com.wire.kalium.network.api.unauthenticated.domainregistration.DomainRegistrationDTO
-import com.wire.kalium.network.utils.NetworkResponse
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
-interface GetDomainRegistrationApi : BaseApi {
-    suspend fun getDomainRegistration(email: String): NetworkResponse<DomainRegistrationDTO>
-
-    companion object {
-        const val MIN_API_VERSION = 8
-    }
-}
+@Serializable
+data class DomainRegistrationRequest(@SerialName("email") val email: String)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unauthenticated/domainregistration/GetDomainRegistrationApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unauthenticated/domainregistration/GetDomainRegistrationApi.kt
@@ -1,0 +1,30 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.base.unauthenticated.domainregistration
+
+import com.wire.kalium.network.api.base.authenticated.BaseApi
+import com.wire.kalium.network.api.unauthenticated.domainregistration.DomainRegistrationDTO
+import com.wire.kalium.network.utils.NetworkResponse
+
+interface GetDomainRegistrationApi : BaseApi {
+    suspend fun getDomainRegistration(domain: String): NetworkResponse<DomainRegistrationDTO>
+
+    companion object {
+        const val MIN_API_VERSION = 8
+    }
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/GetDomainRegistrationApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/GetDomainRegistrationApiV0.kt
@@ -1,0 +1,41 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.v0.unauthenticated
+
+import com.wire.kalium.network.UnauthenticatedNetworkClient
+import com.wire.kalium.network.api.base.unauthenticated.domainregistration.GetDomainRegistrationApi
+import com.wire.kalium.network.api.base.unauthenticated.domainregistration.GetDomainRegistrationApi.Companion.MIN_API_VERSION
+import com.wire.kalium.network.api.unauthenticated.domainregistration.DomainRegistrationDTO
+import com.wire.kalium.network.exceptions.APINotSupported
+import com.wire.kalium.network.utils.NetworkResponse
+
+internal open class GetDomainRegistrationApiV0 internal constructor(
+    private val unauthenticatedNetworkClient: UnauthenticatedNetworkClient
+) : GetDomainRegistrationApi {
+
+    internal val httpClient get() = unauthenticatedNetworkClient.httpClient
+
+    override suspend fun getDomainRegistration(domain: String): NetworkResponse<DomainRegistrationDTO> {
+        return NetworkResponse.Error(
+            APINotSupported(
+                errorBody = "${this::class.simpleName}: ${::getDomainRegistration.name} api is only available on API V${MIN_API_VERSION}"
+            )
+        )
+    }
+
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/GetDomainRegistrationApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/GetDomainRegistrationApiV0.kt
@@ -30,7 +30,7 @@ internal open class GetDomainRegistrationApiV0 internal constructor(
 
     internal val httpClient get() = unauthenticatedNetworkClient.httpClient
 
-    override suspend fun getDomainRegistration(domain: String): NetworkResponse<DomainRegistrationDTO> {
+    override suspend fun getDomainRegistration(email: String): NetworkResponse<DomainRegistrationDTO> {
         return NetworkResponse.Error(
             APINotSupported(
                 errorBody = "${this::class.simpleName}: ${::getDomainRegistration.name} api is only available on API V${MIN_API_VERSION}"

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/networkContainer/UnauthenticatedNetworkContainerV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/networkContainer/UnauthenticatedNetworkContainerV0.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.network.api.base.unauthenticated.sso.SSOLoginApi
 import com.wire.kalium.network.api.base.unauthenticated.verification.VerificationCodeApi
 import com.wire.kalium.network.api.base.unauthenticated.appVersioning.AppVersioningApi
 import com.wire.kalium.network.api.base.unauthenticated.appVersioning.AppVersioningApiImpl
+import com.wire.kalium.network.api.base.unauthenticated.domainregistration.GetDomainRegistrationApi
 import com.wire.kalium.network.api.base.unauthenticated.register.RegisterApi
 import com.wire.kalium.network.api.base.unbound.configuration.ServerConfigApi
 import com.wire.kalium.network.api.base.unbound.configuration.ServerConfigApiImpl
@@ -32,6 +33,7 @@ import com.wire.kalium.network.api.unbound.configuration.ServerConfigDTO
 import com.wire.kalium.network.api.base.unbound.versioning.VersionApi
 import com.wire.kalium.network.api.base.unbound.versioning.VersionApiImpl
 import com.wire.kalium.network.api.v0.unauthenticated.DomainLookupApiV0
+import com.wire.kalium.network.api.v0.unauthenticated.GetDomainRegistrationApiV0
 import com.wire.kalium.network.api.v0.unauthenticated.LoginApiV0
 import com.wire.kalium.network.api.v0.unauthenticated.RegisterApiV0
 import com.wire.kalium.network.api.v0.unauthenticated.SSOLoginApiV0
@@ -69,4 +71,6 @@ class UnauthenticatedNetworkContainerV0 internal constructor(
     override val serverConfigApi: ServerConfigApi
         get() = ServerConfigApiImpl(unauthenticatedNetworkClient)
     override val appVersioningApi: AppVersioningApi get() = AppVersioningApiImpl(unauthenticatedNetworkClient)
+    override val getDomainRegistrationApi: GetDomainRegistrationApi
+        get() = GetDomainRegistrationApiV0(unauthenticatedNetworkClient)
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/unauthenticated/GetDomainRegistrationApiV2.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/unauthenticated/GetDomainRegistrationApiV2.kt
@@ -1,0 +1,25 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.v2.unauthenticated
+
+import com.wire.kalium.network.UnauthenticatedNetworkClient
+import com.wire.kalium.network.api.v0.unauthenticated.GetDomainRegistrationApiV0
+
+internal open class GetDomainRegistrationApiV2 internal constructor(
+    unauthenticatedNetworkClient: UnauthenticatedNetworkClient
+) : GetDomainRegistrationApiV0(unauthenticatedNetworkClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/unauthenticated/networkContainer/UnauthenticatedNetworkContainerV2.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/unauthenticated/networkContainer/UnauthenticatedNetworkContainerV2.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.network.api.model.ProxyCredentialsDTO
 import com.wire.kalium.network.api.base.unauthenticated.appVersioning.AppVersioningApi
 import com.wire.kalium.network.api.base.unauthenticated.appVersioning.AppVersioningApiImpl
 import com.wire.kalium.network.api.base.unauthenticated.domainLookup.DomainLookupApi
+import com.wire.kalium.network.api.base.unauthenticated.domainregistration.GetDomainRegistrationApi
 import com.wire.kalium.network.api.base.unauthenticated.login.LoginApi
 import com.wire.kalium.network.api.base.unauthenticated.register.RegisterApi
 import com.wire.kalium.network.api.base.unauthenticated.sso.SSOLoginApi
@@ -32,6 +33,7 @@ import com.wire.kalium.network.api.unbound.configuration.ServerConfigDTO
 import com.wire.kalium.network.api.base.unbound.versioning.VersionApi
 import com.wire.kalium.network.api.base.unbound.versioning.VersionApiImpl
 import com.wire.kalium.network.api.v2.unauthenticated.DomainLookupApiV2
+import com.wire.kalium.network.api.v2.unauthenticated.GetDomainRegistrationApiV2
 import com.wire.kalium.network.api.v2.unauthenticated.LoginApiV2
 import com.wire.kalium.network.api.v2.unauthenticated.RegisterApiV2
 import com.wire.kalium.network.api.v2.unauthenticated.SSOLoginApiV2
@@ -69,4 +71,6 @@ class UnauthenticatedNetworkContainerV2 internal constructor(
     override val serverConfigApi: ServerConfigApi
         get() = ServerConfigApiImpl(unauthenticatedNetworkClient)
     override val appVersioningApi: AppVersioningApi get() = AppVersioningApiImpl(unauthenticatedNetworkClient)
+    override val getDomainRegistrationApi: GetDomainRegistrationApi
+        get() = GetDomainRegistrationApiV2(unauthenticatedNetworkClient)
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/unauthenticated/GetDomainRegistrationApiV3.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/unauthenticated/GetDomainRegistrationApiV3.kt
@@ -1,0 +1,25 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.v3.unauthenticated
+
+import com.wire.kalium.network.UnauthenticatedNetworkClient
+import com.wire.kalium.network.api.v2.unauthenticated.GetDomainRegistrationApiV2
+
+internal open class GetDomainRegistrationApiV3 internal constructor(
+    unauthenticatedNetworkClient: UnauthenticatedNetworkClient
+) : GetDomainRegistrationApiV2(unauthenticatedNetworkClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/unauthenticated/networkContainer/UnauthenticatedNetworkContainerV3.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/unauthenticated/networkContainer/UnauthenticatedNetworkContainerV3.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.network.api.base.unauthenticated.sso.SSOLoginApi
 import com.wire.kalium.network.api.base.unauthenticated.verification.VerificationCodeApi
 import com.wire.kalium.network.api.base.unauthenticated.appVersioning.AppVersioningApi
 import com.wire.kalium.network.api.base.unauthenticated.appVersioning.AppVersioningApiImpl
+import com.wire.kalium.network.api.base.unauthenticated.domainregistration.GetDomainRegistrationApi
 import com.wire.kalium.network.api.base.unauthenticated.register.RegisterApi
 import com.wire.kalium.network.api.base.unbound.configuration.ServerConfigApi
 import com.wire.kalium.network.api.base.unbound.configuration.ServerConfigApiImpl
@@ -32,6 +33,7 @@ import com.wire.kalium.network.api.unbound.configuration.ServerConfigDTO
 import com.wire.kalium.network.api.base.unbound.versioning.VersionApi
 import com.wire.kalium.network.api.base.unbound.versioning.VersionApiImpl
 import com.wire.kalium.network.api.v3.unauthenticated.DomainLookupApiV3
+import com.wire.kalium.network.api.v3.unauthenticated.GetDomainRegistrationApiV3
 import com.wire.kalium.network.api.v3.unauthenticated.LoginApiV3
 import com.wire.kalium.network.api.v3.unauthenticated.RegisterApiV3
 import com.wire.kalium.network.api.v3.unauthenticated.SSOLoginApiV3
@@ -69,4 +71,6 @@ class UnauthenticatedNetworkContainerV3 internal constructor(
     override val serverConfigApi: ServerConfigApi
         get() = ServerConfigApiImpl(unauthenticatedNetworkClient)
     override val appVersioningApi: AppVersioningApi get() = AppVersioningApiImpl(unauthenticatedNetworkClient)
+    override val getDomainRegistrationApi: GetDomainRegistrationApi
+        get() = GetDomainRegistrationApiV3(unauthenticatedNetworkClient)
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/unauthenticated/GetDomainRegistrationApiV4.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/unauthenticated/GetDomainRegistrationApiV4.kt
@@ -1,0 +1,25 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.v4.unauthenticated
+
+import com.wire.kalium.network.UnauthenticatedNetworkClient
+import com.wire.kalium.network.api.v3.unauthenticated.GetDomainRegistrationApiV3
+
+internal open class GetDomainRegistrationApiV4 internal constructor(
+    unauthenticatedNetworkClient: UnauthenticatedNetworkClient
+) : GetDomainRegistrationApiV3(unauthenticatedNetworkClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/unauthenticated/networkContainer/UnauthenticatedNetworkContainerV4.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/unauthenticated/networkContainer/UnauthenticatedNetworkContainerV4.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.network.api.base.unauthenticated.sso.SSOLoginApi
 import com.wire.kalium.network.api.base.unauthenticated.verification.VerificationCodeApi
 import com.wire.kalium.network.api.base.unauthenticated.appVersioning.AppVersioningApi
 import com.wire.kalium.network.api.base.unauthenticated.appVersioning.AppVersioningApiImpl
+import com.wire.kalium.network.api.base.unauthenticated.domainregistration.GetDomainRegistrationApi
 import com.wire.kalium.network.api.base.unauthenticated.register.RegisterApi
 import com.wire.kalium.network.api.base.unbound.configuration.ServerConfigApi
 import com.wire.kalium.network.api.base.unbound.configuration.ServerConfigApiImpl
@@ -32,6 +33,7 @@ import com.wire.kalium.network.api.unbound.configuration.ServerConfigDTO
 import com.wire.kalium.network.api.base.unbound.versioning.VersionApi
 import com.wire.kalium.network.api.base.unbound.versioning.VersionApiImpl
 import com.wire.kalium.network.api.v4.unauthenticated.DomainLookupApiV4
+import com.wire.kalium.network.api.v4.unauthenticated.GetDomainRegistrationApiV4
 import com.wire.kalium.network.api.v4.unauthenticated.LoginApiV4
 import com.wire.kalium.network.api.v4.unauthenticated.RegisterApiV4
 import com.wire.kalium.network.api.v4.unauthenticated.SSOLoginApiV4
@@ -69,4 +71,6 @@ class UnauthenticatedNetworkContainerV4 internal constructor(
     override val registerApi: RegisterApi get() = RegisterApiV4(unauthenticatedNetworkClient)
     override val sso: SSOLoginApi get() = SSOLoginApiV4(unauthenticatedNetworkClient)
     override val appVersioningApi: AppVersioningApi get() = AppVersioningApiImpl(unauthenticatedNetworkClient)
+    override val getDomainRegistrationApi: GetDomainRegistrationApi
+        get() = GetDomainRegistrationApiV4(unauthenticatedNetworkClient)
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/unauthenticated/GetDomainRegistrationApiV5.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/unauthenticated/GetDomainRegistrationApiV5.kt
@@ -1,0 +1,25 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.v5.unauthenticated
+
+import com.wire.kalium.network.UnauthenticatedNetworkClient
+import com.wire.kalium.network.api.v4.unauthenticated.GetDomainRegistrationApiV4
+
+internal open class GetDomainRegistrationApiV5 internal constructor(
+    unauthenticatedNetworkClient: UnauthenticatedNetworkClient
+) : GetDomainRegistrationApiV4(unauthenticatedNetworkClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/unauthenticated/networkContainer/UnauthenticatedNetworkContainerV5.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/unauthenticated/networkContainer/UnauthenticatedNetworkContainerV5.kt
@@ -18,20 +18,22 @@
 
 package com.wire.kalium.network.api.v5.unauthenticated.networkContainer
 
-import com.wire.kalium.network.api.model.ProxyCredentialsDTO
-import com.wire.kalium.network.api.base.unauthenticated.domainLookup.DomainLookupApi
-import com.wire.kalium.network.api.base.unauthenticated.login.LoginApi
-import com.wire.kalium.network.api.base.unauthenticated.sso.SSOLoginApi
-import com.wire.kalium.network.api.base.unauthenticated.verification.VerificationCodeApi
 import com.wire.kalium.network.api.base.unauthenticated.appVersioning.AppVersioningApi
 import com.wire.kalium.network.api.base.unauthenticated.appVersioning.AppVersioningApiImpl
+import com.wire.kalium.network.api.base.unauthenticated.domainLookup.DomainLookupApi
+import com.wire.kalium.network.api.base.unauthenticated.domainregistration.GetDomainRegistrationApi
+import com.wire.kalium.network.api.base.unauthenticated.login.LoginApi
 import com.wire.kalium.network.api.base.unauthenticated.register.RegisterApi
+import com.wire.kalium.network.api.base.unauthenticated.sso.SSOLoginApi
+import com.wire.kalium.network.api.base.unauthenticated.verification.VerificationCodeApi
 import com.wire.kalium.network.api.base.unbound.configuration.ServerConfigApi
 import com.wire.kalium.network.api.base.unbound.configuration.ServerConfigApiImpl
-import com.wire.kalium.network.api.unbound.configuration.ServerConfigDTO
 import com.wire.kalium.network.api.base.unbound.versioning.VersionApi
 import com.wire.kalium.network.api.base.unbound.versioning.VersionApiImpl
+import com.wire.kalium.network.api.model.ProxyCredentialsDTO
+import com.wire.kalium.network.api.unbound.configuration.ServerConfigDTO
 import com.wire.kalium.network.api.v5.unauthenticated.DomainLookupApiV5
+import com.wire.kalium.network.api.v5.unauthenticated.GetDomainRegistrationApiV5
 import com.wire.kalium.network.api.v5.unauthenticated.LoginApiV5
 import com.wire.kalium.network.api.v5.unauthenticated.RegisterApiV5
 import com.wire.kalium.network.api.v5.unauthenticated.SSOLoginApiV5
@@ -69,4 +71,6 @@ class UnauthenticatedNetworkContainerV5 internal constructor(
     override val registerApi: RegisterApi get() = RegisterApiV5(unauthenticatedNetworkClient)
     override val sso: SSOLoginApi get() = SSOLoginApiV5(unauthenticatedNetworkClient)
     override val appVersioningApi: AppVersioningApi get() = AppVersioningApiImpl(unauthenticatedNetworkClient)
+    override val getDomainRegistrationApi: GetDomainRegistrationApi
+        get() = GetDomainRegistrationApiV5(unauthenticatedNetworkClient)
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v6/unauthenticated/GetDomainRegistrationApiV6.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v6/unauthenticated/GetDomainRegistrationApiV6.kt
@@ -1,0 +1,25 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.v6.unauthenticated
+
+import com.wire.kalium.network.UnauthenticatedNetworkClient
+import com.wire.kalium.network.api.v5.unauthenticated.GetDomainRegistrationApiV5
+
+internal open class GetDomainRegistrationApiV6 internal constructor(
+    unauthenticatedNetworkClient: UnauthenticatedNetworkClient
+) : GetDomainRegistrationApiV5(unauthenticatedNetworkClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v6/unauthenticated/networkContainer/UnauthenticatedNetworkContainerV6.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v6/unauthenticated/networkContainer/UnauthenticatedNetworkContainerV6.kt
@@ -18,20 +18,22 @@
 
 package com.wire.kalium.network.api.v6.unauthenticated.networkContainer
 
-import com.wire.kalium.network.api.model.ProxyCredentialsDTO
-import com.wire.kalium.network.api.base.unauthenticated.domainLookup.DomainLookupApi
-import com.wire.kalium.network.api.base.unauthenticated.login.LoginApi
-import com.wire.kalium.network.api.base.unauthenticated.sso.SSOLoginApi
-import com.wire.kalium.network.api.base.unauthenticated.verification.VerificationCodeApi
 import com.wire.kalium.network.api.base.unauthenticated.appVersioning.AppVersioningApi
 import com.wire.kalium.network.api.base.unauthenticated.appVersioning.AppVersioningApiImpl
+import com.wire.kalium.network.api.base.unauthenticated.domainLookup.DomainLookupApi
+import com.wire.kalium.network.api.base.unauthenticated.domainregistration.GetDomainRegistrationApi
+import com.wire.kalium.network.api.base.unauthenticated.login.LoginApi
 import com.wire.kalium.network.api.base.unauthenticated.register.RegisterApi
+import com.wire.kalium.network.api.base.unauthenticated.sso.SSOLoginApi
+import com.wire.kalium.network.api.base.unauthenticated.verification.VerificationCodeApi
 import com.wire.kalium.network.api.base.unbound.configuration.ServerConfigApi
 import com.wire.kalium.network.api.base.unbound.configuration.ServerConfigApiImpl
-import com.wire.kalium.network.api.unbound.configuration.ServerConfigDTO
 import com.wire.kalium.network.api.base.unbound.versioning.VersionApi
 import com.wire.kalium.network.api.base.unbound.versioning.VersionApiImpl
+import com.wire.kalium.network.api.model.ProxyCredentialsDTO
+import com.wire.kalium.network.api.unbound.configuration.ServerConfigDTO
 import com.wire.kalium.network.api.v6.unauthenticated.DomainLookupApiV6
+import com.wire.kalium.network.api.v6.unauthenticated.GetDomainRegistrationApiV6
 import com.wire.kalium.network.api.v6.unauthenticated.LoginApiV6
 import com.wire.kalium.network.api.v6.unauthenticated.RegisterApiV6
 import com.wire.kalium.network.api.v6.unauthenticated.SSOLoginApiV6
@@ -70,4 +72,6 @@ class UnauthenticatedNetworkContainerV6 internal constructor(
     override val registerApi: RegisterApi get() = RegisterApiV6(unauthenticatedNetworkClient)
     override val sso: SSOLoginApi get() = SSOLoginApiV6(unauthenticatedNetworkClient)
     override val appVersioningApi: AppVersioningApi get() = AppVersioningApiImpl(unauthenticatedNetworkClient)
+    override val getDomainRegistrationApi: GetDomainRegistrationApi
+        get() = GetDomainRegistrationApiV6(unauthenticatedNetworkClient)
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v7/unauthenticated/GetDomainRegistrationApiV7.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v7/unauthenticated/GetDomainRegistrationApiV7.kt
@@ -1,0 +1,25 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.v7.unauthenticated
+
+import com.wire.kalium.network.UnauthenticatedNetworkClient
+import com.wire.kalium.network.api.v6.unauthenticated.GetDomainRegistrationApiV6
+
+internal open class GetDomainRegistrationApiV7 internal constructor(
+    unauthenticatedNetworkClient: UnauthenticatedNetworkClient
+) : GetDomainRegistrationApiV6(unauthenticatedNetworkClient)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v7/unauthenticated/networkContainer/UnauthenticatedNetworkContainerV7.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v7/unauthenticated/networkContainer/UnauthenticatedNetworkContainerV7.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.network.api.v7.unauthenticated.networkContainer
 import com.wire.kalium.network.api.base.unauthenticated.appVersioning.AppVersioningApi
 import com.wire.kalium.network.api.base.unauthenticated.appVersioning.AppVersioningApiImpl
 import com.wire.kalium.network.api.base.unauthenticated.domainLookup.DomainLookupApi
+import com.wire.kalium.network.api.base.unauthenticated.domainregistration.GetDomainRegistrationApi
 import com.wire.kalium.network.api.base.unauthenticated.login.LoginApi
 import com.wire.kalium.network.api.base.unauthenticated.register.RegisterApi
 import com.wire.kalium.network.api.base.unauthenticated.sso.SSOLoginApi
@@ -32,6 +33,7 @@ import com.wire.kalium.network.api.base.unbound.versioning.VersionApiImpl
 import com.wire.kalium.network.api.model.ProxyCredentialsDTO
 import com.wire.kalium.network.api.unbound.configuration.ServerConfigDTO
 import com.wire.kalium.network.api.v7.unauthenticated.DomainLookupApiV7
+import com.wire.kalium.network.api.v7.unauthenticated.GetDomainRegistrationApiV7
 import com.wire.kalium.network.api.v7.unauthenticated.LoginApiV7
 import com.wire.kalium.network.api.v7.unauthenticated.RegisterApiV7
 import com.wire.kalium.network.api.v7.unauthenticated.SSOLoginApiV7
@@ -82,4 +84,6 @@ class UnauthenticatedNetworkContainerV7 internal constructor(
         get() = AppVersioningApiImpl(
             unauthenticatedNetworkClient
         )
+    override val getDomainRegistrationApi: GetDomainRegistrationApi
+        get() = GetDomainRegistrationApiV7(unauthenticatedNetworkClient)
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v8/unauthenticated/GetDomainRegistrationApiV8.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v8/unauthenticated/GetDomainRegistrationApiV8.kt
@@ -1,0 +1,32 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.v8.unauthenticated
+
+import com.wire.kalium.network.UnauthenticatedNetworkClient
+import com.wire.kalium.network.api.unauthenticated.domainregistration.DomainRegistrationDTO
+import com.wire.kalium.network.api.v7.unauthenticated.GetDomainRegistrationApiV7
+import com.wire.kalium.network.utils.NetworkResponse
+
+internal open class GetDomainRegistrationApiV8 internal constructor(
+    private val unauthenticatedNetworkClient: UnauthenticatedNetworkClient
+) : GetDomainRegistrationApiV7(unauthenticatedNetworkClient) {
+
+    override suspend fun getDomainRegistration(domain: String): NetworkResponse<DomainRegistrationDTO> {
+        TODO("ym. to implement")
+    }
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v8/unauthenticated/GetDomainRegistrationApiV8.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v8/unauthenticated/GetDomainRegistrationApiV8.kt
@@ -19,14 +19,26 @@ package com.wire.kalium.network.api.v8.unauthenticated
 
 import com.wire.kalium.network.UnauthenticatedNetworkClient
 import com.wire.kalium.network.api.unauthenticated.domainregistration.DomainRegistrationDTO
+import com.wire.kalium.network.api.unauthenticated.domainregistration.DomainRegistrationRequest
 import com.wire.kalium.network.api.v7.unauthenticated.GetDomainRegistrationApiV7
 import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.wrapKaliumResponse
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 
 internal open class GetDomainRegistrationApiV8 internal constructor(
-    private val unauthenticatedNetworkClient: UnauthenticatedNetworkClient
+    unauthenticatedNetworkClient: UnauthenticatedNetworkClient
 ) : GetDomainRegistrationApiV7(unauthenticatedNetworkClient) {
 
-    override suspend fun getDomainRegistration(domain: String): NetworkResponse<DomainRegistrationDTO> {
-        TODO("ym. to implement")
+    override suspend fun getDomainRegistration(email: String): NetworkResponse<DomainRegistrationDTO> {
+        return wrapKaliumResponse {
+            httpClient.post(PATH_DOMAIN_REGISTRATION) {
+                setBody(DomainRegistrationRequest(email))
+            }
+        }
+    }
+
+    companion object {
+        const val PATH_DOMAIN_REGISTRATION = "get-domain-registration"
     }
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v8/unauthenticated/networkContainer/UnauthenticatedNetworkContainerV8.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v8/unauthenticated/networkContainer/UnauthenticatedNetworkContainerV8.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.network.api.v8.unauthenticated.networkContainer
 import com.wire.kalium.network.api.base.unauthenticated.appVersioning.AppVersioningApi
 import com.wire.kalium.network.api.base.unauthenticated.appVersioning.AppVersioningApiImpl
 import com.wire.kalium.network.api.base.unauthenticated.domainLookup.DomainLookupApi
+import com.wire.kalium.network.api.base.unauthenticated.domainregistration.GetDomainRegistrationApi
 import com.wire.kalium.network.api.base.unauthenticated.login.LoginApi
 import com.wire.kalium.network.api.base.unauthenticated.register.RegisterApi
 import com.wire.kalium.network.api.base.unauthenticated.sso.SSOLoginApi
@@ -32,6 +33,7 @@ import com.wire.kalium.network.api.base.unbound.versioning.VersionApiImpl
 import com.wire.kalium.network.api.model.ProxyCredentialsDTO
 import com.wire.kalium.network.api.unbound.configuration.ServerConfigDTO
 import com.wire.kalium.network.api.v8.unauthenticated.DomainLookupApiV8
+import com.wire.kalium.network.api.v8.unauthenticated.GetDomainRegistrationApiV8
 import com.wire.kalium.network.api.v8.unauthenticated.LoginApiV8
 import com.wire.kalium.network.api.v8.unauthenticated.RegisterApiV8
 import com.wire.kalium.network.api.v8.unauthenticated.SSOLoginApiV8
@@ -82,4 +84,6 @@ class UnauthenticatedNetworkContainerV8 internal constructor(
         get() = AppVersioningApiImpl(
             unauthenticatedNetworkClient
         )
+    override val getDomainRegistrationApi: GetDomainRegistrationApi
+        get() = GetDomainRegistrationApiV8(unauthenticatedNetworkClient)
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/networkContainer/UnauthenticatedNetworkContainer.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/networkContainer/UnauthenticatedNetworkContainer.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.network.networkContainer
 import com.wire.kalium.network.UnauthenticatedNetworkClient
 import com.wire.kalium.network.api.base.unauthenticated.appVersioning.AppVersioningApi
 import com.wire.kalium.network.api.base.unauthenticated.domainLookup.DomainLookupApi
+import com.wire.kalium.network.api.base.unauthenticated.domainregistration.GetDomainRegistrationApi
 import com.wire.kalium.network.api.base.unauthenticated.login.LoginApi
 import com.wire.kalium.network.api.base.unauthenticated.register.RegisterApi
 import com.wire.kalium.network.api.base.unauthenticated.sso.SSOLoginApi
@@ -49,6 +50,7 @@ interface UnauthenticatedNetworkContainer {
     val domainLookupApi: DomainLookupApi
     val remoteVersion: VersionApi
     val serverConfigApi: ServerConfigApi
+    val getDomainRegistrationApi: GetDomainRegistrationApi
 
     @Suppress("LongMethod")
     companion object {

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v8/GetDomainRegistrationApiV8Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v8/GetDomainRegistrationApiV8Test.kt
@@ -1,0 +1,52 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.api.v8
+
+import com.wire.kalium.api.ApiTest
+import com.wire.kalium.mocks.requests.DomainRegistrationRequestJson
+import com.wire.kalium.mocks.responses.DomainRegistrationResponseJson
+import com.wire.kalium.network.api.v8.unauthenticated.GetDomainRegistrationApiV8
+import com.wire.kalium.network.utils.isSuccessful
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+internal class GetDomainRegistrationApiV8Test : ApiTest() {
+
+    @Test
+    fun whenCallingGetDomainRegistration_thenTheRequestShouldBeConfiguredOK() = runTest {
+        val emailToVerify = "test@wire.com"
+        val networkClient = mockUnauthenticatedNetworkClient(
+            SUCCESS_RESPONSE,
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertPost()
+                assertPathEqual("get-domain-registration")
+                assertJsonBodyContent(DomainRegistrationRequestJson.createValid(emailToVerify).rawJson)
+            }
+        )
+
+        val response = GetDomainRegistrationApiV8(networkClient).getDomainRegistration(emailToVerify)
+        assertTrue(response.isSuccessful())
+    }
+
+    companion object {
+        val SUCCESS_RESPONSE = DomainRegistrationResponseJson.success.rawJson
+    }
+}

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v8/GetDomainRegistrationApiV8Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v8/GetDomainRegistrationApiV8Test.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 internal class GetDomainRegistrationApiV8Test : ApiTest() {
@@ -42,11 +43,45 @@ internal class GetDomainRegistrationApiV8Test : ApiTest() {
             }
         )
 
+        GetDomainRegistrationApiV8(networkClient).getDomainRegistration(emailToVerify)
+    }
+
+    @Test
+    fun whenCallingGetDomainRegistration_thenTheResponseShouldBeParsedCorrectly() = runTest {
+        val emailToVerify = "test@wire.com"
+        val networkClient = mockUnauthenticatedNetworkClient(
+            SUCCESS_RESPONSE,
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertPost()
+                assertPathEqual("get-domain-registration")
+                assertJsonBodyContent(DomainRegistrationRequestJson.createValid(emailToVerify).rawJson)
+            }
+        )
+
         val response = GetDomainRegistrationApiV8(networkClient).getDomainRegistration(emailToVerify)
         assertTrue(response.isSuccessful())
     }
 
+    @Test
+    fun givenAnInvalidDomain_whenCallingGetDomainRegistration_thenTheResponseShouldBeParsedCorrectly() = runTest {
+        val emailToVerify = "test@wire.com"
+        val networkClient = mockUnauthenticatedNetworkClient(
+            INVALID_DOMAIN_RESPONSE,
+            statusCode = HttpStatusCode.BadRequest,
+            assertion = {
+                assertPost()
+                assertPathEqual("get-domain-registration")
+                assertJsonBodyContent(DomainRegistrationRequestJson.createValid(emailToVerify).rawJson)
+            }
+        )
+
+        val response = GetDomainRegistrationApiV8(networkClient).getDomainRegistration(emailToVerify)
+        assertFalse(response.isSuccessful())
+    }
+
     companion object {
         val SUCCESS_RESPONSE = DomainRegistrationResponseJson.success.rawJson
+        val INVALID_DOMAIN_RESPONSE = DomainRegistrationResponseJson.invalidDomain.rawJson
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15721" title="WPB-15721" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15721</a>  [Android] - Adopt API v8 for support of domain registration
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Enterprise login requires the implementation of new endpoints, in particular `POST /get-domain-registration`

### Solutions

- Implement the endpoint call 
- Create the serializer for `DomainRedirect Tag` 
- Handle errors

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
