### PR TITLE
feat: error handling simplified, not needed case (WPB-15520)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/LoginDomainPath.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/LoginDomainPath.kt
@@ -19,31 +19,43 @@ package com.wire.kalium.logic.data.auth
 
 internal sealed class LoginDomainPath(val isCloudAccountCreationPossible: Boolean) {
 
+    abstract fun toLogString(): String
+
     /**
      * Regular case for Wire cloud, where the user can login and create an account.
      * This is the default path and also covers pre-authorized and locked values.
      */
-    data object Default : LoginDomainPath(isCloudAccountCreationPossible = true)
+    data object Default : LoginDomainPath(isCloudAccountCreationPossible = true) {
+        override fun toLogString(): String = "Default"
+    }
 
     /**
      * SSO case for Wire cloud, where the user can login using SSO.
      * @param ssoCode the SSO code of a cloud team.
      */
-    data class SSO(val ssoCode: String) : LoginDomainPath(isCloudAccountCreationPossible = false)
+    data class SSO(val ssoCode: String) : LoginDomainPath(isCloudAccountCreationPossible = false) {
+        override fun toLogString(): String = "SSO"
+    }
 
     /**
      * The team has a custom backend, where the user can login.
      * @param backendConfigUrl the URL of the json config from where to fetch the custom backend configurations.
      */
-    data class CustomBackend(val backendConfigUrl: String) : LoginDomainPath(isCloudAccountCreationPossible = false)
+    data class CustomBackend(val backendConfigUrl: String) : LoginDomainPath(isCloudAccountCreationPossible = false) {
+        override fun toLogString(): String = "CustomBackend"
+    }
 
     /**
      * Wire cloud case for users, they can login but not to create an account.
      */
-    data object NoRegistration : LoginDomainPath(isCloudAccountCreationPossible = false)
+    data object NoRegistration : LoginDomainPath(isCloudAccountCreationPossible = false) {
+        override fun toLogString(): String = "NoRegistration"
+    }
 
     /**
      * The user has an existing cloud account, but the domain is already claimed by an organization.
      */
-    data class ExistingAccountWithClaimedDomain(val domain: String) : LoginDomainPath(isCloudAccountCreationPossible = false)
+    data class ExistingAccountWithClaimedDomain(val domain: String) : LoginDomainPath(isCloudAccountCreationPossible = false) {
+        override fun toLogString(): String = "ExistingAccountWithClaimedDomain"
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/GetLoginFlowForDomainUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/GetLoginFlowForDomainUseCase.kt
@@ -57,7 +57,7 @@ internal fun GetLoginFlowForDomainUseCase(
             logger.logStructuredJson(
                 level = KaliumLogLevel.DEBUG,
                 leadingMessage = "Get domain registration",
-                jsonStringKeyValues = mapOf("path" to it)
+                jsonStringKeyValues = mapOf("path" to it.toLogString())
             )
             it.mapLoginPathToResult()
         })

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/GetLoginFlowForDomainUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/GetLoginFlowForDomainUseCase.kt
@@ -83,7 +83,6 @@ internal fun GetLoginFlowForDomainUseCase(
     private fun NetworkFailure.mapFailure() =
         when (this) {
             is NetworkFailure.FeatureNotSupported -> EnterpriseLoginResult.Failure.NotSupported
-            is NetworkFailure.NoNetworkConnection -> EnterpriseLoginResult.Failure.NoNetwork
             else -> EnterpriseLoginResult.Failure.Generic(this)
         }
 }
@@ -103,15 +102,6 @@ sealed interface EnterpriseLoginResult {
         data object NotSupported : Failure() {
             override fun toLogString(): String {
                 return "NotSupported"
-            }
-        }
-
-        /**
-         * No network connection.
-         */
-        data object NoNetwork : Failure() {
-            override fun toLogString(): String {
-                return "NoNetwork"
             }
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/GetLoginFlowForDomainUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/GetLoginFlowForDomainUseCaseTest.kt
@@ -62,18 +62,6 @@ class GetLoginFlowForDomainUseCaseTest {
     }
 
     @Test
-    fun givenEmail_whenInvokedAndError_thenReturnNoNetwork() = runTest {
-        val (arrangement, useCase) = Arrangement()
-            .withDomainRegistrationResult(NetworkFailure.NoNetworkConnection(RuntimeException()).left())
-            .arrange()
-
-        val result = useCase(Arrangement.EMAIL)
-
-        coVerify { arrangement.loginRepository.getDomainRegistration(eq(Arrangement.EMAIL)) }
-        assertEquals(result, EnterpriseLoginResult.Failure.NoNetwork)
-    }
-
-    @Test
     fun givenEmail_whenInvokedAndErrorBecauseOfNotSupported_thenReturnNotSupported() = runTest {
         val (arrangement, useCase) = Arrangement()
             .withDomainRegistrationResult(NetworkFailure.FeatureNotSupported.left())


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15520" title="WPB-15520" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15520</a>  [Android] - Implement error handling for initial screens
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Remove case not needed for UI handling, since we already have a generic case that can transform from CoreFailure.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
