### PR TITLE
fix: suppress buffer error for mls decrypt transaction [WPB-16233]

### DIFF
--- a/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/MLSClientImpl.kt
+++ b/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/MLSClientImpl.kt
@@ -140,6 +140,7 @@ class MLSClientImpl(
         return applicationMessage
     }
 
+    @Suppress("TooGenericExceptionCaught")
     override suspend fun decryptMessage(groupId: MLSGroupId, message: ApplicationMessage): List<DecryptedMessageBundle> {
         var decryptedMessage: DecryptedMessage? = null
 

--- a/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/MLSClientImpl.kt
+++ b/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/MLSClientImpl.kt
@@ -24,6 +24,7 @@ import com.wire.crypto.ConversationConfiguration
 import com.wire.crypto.CoreCrypto
 import com.wire.crypto.CoreCryptoCommand
 import com.wire.crypto.CoreCryptoContext
+import com.wire.crypto.CoreCryptoException
 import com.wire.crypto.CustomConfiguration
 import com.wire.crypto.DecryptedMessage
 import com.wire.crypto.E2eiConversationState
@@ -154,10 +155,10 @@ class MLSClientImpl(
                     decryptedMessage = result
 
                 } catch (throwable: Throwable) {
-                    val isBufferedFutureError = throwable.cause is MlsException.BufferedFutureMessage ||
-                            throwable.message?.contains("BufferedFutureMessage") == true ||
-                            throwable.message
-                                ?.contains("Incoming message is a commit for which we have not yet received all the proposals") == true
+                    val isBufferedFutureError = (
+                            throwable is CoreCryptoException.Mls && throwable.v1 is MlsException.BufferedFutureMessage)
+                            || throwable.message
+                        ?.contains("Incoming message is a commit for which we have not yet received all the proposals") == true
                     if (!isBufferedFutureError) {
                         throw throwable
                     }

--- a/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/MLSClientImpl.kt
+++ b/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/MLSClientImpl.kt
@@ -156,8 +156,8 @@ class MLSClientImpl(
 
                 } catch (throwable: Throwable) {
                     val isBufferedFutureError = (
-                            throwable is CoreCryptoException.Mls && throwable.v1 is MlsException.BufferedFutureMessage)
-                            || throwable.message
+                            throwable is CoreCryptoException.Mls && throwable.v1 is MlsException.BufferedFutureMessage
+                            ) || throwable.message
                         ?.contains("Incoming message is a commit for which we have not yet received all the proposals") == true
                     if (!isBufferedFutureError) {
                         throw throwable


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16233" title="WPB-16233" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16233</a>  [Android] Catch and suppress buffer errors inside transaction
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
- When receiving out-of-order commits (e.g., when a client is missing a preceding commit), the MLS client was throwing a `BufferedFutureMessage` exception instead of buffering and persisting the message.
- This led to transactions always rolling back and no buffered messages actually being saved.

### Causes
- The code did not properly detect or handle `MlsException.BufferedFutureMessage` (wrapped in `CoreCryptoException.Mls`) within the transactional decryption flow.
- As a result, any out-of-order commit triggered a rollback, preventing buffering logic from persisting the messages that should be processed later.

### Solutions
- Updated the `decryptMessage` flow to wrap calls in a transactional API and specifically catch `BufferedFutureMessage` exceptions, allowing the transaction to commit and the message to be buffered rather than rolled back.
- Added tests verifying that out-of-order commits no longer throw exceptions and that previously buffered commits are eventually flushed once the missing epoch is processed.

