### PR TITLE
fix: wipe conversation after member leave event [WPB-16204]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
@@ -49,12 +49,12 @@ import com.wire.kalium.logic.wrapNullableFlowStorageRequest
 import com.wire.kalium.logic.wrapStorageRequest
 import com.wire.kalium.network.api.authenticated.conversation.AddConversationMembersRequest
 import com.wire.kalium.network.api.authenticated.conversation.AddServiceRequest
-import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
 import com.wire.kalium.network.api.authenticated.conversation.ConversationMemberAddedResponse
 import com.wire.kalium.network.api.authenticated.conversation.ConversationMemberRemovedResponse
 import com.wire.kalium.network.api.authenticated.conversation.ConversationResponse
 import com.wire.kalium.network.api.authenticated.conversation.model.ConversationCodeInfo
 import com.wire.kalium.network.api.authenticated.notification.EventContentDTO
+import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
 import com.wire.kalium.network.api.model.ServiceAddedResponse
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.exceptions.isConversationHasNoCode
@@ -493,13 +493,8 @@ internal class ConversationGroupRepositoryImpl(
                     is ConversationEntity.ProtocolInfo.Proteus ->
                         deleteMemberFromCloudAndStorage(userId, conversationId)
 
-                    is ConversationEntity.ProtocolInfo.Mixed ->
-                        deleteMemberFromCloudAndStorage(userId, conversationId)
-                            .flatMap { deleteMemberFromMlsGroup(userId, conversationId, protocol) }
-
-                    is ConversationEntity.ProtocolInfo.MLS -> {
+                    is ConversationEntity.ProtocolInfo.MLSCapable ->
                         deleteMemberFromMlsGroup(userId, conversationId, protocol)
-                    }
                 }
             }
 
