### PR TITLE
fix: update claimed domain "email already in use" conditions [WPB-14339]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/DomainRegistrationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/DomainRegistrationMapper.kt
@@ -29,17 +29,13 @@ internal object DomainRegistrationMapperImpl : DomainRegistrationMapper {
         return when (domainRegistrationDTO.domainRedirect) {
             DomainRedirect.PRE_AUTHORIZED -> LoginDomainPath.Default
             DomainRedirect.LOCKED -> LoginDomainPath.Default
-            DomainRedirect.NONE -> {
-                if (domainRegistrationDTO.dueToExistingAccount == true) {
-                    LoginDomainPath.ExistingAccountWithClaimedDomain(extractDomain(email))
-                } else {
-                    LoginDomainPath.Default
-                }
-            }
-
+            DomainRedirect.NONE -> LoginDomainPath.Default
             DomainRedirect.SSO -> LoginDomainPath.SSO(domainRegistrationDTO.ssoCode!!)
             DomainRedirect.BACKEND -> LoginDomainPath.CustomBackend(domainRegistrationDTO.backendUrl!!)
-            DomainRedirect.NO_REGISTRATION -> LoginDomainPath.NoRegistration
+            DomainRedirect.NO_REGISTRATION -> when (domainRegistrationDTO.dueToExistingAccount) {
+                    true -> LoginDomainPath.ExistingAccountWithClaimedDomain(extractDomain(email))
+                    else -> LoginDomainPath.NoRegistration
+                }
         }
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/auth/login/DomainRegistrationMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/auth/login/DomainRegistrationMapperTest.kt
@@ -17,10 +17,8 @@
  */
 package com.wire.kalium.logic.data.auth.login
 
-import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.data.auth.LoginDomainPath
 import com.wire.kalium.logic.di.MapperProvider
-import com.wire.kalium.logic.feature.auth.LoginRedirectPath
 import com.wire.kalium.network.api.unauthenticated.domainregistration.DomainRedirect
 import com.wire.kalium.network.api.unauthenticated.domainregistration.DomainRegistrationDTO
 import kotlinx.coroutines.test.runTest
@@ -64,18 +62,16 @@ class DomainRegistrationMapperTest {
     }
 
     @Test
-    fun givenADomainRedirectValueDTONoneAndAccountExists_whenMappingToDomain_thenMapCorrectly() = runTest {
+    fun givenADomainRedirectValueDTONoRegistrationAndAccountExists_whenMappingToDomain_thenMapCorrectly() = runTest {
         val domainRegistrationMapper = MapperProvider.domainRegistrationMapper()
 
         val result = domainRegistrationMapper.fromApiModel(
-            Arrangement.provideDomainRegistrationDTO(DomainRedirect.NONE, dueToExistingAccount = true), Arrangement.EMAIL
+            Arrangement.provideDomainRegistrationDTO(DomainRedirect.NO_REGISTRATION, dueToExistingAccount = true), Arrangement.EMAIL
         )
         assertEquals(LoginDomainPath.ExistingAccountWithClaimedDomain::class, result::class)
         assertEquals("wire.com", (result as LoginDomainPath.ExistingAccountWithClaimedDomain).domain)
         assertEquals(false, result.isCloudAccountCreationPossible)
     }
-
-
 
     private object Arrangement {
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14339" title="WPB-14339" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14339</a>  [Android] - Implement UI path 3
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

After some discussions, the conditions for "Email claimed by an on-premises backend" dialog has changed. 
Now, it should be shown when the response is: `domain_redirect=no-registration` and `due_to_existing_account=true`.
In this PR, this change is applied so that it's aligned with the current decision flow:
<img width="1416" alt="image" src="https://github.com/user-attachments/assets/c2c2b2b9-f2cc-4d7f-83c0-9e958afcb7b6" />

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
