### PR TITLE
fix: do not remove favorites folder [WPB-16164]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/folders/ConversationFolderRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/folders/ConversationFolderRepository.kt
@@ -152,9 +152,13 @@ internal class ConversationFolderDataSource internal constructor(
             .v("Removing conversation ${conversationId.toLogString()} from folder ${folderId.obfuscateId()}")
         return wrapStorageRequest {
             conversationFolderDAO.removeConversationFromFolder(conversationId.toDao(), folderId)
-            val conversations = conversationFolderDAO.observeConversationListFromFolder(folderId).first()
-            if (!isFavorite && conversations.isEmpty()) {
-                conversationFolderDAO.removeFolder(folderId)
+            if (!isFavorite) {
+                val conversations = conversationFolderDAO.observeConversationListFromFolder(folderId).first()
+                if (conversations.isEmpty()) {
+                    conversationFolderDAO.removeFolder(folderId)
+                } else {
+                    Unit
+                }
             } else {
                 Unit
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/folder/RemoveConversationFromFavoritesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/folder/RemoveConversationFromFavoritesUseCase.kt
@@ -19,10 +19,10 @@
 package com.wire.kalium.logic.feature.conversation.folder
 
 import com.wire.kalium.common.error.CoreFailure
-import com.wire.kalium.logic.data.conversation.folders.ConversationFolderRepository
-import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.common.functional.flatMap
 import com.wire.kalium.common.functional.fold
+import com.wire.kalium.logic.data.conversation.folders.ConversationFolderRepository
+import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.withContext
@@ -53,7 +53,11 @@ internal class RemoveConversationFromFavoritesUseCaseImpl(
         conversationFolderRepository.getFavoriteConversationFolder().fold(
             { RemoveConversationFromFavoritesUseCase.Result.Failure(it) },
             { folder ->
-                conversationFolderRepository.removeConversationFromFolder(conversationId, folder.id)
+                conversationFolderRepository.removeConversationFromFolder(
+                    conversationId = conversationId,
+                    folderId = folder.id,
+                    isFavorite = true
+                )
                     .flatMap {
                         conversationFolderRepository.syncConversationFoldersFromLocal()
                     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/folders/ConversationFolderRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/folders/ConversationFolderRepositoryTest.kt
@@ -267,6 +267,26 @@ class ConversationFolderRepositoryTest {
     }
 
     @Test
+    fun givenLastConversationRemovedFromFavorite_whenRemovingConversation_thenFavoriteShouldNotBeDeleted() = runTest {
+        // given
+        val folderId = "folder1"
+        val conversationId = TestConversation.ID
+
+        val arrangement = Arrangement()
+            .withRemoveConversationFromFolder()
+            .withConversationsFromFolder(folderId, emptyList())
+
+        // when
+        val result = arrangement.repository.removeConversationFromFolder(conversationId, folderId, true)
+
+        // then
+        result.shouldSucceed()
+
+        coVerify { arrangement.conversationFolderDAO.removeConversationFromFolder(eq(conversationId.toDao()), eq(folderId)) }.wasInvoked()
+        coVerify { arrangement.conversationFolderDAO.removeFolder(eq(folderId)) }.wasNotInvoked()
+    }
+
+    @Test
     fun givenRemainingConversationsInFolder_whenRemovingConversation_thenFolderShouldNotBeDeleted() = runTest {
         // given
         val folderId = "folder1"
@@ -291,6 +311,7 @@ class ConversationFolderRepositoryTest {
         coVerify { arrangement.conversationFolderDAO.removeConversationFromFolder(eq(conversationId.toDao()), eq(folderId)) }.wasInvoked()
         coVerify { arrangement.conversationFolderDAO.removeFolder(eq(folderId)) }.wasNotInvoked()
     }
+
 
     private class Arrangement {
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/folder/RemoveConversationFromFavoritesUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/folder/RemoveConversationFromFavoritesUseCaseTest.kt
@@ -18,12 +18,12 @@
 package com.wire.kalium.logic.feature.conversation.folder
 
 import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.conversation.ConversationFolder
 import com.wire.kalium.logic.data.conversation.folders.ConversationFolderRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestFolder
-import com.wire.kalium.common.functional.Either
 import io.mockative.Mock
 import io.mockative.coEvery
 import io.mockative.coVerify

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/folder/RemoveConversationFromFavoritesUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/folder/RemoveConversationFromFavoritesUseCaseTest.kt
@@ -54,7 +54,7 @@ class RemoveConversationFromFavoritesUseCaseTest {
         }.wasInvoked(exactly = once)
 
         coVerify {
-            arrangement.conversationFolderRepository.removeConversationFromFolder(testConversationId, TestFolder.FAVORITE.id)
+            arrangement.conversationFolderRepository.removeConversationFromFolder(testConversationId, TestFolder.FAVORITE.id, true)
         }.wasInvoked(exactly = once)
     }
 
@@ -95,7 +95,7 @@ class RemoveConversationFromFavoritesUseCaseTest {
         }.wasInvoked(exactly = once)
 
         coVerify {
-            arrangement.conversationFolderRepository.removeConversationFromFolder(testConversationId, TestFolder.FAVORITE.id)
+            arrangement.conversationFolderRepository.removeConversationFromFolder(testConversationId, TestFolder.FAVORITE.id, true)
         }.wasInvoked(exactly = once)
     }
 
@@ -119,7 +119,7 @@ class RemoveConversationFromFavoritesUseCaseTest {
             either: Either<CoreFailure, Unit>
         ) = apply {
             coEvery {
-                conversationFolderRepository.removeConversationFromFolder(conversationId, folderId)
+                conversationFolderRepository.removeConversationFromFolder(conversationId, folderId, true)
             }.returns(either)
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16164" title="WPB-16164" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16164</a>  [Android]Removing conversation from favorites does not take effect and causes the filter functionality to behave abruptly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- added boolean to not remove favorites folder when favorite folder has empty list after removal