### PR TITLE
refactor(backup): replace ByteArray with Uint8Array for JS [WPB-10575]

### DIFF
--- a/backup/src/jsMain/kotlin/com/wire/backup/dump/BackupExportResult.kt
+++ b/backup/src/jsMain/kotlin/com/wire/backup/dump/BackupExportResult.kt
@@ -17,9 +17,13 @@
  */
 package com.wire.backup.dump
 
+import org.khronos.webgl.Uint8Array
+
 @JsExport
 public sealed class BackupExportResult {
-    public class Success(public val bytes: ByteArray) : BackupExportResult()
+    public class Success(
+        public val bytes: Uint8Array
+    ) : BackupExportResult()
     public sealed class Failure(public val message: String) : BackupExportResult() {
         /**
          * Represents an I/O error that occurs during an export process.

--- a/backup/src/jsMain/kotlin/com/wire/backup/dump/MPBackupExporter.kt
+++ b/backup/src/jsMain/kotlin/com/wire/backup/dump/MPBackupExporter.kt
@@ -72,7 +72,7 @@ public actual class MPBackupExporter(
         when (val result = finalize(password, output)) {
             is ExportResult.Failure.IOError -> BackupExportResult.Failure.IOError(result.message)
             is ExportResult.Failure.ZipError -> BackupExportResult.Failure.ZipError(result.message)
-            ExportResult.Success -> BackupExportResult.Success(output.readByteArray())
+            ExportResult.Success -> BackupExportResult.Success(output.readByteArray().toUByteArray().toUInt8Array())
         }
     }
 }

--- a/backup/src/jsMain/kotlin/com/wire/backup/ingest/MPBackupImporter.kt
+++ b/backup/src/jsMain/kotlin/com/wire/backup/ingest/MPBackupImporter.kt
@@ -42,15 +42,15 @@ import kotlin.js.Promise
 public actual class MPBackupImporter : CommonMPBackupImporter() {
     private val inMemoryUnencryptedBuffer = Buffer()
 
-    public fun peekFileData(data: ByteArray): Promise<BackupPeekResult> = GlobalScope.promise {
+    public fun peekFileData(data: Uint8Array): Promise<BackupPeekResult> = GlobalScope.promise {
         val buffer = Buffer()
-        buffer.write(data)
+        buffer.write(data.toUByteArray().toByteArray())
         peekBackup(buffer)
     }
 
-    public fun importFromFileData(data: ByteArray, passphrase: String?): Promise<BackupImportResult> = GlobalScope.promise {
+    public fun importFromFileData(data: Uint8Array, passphrase: String?): Promise<BackupImportResult> = GlobalScope.promise {
         val buffer = Buffer()
-        buffer.write(data)
+        buffer.write(data.toUByteArray().toByteArray())
         importBackup(buffer, passphrase)
     }
 

--- a/samples/src/jsMain/kotlin/samples/backup/BackupSamplesJs.kt
+++ b/samples/src/jsMain/kotlin/samples/backup/BackupSamplesJs.kt
@@ -22,6 +22,7 @@ import com.wire.backup.ingest.BackupPeekResult
 import com.wire.backup.ingest.MPBackupImporter
 import com.wire.backup.ingest.isCreatedBySameUser
 import kotlinx.coroutines.await
+import org.khronos.webgl.Uint8Array
 
 object BackupSamplesJs : BackupSamples() {
 
@@ -51,7 +52,7 @@ object BackupSamplesJs : BackupSamples() {
         println("Backup created file. Raw binary data: $fileData")
     }
 
-    suspend fun peekBackup(data: ByteArray) {
+    suspend fun peekBackup(data: Uint8Array) {
         // Peek into backup file
         val importer = MPBackupImporter()
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10575" title="WPB-10575" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-10575</a>  Cross Platform Backup: Write common backup / restore library
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

JS uses Uint8Array instead of ByteArray when dealing with files.

### Solutions

Ensure compatibility with JavaScript by replacing `ByteArray` with `Uint8Array` in key backup export/import functions. Updated type handling across related classes and methods to support the new standard, maintaining seamless integration with the web platform.

### Testing

N/A - But I've updated the sample to use UInt8Array

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
