### PR TITLE
feat: return exact handle match when searching by name [WPB-16146]

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Search.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Search.sq
@@ -11,7 +11,7 @@ SELECT qualified_id, name, complete_asset_id, preview_asset_id, user_type, conne
     WHERE connection_status = 'ACCEPTED' AND
     qualified_id != (SELECT id FROM SelfUser LIMIT 1) AND
     deleted = 0 AND
-    name LIKE ('%' || :searchQuery || '%');
+    (name LIKE ('%' || :searchQuery || '%') OR handle = :searchQuery);
 
 selectAllConnectedUsersNotInConversation:
 SELECT qualified_id, name, complete_asset_id, preview_asset_id, user_type, connection_status, handle

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
@@ -32,6 +32,7 @@ CREATE TABLE User (
 );
 CREATE INDEX user_team_index ON User(team);
 CREATE INDEX user_service_id ON User(bot_service);
+CREATE INDEX idx_user_connection_deleted_handle ON User (connection_status, deleted, handle);
 
 deleteUser:
 DELETE FROM User WHERE qualified_id = ?;

--- a/persistence/src/commonMain/db_user/migrations/99.sqm
+++ b/persistence/src/commonMain/db_user/migrations/99.sqm
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_user_connection_deleted_handle ON User (connection_status, deleted, handle);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16146" title="WPB-16146" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16146</a>  [Android]Existing connection resets to pending state after adding user to conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

when doing exact handle search without adding @ in the search query the search will be interpreted as only name search form the local DB but remote results will include also exact handle search, this can cause users appear as not connected even if there are connected

### Solutions

miror the BE search logic and add needed index 


Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
