### PR TITLE
fix: ignore invalid leaf signature error on slow sync [WPB-15737]

### DIFF
--- a/.github/workflows/gradle-android-instrumented-tests.yml
+++ b/.github/workflows/gradle-android-instrumented-tests.yml
@@ -89,14 +89,14 @@ jobs:
 
       - name: Archive Test Reports
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-reports
           path: ./**/build/reports/tests/**
 
       - name: Archive Test Results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: |

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationsUseCase.kt
@@ -30,7 +30,6 @@ import com.wire.kalium.logic.functional.foldToEitherWhileRight
 import com.wire.kalium.logic.functional.getOrElse
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.network.exceptions.KaliumException
-import com.wire.kalium.network.exceptions.isMLSProtocol
 
 /**
  * Send an external commit to join all MLS conversations for which the user is a member,
@@ -65,11 +64,10 @@ internal class JoinExistingMLSConversationsUseCaseImpl(
                                 is NetworkFailure -> {
                                     if (it is NetworkFailure.ServerMiscommunication
                                         && it.kaliumException is KaliumException.InvalidRequestError
-                                        && it.kaliumException.isMLSProtocol()
                                     ) {
                                         kaliumLogger.w(
                                             "Failed to establish mls group for ${conversation.id.toLogString()} " +
-                                                    "due to Invalid LeafNode signature, skipping."
+                                                    "due to invalid request error, skipping."
                                         )
                                         Either.Right(Unit)
                                     } else {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
@@ -45,6 +45,7 @@ import com.wire.kalium.network.exceptions.NetworkErrorLabel.MISSING_LEGALHOLD_CO
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.MLS_CLIENT_MISMATCH
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.MLS_COMMIT_MISSING_REFERENCES
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.MLS_MISSING_GROUP_INFO
+import com.wire.kalium.network.exceptions.NetworkErrorLabel.MLS_PROTOCOL_ERROR
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.MLS_STALE_MESSAGE
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.NOT_FOUND
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.NOT_TEAM_MEMBER
@@ -222,6 +223,10 @@ fun KaliumException.InvalidRequestError.isGuestLinkDisabled(): Boolean {
 
 fun KaliumException.InvalidRequestError.isAccessDenied(): Boolean {
     return errorResponse.label == ACCESS_DENIED
+}
+
+fun KaliumException.InvalidRequestError.isMLSProtocol(): Boolean {
+    return errorResponse.label == MLS_PROTOCOL_ERROR
 }
 
 fun KaliumException.InvalidRequestError.isWrongConversationPassword(): Boolean {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/NetworkErrorLabel.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/NetworkErrorLabel.kt
@@ -41,6 +41,7 @@ internal object NetworkErrorLabel {
     const val MLS_UNSUPPORTED_PROPOSAL = "mls-unsupported-proposal"
     const val MLS_KEY_PACKAGE_REF_NOT_FOUND = "mls-key-package-ref-not-found"
     const val MLS_MISSING_GROUP_INFO = "mls-missing-group-info"
+    const val MLS_PROTOCOL_ERROR = "mls-protocol-error"
     const val UNKNOWN_CLIENT = "unknown-client"
     const val NOT_TEAM_MEMBER = "no-team-member"
     const val NO_CONVERSATION = "no-conversation"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15737" title="WPB-15737" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15737</a>  [Android] app stuck on login
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On non recoverable error `Tried to add invalid LeafNode: Invalid LeafNode signature` we are not ignoring this on slow sync during `JOINING_MLS_CONVERSATIONS` which is blocking user for using app

### Solutions

Ignore this error during slow sync
