### PR TITLE
fix: sending a connection request to already connected user [WPB-16146]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
@@ -124,8 +124,7 @@ internal class ConnectionDataSource(
         return wrapApiRequest {
             connectionApi.createConnection(userId.toApi())
         }.flatMap { connection ->
-            val connectionSent = connection.copy(status = ConnectionStateDTO.SENT)
-            handleUserConnectionStatusPersistence(connectionMapper.fromApiToModel(connectionSent))
+            handleUserConnectionStatusPersistence(connectionMapper.fromApiToModel(connection))
         }.map { }
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
@@ -55,6 +55,7 @@ import com.wire.kalium.persistence.dao.UserDAO
 import com.wire.kalium.persistence.dao.conversation.ConversationDAO
 import com.wire.kalium.persistence.dao.member.MemberEntity
 import com.wire.kalium.util.time.UNIX_FIRST_DATE
+import io.mockative.Matchers
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.coEvery
@@ -62,7 +63,10 @@ import io.mockative.coVerify
 import io.mockative.eq
 import io.mockative.fake.valueOf
 import io.mockative.matchers.AnyMatcher
+import io.mockative.matchers.EqualsMatcher
+import io.mockative.matchers.Matcher
 import io.mockative.matchers.PredicateMatcher
+import io.mockative.matches
 import io.mockative.mock
 import io.mockative.once
 import io.mockative.twice
@@ -126,7 +130,9 @@ class ConnectionRepositoryTest {
         arrangement
             .withSuccessfulFetchSelfUserConnectionsResponse(arrangement.stubUserProfileDTO)
             .withSuccessfulGetConversationById(arrangement.stubConversationID1)
-            .withSuccessfulCreateConnectionResponse(userId)
+            .withSuccessfulCreateConnectionResponse(
+                userId = EqualsMatcher(userId)
+            )
             .withSelfUserTeamId(Either.Right(TestUser.SELF.teamId))
             .withFetchSentConversationSucceed()
 
@@ -170,11 +176,15 @@ class ConnectionRepositoryTest {
     fun givenAConnectionRequest_WhenSendingAConnectionAndPersistingReturnsAnError_thenTheConnectionShouldNotBePersisted() = runTest {
         // given
         val userId = NetworkUserId("user_id", "domain_id")
+        val expectedConnection = Arrangement.stubConnectionOne.copy(status = ConnectionStateDTO.SENT)
         val (arrangement, connectionRepository) = Arrangement().arrange()
         arrangement
             .withSuccessfulFetchSelfUserConnectionsResponse(arrangement.stubUserProfileDTO)
             .withSuccessfulGetUserById(arrangement.stubUserEntity.id)
-            .withSuccessfulCreateConnectionResponse(userId)
+            .withSuccessfulCreateConnectionResponse(
+                result = expectedConnection,
+                userId = EqualsMatcher(userId)
+            )
             .withSuccessfulGetConversationById(arrangement.stubConversationID1)
             .withErrorOnPersistingConnectionResponse(userId)
             .withSelfUserTeamId(Either.Right(TestUser.SELF.teamId))
@@ -205,7 +215,7 @@ class ConnectionRepositoryTest {
 
         // when
         val result = connectionRepository.updateConnectionStatus(UserId(userId.value, userId.domain), ConnectionState.ACCEPTED)
-        result.shouldSucceed { arrangement.stubConnectionOne }
+        result.shouldSucceed { Arrangement.stubConnectionOne }
 
         // then
         coVerify {
@@ -328,7 +338,7 @@ class ConnectionRepositoryTest {
 
         // when
         val result = connectionRepository.ignoreConnectionRequest(UserId(userId.value, userId.domain))
-        result.shouldSucceed { arrangement.stubConnectionOne }
+        result.shouldSucceed { Arrangement.stubConnectionOne }
 
         // then
         coVerify {
@@ -368,7 +378,7 @@ class ConnectionRepositoryTest {
 
         // when
         val result = connectionRepository.ignoreConnectionRequest(UserId(userId.value, userId.domain))
-        result.shouldSucceed { arrangement.stubConnectionOne }
+        result.shouldSucceed { Arrangement.stubConnectionOne }
 
         // then
         coVerify {
@@ -388,7 +398,7 @@ class ConnectionRepositoryTest {
 
             // when
             val result = connectionRepository.ignoreConnectionRequest(UserId(userId.value, userId.domain))
-            result.shouldFail { arrangement.stubConnectionOne }
+            result.shouldFail { Arrangement.stubConnectionOne }
 
             // then
             coVerify {
@@ -428,15 +438,7 @@ class ConnectionRepositoryTest {
             conversationRepository = conversationRepository
         )
 
-        val stubConnectionOne = ConnectionDTO(
-            conversationId = "conversationId1",
-            from = "fromId",
-            lastUpdate = Instant.UNIX_FIRST_DATE,
-            qualifiedConversationId = ConversationId("conversationId1", "domain"),
-            qualifiedToId = NetworkUserId("connectionId1", "domain"),
-            status = ConnectionStateDTO.ACCEPTED,
-            toId = "connectionId1"
-        )
+
         val stubConnectionTwo = ConnectionDTO(
             conversationId = "conversationId2",
             from = "fromId",
@@ -503,10 +505,13 @@ class ConnectionRepositoryTest {
             return this
         }
 
-        suspend fun withSuccessfulCreateConnectionResponse(userId: NetworkUserId): Arrangement {
+        suspend fun withSuccessfulCreateConnectionResponse(
+            result: ConnectionDTO = stubConnectionOne,
+            userId: Matcher<NetworkUserId>
+        ): Arrangement {
             coEvery {
-                connectionApi.createConnection(eq(userId))
-            }.returns(NetworkResponse.Success(stubConnectionOne, mapOf(), 200))
+                connectionApi.createConnection(matches { userId.matches(it) })
+            }.returns(NetworkResponse.Success(result, mapOf(), 200))
 
             return this
         }
@@ -623,5 +628,17 @@ class ConnectionRepositoryTest {
         }
 
         fun arrange() = this to connectionRepository
+
+        companion object {
+            val stubConnectionOne = ConnectionDTO(
+                conversationId = "conversationId1",
+                from = "fromId",
+                lastUpdate = Instant.UNIX_FIRST_DATE,
+                qualifiedConversationId = ConversationId("conversationId1", "domain"),
+                qualifiedToId = NetworkUserId("connectionId1", "domain"),
+                status = ConnectionStateDTO.ACCEPTED,
+                toId = "connectionId1"
+            )
+        }
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16146" title="WPB-16146" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16146</a>  [Android]Existing connection resets to pending state after adding user to conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

sending a connection request to already connected user

### Causes (Optional)

when we send a connection the app is overriding the status coming form the backend to "SENT" but we should trust the backend and not assume the new status is sent

### Solutions

do not override the value

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