@@ -547,15 +542,24 @@ internal class ConversationGroupRepositoryImpl(
         userId: UserId,
         conversationId: ConversationId,
         protocol: ConversationEntity.ProtocolInfo.MLSCapable
-    ) =
-        if (userId == selfUserId) {
-            deleteMemberFromCloudAndStorage(userId, conversationId).flatMap {
-                mlsConversationRepository.leaveGroup(GroupID(protocol.groupId))
+    ) = when (protocol) {
+        is ConversationEntity.ProtocolInfo.MLS -> {
+            if (userId == selfUserId) {
+                deleteMemberFromCloudAndStorage(userId, conversationId).flatMap {
+                    mlsConversationRepository.leaveGroup(GroupID(protocol.groupId))
+                }
+            } else {
+                // when removing a member from an MLS group, don't need to call the api
+                mlsConversationRepository.removeMembersFromMLSGroup(GroupID(protocol.groupId), listOf(userId))
             }
-        } else {
-            // when removing a member from an MLS group, don't need to call the api
-            mlsConversationRepository.removeMembersFromMLSGroup(GroupID(protocol.groupId), listOf(userId))
         }
+
+        is ConversationEntity.ProtocolInfo.Mixed -> {
+            deleteMemberFromCloudAndStorage(userId, conversationId).flatMap {
+                mlsConversationRepository.removeMembersFromMLSGroup(GroupID(protocol.groupId), listOf(userId))
+            }
+        }
+    }
 
     private suspend fun deleteMemberFromCloudAndStorage(userId: UserId, conversationId: ConversationId) =
         wrapApiRequest {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1440,7 +1440,10 @@ class UserSessionScope internal constructor(
             persistMessage = persistMessage,
             updateConversationClientsForCurrentCall = updateConversationClientsForCurrentCall,
             legalHoldHandler = legalHoldHandler,
-            selfTeamIdProvider = selfTeamId
+            selfTeamIdProvider = selfTeamId,
+            mlsClientProvider = mlsClientProvider,
+            conversationDAO = userStorage.database.conversationDAO,
+            selfUserId = userId
         )
     private val memberChangeHandler: MemberChangeEventHandler
         get() = MemberChangeEventHandlerImpl(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberLeaveEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberLeaveEventHandlerTest.kt
@@ -17,7 +17,9 @@
  */
 package com.wire.kalium.logic.sync.receiver.conversation
 
+import com.wire.kalium.cryptography.MLSClient
 import com.wire.kalium.logic.CoreFailure
+import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.event.MemberLeaveReason
 import com.wire.kalium.logic.data.id.ConversationId
@@ -38,6 +40,8 @@ import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangeme
 import com.wire.kalium.logic.util.arrangement.usecase.PersistMessageUseCaseArrangement
 import com.wire.kalium.logic.util.arrangement.usecase.PersistMessageUseCaseArrangementImpl
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.persistence.dao.conversation.ConversationDAO
+import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 import com.wire.kalium.util.time.UNIX_FIRST_DATE
 import io.mockative.Mock
 import io.mockative.any
@@ -69,6 +73,7 @@ class MemberLeaveEventHandlerTest {
                     conversationId = EqualsMatcher(event.conversationId.toDao()),
                     memberIdList = EqualsMatcher(list)
                 )
+                withGetConversationProtocolInfoReturns(ConversationEntity.ProtocolInfo.Proteus)
             }
 
         memberLeaveEventHandler.handle(memberLeaveEvent(reason = MemberLeaveReason.Left))
@@ -99,6 +104,7 @@ class MemberLeaveEventHandlerTest {
                 )
                 withPersistingMessage(Either.Left(failure))
                 withDeleteMembersByQualifiedIDThrows(throws = IllegalArgumentException())
+                withGetConversationProtocolInfoReturns(ConversationEntity.ProtocolInfo.Proteus)
             }
 
         memberLeaveEventHandler.handle(memberLeaveEvent(reason = MemberLeaveReason.Left))
@@ -129,6 +135,7 @@ class MemberLeaveEventHandlerTest {
                 withPersistingMessage(Either.Right(Unit), messageMatcher = EqualsMatcher(message))
                 withTeamId(Either.Right(TeamId("teamId")))
                 withIsAtLeastOneUserATeamMember(Either.Right(true))
+                withGetConversationProtocolInfoReturns(ConversationEntity.ProtocolInfo.Proteus)
             }
 
         memberLeaveEventHandler.handle(memberLeaveEvent(reason = MemberLeaveReason.UserDeleted))
@@ -160,6 +167,7 @@ class MemberLeaveEventHandlerTest {
                 withFetchUsersIfUnknownByIdsReturning(Either.Right(Unit), userIdList = EqualsMatcher(event.removedList.toSet()))
                 withTeamId(Either.Right(null))
                 withPersistingMessage(Either.Right(Unit))
+                withGetConversationProtocolInfoReturns(ConversationEntity.ProtocolInfo.Proteus)
             }
 
         memberLeaveEventHandler.handle(memberLeaveEvent(reason = MemberLeaveReason.UserDeleted))
@@ -204,6 +212,7 @@ class MemberLeaveEventHandlerTest {
                     memberIdList = EqualsMatcher(list)
                 )
                 withIsAtLeastOneUserATeamMember(Either.Right(false))
+                withGetConversationProtocolInfoReturns(ConversationEntity.ProtocolInfo.Proteus)
             }
 
         memberLeaveEventHandler.handle(event)
@@ -242,6 +251,7 @@ class MemberLeaveEventHandlerTest {
                     conversationId = EqualsMatcher(event.conversationId.toDao()),
                     memberIdList = EqualsMatcher(list)
                 )
+                withGetConversationProtocolInfoReturns(ConversationEntity.ProtocolInfo.Proteus)
             }
         // when
         memberLeaveEventHandler.handle(event)
