### PR TITLE
refactor: remove not needed usage of observe self user [WPB-15414]

### DIFF
--- a/android/src/main/kotlin/com/wire/kalium/presentation/MainActivity.kt
+++ b/android/src/main/kotlin/com/wire/kalium/presentation/MainActivity.kt
@@ -83,9 +83,9 @@ class MainActivity : ComponentActivity() {
 
             session.users.uploadUserAvatar(tempAvatarPath, imageContent.size.toLong())
 
-            val selfUser = session.users.observeSelfUser().first()
+            val selfUser = session.users.getSelfUser()
 
-            val avatarAsset = when (val publicAsset = session.users.getPublicAsset(selfUser.previewPicture!!)) {
+            val avatarAsset = when (val publicAsset = session.users.getPublicAsset(selfUser?.previewPicture!!)) {
                 is PublicAssetResult.Success -> {
                     // We read the avatar data stored in the assetPath
                     session.kaliumFileSystem.readByteArray(publicAsset.assetPath)
@@ -94,7 +94,7 @@ class MainActivity : ComponentActivity() {
             }
 
             setContent {
-                MainLayout(conversations, selfUser, avatarAsset)
+                MainLayout(conversations, selfUser!!, avatarAsset)
             }
         }
     }

--- a/cli/src/commonMain/kotlin/com/wire/kalium/cli/commands/GenerateEventsCommand.kt
+++ b/cli/src/commonMain/kotlin/com/wire/kalium/cli/commands/GenerateEventsCommand.kt
@@ -58,7 +58,7 @@ class GenerateEventsCommand : CliktCommand(name = "generate-events") {
     }
 
     override fun run() = runBlocking {
-        val selfUserId = userSession.users.observeSelfUser().first().id
+        val selfUserId = userSession.users.getSelfUser()?.id ?: throw PrintMessage("No self user is registered")
         val selfClientId = userSession.clientIdProvider().getOrFail { throw PrintMessage("No self client is registered") }
         val targetUserId = UserId(value = targetUserId, domain = selfUserId.domain)
         val targetClientId = ClientId(targetClientId)

--- a/cli/src/commonMain/kotlin/com/wire/kalium/cli/commands/GenerateEventsCommand.kt
+++ b/cli/src/commonMain/kotlin/com/wire/kalium/cli/commands/GenerateEventsCommand.kt
@@ -32,7 +32,6 @@ import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.data.event.EventGenerator
 import com.wire.kalium.logic.functional.getOrFail
 import com.wire.kalium.network.api.authenticated.notification.NotificationResponse
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Clock

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -56,7 +56,6 @@ import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldHandler
 import com.wire.kalium.logic.wrapApiRequest
-import com.wire.kalium.logic.wrapFlowStorageRequest
 import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.authenticated.teams.TeamMemberDTO
 import com.wire.kalium.network.api.authenticated.teams.TeamMemberIdList
@@ -370,7 +369,6 @@ internal class UserDataSource internal constructor(
 
     override suspend fun observeSelfUser(): Flow<SelfUser> = userDAO.observeUserDetailsByQualifiedID(selfUserId.toDao()).filterNotNull()
             .map(userMapper::fromUserDetailsEntityToSelfUser)
-
 
     override suspend fun observeSelfUserWithTeam(): Flow<Pair<SelfUser, Team?>> {
         return userDAO.getUserDetailsWithTeamByQualifiedID(selfUserId.toDao()).filterNotNull()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/CreateBackupUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/CreateBackupUseCase.kt
@@ -38,6 +38,7 @@ import com.wire.kalium.logic.feature.backup.BackupConstants.createBackupFileName
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.logic.functional.getOrNull
 import com.wire.kalium.logic.functional.nullableFold
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.util.SecurityHelper
@@ -79,7 +80,7 @@ internal class CreateBackupUseCaseImpl(
 ) : CreateBackupUseCase {
 
     override suspend operator fun invoke(password: String): CreateBackupResult = withContext(dispatchers.default) {
-        val userHandle = userRepository.getSelfUser()?.handle?.replace(".", "-")
+        val userHandle = userRepository.getSelfUser().getOrNull()?.handle?.replace(".", "-")
         val timeStamp = DateTimeUtil.currentSimpleDateTimeString()
         val backupName = createBackupFileName(userHandle, timeStamp)
         val backupFilePath = kaliumFileSystem.tempFilePath(backupName)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/CreateObfuscatedCopyUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/CreateObfuscatedCopyUseCase.kt
@@ -36,6 +36,7 @@ import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.logic.functional.getOrNull
 import com.wire.kalium.logic.functional.nullableFold
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.util.createCompressedFile
@@ -73,7 +74,7 @@ class CreateObfuscatedCopyUseCase internal constructor(
 
     @DelicateKaliumApi("This function is used for debugging purposes only")
     suspend operator fun invoke(password: String?): CreateBackupResult = withContext(dispatchers.default) {
-        val userHandle = userRepository.getSelfUser()?.handle?.replace(".", "-")
+        val userHandle = userRepository.getSelfUser().getOrNull()?.handle?.replace(".", "-")
         val timeStamp = DateTimeUtil.currentSimpleDateTimeString()
         val backupName = createFinalZipName(userHandle, timeStamp)
         val backupFilePath = kaliumFileSystem.tempFilePath(backupName)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/RestoreBackupUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/RestoreBackupUseCase.kt
@@ -42,6 +42,7 @@ import com.wire.kalium.logic.feature.backup.RestoreBackupResult.Failure
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.logic.functional.getOrNull
 import com.wire.kalium.logic.functional.mapLeft
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.logic.util.ExtractFilesParam
@@ -159,9 +160,7 @@ internal class RestoreBackupUseCaseImpl(
         password: String
     ): Either<Failure, Unit> {
         val backupSource = kaliumFileSystem.source(encryptedFilePath)
-        val userHandle = userRepository.getSelfUser()?.handle?.map {
-            it.toString().replace(".", "-")
-        }?.first()
+        val userHandle = userRepository.getSelfUser().getOrNull()?.handle?.replace(".", "-")
         val timeStamp = DateTimeUtil.currentIsoDateTimeString()
         val backupName = createBackupFileName(userHandle, timeStamp)
         val extractedBackupPath = extractedBackupRootPath / backupName

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetIncomingCallsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetIncomingCallsUseCase.kt
@@ -27,9 +27,6 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.data.call.Call
-import com.wire.kalium.logic.functional.Either
-import com.wire.kalium.logic.functional.isLeft
-import com.wire.kalium.logic.functional.mapRight
 import com.wire.kalium.logic.functional.nullableFold
 import com.wire.kalium.logic.kaliumLogger
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetIncomingCallsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetIncomingCallsUseCase.kt
@@ -27,6 +27,9 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.data.call.Call
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.isLeft
+import com.wire.kalium.logic.functional.mapRight
 import com.wire.kalium.logic.functional.nullableFold
 import com.wire.kalium.logic.kaliumLogger
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -70,7 +73,6 @@ internal class GetIncomingCallsUseCaseImpl internal constructor(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private suspend fun observeIncomingCallsIfUserStatusAllows(): Flow<List<Call>> =
-        // TODO: do not refresh self form remote in this case and just get status from local
         userRepository.observeSelfUser()
             .flatMapLatest {
                 // if user is AWAY we don't show any IncomingCalls

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCase.kt
@@ -35,6 +35,7 @@ import com.wire.kalium.logic.feature.client.RegisterClientUseCase.Companion.FIRS
 import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
+import com.wire.kalium.logic.functional.getOrNull
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.kaliumLogger
 import com.wire.kalium.network.exceptions.AuthenticationCodeFailure
@@ -175,7 +176,10 @@ class RegisterClientUseCaseImpl @OptIn(DelicateKaliumApi::class) internal constr
     }
 
     private suspend fun currentlyStoredVerificationCode(): String? {
-        val userEmail = userRepository.getSelfUser()?.email
+        val userEmail = userRepository.getSelfUser()
+            .map {
+                it.email
+            }.getOrNull()
         return userEmail?.let { secondFactorVerificationRepository.getStoredVerificationCode(it) }
     }
 
@@ -206,7 +210,7 @@ class RegisterClientUseCaseImpl @OptIn(DelicateKaliumApi::class) internal constr
             RegisterClientResult.Failure.InvalidCredentials.Missing2FA
 
         AuthenticationCodeFailure.INVALID_OR_EXPIRED_AUTHENTICATION_CODE -> {
-            userRepository.getSelfUser()?.email?.let {
+            userRepository.getSelfUser().getOrNull()?.email?.let {
                 secondFactorVerificationRepository.clearStoredVerificationCode(it)
             }
             RegisterClientResult.Failure.InvalidCredentials.Invalid2FA

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/SyncSelfTeamUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/SyncSelfTeamUseCase.kt
@@ -26,7 +26,6 @@ import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.onSuccess
 import com.wire.kalium.logic.kaliumLogger
-import kotlinx.coroutines.flow.first
 
 internal interface SyncSelfTeamUseCase {
     suspend operator fun invoke(): Either<CoreFailure, Unit>

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/SyncSelfTeamUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/SyncSelfTeamUseCase.kt
@@ -38,22 +38,21 @@ internal class SyncSelfTeamUseCaseImpl(
     private val fetchedUsersLimit: Int?
 ) : SyncSelfTeamUseCase {
 
-    override suspend fun invoke(): Either<CoreFailure, Unit> {
-        val user = userRepository.observeSelfUser().first()
-
-        return user.teamId?.let { teamId ->
-            teamRepository.fetchTeamById(teamId = teamId).flatMap {
-                teamRepository.fetchMembersByTeamId(
-                    teamId = teamId,
-                    userDomain = user.id.domain,
-                    fetchedUsersLimit = fetchedUsersLimit
-                )
-            }.onSuccess {
-                teamRepository.syncServices(teamId = teamId)
+    override suspend fun invoke(): Either<CoreFailure, Unit> =
+        userRepository.getSelfUser().flatMap { selfUser ->
+            selfUser.teamId?.let { teamId ->
+                teamRepository.fetchTeamById(teamId = teamId).flatMap {
+                    teamRepository.fetchMembersByTeamId(
+                        teamId = teamId,
+                        userDomain = selfUser.id.domain,
+                        fetchedUsersLimit = fetchedUsersLimit
+                    )
+                }.onSuccess {
+                    teamRepository.syncServices(teamId = teamId)
+                }
+            } ?: run {
+                kaliumLogger.withFeatureId(SYNC).i("Skipping team sync because user doesn't belong to a team")
+                Either.Right(Unit)
             }
-        } ?: run {
-            kaliumLogger.withFeatureId(SYNC).i("Skipping team sync because user doesn't belong to a team")
-            Either.Right(Unit)
         }
-    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/GetSelfUserUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/GetSelfUserUseCase.kt
@@ -20,9 +20,7 @@ package com.wire.kalium.logic.feature.user
 
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserRepository
-import com.wire.kalium.util.KaliumDispatcher
-import com.wire.kalium.util.KaliumDispatcherImpl
-import kotlinx.coroutines.withContext
+import com.wire.kalium.logic.functional.getOrNull
 
 /**
  * This use case is responsible for retrieving the current user.
@@ -38,10 +36,6 @@ interface GetSelfUserUseCase {
 
 internal class GetSelfUserUseCaseImpl internal constructor(
     private val userRepository: UserRepository,
-    private val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) : GetSelfUserUseCase {
-
-    override suspend operator fun invoke(): SelfUser? = withContext(dispatcher.io) {
-        userRepository.getSelfUser()
-    }
+    override suspend operator fun invoke(): SelfUser? = userRepository.getSelfUser().getOrNull()
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveSelfUserUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveSelfUserUseCase.kt
@@ -18,8 +18,10 @@
 
 package com.wire.kalium.logic.feature.user
 
+import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.functional.Either
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.flow.Flow
@@ -39,10 +41,8 @@ interface ObserveSelfUserUseCase {
 
 internal class ObserveSelfUserUseCaseImpl internal constructor(
     private val userRepository: UserRepository,
-    private val dispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) : ObserveSelfUserUseCase {
 
-    override suspend operator fun invoke(): Flow<SelfUser> = withContext(dispatcher.io) {
-        userRepository.observeSelfUser()
-    }
+    override suspend operator fun invoke(): Flow<SelfUser> = userRepository.observeSelfUser()
+
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveSelfUserUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/ObserveSelfUserUseCase.kt
@@ -18,14 +18,9 @@
 
 package com.wire.kalium.logic.feature.user
 
-import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserRepository
-import com.wire.kalium.logic.functional.Either
-import com.wire.kalium.util.KaliumDispatcher
-import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.withContext
 
 /**
  * This use case is responsible for observing the current user.

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateSelfUserSupportedProtocolsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateSelfUserSupportedProtocolsUseCase.kt
@@ -59,7 +59,7 @@ internal class UpdateSelfUserSupportedProtocolsUseCaseImpl(
             logger.d("Skip updating supported protocols, since MLS is not supported.")
             Either.Right(false)
         } else {
-            (userRepository.getSelfUser()?.let { selfUser ->
+            (userRepository.getSelfUser().flatMap { selfUser ->
                 selfSupportedProtocols().flatMap { newSupportedProtocols ->
                     logger.i(
                         "Updating supported protocols = $newSupportedProtocols previously = ${selfUser.supportedProtocols}"
@@ -81,7 +81,7 @@ internal class UpdateSelfUserSupportedProtocolsUseCaseImpl(
                         else -> Either.Left(it)
                     }
                 }
-            } ?: Either.Left(StorageFailure.DataNotFound))
+            })
         }
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/client/E2EIClientProviderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/client/E2EIClientProviderTest.kt
@@ -17,12 +17,14 @@
  */
 package com.wire.kalium.logic.client
 
+import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.client.E2EIClientProvider
 import com.wire.kalium.logic.data.client.EI2EIClientProviderImpl
 import com.wire.kalium.logic.data.mls.CipherSuite
 import com.wire.kalium.logic.data.mls.SupportedCipherSuite
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.functional.left
 import com.wire.kalium.logic.functional.right
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import com.wire.kalium.logic.test_util.testKaliumDispatcher
@@ -46,7 +48,7 @@ class E2EIClientProviderTest {
                 dispatcher = this@runTest.testKaliumDispatcher
                 withGetMLSClientSuccessful()
                 withE2EINewActivationEnrollmentSuccessful()
-                withSelfUser(TestUser.SELF)
+                withSelfUser(TestUser.SELF.right())
                 withE2EIEnabled(false)
             }
 
@@ -72,7 +74,7 @@ class E2EIClientProviderTest {
                 dispatcher = this@runTest.testKaliumDispatcher
                 withGetMLSClientSuccessful()
                 withE2EINewRotationEnrollmentSuccessful()
-                withSelfUser(TestUser.SELF)
+                withSelfUser(TestUser.SELF.right())
                 withE2EIEnabled(true)
             }
 
@@ -102,7 +104,7 @@ class E2EIClientProviderTest {
                 dispatcher = this@runTest.testKaliumDispatcher
                 withGetMLSClientSuccessful()
                 withE2EINewRotationEnrollmentSuccessful()
-                withSelfUser(null)
+                withSelfUser(StorageFailure.DataNotFound.left())
                 withE2EIEnabled(true)
             }
 
@@ -139,7 +141,7 @@ class E2EIClientProviderTest {
                 dispatcher = this@runTest.testKaliumDispatcher
                 withGettingCoreCryptoSuccessful()
                 withGetNewAcmeEnrollmentSuccessful()
-                withSelfUser(TestUser.SELF)
+                withSelfUser(TestUser.SELF.right())
                 withGetOrFetchMLSConfig(supportedCipherSuite)
             }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -44,6 +44,7 @@ import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestTeam
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.right
 import com.wire.kalium.logic.sync.receiver.conversation.RenamedConversationEventHandler
 import com.wire.kalium.logic.util.arrangement.dao.MemberDAOArrangement
 import com.wire.kalium.logic.util.arrangement.dao.MemberDAOArrangementImpl
@@ -1517,7 +1518,7 @@ class ConversationRepositoryTest {
         suspend fun withSelfUser(selfUser: SelfUser) = apply {
             coEvery {
                 userRepository.getSelfUser()
-            }.returns(selfUser)
+            }.returns(selfUser.right())
         }
 
         suspend fun withFetchConversationsDetails(response: NetworkResponse<ConversationResponse>) = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/CreateBackupUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/CreateBackupUseCaseTest.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.logic.feature.backup.BackupConstants.BACKUP_ENCRYPTED_FIL
 import com.wire.kalium.logic.feature.backup.BackupConstants.BACKUP_METADATA_FILE_NAME
 import com.wire.kalium.logic.framework.TestUser.SELF
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.right
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import com.wire.kalium.logic.util.ExtractFilesParam
 import com.wire.kalium.logic.util.IgnoreIOS
@@ -233,7 +234,7 @@ class CreateBackupUseCaseTest {
         suspend fun withUserHandle(selfUser: SelfUser) = apply {
             coEvery {
                 userRepository.getSelfUser()
-            }.returns(selfUser)
+            }.returns(selfUser.right())
         }
 
         fun arrange(): Pair<Arrangement, CreateBackupUseCase> =

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/RestoreBackupUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/RestoreBackupUseCaseTest.kt
@@ -35,6 +35,7 @@ import com.wire.kalium.logic.feature.backup.BackupConstants.BACKUP_ENCRYPTED_FIL
 import com.wire.kalium.logic.feature.backup.BackupConstants.BACKUP_USER_DB_NAME
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.right
 import com.wire.kalium.logic.util.ExtractFilesParam
 import com.wire.kalium.logic.util.IgnoreIOS
 import com.wire.kalium.logic.util.createCompressedFile
@@ -345,7 +346,7 @@ class RestoreBackupUseCaseTest {
         suspend fun withSelfUser(selfUser: SelfUser) = apply {
             coEvery {
                 userRepository.getSelfUser()
-            }.returns(selfUser)
+            }.returns(selfUser.right())
         }
 
         lateinit var extractZipFile: (

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/RegisterClientUseCaseTest.kt
@@ -39,6 +39,7 @@ import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.right
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import com.wire.kalium.logic.test_util.TestNetworkException
 import com.wire.kalium.logic.test_util.testKaliumDispatcher
@@ -478,7 +479,7 @@ class RegisterClientUseCaseTest {
         suspend fun withSelfUser(selfUser: SelfUser) = apply {
             coEvery {
                 userRepository.getSelfUser()
-            }.returns(selfUser)
+            }.returns(selfUser.right())
         }
 
         suspend fun withRegisterClient(result: Either<NetworkFailure, Client>) = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/protocol/OneOnOneProtocolSelectorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/protocol/OneOnOneProtocolSelectorTest.kt
@@ -46,14 +46,13 @@ class OneOnOneProtocolSelectorTest {
         val failure = StorageFailure.DataNotFound
         val (_, oneOnOneProtocolSelector) = arrange {
             withUserByIdReturning(Either.Right(TestUser.OTHER))
-            withSelfUserReturning(null)
+            withSelfUserReturning(StorageFailure.DataNotFound.left())
             withGetDefaultProtocolReturning(failure.left())
         }
 
         oneOnOneProtocolSelector.getProtocolForUser(TestUser.USER_ID)
             .shouldFail {
-                assertIs<CoreFailure.Unknown>(it)
-                assertIs<NullPointerException>(it.rootCause)
+                assertIs<StorageFailure.DataNotFound>(it)
             }
     }
 
@@ -61,7 +60,7 @@ class OneOnOneProtocolSelectorTest {
     fun givenFailureToFindOtherUser_thenShouldPropagateFailure() = runTest {
         val failure = StorageFailure.DataNotFound
         val (_, oneOnOneProtocolSelector) = arrange {
-            withSelfUserReturning(TestUser.SELF)
+            withSelfUserReturning(TestUser.SELF.right())
             withUserByIdReturning(failure.left())
             withGetDefaultProtocolReturning(failure.left())
         }
@@ -76,7 +75,7 @@ class OneOnOneProtocolSelectorTest {
     fun givenOtherUserId_thenShouldCallRepoWithCorrectUserId() = runTest {
         val failure = StorageFailure.DataNotFound
         val (arrangement, oneOnOneProtocolSelector) = arrange {
-            withSelfUserReturning(TestUser.SELF)
+            withSelfUserReturning(TestUser.SELF.right())
             withUserByIdReturning(Either.Left(failure))
             withGetDefaultProtocolReturning(failure.left())
         }
@@ -93,7 +92,7 @@ class OneOnOneProtocolSelectorTest {
         val failure = StorageFailure.DataNotFound
         val supportedProtocols = setOf(SupportedProtocol.MLS, SupportedProtocol.PROTEUS)
         val (arrangement, oneOnOneProtocolSelector) = arrange {
-            withSelfUserReturning(TestUser.SELF.copy(supportedProtocols = supportedProtocols))
+            withSelfUserReturning(TestUser.SELF.copy(supportedProtocols = supportedProtocols).right())
             withUserByIdReturning(Either.Right(TestUser.OTHER.copy(supportedProtocols = supportedProtocols)))
             withGetDefaultProtocolReturning(failure.left())
         }
@@ -109,7 +108,7 @@ class OneOnOneProtocolSelectorTest {
         val bothProtocols = setOf(SupportedProtocol.MLS, SupportedProtocol.PROTEUS)
         val failure = StorageFailure.DataNotFound
         val (_, oneOnOneProtocolSelector) = arrange {
-            withSelfUserReturning(TestUser.SELF.copy(supportedProtocols = bothProtocols))
+            withSelfUserReturning(TestUser.SELF.copy(supportedProtocols = bothProtocols).right())
             withUserByIdReturning(Either.Right(TestUser.OTHER.copy(supportedProtocols = setOf(SupportedProtocol.PROTEUS))))
             withGetDefaultProtocolReturning(failure.left())
         }
@@ -125,7 +124,7 @@ class OneOnOneProtocolSelectorTest {
         val failure = StorageFailure.DataNotFound
         val mlsSet = setOf(SupportedProtocol.MLS)
         val (_, oneOnOneProtocolSelector) = arrange {
-            withSelfUserReturning(TestUser.SELF.copy(supportedProtocols = mlsSet))
+            withSelfUserReturning(TestUser.SELF.copy(supportedProtocols = mlsSet).right())
             withUserByIdReturning(Either.Right(TestUser.OTHER.copy(supportedProtocols = mlsSet)))
             withGetDefaultProtocolReturning(failure.left())
         }
@@ -140,7 +139,7 @@ class OneOnOneProtocolSelectorTest {
     fun givenUsersHaveNoProtocolInCommon_thenShouldReturnNoCommonProtocol() = runTest {
         val failure = StorageFailure.DataNotFound
         val (_, oneOnOneProtocolSelector) = arrange {
-            withSelfUserReturning(TestUser.SELF.copy(supportedProtocols = setOf(SupportedProtocol.MLS)))
+            withSelfUserReturning(TestUser.SELF.copy(supportedProtocols = setOf(SupportedProtocol.MLS)).right())
             withUserByIdReturning(Either.Right(TestUser.OTHER.copy(supportedProtocols = setOf(SupportedProtocol.PROTEUS))))
             withGetDefaultProtocolReturning(failure.left())
         }
@@ -155,7 +154,7 @@ class OneOnOneProtocolSelectorTest {
     fun givenUsersHaveNoProtocolInCommon_thenShouldReturnNoCommonProtocol_2() = runTest {
         val failure = StorageFailure.DataNotFound
         val (_, oneOnOneProtocolSelector) = arrange {
-            withSelfUserReturning(TestUser.SELF.copy(supportedProtocols = setOf(SupportedProtocol.PROTEUS)))
+            withSelfUserReturning(TestUser.SELF.copy(supportedProtocols = setOf(SupportedProtocol.PROTEUS)).right())
             withUserByIdReturning(Either.Right(TestUser.OTHER.copy(supportedProtocols = setOf(SupportedProtocol.MLS))))
             withGetDefaultProtocolReturning(failure.left())
         }
@@ -169,7 +168,7 @@ class OneOnOneProtocolSelectorTest {
     @Test
     fun givenUsersHaveProtocolInCommonIncludingDefaultProtocol_thenShouldReturnDefaultProtocolAsCommonProtocol() = runTest {
         val (_, oneOnOneProtocolSelector) = arrange {
-            withSelfUserReturning(TestUser.SELF.copy(supportedProtocols = setOf(SupportedProtocol.MLS, SupportedProtocol.PROTEUS)))
+            withSelfUserReturning(TestUser.SELF.copy(supportedProtocols = setOf(SupportedProtocol.MLS, SupportedProtocol.PROTEUS)).right())
             withUserByIdReturning(Either.Right(TestUser.OTHER.copy(supportedProtocols = setOf(SupportedProtocol.MLS))))
             withGetDefaultProtocolReturning(SupportedProtocol.MLS.right())
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/UpdateSupportedProtocolsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/UpdateSupportedProtocolsUseCaseTest.kt
@@ -34,6 +34,7 @@ import com.wire.kalium.logic.featureFlags.FeatureSupport
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.functional.right
 import com.wire.kalium.logic.util.arrangement.provider.CurrentClientIdProviderArrangement
 import com.wire.kalium.logic.util.arrangement.provider.CurrentClientIdProviderArrangementImpl
 import com.wire.kalium.logic.util.shouldSucceed
@@ -336,7 +337,7 @@ class UpdateSupportedProtocolsUseCaseTest {
 
         suspend fun withGetSelfUserSuccessful(supportedProtocols: Set<SupportedProtocol>? = null) = apply {
             coEvery { userRepository.getSelfUser() }
-                .returns(TestUser.SELF.copy(supportedProtocols = supportedProtocols))
+                .returns(TestUser.SELF.copy(supportedProtocols = supportedProtocols).right())
         }
 
         suspend fun withUpdateSupportedProtocolsSuccessful() = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/provider/E2EIClientProviderArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/provider/E2EIClientProviderArrangement.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.logic.util.arrangement.provider
 import com.wire.kalium.cryptography.CoreCryptoCentral
 import com.wire.kalium.cryptography.E2EIClient
 import com.wire.kalium.cryptography.MLSClient
+import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.mls.SupportedCipherSuite
@@ -63,7 +64,7 @@ interface E2EIClientProviderArrangement {
 
     suspend fun withE2EIEnabled(isEnabled: Boolean)
 
-    suspend fun withSelfUser(selfUser: SelfUser?)
+    suspend fun withSelfUser(result: Either<StorageFailure, SelfUser>)
 
     suspend fun withGetOrFetchMLSConfig(result: SupportedCipherSuite)
 }
@@ -111,10 +112,10 @@ class E2EIClientProviderArrangementImpl : E2EIClientProviderArrangement {
         }.returns(isEnabled)
     }
 
-    override suspend fun withSelfUser(selfUser: SelfUser?) {
+    override suspend fun withSelfUser(result: Either<StorageFailure, SelfUser>) {
         coEvery {
             userRepository.getSelfUser()
-        }.returns(selfUser)
+        }.returns(result)
     }
 
     override suspend fun withGetOrFetchMLSConfig(result: SupportedCipherSuite) {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/UserRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/UserRepositoryArrangement.kt
@@ -56,7 +56,7 @@ internal interface UserRepositoryArrangement {
         userIdMatcher: Matcher<UserId> = AnyMatcher(valueOf())
     )
 
-    suspend fun withSelfUserReturning(selfUser: SelfUser?)
+    suspend fun withSelfUserReturning(result: Either<StorageFailure, SelfUser>)
 
     suspend fun withObservingSelfUserReturning(selfUserFlow: Flow<SelfUser>)
 
@@ -144,10 +144,10 @@ internal open class UserRepositoryArrangementImpl : UserRepositoryArrangement {
             .returns(Either.Right(result))
     }
 
-    override suspend fun withSelfUserReturning(selfUser: SelfUser?) {
+    override suspend fun withSelfUserReturning(result: Either<StorageFailure, SelfUser>) {
         coEvery {
             userRepository.getSelfUser()
-        }.returns(selfUser)
+        }.returns(result)
     }
 
     override suspend fun withObservingSelfUserReturning(selfUserFlow: Flow<SelfUser>) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15414" title="WPB-15414" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15414</a>  [Android] Fix issue with self user observation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

ObserveSelfUserUseCase is often used like this:
val userId = observeSelf().first()

This may cause two issues: 

    NoSuchElementException if emptyFlow is returned.

    Endless waiting for item if flow does not emit any blocking the UI in inconsistent state.

### Solutions

Replace with GetSelfUserUseCase and handle possible null return value.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
