### PR TITLE
fix: stale participant concurrent modification exeption [WPB-15340]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
@@ -163,7 +163,7 @@ internal class CallDataSource(
     private val job = SupervisorJob() // TODO(calling): clear job method
     private val scope = CoroutineScope(job + kaliumDispatchers.io)
     private val callJobs = ConcurrentMutableMap<ConversationId, Job>()
-    val staleParticipantJobs = ConcurrentMutableMap<QualifiedClientID, Job>()
+    private val staleParticipantJobs = ConcurrentMutableMap<QualifiedClientID, Job>()
 
     override suspend fun observeCurrentCall(conversationId: ConversationId): Flow<Call?> = _callMetadataProfile.map {
         it[conversationId]?.let { currentCall ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/confirmation/ConfirmationDeliveryHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/confirmation/ConfirmationDeliveryHandler.kt
@@ -103,7 +103,6 @@ internal class ConfirmationDeliveryHandlerImpl(
                             leadingMessage = "Skipping group conversation: ${conversation.id.toLogString()}",
                             jsonStringKeyValues = mapOf(
                                 "conversationId" to conversation.id.toLogString(),
-                                "messages" to messages.joinToString { it.obfuscateId() },
                                 "messageCount" to messages.size
                             )
                         )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15340" title="WPB-15340" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15340</a>  [Android] Crash when hanging up a call in MLS group
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- Fixed a **ConcurrentModificationException** crash occurring in `leaveMlsConference()`, which was triggered when multiple threads attempted to modify `staleParticipantJobs` simultaneously.
- The issue was observed when ending a call in a group conversation where different users had mixed MLS and Proteus protocols.

### Causes

- `staleParticipantJobs` is a `ConcurrentMutableMap`, but previous implementations did not ensure thread-safe modifications when iterating over and modifying the collection at the same time.
- When a participant was marked as "stale" (i.e., `hasEstablishedAudio = false`), a delayed coroutine was scheduled to remove them from the MLS group.
- `leaveMlsConference()` iterated over `staleParticipantJobs`, removing and canceling jobs. However, `updateCallParticipants()` could simultaneously modify this map, leading to a `ConcurrentModificationException`.

### Solutions

- Refactored `leaveMlsConference()` to use the **`block {}` method** from `ConcurrentMutableMap`, ensuring that all modifications are performed in a thread-safe manner.
- This prevents concurrent iterations and modifications from causing a crash while still allowing multiple coroutines to access and modify `staleParticipantJobs` safely.
