### PR TITLE
feat: differentiate specific login account errors [WPB-16375]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
@@ -33,6 +33,8 @@ import com.wire.kalium.common.functional.map
 import com.wire.kalium.network.exceptions.AuthenticationCodeFailure
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.exceptions.authenticationCodeFailure
+import com.wire.kalium.network.exceptions.isAccountPendingActivation
+import com.wire.kalium.network.exceptions.isAccountSuspended
 import com.wire.kalium.network.exceptions.isBadRequest
 import com.wire.kalium.network.exceptions.isInvalidCredentials
 
@@ -67,6 +69,17 @@ sealed class AuthenticationResult {
          * The user has entered a text that isn't considered a valid email or handle
          */
         data object InvalidUserIdentifier : Failure()
+
+        /**
+         * The user's account has been suspended, for instance via backoffice
+         */
+        data object AccountSuspended : Failure()
+
+        /**
+         * The user has been invited to a team but hasn't accepted the invitation yet
+         */
+        data object AccountPendingActivation : Failure()
+
         data class Generic(val genericFailure: CoreFailure) : Failure()
     }
 }
@@ -163,6 +176,8 @@ internal class LoginUseCaseImpl internal constructor(
             kaliumException.isInvalidCredentials() || kaliumException.isBadRequest() -> {
                 AuthenticationResult.Failure.InvalidCredentials.InvalidPasswordIdentityCombination
             }
+            kaliumException.isAccountSuspended() -> AuthenticationResult.Failure.AccountSuspended
+            kaliumException.isAccountPendingActivation() -> AuthenticationResult.Failure.AccountPendingActivation
 
             else -> when (kaliumException.authenticationCodeFailure) {
                 AuthenticationCodeFailure.MISSING_AUTHENTICATION_CODE ->

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCaseTest.kt
@@ -486,6 +486,70 @@ class LoginUseCaseTest {
         }.wasNotInvoked()
     }
 
+    @Test
+    fun givenAccountSuspended_whenLoggingIn_thenReturnAccountSuspendedFailure() = runTest {
+        val invalidAuthCodeFailure = NetworkFailure.ServerMiscommunication(TestNetworkException.accountSuspended)
+
+        val (arrangement, loginUseCase) = Arrangement()
+            .withLoginUsingEmailResulting(Either.Left(invalidAuthCodeFailure))
+            .withLoginUsingHandleResulting(Either.Left(invalidAuthCodeFailure))
+            .arrange()
+
+        // email
+        val loginEmailResult = loginUseCase(TEST_EMAIL, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_LABEL)
+        assertEquals(AuthenticationResult.Failure.AccountSuspended, loginEmailResult)
+
+        coVerify {
+            arrangement.loginRepository.loginWithEmail(TEST_EMAIL, TEST_PASSWORD, TEST_LABEL, TEST_PERSIST_CLIENT)
+        }.wasInvoked(exactly = once)
+        coVerify {
+            arrangement.loginRepository.loginWithHandle(any(), any(), any(), any())
+        }.wasNotInvoked()
+
+        // user handle
+        val loginHandleResult = loginUseCase(TEST_HANDLE, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_LABEL)
+        assertEquals(AuthenticationResult.Failure.AccountSuspended, loginHandleResult)
+
+        coVerify {
+            arrangement.loginRepository.loginWithHandle(TEST_HANDLE, TEST_PASSWORD, TEST_LABEL, TEST_PERSIST_CLIENT)
+        }.wasInvoked(exactly = once)
+        coVerify {
+            arrangement.loginRepository.loginWithEmail(any(), any(), any(), any(), any())
+        }.wasNotInvoked()
+    }
+
+    @Test
+    fun givenAccountPendingActivation_whenLoggingIn_thenReturnAccountPendingActivationFailure() = runTest {
+        val invalidAuthCodeFailure = NetworkFailure.ServerMiscommunication(TestNetworkException.accountPendingActivation)
+
+        val (arrangement, loginUseCase) = Arrangement()
+            .withLoginUsingEmailResulting(Either.Left(invalidAuthCodeFailure))
+            .withLoginUsingHandleResulting(Either.Left(invalidAuthCodeFailure))
+            .arrange()
+
+        // email
+        val loginEmailResult = loginUseCase(TEST_EMAIL, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_LABEL)
+        assertEquals(AuthenticationResult.Failure.AccountPendingActivation, loginEmailResult)
+
+        coVerify {
+            arrangement.loginRepository.loginWithEmail(TEST_EMAIL, TEST_PASSWORD, TEST_LABEL, TEST_PERSIST_CLIENT)
+        }.wasInvoked(exactly = once)
+        coVerify {
+            arrangement.loginRepository.loginWithHandle(any(), any(), any(), any())
+        }.wasNotInvoked()
+
+        // user handle
+        val loginHandleResult = loginUseCase(TEST_HANDLE, TEST_PASSWORD, TEST_PERSIST_CLIENT, TEST_LABEL)
+        assertEquals(AuthenticationResult.Failure.AccountPendingActivation, loginHandleResult)
+
+        coVerify {
+            arrangement.loginRepository.loginWithHandle(TEST_HANDLE, TEST_PASSWORD, TEST_LABEL, TEST_PERSIST_CLIENT)
+        }.wasInvoked(exactly = once)
+        coVerify {
+            arrangement.loginRepository.loginWithEmail(any(), any(), any(), any(), any())
+        }.wasNotInvoked()
+    }
+
     private class Arrangement {
 
         @Mock

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/test_util/TestNetworkException.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/test_util/TestNetworkException.kt
@@ -134,6 +134,14 @@ object TestNetworkException {
     val federationNotEnabled = KaliumException.FederationError(
         ErrorResponse(400, "no federator configured", "federation-not-enabled")
     )
+
+    val accountSuspended = KaliumException.InvalidRequestError(
+        ErrorResponse(403, message = "account suspended", label = "suspended")
+    )
+
+    val accountPendingActivation = KaliumException.InvalidRequestError(
+        ErrorResponse(403, message = "account pending activation", label = "pending-activation")
+    )
 }
 
 object TestNetworkResponseError {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
@@ -27,6 +27,8 @@ import com.wire.kalium.network.api.model.ErrorResponse
 import com.wire.kalium.network.api.model.FederationConflictResponse
 import com.wire.kalium.network.api.model.FederationUnreachableResponse
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.ACCESS_DENIED
+import com.wire.kalium.network.exceptions.NetworkErrorLabel.ACCOUNT_PENDING_ACTIVATION
+import com.wire.kalium.network.exceptions.NetworkErrorLabel.ACCOUNT_SUSPENDED
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.BAD_REQUEST
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.BLACKLISTED_EMAIL
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.DOMAIN_BLOCKED_FOR_REGISTRATION
@@ -242,3 +244,5 @@ val KaliumException.InvalidRequestError.authenticationCodeFailure: Authenticatio
 fun KaliumException.FederationError.isFederationDenied() = errorResponse.label == FEDERATION_DENIED
 fun KaliumException.FederationError.isFederationNotEnabled() = errorResponse.label == FEDERATION_NOT_ENABLED
 fun KaliumException.InvalidRequestError.isMissingLegalHoldConsent(): Boolean = errorResponse.label == MISSING_LEGALHOLD_CONSENT
+fun KaliumException.InvalidRequestError.isAccountSuspended(): Boolean = errorResponse.label == ACCOUNT_SUSPENDED
+fun KaliumException.InvalidRequestError.isAccountPendingActivation(): Boolean = errorResponse.label == ACCOUNT_PENDING_ACTIVATION

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/NetworkErrorLabel.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/NetworkErrorLabel.kt
@@ -51,6 +51,8 @@ internal object NetworkErrorLabel {
     const val WRONG_CONVERSATION_PASSWORD = "invalid-conversation-password"
     const val NOT_FOUND = "not-found"
     const val MISSING_LEGALHOLD_CONSENT = "missing-legalhold-consent"
+    const val ACCOUNT_SUSPENDED = "suspended"
+    const val ACCOUNT_PENDING_ACTIVATION = "pending-activation"
 
     // Federation
     const val FEDERATION_FAILURE = "federation-remote-error"

--- a/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/InstanceService.kt
+++ b/testservice/src/main/kotlin/com/wire/kalium/testservice/managed/InstanceService.kt
@@ -198,6 +198,12 @@ class InstanceService(
             AuthenticationResult.Failure.SocketError ->
                 throw WebApplicationException("Instance $instanceId: Login failed, socket error!")
 
+            AuthenticationResult.Failure.AccountSuspended ->
+                throw WebApplicationException("Instance $instanceId: Login failed, account suspended!")
+
+            AuthenticationResult.Failure.AccountPendingActivation ->
+                throw WebApplicationException("Instance $instanceId: Login failed, account pending activation!")
+
             is AuthenticationResult.Success -> {
                 log.info("Instance $instanceId: Login successful")
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16375" title="WPB-16375" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16375</a>  [Android] Add account suspended and pending activation errors
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

For the enterprise login, we need to differentiate two additional login error codes related to the account state: 
- `suspended`, when the user's account has been suspended, for instance via backoffice
- `pending-activation`, when the user has been invited to a team but hasn't accepted the invitation yet

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
