### PR TITLE
feat: Add cron job to restart kalium-testservice every evening

### DIFF
--- a/testservice/ansible/roles/kalium-testservice/tasks/main.yml
+++ b/testservice/ansible/roles/kalium-testservice/tasks/main.yml
@@ -86,3 +86,9 @@
     enabled: true
     state: restarted
 
+- name: Restart kalium-testservice every evening
+  cron:
+    name: "Restart kalium-testservice"
+    minute: "30"
+    hour: "20"
+    job: "systemctl restart kalium-testservice"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Just restarts the testservice every evening at 20:30 on node018