### PR TITLE
fix: implement missing domain redirect backend request to get config url [WPB-14341]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/login/LoginRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/login/LoginRepository.kt
@@ -91,7 +91,7 @@ internal class LoginRepositoryImpl internal constructor(
     }
 
     override suspend fun fetchDomainRedirectCustomBackendConfig(backendUrl: String): Either<NetworkFailure, DomainLookupResult> =
-        wrapApiRequest{
+        wrapApiRequest {
             getDomainRegistrationApi.customBackendConfig(backendUrl)
         }.map {
             DomainLookupResult(it.configJsonUrl, it.webappWelcomeUrl)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/login/LoginRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/login/LoginRepository.kt
@@ -50,6 +50,7 @@ internal interface LoginRepository {
     ): Either<NetworkFailure, Pair<AccountTokens, SsoId?>>
 
     suspend fun getDomainRegistration(email: String): Either<NetworkFailure, LoginDomainPath>
+    suspend fun fetchDomainRedirectCustomBackendConfig(backendUrl: String): Either<NetworkFailure, DomainLookupResult>
 }
 
 internal class LoginRepositoryImpl internal constructor(
@@ -88,6 +89,13 @@ internal class LoginRepositoryImpl internal constructor(
     }.map {
         domainRegistrationMapper.fromApiModel(it, email)
     }
+
+    override suspend fun fetchDomainRedirectCustomBackendConfig(backendUrl: String): Either<NetworkFailure, DomainLookupResult> =
+        wrapApiRequest{
+            getDomainRegistrationApi.customBackendConfig(backendUrl)
+        }.map {
+            DomainLookupResult(it.configJsonUrl, it.webappWelcomeUrl)
+        }
 
     private suspend fun login(
         loginParam: LoginParam,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unauthenticated/domainregistration/GetDomainRegistrationApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unauthenticated/domainregistration/GetDomainRegistrationApi.kt
@@ -18,11 +18,13 @@
 package com.wire.kalium.network.api.base.unauthenticated.domainregistration
 
 import com.wire.kalium.network.api.base.authenticated.BaseApi
+import com.wire.kalium.network.api.unauthenticated.domainLookup.DomainLookupResponse
 import com.wire.kalium.network.api.unauthenticated.domainregistration.DomainRegistrationDTO
 import com.wire.kalium.network.utils.NetworkResponse
 
 interface GetDomainRegistrationApi : BaseApi {
     suspend fun getDomainRegistration(email: String): NetworkResponse<DomainRegistrationDTO>
+    suspend fun customBackendConfig(backendUrl: String): NetworkResponse<DomainLookupResponse>
 
     companion object {
         const val MIN_API_VERSION = 8

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/GetDomainRegistrationApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/GetDomainRegistrationApiV0.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.network.api.v0.unauthenticated
 import com.wire.kalium.network.UnauthenticatedNetworkClient
 import com.wire.kalium.network.api.base.unauthenticated.domainregistration.GetDomainRegistrationApi
 import com.wire.kalium.network.api.base.unauthenticated.domainregistration.GetDomainRegistrationApi.Companion.MIN_API_VERSION
+import com.wire.kalium.network.api.unauthenticated.domainLookup.DomainLookupResponse
 import com.wire.kalium.network.api.unauthenticated.domainregistration.DomainRegistrationDTO
 import com.wire.kalium.network.exceptions.APINotSupported
 import com.wire.kalium.network.utils.NetworkResponse
@@ -34,6 +35,14 @@ internal open class GetDomainRegistrationApiV0 internal constructor(
         return NetworkResponse.Error(
             APINotSupported(
                 errorBody = "${this::class.simpleName}: ${::getDomainRegistration.name} api is only available on API V${MIN_API_VERSION}"
+            )
+        )
+    }
+
+    override suspend fun customBackendConfig(backendUrl: String): NetworkResponse<DomainLookupResponse> {
+        return NetworkResponse.Error(
+            APINotSupported(
+                errorBody = "${this::class.simpleName}: ${::customBackendConfig.name} api is only available on API V${MIN_API_VERSION}"
             )
         )
     }

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v8/unauthenticated/GetDomainRegistrationApiV8.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v8/unauthenticated/GetDomainRegistrationApiV8.kt
@@ -18,13 +18,19 @@
 package com.wire.kalium.network.api.v8.unauthenticated
 
 import com.wire.kalium.network.UnauthenticatedNetworkClient
+import com.wire.kalium.network.api.unauthenticated.domainLookup.DomainLookupResponse
 import com.wire.kalium.network.api.unauthenticated.domainregistration.DomainRegistrationDTO
 import com.wire.kalium.network.api.unauthenticated.domainregistration.DomainRegistrationRequest
 import com.wire.kalium.network.api.v7.unauthenticated.GetDomainRegistrationApiV7
 import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.setUrl
 import com.wire.kalium.network.utils.wrapKaliumResponse
+import io.ktor.client.request.accept
+import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.Url
 
 internal open class GetDomainRegistrationApiV8 internal constructor(
     unauthenticatedNetworkClient: UnauthenticatedNetworkClient
@@ -34,6 +40,15 @@ internal open class GetDomainRegistrationApiV8 internal constructor(
         return wrapKaliumResponse {
             httpClient.post(PATH_DOMAIN_REGISTRATION) {
                 setBody(DomainRegistrationRequest(email))
+            }
+        }
+    }
+
+    override suspend fun customBackendConfig(backendUrl: String): NetworkResponse<DomainLookupResponse> {
+        return wrapKaliumResponse<DomainLookupResponse> {
+            httpClient.get {
+                accept(ContentType.Text.Plain)
+                setUrl(Url(backendUrl))
             }
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14341" title="WPB-14341" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14341</a>  [Android] - Implement UI paths 5 & 8
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

In case of `domain_redirect:backend` the app uses `backend_url` as the url to get the backend config json, but in fact, this is the url to download the "domain redirect details" json, which contains `config_json_url` field which is the url to get the backend config json that we need.
Everything is explained here: https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/150930346/Use+case+connect+to+a+custom+backend+via+domain+redirect

So fetching `backend_url` doesn't return `ServerConfig.Links` directly but instead it returns this json:
```
{
  "config_json_url": "https://wire-rest.https.orange.com/config.json",
  "webapp_welcome_url": "https://app.wire.orange.com/"
}
```
This is the same response as "domain lookup" one that we get from `GET /custom-backend/by-domain/{domain}` so the response classes are simply reused.
Then, to get the required `ServerConfig.Links`, the app needs to also fetch `config_json_url`.

This PR implements this additional required request in between.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
