### PR TITLE
feat: adapt api v8 changes [WPB-15722]

### DIFF
--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientModel.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientModel.kt
@@ -71,6 +71,7 @@ enum class DeviceType {
 
 sealed class ClientCapability {
     data object LegalHoldImplicitConsent : ClientCapability()
+    data object ConsumableNotifications : ClientCapability()
     data class Unknown(val name: String) : ClientCapability()
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientMapper.kt
@@ -198,11 +198,13 @@ class ClientMapper(
 
     private fun toClientCapabilityDTO(clientCapability: ClientCapability): ClientCapabilityDTO = when (clientCapability) {
         ClientCapability.LegalHoldImplicitConsent -> ClientCapabilityDTO.LegalHoldImplicitConsent
+        ClientCapability.ConsumableNotifications -> ClientCapabilityDTO.ConsumableNotifications
         is ClientCapability.Unknown -> ClientCapabilityDTO.Unknown(clientCapability.name)
     }
 
     private fun fromClientCapabilityDTO(clientCapabilityDTO: ClientCapabilityDTO): ClientCapability = when (clientCapabilityDTO) {
         ClientCapabilityDTO.LegalHoldImplicitConsent -> ClientCapability.LegalHoldImplicitConsent
+        ClientCapabilityDTO.ConsumableNotifications -> ClientCapability.ConsumableNotifications
         is ClientCapabilityDTO.Unknown -> ClientCapability.Unknown(clientCapabilityDTO.name)
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepository.kt
@@ -63,7 +63,7 @@ interface KeyPackageRepository {
 
     suspend fun replaceKeyPackages(clientId: ClientId, keyPackages: List<ByteArray>, cipherSuite: CipherSuite): Either<CoreFailure, Unit>
 
-    suspend fun getAvailableKeyPackageCount(clientId: ClientId): Either<NetworkFailure, KeyPackageCountDTO>
+    suspend fun getAvailableKeyPackageCount(clientId: ClientId, cipherSuite: CipherSuite): Either<NetworkFailure, KeyPackageCountDTO>
 
     suspend fun validKeyPackageCount(clientId: ClientId): Either<CoreFailure, Int>
 }
@@ -138,8 +138,11 @@ class KeyPackageDataSource(
             }
         }
 
-    override suspend fun getAvailableKeyPackageCount(clientId: ClientId): Either<NetworkFailure, KeyPackageCountDTO> =
+    override suspend fun getAvailableKeyPackageCount(
+        clientId: ClientId,
+        cipherSuite: CipherSuite
+    ): Either<NetworkFailure, KeyPackageCountDTO> =
         wrapApiRequest {
-            keyPackageApi.getAvailableKeyPackageCount(clientId.value)
+            keyPackageApi.getAvailableKeyPackageCount(clientId.value, cipherSuite.tag)
         }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
@@ -104,14 +104,21 @@ class ClientScope @OptIn(DelicateKaliumApi::class) internal constructor(
     val deregisterNativePushToken: DeregisterTokenUseCase
         get() = DeregisterTokenUseCaseImpl(clientRepository, notificationTokenRepository)
     val mlsKeyPackageCountUseCase: MLSKeyPackageCountUseCase
-        get() = MLSKeyPackageCountUseCaseImpl(keyPackageRepository, clientIdProvider, keyPackageLimitsProvider, userConfigRepository)
+        get() = MLSKeyPackageCountUseCaseImpl(
+            keyPackageRepository = keyPackageRepository,
+            currentClientIdProvider = clientIdProvider,
+            mlsClientProvider = mlsClientProvider,
+            keyPackageLimitsProvider = keyPackageLimitsProvider,
+            userConfigRepository = userConfigRepository,
+        )
     val restartSlowSyncProcessForRecoveryUseCase: RestartSlowSyncProcessForRecoveryUseCase
         get() = RestartSlowSyncProcessForRecoveryUseCaseImpl(slowSyncRepository)
     val refillKeyPackages: RefillKeyPackagesUseCase
         get() = RefillKeyPackagesUseCaseImpl(
-            keyPackageRepository,
-            keyPackageLimitsProvider,
-            clientIdProvider
+            keyPackageRepository = keyPackageRepository,
+            keyPackageLimitsProvider = keyPackageLimitsProvider,
+            mlsClientProvider = mlsClientProvider,
+            currentClientIdProvider = clientIdProvider,
         )
 
     val observeCurrentClientId: ObserveCurrentClientIdUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/MLSKeyPackageCountUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/MLSKeyPackageCountUseCase.kt
@@ -27,7 +27,6 @@ import com.wire.kalium.logic.data.keypackage.KeyPackageLimitsProvider
 import com.wire.kalium.logic.data.keypackage.KeyPackageRepository
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.mls.CipherSuite
-import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.getOrElse
 import com.wire.kalium.logic.functional.map

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/MLSKeyPackageCountUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/MLSKeyPackageCountUseCase.kt
@@ -21,12 +21,16 @@ package com.wire.kalium.logic.feature.keypackage
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.keypackage.KeyPackageLimitsProvider
 import com.wire.kalium.logic.data.keypackage.KeyPackageRepository
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
+import com.wire.kalium.logic.data.mls.CipherSuite
+import com.wire.kalium.logic.functional.flatMap
 import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.getOrElse
+import com.wire.kalium.logic.functional.map
 
 /**
  * This use case will return the current number of key packages.
@@ -38,6 +42,7 @@ interface MLSKeyPackageCountUseCase {
 internal class MLSKeyPackageCountUseCaseImpl(
     private val keyPackageRepository: KeyPackageRepository,
     private val currentClientIdProvider: CurrentClientIdProvider,
+    private val mlsClientProvider: MLSClientProvider,
     private val keyPackageLimitsProvider: KeyPackageLimitsProvider,
     private val userConfigRepository: UserConfigRepository
 ) : MLSKeyPackageCountUseCase {
@@ -47,19 +52,24 @@ internal class MLSKeyPackageCountUseCaseImpl(
             false -> validKeyPackagesCountFromMLSClient()
         }
 
-    private suspend fun validKeyPackagesCountFromAPI() = currentClientIdProvider().fold({
-        MLSKeyPackageCountResult.Failure.FetchClientIdFailure(it)
-    }, { selfClient ->
-        if (userConfigRepository.isMLSEnabled().getOrElse(false)) {
-            keyPackageRepository.getAvailableKeyPackageCount(selfClient)
-                .fold(
-                    { MLSKeyPackageCountResult.Failure.NetworkCallFailure(it) },
-                    { MLSKeyPackageCountResult.Success(selfClient, it.count, keyPackageLimitsProvider.needsRefill(it.count)) }
-                )
-        } else {
-            MLSKeyPackageCountResult.Failure.NotEnabled
+    @Suppress("ReturnCount")
+    private suspend fun validKeyPackagesCountFromAPI(): MLSKeyPackageCountResult {
+        val selfClientId = currentClientIdProvider().getOrElse {
+            return MLSKeyPackageCountResult.Failure.FetchClientIdFailure(it)
         }
-    })
+
+        if (!userConfigRepository.isMLSEnabled().getOrElse(false)) {
+            return MLSKeyPackageCountResult.Failure.NotEnabled
+        }
+
+        val cipherSuite = mlsClientProvider.getMLSClient().map { CipherSuite.fromTag(it.getDefaultCipherSuite()) }
+            .getOrElse { return MLSKeyPackageCountResult.Failure.Generic(it) }
+
+        return keyPackageRepository.getAvailableKeyPackageCount(selfClientId, cipherSuite).fold(
+            { MLSKeyPackageCountResult.Failure.NetworkCallFailure(it) },
+            { MLSKeyPackageCountResult.Success(selfClientId, it.count, keyPackageLimitsProvider.needsRefill(it.count)) }
+        )
+    }
 
     private suspend fun validKeyPackagesCountFromMLSClient() =
         currentClientIdProvider().fold({

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepositoryTest.kt
@@ -70,13 +70,13 @@ class KeyPackageRepositoryTest {
 
     @Test
     fun givenExistingClient_whenGettingAvailableKeyPackageCount_thenResultShouldBePropagated() = runTest {
-
+        val cipherSuite = CipherSuite.fromTag(1)
         val (_, keyPackageRepository) = Arrangement()
             .withMLSClient()
             .withGetAvailableKeyPackageCountSuccessful()
             .arrange()
 
-        val keyPackageCount = keyPackageRepository.getAvailableKeyPackageCount(Arrangement.SELF_CLIENT_ID)
+        val keyPackageCount = keyPackageRepository.getAvailableKeyPackageCount(Arrangement.SELF_CLIENT_ID, cipherSuite)
 
         assertIs<Either.Right<KeyPackageCountDTO>>(keyPackageCount)
         assertEquals(Arrangement.KEY_PACKAGE_COUNT_DTO.count, keyPackageCount.value.count)
@@ -210,7 +210,7 @@ class KeyPackageRepositoryTest {
 
         suspend fun withGetAvailableKeyPackageCountSuccessful() = apply {
             coEvery {
-                keyPackageApi.getAvailableKeyPackageCount(eq(SELF_CLIENT_ID.value))
+                keyPackageApi.getAvailableKeyPackageCount(eq(SELF_CLIENT_ID.value), any())
             }.returns(NetworkResponse.Success(KEY_PACKAGE_COUNT_DTO, mapOf(), 200))
         }
 

--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/client/ClientRequest.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/client/ClientRequest.kt
@@ -96,6 +96,9 @@ enum class DeviceTypeDTO {
 sealed class ClientCapabilityDTO {
     @SerialName("legalhold-implicit-consent")
     data object LegalHoldImplicitConsent : ClientCapabilityDTO()
+
+    @SerialName("consumable-notifications")
+    data object ConsumableNotifications : ClientCapabilityDTO()
     data class Unknown(val name: String) : ClientCapabilityDTO()
 }
 
@@ -110,8 +113,12 @@ object ClientCapabilityDTOSerializer : KSerializer<ClientCapabilityDTO> {
             is ClientCapabilityDTO.LegalHoldImplicitConsent ->
                 encoder.encodeString("legalhold-implicit-consent")
 
+            ClientCapabilityDTO.ConsumableNotifications ->
+                encoder.encodeString("consumable-notifications")
+
             is ClientCapabilityDTO.Unknown ->
                 encoder.encodeString(value.name)
+
         }
     }
 

--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/client/ClientRequest.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/client/ClientRequest.kt
@@ -125,6 +125,7 @@ object ClientCapabilityDTOSerializer : KSerializer<ClientCapabilityDTO> {
     override fun deserialize(decoder: Decoder): ClientCapabilityDTO {
         return when (val value = decoder.decodeString()) {
             "legalhold-implicit-consent" -> ClientCapabilityDTO.LegalHoldImplicitConsent
+            "consumable-notifications" -> ClientCapabilityDTO.ConsumableNotifications
             else -> ClientCapabilityDTO.Unknown(value)
         }
     }

--- a/network-model/src/commonTest/kotlin/com/wire/kalium/network/api/authenticated/client/ClientCapabilityDTOSerializerTest.kt
+++ b/network-model/src/commonTest/kotlin/com/wire/kalium/network/api/authenticated/client/ClientCapabilityDTOSerializerTest.kt
@@ -36,6 +36,13 @@ class ClientCapabilityDTOSerializerTest {
     }
 
     @Test
+    fun serialize_consumable_notifications() {
+        val capability = ClientCapabilityDTO.ConsumableNotifications
+        val result = json.encodeToString(ClientCapabilityDTO.serializer(), capability)
+        assertEquals("\"consumable-notifications\"", result)
+    }
+
+    @Test
     fun serialize_unknown_capability() {
         val capability = ClientCapabilityDTO.Unknown("custom-capability")
         val result = json.encodeToString(ClientCapabilityDTO.serializer(), capability)
@@ -47,6 +54,13 @@ class ClientCapabilityDTOSerializerTest {
         val jsonString = "\"legalhold-implicit-consent\""
         val result = json.decodeFromString(ClientCapabilityDTO.serializer(), jsonString)
         assertEquals(ClientCapabilityDTO.LegalHoldImplicitConsent, result)
+    }
+
+    @Test
+    fun deserialize_consumable_notifications() {
+        val jsonString = "\"consumable-notifications\""
+        val result = json.decodeFromString(ClientCapabilityDTO.serializer(), jsonString)
+        assertEquals(ClientCapabilityDTO.ConsumableNotifications, result)
     }
 
     @Test

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/keypackage/KeyPackageApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/keypackage/KeyPackageApi.kt
@@ -89,5 +89,8 @@ interface KeyPackageApi {
      *
      * @return unclaimed key package count
      */
-    suspend fun getAvailableKeyPackageCount(clientId: String): NetworkResponse<KeyPackageCountDTO>
+    suspend fun getAvailableKeyPackageCount(
+        clientId: String,
+        cipherSuite: Int,
+    ): NetworkResponse<KeyPackageCountDTO>
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/ConversationApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/ConversationApiV0.kt
@@ -370,7 +370,7 @@ internal open class ConversationApiV0 internal constructor(
         messageTimer: Long?
     ): NetworkResponse<EventContentDTO.Conversation.MessageTimerUpdate> =
         wrapKaliumResponse {
-            httpClient.put("$PATH_CONVERSATIONS/${conversationId.value}/$PATH_MESSAGE_TIMER") {
+            httpClient.put("$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/$PATH_MESSAGE_TIMER") {
                 setBody(ConversationMessageTimerDTO(messageTimer))
             }
         }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/KeyPackageApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/KeyPackageApiV0.kt
@@ -47,7 +47,7 @@ internal open class KeyPackageApiV0 internal constructor() : KeyPackageApi {
         APINotSupported("MLS: replaceKeyPackages api is only available on API V5")
     )
 
-    override suspend fun getAvailableKeyPackageCount(clientId: String): NetworkResponse<KeyPackageCountDTO> =
+    override suspend fun getAvailableKeyPackageCount(clientId: String, cipherSuite: Int): NetworkResponse<KeyPackageCountDTO> =
         NetworkResponse.Error(
             APINotSupported("MLS: getAvailableKeyPackageCount api is only available on API V5")
         )

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/KeyPackageApiV5.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/KeyPackageApiV5.kt
@@ -79,8 +79,15 @@ internal open class KeyPackageApiV5 internal constructor(
             }
         }
 
-    override suspend fun getAvailableKeyPackageCount(clientId: String): NetworkResponse<KeyPackageCountDTO> =
-        wrapKaliumResponse { httpClient.get("$PATH_KEY_PACKAGES/$PATH_SELF/$clientId/$PATH_COUNT") }
+    override suspend fun getAvailableKeyPackageCount(
+        clientId: String,
+        cipherSuite: Int,
+    ): NetworkResponse<KeyPackageCountDTO> =
+        wrapKaliumResponse {
+            httpClient.get("$PATH_KEY_PACKAGES/$PATH_SELF/$clientId/$PATH_COUNT") {
+                parameter(QUERY_CIPHER_SUITE, cipherSuite.toHexString())
+            }
+        }
 
     private companion object {
         const val PATH_KEY_PACKAGES = "mls/key-packages"

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v5/KeyPackageApiV5Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v5/KeyPackageApiV5Test.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageApi
 import com.wire.kalium.network.api.model.UserId
 import com.wire.kalium.network.api.v5.authenticated.KeyPackageApiV5
 import com.wire.kalium.network.utils.isSuccessful
+import com.wire.kalium.util.int.toHexString
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -34,17 +35,21 @@ internal class KeyPackageApiV5Test : ApiTest() {
 
     @Test
     fun givenAValidClientId_whenCallingGetAvailableKeyPackageCountEndpoint_theRequestShouldBeConfiguredCorrectly() = runTest {
+        val cipherSuite = 0
+        val expectedCipherSuite = cipherSuite.toHexString()
+
         val networkClient = mockAuthenticatedNetworkClient(
             KeyPackageJson.keyPackageCountJson(KEY_PACKAGE_COUNT).rawJson,
             statusCode = HttpStatusCode.OK,
             assertion = {
                 assertGet()
                 assertPathEqual(KEY_PACKAGE_COUNT_PATH)
+                assertQueryParameter(name = "ciphersuite", hasValue = expectedCipherSuite)
             }
         )
         val keyPackageApi: KeyPackageApi = KeyPackageApiV5(networkClient)
 
-        val response = keyPackageApi.getAvailableKeyPackageCount(VALID_CLIENT_ID)
+        val response = keyPackageApi.getAvailableKeyPackageCount(VALID_CLIENT_ID, cipherSuite)
         assertTrue(response.isSuccessful())
         assertEquals(response.value.count, KEY_PACKAGE_COUNT)
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15722" title="WPB-15722" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15722</a>  [Android] - Adopt API v8 changes in existing endpoints
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

add the following changes 
## Removed endpoints in V8

- `GET /calls/config`. Use `GET /calls/config/v2` instead. (Do not mind the double versioning. This will be cleaned up as soon as we get to it)
	- already used
    
- `POST /password-reset/:key`. Use `POST /password-reset/complete` instead.
	- not used
    
- `POST /onboarding/v3`
	- not used
    
- `PUT /conversations/:cnv`. Use `PUT /conversations/:domain/:conv/name` instead.
	- already uesd
    
- `PUT /conversations/:cnv/name`. Use `PUT /conversations/:domain/:conv/name` instead.
	- already used
- - `PUT /conversations/:cnv/message-timer`. Use `/conversations/:domain/:cnv/message-timer` instead
	- done
    
- `PUT /conversations/:cnv/receit-mode`. Use `PUT /conversations/:domain/:cnv/receipt-mode` instead
	- already used
    
- `PUT /conversations/:cnv/self`. Use `/conversations/:domain/:conv/self` instead.
	- already used
    
- `GET /conversations/:cnv/self`.
	- not used

## Changed endpoints in V8

- There is a new type of capability in `capabilities` field for `Client`: `consumable-notifications`. This will only show up when using API v7. In the notifications containing the `Client` structure, this capability will not be visible.
	- done
    
- `GET /scim/auth-tokens` returns an array of `ScimTokenInfo`items which now have a (non-optional) additional field: `name`.
	- not used in the app
    
- `POST /scim/auth-tokens` request has a new optional field: `name`. If not specified, the name will be set to the ID of the SCIM token by the backend. (Same for scim token info coming back from the server in this or other routes, except on the way back from the server the `name` field is always set to a value, either user-specified or the UUID, like in get.)
	- not used
    
- `POST /scim/auth-tokens` request has a new optional field: `idp id` (UUIDv4). If specified, the scim peer will associate with the given idp and share the same user base. If not, the scim peer will provision password-authenticated users. (Same field in idp info coming back from the server in this or other routes; the `idp id` field may be missing if no `idp id` was specified).  
    **NOTE:** this changes the behavior of a request without `idp`:  
    - V1..V7: if there is an idp registered with the team, associate.  
    - V8 and higher (later, younger): never associate.  
    - The restriction that you can only have at least one scim token _or_ multiple IdPs configured in one team, but not both, has been lifted: you can now create multiple IdPs, and associate multiple scim tokens with 0 or 1 or the existing idps.  
	    - not used
- The `ciphersuite` or `ciphersuites` query parameters were optional before and are required now for the endpoints
    
    - `POST /mls/key-packages/claim/{user_domain}/{user}` (claim key packages),
	    - already required
        
    - `DELETE /mls/key-packages/self/{client}` (delete key packages),
	    - not used
    - `PUT /mls/key-packages/self/{client}` (replace key packages), and
	    - already done
    - `GET /mls/key-packages/self/{client}/count` (count key packages).
	    - done

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
