### PR TITLE
fix: recover when getting error for updating connection status [WPB-16146]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
@@ -55,6 +55,8 @@ import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.base.authenticated.connection.ConnectionApi
 import com.wire.kalium.network.api.authenticated.connection.ConnectionDTO
 import com.wire.kalium.network.api.authenticated.connection.ConnectionStateDTO
+import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.network.exceptions.isBadConnectionStatusUpdate
 import com.wire.kalium.persistence.dao.ConnectionDAO
 import com.wire.kalium.persistence.dao.ConnectionEntity
 import com.wire.kalium.persistence.dao.UserDAO
@@ -129,14 +131,27 @@ internal class ConnectionDataSource(
         }.map { }
     }
 
-    private suspend fun updateRemoteConnectionStatus(userId: UserId, connectionState: ConnectionState): Either<CoreFailure, ConnectionDTO> {
+    suspend fun updateRemoteConnectionStatus(userId: UserId, connectionState: ConnectionState): Either<CoreFailure, ConnectionDTO> {
         val isValidConnectionState = isValidConnectionState(connectionState)
         val newConnectionStatus = connectionStatusMapper.toApiModel(connectionState)
         if (!isValidConnectionState || newConnectionStatus == null) {
             return Either.Left(InvalidMappingFailure)
         }
 
-        return wrapApiRequest { connectionApi.updateConnection(userId.toApi(), newConnectionStatus) }
+        return wrapApiRequest { connectionApi.updateConnection(userId.toApi(), newConnectionStatus) }.onFailure { networkFailure ->
+            if (networkFailure is NetworkFailure.ServerMiscommunication &&
+                networkFailure.kaliumException is KaliumException.InvalidRequestError &&
+                networkFailure.kaliumException.isBadConnectionStatusUpdate()
+            ) {
+                kaliumLogger.e(
+                    "Failed to update connection status for ${userId.toLogString()}" +
+                            " to $connectionState, probably due to internal data error recovering"
+                )
+                wrapApiRequest { connectionApi.userConnectionInfo(userId.toApi()) }.flatMap {
+                    persistConnection(connectionMapper.fromApiToModel(it))
+                }
+            }
+        }
     }
 
     override suspend fun updateConnectionStatus(userId: UserId, connectionState: ConnectionState): Either<CoreFailure, Connection> =
@@ -273,7 +288,7 @@ internal class ConnectionDataSource(
     }
 
     override suspend fun getConnection(conversationId: ConversationId) = wrapStorageRequest {
-            connectionDAO.getConnection(conversationId.toDao())?.let { connectionMapper.fromDaoToConversationDetails(it) }
+        connectionDAO.getConnection(conversationId.toDao())?.let { connectionMapper.fromDaoToConversationDetails(it) }
     }
 
     /**

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
@@ -138,7 +138,9 @@ internal class ConnectionDataSource(
             return Either.Left(InvalidMappingFailure)
         }
 
-        return wrapApiRequest { connectionApi.updateConnection(userId.toApi(), newConnectionStatus) }.onFailure { networkFailure ->
+        return wrapApiRequest {
+            connectionApi.updateConnection(userId.toApi(), newConnectionStatus)
+        }.onFailure { networkFailure ->
             if (networkFailure is NetworkFailure.ServerMiscommunication &&
                 networkFailure.kaliumException is KaliumException.InvalidRequestError &&
                 networkFailure.kaliumException.isBadConnectionStatusUpdate()

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/connection/ConnectionApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/connection/ConnectionApi.kt
@@ -25,8 +25,8 @@ import com.wire.kalium.network.api.model.UserId
 import com.wire.kalium.network.utils.NetworkResponse
 
 interface ConnectionApi {
-
     suspend fun fetchSelfUserConnections(pagingState: String?): NetworkResponse<ConnectionResponse>
     suspend fun createConnection(userId: UserId): NetworkResponse<ConnectionDTO>
     suspend fun updateConnection(userId: UserId, connectionStatus: ConnectionStateDTO): NetworkResponse<ConnectionDTO>
+    suspend fun userConnectionInfo(userId: UserId): NetworkResponse<ConnectionDTO>
 }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/ConnectionApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/ConnectionApiV0.kt
@@ -28,6 +28,7 @@ import com.wire.kalium.network.api.model.PaginationRequest
 import com.wire.kalium.network.api.model.UserId
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.wrapKaliumResponse
+import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
@@ -55,6 +56,10 @@ internal open class ConnectionApiV0 internal constructor(private val authenticat
                 setBody(UpdateConnectionRequest(connectionStatus))
             }
         }
+
+    override suspend fun userConnectionInfo(userId: UserId): NetworkResponse<ConnectionDTO> = wrapKaliumResponse {
+        httpClient.get("$PATH_CONNECTIONS_ENDPOINTS/${userId.domain}/${userId.value}")
+    }
 
     protected companion object {
         const val PATH_CONNECTIONS = "list-connections"

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.network.api.model.ErrorResponse
 import com.wire.kalium.network.api.model.FederationConflictResponse
 import com.wire.kalium.network.api.model.FederationUnreachableResponse
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.ACCESS_DENIED
+import com.wire.kalium.network.exceptions.NetworkErrorLabel.BAD_CONNECTION_UPDATE
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.BAD_REQUEST
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.BLACKLISTED_EMAIL
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.DOMAIN_BLOCKED_FOR_REGISTRATION
@@ -232,6 +233,10 @@ fun KaliumException.InvalidRequestError.isMLSProtocol(): Boolean {
 fun KaliumException.InvalidRequestError.isWrongConversationPassword(): Boolean {
     return (errorResponse.label == WRONG_CONVERSATION_PASSWORD) ||
             (errorResponse.label == BAD_REQUEST && errorResponse.message.contains("password"))
+}
+
+fun KaliumException.InvalidRequestError.isBadConnectionStatusUpdate(): Boolean {
+    return errorResponse.label == BAD_CONNECTION_UPDATE
 }
 
 val KaliumException.InvalidRequestError.authenticationCodeFailure: AuthenticationCodeFailure?

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/NetworkErrorLabel.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/NetworkErrorLabel.kt
@@ -58,6 +58,8 @@ internal object NetworkErrorLabel {
     const val FEDERATION_NOT_ENABLED = "federation-not-enabled"
     const val FEDERATION_UNREACHABLE_DOMAINS = "federation-unreachable-domains-error"
 
+    // connection
+    const val BAD_CONNECTION_UPDATE = "bad-conn-update"
     object KaliumCustom {
         const val MISSING_REFRESH_TOKEN = "missing-refresh_token"
         const val MISSING_NONCE = "missing-nonce"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16146" title="WPB-16146" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16146</a>  [Android]Existing connection resets to pending state after adding user to conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

a broken connection request can never be restored

### Solutions

when updating a connection and getting 403 with `bac_conn_update` then recover by calling the backend to get the updated status of this request

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
