### PR TITLE
fix: remove folder when conversation list is empty [WPB-15892]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/folders/ConversationFolderRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/folders/ConversationFolderRepository.kt
@@ -47,6 +47,7 @@ import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.persistence.dao.conversation.folder.ConversationFolderDAO
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 
 internal interface ConversationFolderRepository {
@@ -142,6 +143,12 @@ internal class ConversationFolderDataSource internal constructor(
             .v("Removing conversation ${conversationId.toLogString()} from folder ${folderId.obfuscateId()}")
         return wrapStorageRequest {
             conversationFolderDAO.removeConversationFromFolder(conversationId.toDao(), folderId)
+            val conversations = conversationFolderDAO.observeConversationListFromFolder(folderId).first()
+            if (conversations.isEmpty()) {
+                conversationFolderDAO.removeFolder(folderId)
+            } else {
+                Unit
+            }
         }
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/folders/ConversationFolderRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/folders/ConversationFolderRepositoryTest.kt
@@ -183,6 +183,7 @@ class ConversationFolderRepositoryTest {
         val arrangement = Arrangement()
             .withRemoveConversationFromFolder()
             .withGetFoldersWithConversations()
+            .withConversationsFromFolder(folderId, listOf())
             .withUpdateLabels(NetworkResponse.Success(Unit, mapOf(), 200))
 
         // when
@@ -243,6 +244,52 @@ class ConversationFolderRepositoryTest {
         // then
         result.shouldSucceed()
         coVerify { arrangement.conversationFolderDAO.addFolder(eq(folder.toDao())) }.wasInvoked()
+    }
+
+    @Test
+    fun givenLastConversationRemovedFromFolder_whenRemovingConversation_thenFolderShouldBeDeleted() = runTest {
+        // given
+        val folderId = "folder1"
+        val conversationId = TestConversation.ID
+
+        val arrangement = Arrangement()
+            .withRemoveConversationFromFolder()
+            .withConversationsFromFolder(folderId, emptyList())
+
+        // when
+        val result = arrangement.repository.removeConversationFromFolder(conversationId, folderId)
+
+        // then
+        result.shouldSucceed()
+
+        coVerify { arrangement.conversationFolderDAO.removeConversationFromFolder(eq(conversationId.toDao()), eq(folderId)) }.wasInvoked()
+        coVerify { arrangement.conversationFolderDAO.removeFolder(eq(folderId)) }.wasInvoked()
+    }
+
+    @Test
+    fun givenRemainingConversationsInFolder_whenRemovingConversation_thenFolderShouldNotBeDeleted() = runTest {
+        // given
+        val folderId = "folder1"
+        val conversationId = TestConversation.ID
+        val remainingConversation = ConversationDetailsWithEventsEntity(
+            conversationViewEntity = TestConversation.VIEW_ENTITY,
+            lastMessage = null,
+            messageDraft = null,
+            unreadEvents = ConversationUnreadEventEntity(TestConversation.VIEW_ENTITY.id, mapOf())
+        )
+
+        val arrangement = Arrangement()
+            .withRemoveConversationFromFolder()
+            .withConversationsFromFolder(folderId, listOf(remainingConversation))
+
+        // when
+        val result = arrangement.repository.removeConversationFromFolder(conversationId, folderId)
+
+        // then
+        result.shouldSucceed()
+
+        coVerify { arrangement.conversationFolderDAO.removeConversationFromFolder(eq(conversationId.toDao()), eq(folderId)) }.wasInvoked()
+        coVerify { arrangement.conversationFolderDAO.removeFolder(eq(folderId)) }.wasNotInvoked()
     }
 
     private class Arrangement {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15892" title="WPB-15892" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15892</a>  [Android] It should not be possible to create empty folders
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Because backend doesn't clean folders by itself we need to check if they are empty after conversation from folder removal