### PR TITLE
feat(backup): paginate different types of content [WPB-10575]

### DIFF
--- a/backup/src/commonMain/kotlin/com/wire/backup/dump/MPBackupExporter.kt
+++ b/backup/src/commonMain/kotlin/com/wire/backup/dump/MPBackupExporter.kt
@@ -27,8 +27,8 @@ import com.wire.backup.encryption.XChaChaPoly1305AuthenticationData
 import com.wire.backup.envelope.BackupHeader
 import com.wire.backup.envelope.BackupHeaderSerializer
 import com.wire.backup.envelope.HashData
-import com.wire.backup.filesystem.BackupEntry
-import com.wire.backup.filesystem.EntryStorage
+import com.wire.backup.filesystem.BackupPage
+import com.wire.backup.filesystem.BackupPageStorage
 import com.wire.backup.ingest.MPBackupMapper
 import com.wire.kalium.protobuf.backup.BackupData
 import com.wire.kalium.protobuf.backup.BackupInfo
@@ -83,7 +83,12 @@ public abstract class CommonMPBackupExporter(
     private fun flushUsers() {
         if (usersChunk.isEmpty()) return
         val backupData = BackupData(backupInfo, users = usersChunk)
-        storage.persistEntry(BackupEntry(USERS_ENTRY_PREFIX + persistedUserChunks + ENTRY_SUFFIX, backupData.asSource()))
+        storage.persistEntry(
+            BackupPage(
+                name = BackupPage.USERS_PREFIX + persistedUserChunks + BackupPage.PAGE_SUFFIX,
+                data = backupData.asSource()
+            )
+        )
         persistedUserChunks++
         usersChunk.clear()
     }
@@ -99,7 +104,12 @@ public abstract class CommonMPBackupExporter(
     private fun flushConversations() {
         if (conversationsChunk.isEmpty()) return
         val backupData = BackupData(backupInfo, conversations = conversationsChunk)
-        storage.persistEntry(BackupEntry(CONVERSATIONS_ENTRY_PREFIX + persistedConversationsChunks + ENTRY_SUFFIX, backupData.asSource()))
+        storage.persistEntry(
+            BackupPage(
+                name = BackupPage.CONVERSATIONS_PREFIX + persistedConversationsChunks + BackupPage.PAGE_SUFFIX,
+                data = backupData.asSource()
+            )
+        )
         persistedConversationsChunks++
         conversationsChunk.clear()
     }
@@ -115,7 +125,12 @@ public abstract class CommonMPBackupExporter(
     private fun flushMessages() {
         if (messagesChunk.isEmpty()) return
         val backupData = BackupData(backupInfo, messages = messagesChunk)
-        storage.persistEntry(BackupEntry(MESSAGES_ENTRY_PREFIX + persistedMessagesChunks + ENTRY_SUFFIX, backupData.asSource()))
+        storage.persistEntry(
+            BackupPage(
+                name = BackupPage.MESSAGES_PREFIX + persistedMessagesChunks + BackupPage.PAGE_SUFFIX,
+                data = backupData.asSource()
+            )
+        )
         persistedMessagesChunks++
         messagesChunk.clear()
     }
@@ -180,19 +195,15 @@ public abstract class CommonMPBackupExporter(
         ExportResult.Failure.IOError(t.message ?: "Unknown IO error.")
     }
 
-    internal abstract val storage: EntryStorage
+    internal abstract val storage: BackupPageStorage
 
-    internal abstract fun zipEntries(data: List<BackupEntry>): Deferred<Source>
+    internal abstract fun zipEntries(data: List<BackupPage>): Deferred<Source>
 
     private companion object {
         /**
          * Amount of items (conversations or messages) to be put into a single page / entry
          */
         const val ITEMS_CHUNK_SIZE = 1_000
-        const val USERS_ENTRY_PREFIX = "users"
-        const val CONVERSATIONS_ENTRY_PREFIX = "conversations"
-        const val MESSAGES_ENTRY_PREFIX = "messages"
-        const val ENTRY_SUFFIX = ".binpb"
     }
 }
 

--- a/backup/src/commonMain/kotlin/com/wire/backup/filesystem/BackupPageStorage.kt
+++ b/backup/src/commonMain/kotlin/com/wire/backup/filesystem/BackupPageStorage.kt
@@ -22,14 +22,21 @@ import okio.Source
 /**
  * Storage used during export/import of backups.
  */
-internal interface EntryStorage {
-    fun persistEntry(backupEntry: BackupEntry)
-    operator fun get(entryName: String): BackupEntry?
-    fun listEntries(): List<BackupEntry>
+internal interface BackupPageStorage {
+    fun persistEntry(backupPage: BackupPage)
+    operator fun get(entryName: String): BackupPage?
+    fun listEntries(): List<BackupPage>
     fun clear()
 }
 
-internal data class BackupEntry(
+internal data class BackupPage(
     val name: String,
     val data: Source,
-)
+) {
+    internal companion object {
+        const val CONVERSATIONS_PREFIX = "conversations_"
+        const val MESSAGES_PREFIX = "messages_"
+        const val USERS_PREFIX = "users_"
+        const val PAGE_SUFFIX = ".binpb"
+    }
+}

--- a/backup/src/commonMain/kotlin/com/wire/backup/filesystem/InMemoryBackupPageStorage.kt
+++ b/backup/src/commonMain/kotlin/com/wire/backup/filesystem/InMemoryBackupPageStorage.kt
@@ -24,23 +24,23 @@ import okio.buffer
  * As JS on a browser doesn't have access to files, we just write stuff in memory.
  * It is also useful for tests.
  */
-internal class InMemoryEntryStorage : EntryStorage {
+internal class InMemoryBackupPageStorage : BackupPageStorage {
 
     private val entries = mutableMapOf<String, ByteArray>()
 
-    override fun persistEntry(backupEntry: BackupEntry) {
-        check(!entries.containsKey(backupEntry.name)) { "Entry with name ${backupEntry.name} already exists." }
-        entries[backupEntry.name] = backupEntry.data.buffer().readByteArray()
+    override fun persistEntry(backupPage: BackupPage) {
+        check(!entries.containsKey(backupPage.name)) { "Entry with name ${backupPage.name} already exists." }
+        entries[backupPage.name] = backupPage.data.buffer().readByteArray()
     }
 
-    override operator fun get(entryName: String): BackupEntry? = entries[entryName]?.let {
+    override operator fun get(entryName: String): BackupPage? = entries[entryName]?.let {
         val buffer = Buffer().apply { write(it) }
-        BackupEntry(entryName, buffer)
+        BackupPage(entryName, buffer)
     }
 
-    override fun listEntries(): List<BackupEntry> = entries.map { data ->
+    override fun listEntries(): List<BackupPage> = entries.map { data ->
         val buffer = Buffer().apply { write(data.value) }
-        BackupEntry(data.key, buffer)
+        BackupPage(data.key, buffer)
     }
 
     override fun clear() {

--- a/backup/src/commonMain/kotlin/com/wire/backup/ingest/BackupImportPager.kt
+++ b/backup/src/commonMain/kotlin/com/wire/backup/ingest/BackupImportPager.kt
@@ -17,24 +17,93 @@
  */
 package com.wire.backup.ingest
 
-import com.wire.backup.data.BackupData
-import com.wire.backup.filesystem.EntryStorage
+import com.wire.backup.data.BackupConversation
+import com.wire.backup.data.BackupMessage
+import com.wire.backup.data.BackupUser
+import com.wire.backup.filesystem.BackupPage
+import com.wire.kalium.protobuf.backup.BackupData
+import com.wire.kalium.protobuf.decodeFromByteArray
 import okio.buffer
-import pbandk.decodeFromByteArray
 import kotlin.js.JsExport
-import com.wire.kalium.protobuf.backup.BackupData as ProtoBackupData
 
 @JsExport
-public class BackupImportPager internal constructor(private val storage: EntryStorage) {
+public class BackupImportPager internal constructor(private val entries: List<BackupPage>) {
+
+    public val totalPagesCount: Int = entries.size
+
+    public val conversationsPager: ConversationPager by lazy {
+        ConversationPager(entries.filter { it.name.startsWith(BackupPage.CONVERSATIONS_PREFIX) })
+    }
+
+    public val messagesPager: MessagePager by lazy {
+        MessagePager(entries.filter { it.name.startsWith(BackupPage.MESSAGES_PREFIX) })
+    }
+
+    public val usersPager: UserPager by lazy {
+        UserPager(entries.filter { it.name.startsWith(BackupPage.USERS_PREFIX) })
+    }
+
+}
+
+// The abstract / implementation are done this way to avoid having GenericClass<Data>, which can be lost on ObjC/Swift interop.
+// Otherwise, it could have been just a single class.
+/**
+ * Handles paginated backup data import. This class provides functionality
+ * to process and consume data from multiple ordered pages with a custom mapping applied to the data.
+ *
+ * It is guaranteed that the data will be read in the same order it was written during backup exporting.
+ *
+ * @param T Type of the data elements that are contained in each backup page.
+ * @param entries Initial list of {@link BackupPage} representing the available backup pages.
+ *                These pages are sorted based on their name, extracting numeric segments for ordering.
+ */
+@JsExport
+public abstract class BackupImportDataPager<T> internal constructor(entries: List<BackupPage>) {
+    private var nextPageIndex = 0
+    private val pages = entries.sortedBy {
+        it.name.filter { char -> char.isDigit() }.toInt()
+    }.toMutableList()
     private val mapper = MPBackupMapper()
-    private var currentPageIndex = 0
-    private val entries = storage.listEntries().toMutableList()
+    public val totalPages: Int = pages.size
 
-    public fun hasMorePages(): Boolean = currentPageIndex < entries.size
+    /**
+     * @return true if there are more pages to be read through [nextPage]. False otherwise.
+     */
+    public fun hasMorePages(): Boolean = nextPageIndex < totalPages
 
-    public fun nextPage(): BackupData? {
-        val page = entries.removeFirstOrNull() ?: return null
+    /**
+     * Gets the data stored in the next page, **consuming** it in the process.
+     * @throws IllegalStateException if there are no further available pages.
+     * @see hasMorePages
+     */
+    public fun nextPage(): Array<T> {
+        val page = pages.removeFirstOrNull()
+            ?: throw IllegalStateException("No more pages to consume! Check if there are pages before requesting one")
+        nextPageIndex++
         val bytes = page.data.buffer().readByteArray()
-        return mapper.fromProtoToBackupModel(ProtoBackupData.decodeFromByteArray(bytes))
+        return mapPageData(mapper, bytes)
+    }
+
+    internal abstract fun mapPageData(mapper: MPBackupMapper, bytes: ByteArray): Array<T>
+}
+
+@JsExport
+public class ConversationPager internal constructor(entries: List<BackupPage>) : BackupImportDataPager<BackupConversation>(entries) {
+    override fun mapPageData(mapper: MPBackupMapper, bytes: ByteArray): Array<BackupConversation> {
+        return mapper.fromProtoToBackupModel(BackupData.decodeFromByteArray(bytes)).conversations
+    }
+}
+
+@JsExport
+public class UserPager internal constructor(entries: List<BackupPage>) : BackupImportDataPager<BackupUser>(entries) {
+    override fun mapPageData(mapper: MPBackupMapper, bytes: ByteArray): Array<BackupUser> {
+        return mapper.fromProtoToBackupModel(BackupData.decodeFromByteArray(bytes)).users
+    }
+}
+
+@JsExport
+public class MessagePager internal constructor(entries: List<BackupPage>) : BackupImportDataPager<BackupMessage>(entries) {
+    override fun mapPageData(mapper: MPBackupMapper, bytes: ByteArray): Array<BackupMessage> {
+        return mapper.fromProtoToBackupModel(BackupData.decodeFromByteArray(bytes)).messages
     }
 }

--- a/backup/src/commonMain/kotlin/com/wire/backup/ingest/MPBackupImporter.kt
+++ b/backup/src/commonMain/kotlin/com/wire/backup/ingest/MPBackupImporter.kt
@@ -24,7 +24,7 @@ import com.wire.backup.encryption.XChaChaPoly1305AuthenticationData
 import com.wire.backup.envelope.BackupHeader
 import com.wire.backup.envelope.BackupHeaderSerializer
 import com.wire.backup.envelope.HeaderParseResult
-import com.wire.backup.filesystem.EntryStorage
+import com.wire.backup.filesystem.BackupPageStorage
 import okio.Buffer
 import okio.Sink
 import okio.Source
@@ -111,7 +111,7 @@ public abstract class CommonMPBackupImporter internal constructor(
         }
         sink.close()
         return try {
-            BackupImportResult.Success(BackupImportPager(unzipAllEntries()))
+            BackupImportResult.Success(BackupImportPager(unzipAllEntries().listEntries()))
         } catch (t: Throwable) {
             BackupImportResult.Failure.UnzippingError(t.message ?: "Unknown zipping error.")
         }
@@ -154,7 +154,7 @@ public abstract class CommonMPBackupImporter internal constructor(
     /**
      * Unzips all entries in the zip archive stored in the sink returned by [getUnencryptedArchiveSink].
      */
-    internal abstract suspend fun unzipAllEntries(): EntryStorage
+    internal abstract suspend fun unzipAllEntries(): BackupPageStorage
 }
 
 public expect class MPBackupImporter : CommonMPBackupImporter

--- a/backup/src/commonTest/kotlin/com/wire/backup/BackupEndToEndTest.kt
+++ b/backup/src/commonTest/kotlin/com/wire/backup/BackupEndToEndTest.kt
@@ -99,10 +99,8 @@ class BackupEndToEndTest {
         assertIs<BackupImportResult.Success>(result)
         val pager = result.pager
         val allMessages = mutableListOf<BackupMessage>()
-        while (pager.hasMorePages()) {
-            pager.nextPage()?.let { page ->
-                allMessages.addAll(page.messages)
-            }
+        while (pager.messagesPager.hasMorePages()) {
+            allMessages.addAll(pager.messagesPager.nextPage())
         }
         val firstMessage = allMessages.first()
         assertEquals(expectedMessage.conversationId, firstMessage.conversationId)

--- a/backup/src/commonTest/kotlin/com/wire/backup/dump/MPBackupExporterTest.kt
+++ b/backup/src/commonTest/kotlin/com/wire/backup/dump/MPBackupExporterTest.kt
@@ -18,9 +18,9 @@
 package com.wire.backup.dump
 
 import com.wire.backup.data.BackupQualifiedId
-import com.wire.backup.filesystem.BackupEntry
-import com.wire.backup.filesystem.EntryStorage
-import com.wire.backup.filesystem.InMemoryEntryStorage
+import com.wire.backup.filesystem.BackupPage
+import com.wire.backup.filesystem.BackupPageStorage
+import com.wire.backup.filesystem.InMemoryBackupPageStorage
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.test.runTest
 import okio.Buffer
@@ -37,9 +37,9 @@ class MPBackupExporterTest {
         val subject = object : CommonMPBackupExporter(
             BackupQualifiedId("user", "domain")
         ) {
-            override val storage: EntryStorage = InMemoryEntryStorage()
+            override val storage: BackupPageStorage = InMemoryBackupPageStorage()
 
-            override fun zipEntries(data: List<BackupEntry>): Deferred<Source> {
+            override fun zipEntries(data: List<BackupPage>): Deferred<Source> {
                 throw thrownException
             }
         }

--- a/backup/src/commonTest/kotlin/com/wire/backup/filesystem/BackupPageStorageTest.kt
+++ b/backup/src/commonTest/kotlin/com/wire/backup/filesystem/BackupPageStorageTest.kt
@@ -29,9 +29,9 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 
-internal expect fun createTestStorage(): EntryStorage
+internal expect fun createTestStorage(): BackupPageStorage
 
-class EntryStorageTest {
+class BackupPageStorageTest {
 
     private val entryStorage = createTestStorage()
 
@@ -63,7 +63,7 @@ class EntryStorageTest {
         val entryData = Buffer().apply { write(expectedData) }
         val entryName = "test.bin"
 
-        entryStorage.persistEntry(BackupEntry(entryName, entryData))
+        entryStorage.persistEntry(BackupPage(entryName, entryData))
 
         val result = entryStorage[entryName]
         assertNotNull(result)
@@ -76,9 +76,9 @@ class EntryStorageTest {
         val entryData = Buffer().apply { write(expectedData) }
         val entryName = "test.bin"
 
-        entryStorage.persistEntry(BackupEntry(entryName, entryData))
+        entryStorage.persistEntry(BackupPage(entryName, entryData))
         assertFailsWith<IllegalStateException> {
-            entryStorage.persistEntry(BackupEntry(entryName, entryData.copy()))
+            entryStorage.persistEntry(BackupPage(entryName, entryData.copy()))
         }
     }
 
@@ -88,7 +88,7 @@ class EntryStorageTest {
         val entryData = Buffer().apply { write(expectedData) }
         val entryName = "test.bin"
 
-        entryStorage.persistEntry(BackupEntry(entryName, entryData))
+        entryStorage.persistEntry(BackupPage(entryName, entryData))
 
         val result = entryStorage.listEntries()
         assertEquals(1, result.size)
@@ -102,7 +102,7 @@ class EntryStorageTest {
         val entryData = Buffer().apply { write(expectedData) }
         val entryName = "test.bin"
 
-        entryStorage.persistEntry(BackupEntry(entryName, entryData))
+        entryStorage.persistEntry(BackupPage(entryName, entryData))
         entryStorage.clear()
 
         val result = entryStorage[entryName]

--- a/backup/src/commonTest/kotlin/com/wire/backup/ingest/BackupImportPagerTest.kt
+++ b/backup/src/commonTest/kotlin/com/wire/backup/ingest/BackupImportPagerTest.kt
@@ -1,0 +1,135 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.backup.ingest
+
+import com.wire.backup.data.BackupConversation
+import com.wire.backup.data.BackupDateTime
+import com.wire.backup.data.BackupMessage
+import com.wire.backup.data.BackupMessageContent
+import com.wire.backup.data.BackupQualifiedId
+import com.wire.backup.data.BackupUser
+import com.wire.backup.filesystem.BackupPage
+import com.wire.kalium.protobuf.backup.BackupData
+import com.wire.kalium.protobuf.backup.BackupInfo
+import com.wire.kalium.protobuf.backup.ExportedQualifiedId
+import com.wire.kalium.protobuf.encodeToByteArray
+import okio.Buffer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class BackupImportPagerTest {
+
+    @Test
+    fun givenMultiplePages_whenConsuming_thenShouldSplitBetweenDifferentContentCorrectly() {
+        val expectedConversations = listOf(
+            fakeConversation(0),
+            fakeConversation(1),
+            fakeConversation(2),
+            fakeConversation(3),
+        )
+        val user0 = BackupUser(fakeId(0), "USER 0", "user")
+        val expectedMessages = listOf(
+            fakeMessage(0),
+            fakeMessage(1)
+        )
+        val expectedUsers = listOf(
+            user0,
+            user0.copy(id = fakeId(1))
+        )
+        val pages = listOf(
+            fakeBackupPage(BackupPage.CONVERSATIONS_PREFIX + "0", expectedConversations[0]),
+            fakeBackupPage(BackupPage.MESSAGES_PREFIX + "1", message = expectedMessages[1]),
+            fakeBackupPage(BackupPage.CONVERSATIONS_PREFIX + "11", expectedConversations[3]),
+            fakeBackupPage(BackupPage.MESSAGES_PREFIX + "0", message = expectedMessages[0]),
+            fakeBackupPage(BackupPage.USERS_PREFIX + "0", user = expectedUsers[0]),
+            fakeBackupPage(BackupPage.CONVERSATIONS_PREFIX + "1", expectedConversations[1]),
+            fakeBackupPage(BackupPage.USERS_PREFIX + "1", user = expectedUsers[1]),
+            fakeBackupPage(BackupPage.CONVERSATIONS_PREFIX + "2", expectedConversations[2]),
+        )
+        val pager = BackupImportPager(pages)
+
+        assertTrue { pager.usersPager.hasMorePages() }
+        assertEquals(expectedUsers.size, pager.usersPager.totalPages)
+        assertEquals(expectedUsers[0], pager.usersPager.nextPage().first())
+        assertEquals(expectedUsers[1], pager.usersPager.nextPage().first())
+        assertFalse { pager.usersPager.hasMorePages() }
+
+        assertTrue { pager.conversationsPager.hasMorePages() }
+        assertEquals(expectedConversations.size, pager.conversationsPager.totalPages)
+        assertEquals(expectedConversations[0], pager.conversationsPager.nextPage().first())
+        assertEquals(expectedConversations[1], pager.conversationsPager.nextPage().first())
+        assertEquals(expectedConversations[2], pager.conversationsPager.nextPage().first())
+        assertEquals(expectedConversations[3], pager.conversationsPager.nextPage().first())
+        assertFalse { pager.conversationsPager.hasMorePages() }
+
+        assertTrue { pager.messagesPager.hasMorePages() }
+        assertEquals(expectedMessages.size, pager.messagesPager.totalPages)
+        assertEquals(expectedMessages[0], pager.messagesPager.nextPage().first())
+        assertEquals(expectedMessages[1], pager.messagesPager.nextPage().first())
+        assertFalse { pager.messagesPager.hasMorePages() }
+    }
+
+    @Test
+    fun givenNoPages_whenConsuming_thenShouldCorrectlySayNoMorePages() {
+        val pager = BackupImportPager(listOf())
+
+        assertEquals(0, pager.usersPager.totalPages)
+        assertFalse { pager.usersPager.hasMorePages() }
+        assertFalse { pager.messagesPager.hasMorePages() }
+        assertFalse { pager.conversationsPager.hasMorePages() }
+    }
+
+    private fun fakeConversation(id: Int) = BackupConversation(BackupQualifiedId("conv$id", "domain"), "$id")
+
+    private fun fakeMessage(id: Int) = BackupMessage(
+        "message$id",
+        BackupQualifiedId("conv0", "domain"),
+        fakeId(id),
+        "clientId",
+        BackupDateTime(42L),
+        BackupMessageContent.Text("hey$id")
+    )
+
+    private fun fakeId(id: Int) = BackupQualifiedId("id$id", "domain")
+
+    private fun fakeBackupPage(
+        backupPageName: String,
+        conversation: BackupConversation? = null,
+        message: BackupMessage? = null,
+        user: BackupUser? = null,
+    ): BackupPage {
+        val mapper = MPBackupMapper()
+        val data = BackupData(
+            BackupInfo(
+                platform = "Platform",
+                version = "Version",
+                userId = ExportedQualifiedId("id", "domain"),
+                creationTime = 42L,
+                clientId = "clientId"
+            ),
+            conversations = conversation?.let { listOf(mapper.mapConversationToProtobuf(it)) } ?: listOf(),
+            users = user?.let { listOf(mapper.mapUserToProtobuf(it)) } ?: listOf(),
+            messages = message?.let { listOf(mapper.mapMessageToProtobuf(it)) } ?: listOf()
+        )
+        val buffer = Buffer()
+        buffer.write(data.encodeToByteArray())
+        return BackupPage(backupPageName + BackupPage.PAGE_SUFFIX, buffer.copy())
+    }
+}

--- a/backup/src/commonTest/kotlin/com/wire/backup/ingest/MPBackupImporterTest.kt
+++ b/backup/src/commonTest/kotlin/com/wire/backup/ingest/MPBackupImporterTest.kt
@@ -26,8 +26,8 @@ import com.wire.backup.envelope.BackupHeaderSerializer
 import com.wire.backup.envelope.HashData
 import com.wire.backup.envelope.HeaderParseResult
 import com.wire.backup.envelope.header.FakeHeaderSerializer
-import com.wire.backup.filesystem.EntryStorage
-import com.wire.backup.filesystem.InMemoryEntryStorage
+import com.wire.backup.filesystem.BackupPageStorage
+import com.wire.backup.filesystem.InMemoryBackupPageStorage
 import kotlinx.coroutines.test.runTest
 import okio.Buffer
 import okio.Sink
@@ -39,7 +39,7 @@ import kotlin.test.assertIs
 class MPBackupImporterTest {
 
     private fun createSubject(
-        unzipEntries: () -> EntryStorage = { InMemoryEntryStorage() },
+        unzipEntries: () -> BackupPageStorage = { InMemoryBackupPageStorage() },
         encryptedStream: EncryptedStream<XChaChaPoly1305AuthenticationData> = EncryptedStream.XChaCha20Poly1305,
         headerSerializer: BackupHeaderSerializer = BackupHeaderSerializer.Default,
     ): CommonMPBackupImporter = object : CommonMPBackupImporter(encryptedStream, headerSerializer) {

--- a/backup/src/jsMain/kotlin/com/wire/backup/dump/MPBackupExporter.kt
+++ b/backup/src/jsMain/kotlin/com/wire/backup/dump/MPBackupExporter.kt
@@ -18,9 +18,9 @@
 package com.wire.backup.dump
 
 import com.wire.backup.data.BackupQualifiedId
-import com.wire.backup.filesystem.BackupEntry
-import com.wire.backup.filesystem.EntryStorage
-import com.wire.backup.filesystem.InMemoryEntryStorage
+import com.wire.backup.filesystem.BackupPage
+import com.wire.backup.filesystem.BackupPageStorage
+import com.wire.backup.filesystem.InMemoryBackupPageStorage
 import ext.libsodium.com.ionspin.kotlin.crypto.toUByteArray
 import ext.libsodium.com.ionspin.kotlin.crypto.toUInt8Array
 import kotlinx.coroutines.Deferred
@@ -37,11 +37,11 @@ public actual class MPBackupExporter(
     selfUserId: BackupQualifiedId
 ) : CommonMPBackupExporter(selfUserId) {
 
-    override val storage: EntryStorage = InMemoryEntryStorage()
+    override val storage: BackupPageStorage = InMemoryBackupPageStorage()
 
     // This shouldn't be used by clients anyway, so it's fine if we can't sport it to JS!
     @Suppress("NON_EXPORTABLE_TYPE")
-    override fun zipEntries(data: List<BackupEntry>): Deferred<Source> {
+    override fun zipEntries(data: List<BackupPage>): Deferred<Source> {
         val zip = JSZip()
         data.forEach { entry ->
             // TODO: Save memory and improve performance by avoid array duplication!

--- a/backup/src/jsTest/kotlin/com/wire/backup/filesystem/EntryStorageTest.kt
+++ b/backup/src/jsTest/kotlin/com/wire/backup/filesystem/EntryStorageTest.kt
@@ -17,4 +17,4 @@
  */
 package com.wire.backup.filesystem
 
-internal actual fun createTestStorage(): EntryStorage = InMemoryEntryStorage()
+internal actual fun createTestStorage(): BackupPageStorage = InMemoryBackupPageStorage()

--- a/backup/src/nonJsMain/kotlin/com/wire/backup/dump/MPBackupExporter.kt
+++ b/backup/src/nonJsMain/kotlin/com/wire/backup/dump/MPBackupExporter.kt
@@ -19,9 +19,9 @@ package com.wire.backup.dump
 
 import com.rickclephas.kmp.nativecoroutines.NativeCoroutines
 import com.wire.backup.data.BackupQualifiedId
-import com.wire.backup.filesystem.BackupEntry
-import com.wire.backup.filesystem.EntryStorage
-import com.wire.backup.filesystem.FileBasedEntryStorage
+import com.wire.backup.filesystem.BackupPage
+import com.wire.backup.filesystem.BackupPageStorage
+import com.wire.backup.filesystem.FileBasedBackupPageStorage
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
 import okio.FileSystem
@@ -40,13 +40,13 @@ public actual class MPBackupExporter(
 
     private val fileSystem = FileSystem.SYSTEM
 
-    override val storage: EntryStorage = FileBasedEntryStorage(
+    override val storage: BackupPageStorage = FileBasedBackupPageStorage(
         fileSystem = fileSystem,
         workDirectory = workDirectoryPath,
         shouldBeCleared = true
     )
 
-    override fun zipEntries(data: List<BackupEntry>): Deferred<Source> {
+    override fun zipEntries(data: List<BackupPage>): Deferred<Source> {
         val entries = data.map { fileSystem.canonicalize(workDirectoryPath / it.name).toString() }
         val pathToZippedArchive = fileZipper.zip(entries).toPath()
         return CompletableDeferred(

--- a/backup/src/nonJsMain/kotlin/com/wire/backup/filesystem/FileBasedBackupPageStorage.kt
+++ b/backup/src/nonJsMain/kotlin/com/wire/backup/filesystem/FileBasedBackupPageStorage.kt
@@ -20,11 +20,11 @@ package com.wire.backup.filesystem
 import okio.FileSystem
 import okio.Path
 
-internal class FileBasedEntryStorage(
+internal class FileBasedBackupPageStorage(
     private val fileSystem: FileSystem,
     private val workDirectory: Path,
     shouldBeCleared: Boolean,
-) : EntryStorage {
+) : BackupPageStorage {
 
     init {
         if (!fileSystem.exists(workDirectory)) {
@@ -38,27 +38,27 @@ internal class FileBasedEntryStorage(
         }
     }
 
-    override fun persistEntry(backupEntry: BackupEntry) {
-        check(!fileSystem.exists(workDirectory / backupEntry.name)) {
-            "File with name ${backupEntry.name} already exists!"
+    override fun persistEntry(backupPage: BackupPage) {
+        check(!fileSystem.exists(workDirectory / backupPage.name)) {
+            "File with name ${backupPage.name} already exists!"
         }
-        fileSystem.write(workDirectory / backupEntry.name) {
-            writeAll(backupEntry.data)
+        fileSystem.write(workDirectory / backupPage.name) {
+            writeAll(backupPage.data)
         }
     }
 
-    override operator fun get(entryName: String): BackupEntry? {
+    override operator fun get(entryName: String): BackupPage? {
         val entryFile = workDirectory / entryName
         return if (fileSystem.exists(entryFile)) {
-            BackupEntry(entryName, fileSystem.openReadOnly(entryFile).source())
+            BackupPage(entryName, fileSystem.openReadOnly(entryFile).source())
         } else {
             null
         }
     }
 
-    override fun listEntries(): List<BackupEntry> =
+    override fun listEntries(): List<BackupPage> =
         fileSystem.list(workDirectory).map {
-            BackupEntry(it.name, fileSystem.openReadOnly(it).source())
+            BackupPage(it.name, fileSystem.openReadOnly(it).source())
         }
 
     override fun clear() {

--- a/backup/src/nonJsMain/kotlin/com/wire/backup/ingest/MPBackupImporter.kt
+++ b/backup/src/nonJsMain/kotlin/com/wire/backup/ingest/MPBackupImporter.kt
@@ -18,8 +18,8 @@
 package com.wire.backup.ingest
 
 import com.rickclephas.kmp.nativecoroutines.NativeCoroutines
-import com.wire.backup.filesystem.EntryStorage
-import com.wire.backup.filesystem.FileBasedEntryStorage
+import com.wire.backup.filesystem.BackupPageStorage
+import com.wire.backup.filesystem.FileBasedBackupPageStorage
 import okio.FileSystem
 import okio.Path
 import okio.Path.Companion.toPath
@@ -73,9 +73,9 @@ public actual class MPBackupImporter(
         return FileSystem.SYSTEM.sink(archiveZipPath)
     }
 
-    override suspend fun unzipAllEntries(): EntryStorage {
+    override suspend fun unzipAllEntries(): BackupPageStorage {
         val unzipPath = backupFileUnzipper.unzipBackup(archiveZipPath.toString())
-        return FileBasedEntryStorage(FileSystem.SYSTEM, unzipPath.toPath(), false)
+        return FileBasedBackupPageStorage(FileSystem.SYSTEM, unzipPath.toPath(), false)
     }
 
     private companion object {

--- a/backup/src/nonJsTest/kotlin/com/wire/backup/filesystem/EntryStorageTest.kt
+++ b/backup/src/nonJsTest/kotlin/com/wire/backup/filesystem/EntryStorageTest.kt
@@ -20,8 +20,8 @@ package com.wire.backup.filesystem
 import okio.FileSystem
 import okio.SYSTEM
 
-internal actual fun createTestStorage(): EntryStorage {
-    return FileBasedEntryStorage(
+internal actual fun createTestStorage(): BackupPageStorage {
+    return FileBasedBackupPageStorage(
         FileSystem.SYSTEM,
         FileSystem.SYSTEM_TEMPORARY_DIRECTORY / "kalium-test-backup",
         true


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10575" title="WPB-10575" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-10575</a>  Cross Platform Backup: Write common backup / restore library
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We can make it easier to clients to consume the data in the same exact order every time.
Otherwise, clients can shoot themselves in the foot if the data being saved into the DB is not properly sorted, by failing to satisfy DB constraints, for example.

### Solutions

Split the pager into smaller pagers. One for each:
- Conversations
- Users
- Messages

These will make sure that the pages are always consumed in order.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
