### PR TITLE
feat: enable creating account when claimed domain and email in use [WPB-14339]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginRedirectPath.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginRedirectPath.kt
@@ -47,5 +47,5 @@ sealed class LoginRedirectPath(val isCloudAccountCreationPossible: Boolean) {
     /**
      * The user has an existing cloud account, but the domain is already claimed by an organization.
      */
-    data class ExistingAccountWithClaimedDomain(val domain: String) : LoginRedirectPath(isCloudAccountCreationPossible = false)
+    data class ExistingAccountWithClaimedDomain(val domain: String) : LoginRedirectPath(isCloudAccountCreationPossible = true)
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14339" title="WPB-14339" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14339</a>  [Android] - Implement UI path 3
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

According to the specifications, when the app shows the dialog informing about domain being claimed and this email already being in use, the user should have the possibility to create new account:
<img width="436" alt="image" src="https://github.com/user-attachments/assets/89bd032f-8d21-4b57-815d-ffc9fdcbecb9" />

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
