### PR TITLE
feat: support for local assets preview (#WPB-15738)

### DIFF
--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/AssetContent.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/AssetContent.kt
@@ -23,7 +23,8 @@ data class AssetContent(
     val name: String? = null,
     val mimeType: String,
     val metadata: AssetMetadata? = null,
-    val remoteData: RemoteData
+    val remoteData: RemoteData,
+    val localData: LocalData? = null,
 ) {
 
     private val isPreviewMessage = sizeInBytes > 0 && !hasValidRemoteData()
@@ -62,6 +63,10 @@ data class AssetContent(
             }
         }
     }
+
+    data class LocalData(
+        val assetDataPath: String,
+    )
 
     data class RemoteData(
         val otrKey: ByteArray,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/asset/AssetMapper.kt
@@ -118,7 +118,8 @@ class AssetMapperImpl(
                         assetEncryptionAlgorithm?.contains("GCM") == true -> AES_GCM
                         else -> AES_CBC
                     }
-                )
+                ),
+                localData = assetDataPath?.let { AssetContent.LocalData(it) }
             )
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1880,7 +1880,6 @@ class UserSessionScope internal constructor(
             staleEpochVerifier,
             legalHoldHandler,
             observeFileSharingStatus,
-            cells.publishAttachments,
             this,
             userScopedLogger,
         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -18,7 +18,6 @@
 
 package com.wire.kalium.logic.feature.message
 
-import com.wire.kalium.cells.domain.usecase.PublishAttachmentsUseCase
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.data.asset.AssetRepository
@@ -127,7 +126,6 @@ class MessageScope internal constructor(
     private val staleEpochVerifier: StaleEpochVerifier,
     private val legalHoldHandler: LegalHoldHandler,
     private val observeFileSharingStatusUseCase: ObserveFileSharingStatusUseCase,
-    private val publishAttachmentsUseCase: PublishAttachmentsUseCase,
     private val scope: CoroutineScope,
     kaliumLogger: KaliumLogger,
     internal val dispatcher: KaliumDispatcher = KaliumDispatcherImpl,
@@ -236,7 +234,6 @@ class MessageScope internal constructor(
             messageSendFailureHandler = messageSendFailureHandler,
             userPropertyRepository = userPropertyRepository,
             selfDeleteTimer = observeSelfDeletingMessages,
-            publishAttachmentsUseCase = publishAttachmentsUseCase,
             scope = scope
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
@@ -19,29 +19,27 @@
 package com.wire.kalium.logic.feature.message
 
 import com.benasher44.uuid.uuid4
-import com.wire.kalium.cells.domain.usecase.PublishAttachmentsUseCase
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.common.functional.getOrNull
+import com.wire.kalium.common.functional.onFailure
+import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.cryptography.utils.AES256Key
 import com.wire.kalium.cryptography.utils.generateRandomAES256Key
-import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
+import com.wire.kalium.logic.data.message.linkpreview.MessageLinkPreview
 import com.wire.kalium.logic.data.message.mention.MessageMention
 import com.wire.kalium.logic.data.properties.UserPropertyRepository
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
-import com.wire.kalium.logic.data.id.CurrentClientIdProvider
-import com.wire.kalium.logic.data.message.linkpreview.MessageLinkPreview
 import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTimerSettingsForConversationUseCase
-import com.wire.kalium.common.functional.Either
-import com.wire.kalium.common.functional.flatMap
-import com.wire.kalium.common.functional.getOrElse
-import com.wire.kalium.common.functional.getOrNull
-import com.wire.kalium.common.functional.onFailure
-import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.CoroutineScope
@@ -65,7 +63,6 @@ class SendTextMessageUseCase internal constructor(
     private val messageSendFailureHandler: MessageSendFailureHandler,
     private val userPropertyRepository: UserPropertyRepository,
     private val selfDeleteTimer: ObserveSelfDeletionTimerSettingsForConversationUseCase,
-    private val publishAttachmentsUseCase: PublishAttachmentsUseCase,
     private val dispatchers: KaliumDispatcher = KaliumDispatcherImpl,
     private val scope: CoroutineScope
 ) {
@@ -89,23 +86,11 @@ class SendTextMessageUseCase internal constructor(
 
         val previews = uploadLinkPreviewImages(linkPreviews)
 
-        val attachments = publishAttachmentsUseCase.invoke(conversationId).getOrElse { emptyList() }
-
-        val textWithAttachments = if (attachments.isNotEmpty()) {
-            buildString {
-                append(text)
-                appendLine()
-                attachments.forEach { appendLine(it) }
-            }
-        } else {
-            text
-        }
-
         provideClientId().flatMap { clientId ->
             val message = Message.Regular(
                 id = generatedMessageUuid,
                 content = MessageContent.Text(
-                    value = textWithAttachments,
+                    value = text,
                     linkPreviews = previews,
                     mentions = mentions,
                     quotedMessageReference = quotedMessageId?.let { quotedMessageId ->

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageCaseTest.kt
@@ -312,9 +312,6 @@ class SendTextMessageCaseTest {
         @Mock
         val observeSelfDeletionTimerSettingsForConversation = mock(ObserveSelfDeletionTimerSettingsForConversationUseCase::class)
 
-        @Mock
-        val publishAttachmentsUseCase = mock(PublishAttachmentsUseCase::class)
-
         suspend fun withSendMessageSuccess() = apply {
             coEvery {
                 messageSender.sendMessage(any(), any())
@@ -380,7 +377,6 @@ class SendTextMessageCaseTest {
             messageSendFailureHandler,
             userPropertyRepository,
             observeSelfDeletionTimerSettingsForConversation,
-            publishAttachmentsUseCase,
             scope = coroutineScope,
             dispatchers = coroutineScope.testKaliumDispatcher
         )

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/MessageDetailsView.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/MessageDetailsView.sq
@@ -60,6 +60,7 @@ AssetContent.asset_width AS assetWidth,
 AssetContent.asset_height AS assetHeight,
 AssetContent.asset_duration_ms AS assetDuration,
 AssetContent.asset_normalized_loudness AS assetNormalizedLoudness,
+AssetData.data_path AS assetDataPath,
 MissedCallContent.caller_id AS callerId,
 MemberChangeContent.member_change_list AS memberChangeList,
 MemberChangeContent.member_change_type AS memberChangeType,
@@ -148,6 +149,7 @@ FROM Message
 JOIN UserDetails ON Message.sender_user_id = UserDetails.qualified_id
 LEFT JOIN MessageTextContent AS TextContent ON Message.id = TextContent.message_id AND Message.conversation_id = TextContent.conversation_id
 LEFT JOIN MessageAssetContent AS AssetContent ON Message.id = AssetContent.message_id AND Message.conversation_id = AssetContent.conversation_id
+LEFT JOIN Asset AS AssetData ON AssetContent.asset_id = AssetData.key
 LEFT JOIN MessageMissedCallContent AS MissedCallContent ON Message.id = MissedCallContent.message_id AND Message.conversation_id = MissedCallContent.conversation_id
 LEFT JOIN MessageMemberChangeContent AS MemberChangeContent ON Message.id = MemberChangeContent.message_id AND Message.conversation_id = MemberChangeContent.conversation_id
 LEFT JOIN MessageUnknownContent AS UnknownContent ON Message.id = UnknownContent.message_id AND Message.conversation_id = UnknownContent.conversation_id

--- a/persistence/src/commonMain/db_user/migrations/99.sqm
+++ b/persistence/src/commonMain/db_user/migrations/99.sqm
@@ -11,3 +11,170 @@ CREATE TABLE IF NOT EXISTS MessageAttachmentDraft (
     FOREIGN KEY (conversation_id) REFERENCES Conversation(qualified_id) ON DELETE CASCADE ON UPDATE CASCADE,
     PRIMARY KEY (attachment_id)
 );
+
+DROP VIEW IF EXISTS MessageDetailsView;
+
+CREATE VIEW IF NOT EXISTS MessageDetailsView
+AS SELECT
+Message.id AS id,
+Message.conversation_id AS conversationId,
+Message.content_type AS contentType,
+Message.creation_date AS date,
+Message.sender_user_id AS senderUserId,
+Message.sender_client_id AS senderClientId,
+Message.status AS status,
+Message.last_edit_date AS lastEditTimestamp,
+Message.visibility AS visibility,
+Message.expects_read_confirmation AS expectsReadConfirmation,
+Message.expire_after_millis AS expireAfterMillis,
+Message.self_deletion_end_date AS selfDeletionEndDate,
+IFNULL ((SELECT COUNT (*) FROM Receipt WHERE message_id = Message.id AND type = 'READ'), 0) AS readCount,
+UserDetails.name AS senderName,
+UserDetails.handle AS senderHandle,
+UserDetails.email AS senderEmail,
+UserDetails.phone AS senderPhone,
+UserDetails.accent_id AS senderAccentId,
+UserDetails.team AS senderTeamId,
+UserDetails.connection_status AS senderConnectionStatus,
+UserDetails.preview_asset_id AS senderPreviewAssetId,
+UserDetails.complete_asset_id AS senderCompleteAssetId,
+UserDetails.user_availability_status AS senderAvailabilityStatus,
+UserDetails.user_type AS senderUserType,
+UserDetails.bot_service AS senderBotService,
+UserDetails.deleted AS senderIsDeleted,
+UserDetails.expires_at AS senderExpiresAt,
+UserDetails.defederated AS senderDefederated,
+UserDetails.supported_protocols AS senderSupportedProtocols,
+UserDetails.active_one_on_one_conversation_id AS senderActiveOneOnOneConversationId,
+UserDetails.is_proteus_verified AS senderIsProteusVerified,
+UserDetails.is_under_legal_hold AS senderIsUnderLegalHold,
+(Message.sender_user_id == SelfUser.id) AS isSelfMessage,
+TextContent.text_body AS text,
+TextContent.is_quoting_self AS isQuotingSelfUser,
+AssetContent.asset_size AS assetSize,
+AssetContent.asset_name AS assetName,
+AssetContent.asset_mime_type AS assetMimeType,
+AssetContent.asset_otr_key AS assetOtrKey,
+AssetContent.asset_sha256 AS assetSha256,
+AssetContent.asset_id AS assetId,
+AssetContent.asset_token AS assetToken,
+AssetContent.asset_domain AS assetDomain,
+AssetContent.asset_encryption_algorithm AS assetEncryptionAlgorithm,
+AssetContent.asset_width AS assetWidth,
+AssetContent.asset_height AS assetHeight,
+AssetContent.asset_duration_ms AS assetDuration,
+AssetContent.asset_normalized_loudness AS assetNormalizedLoudness,
+AssetData.data_path AS assetDataPath,
+MissedCallContent.caller_id AS callerId,
+MemberChangeContent.member_change_list AS memberChangeList,
+MemberChangeContent.member_change_type AS memberChangeType,
+UnknownContent.unknown_type_name AS unknownContentTypeName,
+UnknownContent.unknown_encoded_data AS unknownContentData,
+RestrictedAssetContent.asset_mime_type AS restrictedAssetMimeType,
+RestrictedAssetContent.asset_size AS restrictedAssetSize,
+RestrictedAssetContent.asset_name AS restrictedAssetName,
+FailedToDecryptContent.unknown_encoded_data AS failedToDecryptData,
+FailedToDecryptContent.error_code AS decryptionErrorCode,
+FailedToDecryptContent.is_decryption_resolved AS isDecryptionResolved,
+ConversationNameChangedContent.conversation_name AS conversationName,
+'{' || IFNULL(
+    (SELECT GROUP_CONCAT('"' || emoji || '":' || count)
+    FROM (
+        SELECT COUNT(*) count, Reaction.emoji emoji
+        FROM Reaction
+        WHERE Reaction.message_id = Message.id
+        AND Reaction.conversation_id = Message.conversation_id
+        GROUP BY Reaction.emoji
+    )),
+    '')
+|| '}' AS allReactionsJson,
+IFNULL(
+    (SELECT '[' || GROUP_CONCAT('"' || Reaction.emoji || '"') || ']'
+    FROM Reaction
+    WHERE Reaction.message_id = Message.id
+        AND Reaction.conversation_id = Message.conversation_id
+        AND Reaction.sender_id = SelfUser.id
+    ),
+    '[]'
+) AS selfReactionsJson,
+IFNULL(
+    (SELECT '[' || GROUP_CONCAT(
+        '{"start":' || start || ', "length":' || length ||
+        ', "userId":{"value":"' || replace(substr(user_id, 0, instr(user_id, '@')), '@', '') || '"' ||
+        ',"domain":"' || replace(substr(user_id, instr(user_id, '@')+1, length(user_id)), '@', '') || '"' ||
+        '}' || '}') || ']'
+    FROM MessageMention
+    WHERE MessageMention.message_id = Message.id
+        AND MessageMention.conversation_id = Message.conversation_id
+    ),
+    '[]'
+) AS mentions,
+TextContent.quoted_message_id AS quotedMessageId,
+QuotedMessage.sender_user_id AS quotedSenderId,
+TextContent.is_quote_verified AS isQuoteVerified,
+QuotedSender.name AS quotedSenderName,
+QuotedMessage.creation_date AS quotedMessageDateTime,
+QuotedMessage.last_edit_date AS quotedMessageEditTimestamp,
+QuotedMessage.visibility AS quotedMessageVisibility,
+QuotedMessage.content_type AS quotedMessageContentType,
+QuotedTextContent.text_body AS quotedTextBody,
+QuotedAssetContent.asset_mime_type AS quotedAssetMimeType,
+QuotedAssetContent.asset_name AS quotedAssetName,
+QuotedLocationContent.name AS quotedLocationName,
+
+NewConversationReceiptMode.receipt_mode AS newConversationReceiptMode,
+
+ConversationReceiptModeChanged.receipt_mode AS conversationReceiptModeChanged,
+ConversationTimerChangedContent.message_timer AS messageTimerChanged,
+FailedRecipientsWithNoClients.recipient_failure_list AS recipientsFailedWithNoClientsList,
+FailedRecipientsDeliveryFailed.recipient_failure_list AS recipientsFailedDeliveryList,
+
+IFNULL(
+    (SELECT '[' ||
+            GROUP_CONCAT('{"text":"' || text || '", "id":"' || id || '""is_selected":' || is_selected || '}')
+        || ']'
+    FROM ButtonContent
+    WHERE ButtonContent.message_id = Message.id
+        AND ButtonContent.conversation_id = Message.conversation_id
+    ),
+    '[]'
+) AS buttonsJson,
+FederationTerminatedContent.domain_list AS federationDomainList,
+FederationTerminatedContent.federation_type AS federationType,
+ConversationProtocolChangedContent.protocol AS conversationProtocolChanged,
+ConversationLocationContent.latitude AS latitude,
+ConversationLocationContent.longitude AS longitude,
+ConversationLocationContent.name AS locationName,
+ConversationLocationContent.zoom AS locationZoom,
+LegalHoldContent.legal_hold_member_list AS legalHoldMemberList,
+LegalHoldContent.legal_hold_type AS legalHoldType
+
+FROM Message
+JOIN UserDetails ON Message.sender_user_id = UserDetails.qualified_id
+LEFT JOIN MessageTextContent AS TextContent ON Message.id = TextContent.message_id AND Message.conversation_id = TextContent.conversation_id
+LEFT JOIN MessageAssetContent AS AssetContent ON Message.id = AssetContent.message_id AND Message.conversation_id = AssetContent.conversation_id
+LEFT JOIN Asset AS AssetData ON AssetContent.asset_id = AssetData.key
+LEFT JOIN MessageMissedCallContent AS MissedCallContent ON Message.id = MissedCallContent.message_id AND Message.conversation_id = MissedCallContent.conversation_id
+LEFT JOIN MessageMemberChangeContent AS MemberChangeContent ON Message.id = MemberChangeContent.message_id AND Message.conversation_id = MemberChangeContent.conversation_id
+LEFT JOIN MessageUnknownContent AS UnknownContent ON Message.id = UnknownContent.message_id AND Message.conversation_id = UnknownContent.conversation_id
+LEFT JOIN MessageRestrictedAssetContent AS RestrictedAssetContent ON Message.id = RestrictedAssetContent.message_id AND RestrictedAssetContent.conversation_id = RestrictedAssetContent.conversation_id
+LEFT JOIN MessageFailedToDecryptContent AS FailedToDecryptContent ON Message.id = FailedToDecryptContent.message_id AND Message.conversation_id = FailedToDecryptContent.conversation_id
+LEFT JOIN MessageConversationChangedContent AS ConversationNameChangedContent ON Message.id = ConversationNameChangedContent.message_id AND Message.conversation_id = ConversationNameChangedContent.conversation_id
+LEFT JOIN MessageRecipientFailure AS FailedRecipientsWithNoClients ON Message.id = FailedRecipientsWithNoClients.message_id AND Message.conversation_id = FailedRecipientsWithNoClients.conversation_id AND FailedRecipientsWithNoClients.recipient_failure_type = 'NO_CLIENTS_TO_DELIVER'
+LEFT JOIN MessageRecipientFailure AS FailedRecipientsDeliveryFailed ON Message.id = FailedRecipientsDeliveryFailed.message_id AND Message.conversation_id = FailedRecipientsDeliveryFailed.conversation_id AND FailedRecipientsDeliveryFailed.recipient_failure_type = 'MESSAGE_DELIVERY_FAILED'
+
+-- joins for quoted messages
+LEFT JOIN Message AS QuotedMessage ON QuotedMessage.id = TextContent.quoted_message_id AND QuotedMessage.conversation_id = TextContent.conversation_id
+LEFT JOIN User AS QuotedSender ON QuotedMessage.sender_user_id = QuotedSender.qualified_id
+LEFT JOIN MessageTextContent AS QuotedTextContent ON QuotedTextContent.message_id = QuotedMessage.id AND QuotedMessage.conversation_id = TextContent.conversation_id
+LEFT JOIN MessageAssetContent AS QuotedAssetContent ON QuotedAssetContent.message_id = QuotedMessage.id AND QuotedMessage.conversation_id = TextContent.conversation_id
+LEFT JOIN MessageConversationLocationContent AS QuotedLocationContent ON QuotedLocationContent.message_id = QuotedMessage.id AND QuotedMessage.conversation_id = TextContent.conversation_id
+-- end joins for quoted messages
+LEFT JOIN MessageNewConversationReceiptModeContent AS NewConversationReceiptMode ON Message.id = NewConversationReceiptMode.message_id AND Message.conversation_id = NewConversationReceiptMode.conversation_id
+LEFT JOIN MessageConversationReceiptModeChangedContent AS ConversationReceiptModeChanged ON Message.id = ConversationReceiptModeChanged.message_id AND Message.conversation_id = ConversationReceiptModeChanged.conversation_id
+LEFT JOIN MessageConversationTimerChangedContent AS ConversationTimerChangedContent ON Message.id = ConversationTimerChangedContent.message_id AND Message.conversation_id = ConversationTimerChangedContent.conversation_id
+LEFT JOIN MessageFederationTerminatedContent AS FederationTerminatedContent ON Message.id = FederationTerminatedContent.message_id AND Message.conversation_id = FederationTerminatedContent.conversation_id
+LEFT JOIN MessageConversationProtocolChangedContent AS ConversationProtocolChangedContent ON Message.id = ConversationProtocolChangedContent.message_id AND Message.conversation_id = ConversationProtocolChangedContent.conversation_id
+LEFT JOIN MessageConversationLocationContent AS ConversationLocationContent ON Message.id = ConversationLocationContent.message_id AND Message.conversation_id = ConversationLocationContent.conversation_id
+LEFT JOIN MessageLegalHoldContent AS LegalHoldContent ON Message.id = LegalHoldContent.message_id AND Message.conversation_id = LegalHoldContent.conversation_id
+LEFT JOIN SelfUser;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
@@ -291,6 +291,10 @@ sealed class MessageEntityContent {
         val assetHeight: Int? = null,
         val assetDurationMs: Long? = null,
         val assetNormalizedLoudness: ByteArray? = null,
+
+        // Local path
+        val assetDataPath: String? = null,
+
     ) : Regular()
 
     data class Knock(val hotKnock: Boolean) : Regular()

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
@@ -477,6 +477,7 @@ object MessageMapper {
         assetHeight: Int?,
         assetDuration: Long?,
         assetNormalizedLoudness: ByteArray?,
+        assetDataPath: String?,
         callerId: QualifiedIDEntity?,
         memberChangeList: List<QualifiedIDEntity>?,
         memberChangeType: MessageEntity.MemberChangeType?,
@@ -560,7 +561,8 @@ object MessageMapper {
                 assetWidth = assetWidth,
                 assetHeight = assetHeight,
                 assetDurationMs = assetDuration,
-                assetNormalizedLoudness = assetNormalizedLoudness
+                assetNormalizedLoudness = assetNormalizedLoudness,
+                assetDataPath = assetDataPath,
             )
 
             MessageEntity.ContentType.KNOCK -> MessageEntityContent.Knock(false)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15738" title="WPB-15738" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15738</a>  [Android] Video preview
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

https://wearezeta.atlassian.net/browse/WPB-15738
https://wearezeta.atlassian.net/browse/WPB-15736
----
#### PR Submission Checklist for internal contributors

# What's new in this PR?

Support for rendering assets preview after downloading / decrypting. To show local preview user needs to download and decrypt the asset file.
- Added `LocalData` field to asset data to have a reference to local file for the asset. This file is used for rendering video / pdf previews.
- Added local data path to the MessageDetailsView to return it with the messages query from the database.
- `SendTextMessageUseCase` removed test code for sending multiple attachments.
