### PR TITLE
fix: Mic icon shows muted, but participants can hear me (WPB-16281)

### DIFF
--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -45,7 +45,7 @@ class CallManagerImpl : CallManager {
         TODO("Not yet implemented")
     }
 
-    override suspend fun answerCall(conversationId: ConversationId, isAudioCbr: Boolean) {
+    override suspend fun answerCall(conversationId: ConversationId, isAudioCbr: Boolean, isVideoCall: Boolean) {
         TODO("Not yet implemented")
     }
 

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -329,17 +329,19 @@ class CallManagerImpl internal constructor(
 
     override suspend fun answerCall(
         conversationId: ConversationId,
-        isAudioCbr: Boolean
+        isAudioCbr: Boolean,
+        isVideoCall: Boolean
     ) {
         withCalling {
             callingLogger.d(
                 "$TAG -> answering call for conversation = " +
                         "${conversationId.toLogString()}.."
             )
+            val callType = if (isVideoCall) CallTypeCalling.VIDEO else CallTypeCalling.AUDIO
             wcall_answer(
                 inst = deferredHandle.await(),
                 conversationId = federatedIdMapper.parseToFederatedId(conversationId),
-                callType = CallTypeCalling.AUDIO.avsValue,
+                callType = callType.avsValue,
                 cbrEnabled = isAudioCbr
             )
             callingLogger.d(

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/util/DummyCallManager.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/util/DummyCallManager.kt
@@ -41,7 +41,7 @@ class DummyCallManager : CallManager {
     ) {
     }
 
-    override suspend fun answerCall(conversationId: ConversationId, isAudioCbr: Boolean) {}
+    override suspend fun answerCall(conversationId: ConversationId, isAudioCbr: Boolean, isVideoCall: Boolean) {}
 
     override suspend fun endCall(conversationId: ConversationId) {}
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManager.kt
@@ -42,7 +42,7 @@ interface CallManager {
         isAudioCbr: Boolean
     )
 
-    suspend fun answerCall(conversationId: ConversationId, isAudioCbr: Boolean)
+    suspend fun answerCall(conversationId: ConversationId, isAudioCbr: Boolean, isVideoCall: Boolean = false)
     suspend fun endCall(conversationId: ConversationId)
     suspend fun rejectCall(conversationId: ConversationId)
     suspend fun muteCall(shouldMute: Boolean)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
@@ -40,8 +40,6 @@ import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.EndCallUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.FlipToBackCameraUseCase
 import com.wire.kalium.logic.feature.call.usecase.FlipToFrontCameraUseCase
-import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallWithSortedParticipantsUseCase
-import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallWithSortedParticipantsUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.GetCallConversationTypeProvider
 import com.wire.kalium.logic.feature.call.usecase.GetIncomingCallsUseCase
 import com.wire.kalium.logic.feature.call.usecase.GetIncomingCallsUseCaseImpl
@@ -53,15 +51,18 @@ import com.wire.kalium.logic.feature.call.usecase.IsLastCallClosedUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.MuteCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.MuteCallUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.ObserveAskCallFeedbackUseCase
-import com.wire.kalium.logic.feature.call.usecase.observeAskCallFeedbackUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveConferenceCallingEnabledUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveConferenceCallingEnabledUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.ObserveEndCallDueToConversationDegradationUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveEndCallDueToConversationDegradationUseCaseImpl
+import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallWithSortedParticipantsUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallWithSortedParticipantsUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.ObserveInCallReactionsUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveInCallReactionsUseCaseImpl
+import com.wire.kalium.logic.feature.call.usecase.ObserveOngoingAndIncomingCallsUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveOngoingAndIncomingCallsUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.ObserveOngoingCallsUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveOngoingCallsUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.ObserveOutgoingCallUseCase
@@ -82,6 +83,7 @@ import com.wire.kalium.logic.feature.call.usecase.UnMuteCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.UnMuteCallUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.UpdateConversationClientsForCurrentCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.UpdateConversationClientsForCurrentCallUseCaseImpl
+import com.wire.kalium.logic.feature.call.usecase.observeAskCallFeedbackUseCase
 import com.wire.kalium.logic.feature.call.usecase.video.SetVideoSendStateUseCase
 import com.wire.kalium.logic.feature.call.usecase.video.UpdateVideoStateUseCase
 import com.wire.kalium.logic.feature.user.ShouldAskCallFeedbackUseCase
@@ -140,6 +142,10 @@ class CallsScope internal constructor(
             callRepository = callRepository,
         )
 
+    val observeOngoingAndIncomingCalls: ObserveOngoingAndIncomingCallsUseCase by lazy {
+        ObserveOngoingAndIncomingCallsUseCaseImpl(callRepository = callRepository)
+    }
+
     val observeEstablishedCallWithSortedParticipants: ObserveEstablishedCallWithSortedParticipantsUseCase
         get() = ObserveEstablishedCallWithSortedParticipantsUseCaseImpl(
             callRepository = callRepository,
@@ -158,10 +164,9 @@ class CallsScope internal constructor(
 
     val answerCall: AnswerCallUseCase
         get() = AnswerCallUseCaseImpl(
-            getIncomingCalls,
+            observeOngoingAndIncomingCalls,
             callManager,
             muteCall,
-            unMuteCall,
             kaliumConfigs
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/ObserveOngoingAndIncomingCalls.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/ObserveOngoingAndIncomingCalls.kt
@@ -1,0 +1,45 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.call.usecase
+
+import com.wire.kalium.logic.data.call.Call
+import com.wire.kalium.logic.data.call.CallRepository
+import com.wire.kalium.logic.data.call.CallStatus
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
+
+/**
+ * This use case is responsible for observing the ongoing and incoming calls.
+ */
+interface ObserveOngoingAndIncomingCallsUseCase {
+    suspend operator fun invoke(): Flow<List<Call>>
+}
+
+internal class ObserveOngoingAndIncomingCallsUseCaseImpl(
+    private val callRepository: CallRepository
+) : ObserveOngoingAndIncomingCallsUseCase {
+
+    override suspend fun invoke(): Flow<List<Call>> {
+        return callRepository.callsFlow().map {
+            it.filter { call ->
+                call.status == CallStatus.INCOMING || call.status == CallStatus.STILL_ONGOING
+            }
+        }.filter { it.isNotEmpty() }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/ObserveOngoingAndIncomingCallsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/ObserveOngoingAndIncomingCallsUseCaseTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.call.usecase
+
+import com.wire.kalium.logic.data.call.Call
+import com.wire.kalium.logic.data.call.CallRepository
+import com.wire.kalium.logic.data.call.CallStatus
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.feature.call.usecase.AnswerCallUseCaseTest.Companion.conversationId
+import com.wire.kalium.logic.framework.TestCall
+import io.mockative.Mock
+import io.mockative.coEvery
+import io.mockative.mock
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ObserveOngoingAndIncomingCallsUseCaseTest {
+
+    @Mock
+    val callRepository = mock(CallRepository::class)
+
+    private lateinit var observeOngoingAndIncomingCalls: ObserveOngoingAndIncomingCallsUseCase
+
+    @BeforeTest
+    fun setUp() {
+        observeOngoingAndIncomingCalls = ObserveOngoingAndIncomingCallsUseCaseImpl(
+            callRepository = callRepository,
+        )
+    }
+
+    @Test
+    fun givenCallsWithDifferentStatuses_whenInvokeIsCalled_thenItFiltersIncomingAndOngoingCalls() = runTest {
+
+        coEvery {
+            callRepository.callsFlow()
+        }.returns(
+            flowOf(
+                listOf(
+                    call.copy(status = CallStatus.STARTED),
+                    call.copy(status = CallStatus.ESTABLISHED),
+                    call.copy(status = CallStatus.INCOMING),
+                    call.copy(status = CallStatus.STILL_ONGOING),
+                )
+            )
+        )
+
+        val result = observeOngoingAndIncomingCalls.invoke()
+
+        result.first().let {
+            assertEquals(2, it.size)
+            assertEquals(CallStatus.INCOMING, it[0].status)
+            assertEquals(CallStatus.STILL_ONGOING, it[1].status)
+        }
+    }
+
+    companion object {
+        val call = Call(
+            conversationId = conversationId,
+            status = CallStatus.INCOMING,
+            isMuted = true,
+            isCameraOn = false,
+            isCbrEnabled = false,
+            callerId = TestCall.CALLER_ID,
+            conversationName = "caller-name",
+            conversationType = Conversation.Type.GROUP,
+            callerName = "Name",
+            callerTeamName = "group",
+            establishedTime = null
+        )
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16281" title="WPB-16281" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16281</a>  [Android]Mic icon shows muted, but participants can hear me
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1- When enabling video before accepting a call, call does not connect to user 
2- Mic icon shows muted, but participants can hear me

### Causes (Optional)

1- There is an additional signalling happening because we are calling set_video_send_state after we answer the call which may confuse the SFT.
2- we recently changed AnsweredCallUSeCase to use incomingCalls flow, but this flow does not include ongoing calls that use can join.

### Solutions

1- The root cause should be fixed on SFT, but from our side we are removing the additional signalling by passing `isVideoEnabled` value when we answer the call.
2. use incoming and ongoing calls flow instead.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