@@ -249,6 +259,52 @@ class MemberLeaveEventHandlerTest {
         coVerify {
             arrangement.legalHoldHandler.handleConversationMembersChanged(eq(event.conversationId))
         }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenUserLeavesMLSGroup_whenHandlingMemberLeaveEvent_thenMLSClientShouldWipeConversation() = runTest {
+        val event = memberLeaveEvent(reason = MemberLeaveReason.Left)
+
+        val (arrangement, memberLeaveEventHandler) = Arrangement()
+            .arrange {
+                withFetchUsersIfUnknownByIdsReturning(Either.Right(Unit), userIdList = EqualsMatcher(event.removedList.toSet()))
+                withPersistingMessage(Either.Right(Unit))
+                withDeleteMembersByQualifiedID(
+                    result = list.size.toLong(),
+                    conversationId = EqualsMatcher(event.conversationId.toDao()),
+                    memberIdList = EqualsMatcher(list)
+                )
+                withGetConversationProtocolInfoReturns(mlsProtocolInfo1)
+            }
+
+        memberLeaveEventHandler.handle(event)
+
+        coVerify {
+            arrangement.mlsClient.wipeConversation(eq(mlsProtocolInfo1.groupId))
+        }.wasInvoked(once)
+    }
+
+    @Test
+    fun givenOtherUsersRemainInMLSGroup_whenHandlingMemberLeaveEvent_thenDoNotWipeConversation() = runTest {
+        val event = memberLeaveEvent(reason = MemberLeaveReason.Removed).copy(
+            removedList = listOf(UserId("userId1", "domain"), UserId("userId2", "domain"))
+        )
+
+        val (arrangement, memberLeaveEventHandler) = Arrangement()
+            .arrange {
+                withPersistingMessage(Either.Right(Unit))
+                withFetchUsersIfUnknownByIdsReturning(Either.Right(Unit), userIdList = EqualsMatcher(event.removedList.toSet()))
+                withDeleteMembersByQualifiedID(
+                    result = list.size.toLong(),
+                    conversationId = EqualsMatcher(event.conversationId.toDao()),
+                    memberIdList = EqualsMatcher(list)
+                )
+                withGetConversationProtocolInfoReturns(mlsProtocolInfo1)
+            }
+
+        memberLeaveEventHandler.handle(event)
+
+        coVerify { arrangement.mlsClient.wipeConversation(any()) }.wasNotInvoked()
     }
 
     private class Arrangement :
@@ -263,12 +319,33 @@ class MemberLeaveEventHandlerTest {
         @Mock
         val legalHoldHandler = mock(LegalHoldHandler::class)
 
+        @Mock
+        val mlsClientProvider = mock(MLSClientProvider::class)
+
+        @Mock
+        val conversationDAO = mock(ConversationDAO::class)
+
+        @Mock
+        val mlsClient = mock(MLSClient::class)
+
         private lateinit var memberLeaveEventHandler: MemberLeaveEventHandler
+
+        suspend fun withGetConversationProtocolInfoReturns(protocolInfo: ConversationEntity.ProtocolInfo) = apply {
+            coEvery {
+                conversationDAO.getConversationProtocolInfo(any())
+            }.returns(protocolInfo)
+        }
 
         suspend fun arrange(block: suspend Arrangement.() -> Unit): Pair<Arrangement, MemberLeaveEventHandler> = run {
             coEvery {
                 legalHoldHandler.handleConversationMembersChanged(any())
             }.returns(Either.Right(Unit))
+            coEvery {
+                mlsClientProvider.getMLSClient(any())
+            }.returns(Either.Right(mlsClient))
+            coEvery {
+                mlsClient.wipeConversation(any())
+            }.returns(Unit)
             block()
             memberLeaveEventHandler = MemberLeaveEventHandlerImpl(
                 memberDAO = memberDAO,
@@ -276,7 +353,10 @@ class MemberLeaveEventHandlerTest {
                 persistMessage = persistMessageUseCase,
                 updateConversationClientsForCurrentCall = lazy { updateConversationClientsForCurrentCall },
                 legalHoldHandler = legalHoldHandler,
-                selfTeamIdProvider = selfTeamIdProvider
+                selfTeamIdProvider = selfTeamIdProvider,
+                mlsClientProvider = mlsClientProvider,
+                conversationDAO = conversationDAO,
+                selfUserId = userId
             )
             this to memberLeaveEventHandler
         }
@@ -290,6 +370,14 @@ class MemberLeaveEventHandlerTest {
 
         val conversationId = ConversationId("conversationId", "domain")
         val list = listOf(qualifiedUserIdEntity)
+
+        val mlsProtocolInfo1 = ConversationEntity.ProtocolInfo.MLS(
+            "group2",
+            ConversationEntity.GroupState.ESTABLISHED,
+            0UL,
+            Instant.parse("2021-03-30T15:36:00.000Z"),
+            cipherSuite = ConversationEntity.CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+        )
 
         fun memberLeaveEvent(reason: MemberLeaveReason) = Event.Conversation.MemberLeave(
             id = "id",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16204" title="WPB-16204" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16204</a>  [Android] First message missing after leaving and being added to MLS group
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When the user is logged in to two clients, web and android, is added to a conversation, then leaves from web and then is added again then:
- when web client sends first message android client will not receive this message and will show recovery system message

### Causes (Optional)

First message after rejoining to conversation is not visible to other client

### Solutions

- wipe mls conversation if Member remove event contains self user
- fixed issue for triggering requesting twice to remove self user from conversation
