### PR TITLE
fix: persist self email to register device with 2fa [WPB-16573]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -83,6 +83,7 @@ import kotlinx.coroutines.flow.map
 @Suppress("TooManyFunctions")
 interface UserRepository {
     suspend fun fetchSelfUser(): Either<CoreFailure, Unit>
+    suspend fun insertSelfIncompleteUserWithOnlyEmail(email: String): Either<CoreFailure, Unit>
 
     /**
      * Fetches user information for all of users id stored in the DB
@@ -202,6 +203,10 @@ internal class UserDataSource internal constructor(
                     }
             }
         }
+
+    override suspend fun insertSelfIncompleteUserWithOnlyEmail(email: String): Either<CoreFailure, Unit> = wrapStorageRequest {
+        userDAO.insertOrIgnoreIncompleteUserWithOnlyEmail(selfUserId.toDao(), email)
+    }
 
     private suspend fun updateSelfUserProviderAccountInfo(userDTO: SelfUserDTO): Either<StorageFailure, Unit> =
         sessionRepository.updateSsoIdAndScimInfo(userDTO.id.toModel(), idMapper.toSsoId(userDTO.ssoID), userDTO.managedByDTO)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/PersistSelfUserEmailUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/PersistSelfUserEmailUseCase.kt
@@ -27,6 +27,10 @@ sealed class PersistSelfUserEmailResult {
 }
 
 interface PersistSelfUserEmailUseCase {
+    /**
+     * Persists the email of the self user before full data is fetched so that it can be used to complete the client registration with 2fa.
+     * @param email The email address of the self user
+     */
     suspend operator fun invoke(email: String): PersistSelfUserEmailResult
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/PersistSelfUserEmailUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/PersistSelfUserEmailUseCase.kt
@@ -34,7 +34,7 @@ interface PersistSelfUserEmailUseCase {
     suspend operator fun invoke(email: String): PersistSelfUserEmailResult
 }
 
-class PersistSelfUserEmailUseCaseImpl(
+internal class PersistSelfUserEmailUseCaseImpl(
     private val userRepository: UserRepository,
 ) : PersistSelfUserEmailUseCase {
     override suspend fun invoke(email: String): PersistSelfUserEmailResult =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/PersistSelfUserEmailUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/PersistSelfUserEmailUseCase.kt
@@ -1,0 +1,43 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.auth
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.user.UserRepository
+
+sealed class PersistSelfUserEmailResult {
+    data object Success : PersistSelfUserEmailResult()
+    data class Failure(val coreFailure: CoreFailure) : PersistSelfUserEmailResult()
+}
+
+interface PersistSelfUserEmailUseCase {
+    suspend operator fun invoke(email: String): PersistSelfUserEmailResult
+}
+
+class PersistSelfUserEmailUseCaseImpl(
+    private val userRepository: UserRepository,
+) : PersistSelfUserEmailUseCase {
+    override suspend fun invoke(email: String): PersistSelfUserEmailResult =
+        userRepository.insertSelfIncompleteUserWithOnlyEmail(email).let {
+            when (it) {
+                is Either.Left -> PersistSelfUserEmailResult.Failure(it.value)
+                is Either.Right -> PersistSelfUserEmailResult.Success
+            }
+        }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
@@ -46,6 +46,8 @@ import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCase
 import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCaseImpl
 import com.wire.kalium.logic.feature.asset.GetAvatarAssetUseCase
 import com.wire.kalium.logic.feature.asset.GetAvatarAssetUseCaseImpl
+import com.wire.kalium.logic.feature.auth.PersistSelfUserEmailUseCase
+import com.wire.kalium.logic.feature.auth.PersistSelfUserEmailUseCaseImpl
 import com.wire.kalium.logic.feature.auth.ValidateUserHandleUseCase
 import com.wire.kalium.logic.feature.auth.ValidateUserHandleUseCaseImpl
 import com.wire.kalium.logic.feature.client.FinalizeMLSClientAfterE2EIEnrollment
@@ -127,6 +129,7 @@ class UserScope internal constructor(
     val getSelfUserWithTeam: ObserveSelfUserWithTeamUseCase get() = ObserveSelfUserWithTeamUseCaseImpl(userRepository)
     val observeUserInfo: ObserveUserInfoUseCase get() = ObserveUserInfoUseCaseImpl(userRepository, teamRepository)
     val uploadUserAvatar: UploadUserAvatarUseCase get() = UploadUserAvatarUseCaseImpl(userRepository, assetRepository)
+    val persistSelfUserEmail: PersistSelfUserEmailUseCase get() = PersistSelfUserEmailUseCaseImpl(userRepository)
 
     val getPublicAsset: GetAvatarAssetUseCase get() = GetAvatarAssetUseCaseImpl(assetRepository, userRepository)
     val enrollE2EI: EnrollE2EIUseCase get() = EnrollE2EIUseCaseImpl(e2EIRepository)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/PersistSelfUserEmailUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/PersistSelfUserEmailUseCaseTest.kt
@@ -67,22 +67,22 @@ class PersistSelfUserEmailUseCaseTest {
         @Mock
         val userRepository: UserRepository = mock(UserRepository::class)
 
-        val useCase by lazy {
+        internal val useCase by lazy {
             PersistSelfUserEmailUseCaseImpl(userRepository = userRepository)
         }
 
-        suspend fun withSuccess() = apply {
+        internal suspend fun withSuccess() = apply {
             coEvery {
                 userRepository.insertSelfIncompleteUserWithOnlyEmail(any())
             }.returns(Either.Right(Unit))
         }
 
-        suspend fun withFailure() = apply {
+        internal suspend fun withFailure() = apply {
             coEvery {
                 userRepository.insertSelfIncompleteUserWithOnlyEmail(any())
             }.returns(Either.Left(StorageFailure.Generic(RuntimeException("DB failed"))))
         }
 
-        fun arrange() = this to useCase
+        internal fun arrange() = this to useCase
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/PersistSelfUserEmailUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/PersistSelfUserEmailUseCaseTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.auth
+
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.user.UserRepository
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.coEvery
+import io.mockative.coVerify
+import io.mockative.eq
+import io.mockative.mock
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertIs
+
+class PersistSelfUserEmailUseCaseTest {
+
+    @Test
+    fun givenEmail_whenPersistSelfUserEmailSucceeds_thenReturnSuccess() = runTest {
+        val email = "user@email.com"
+        val (arrangement, useCase) = Arrangement()
+            .withSuccess()
+            .arrange()
+
+        val result = useCase(email)
+
+        assertIs<PersistSelfUserEmailResult.Success>(result)
+        coVerify {
+            arrangement.userRepository.insertSelfIncompleteUserWithOnlyEmail(eq(email))
+        }.wasInvoked(exactly = 1)
+    }
+
+    @Test
+    fun givenEmail_whenPersistSelfUserEmailFails_thenReturnFailure() = runTest {
+        val email = "user@email.com"
+        val (arrangement, useCase) = Arrangement()
+            .withFailure()
+            .arrange()
+
+        val result = useCase(email)
+
+        assertIs<PersistSelfUserEmailResult.Failure>(result)
+        coVerify {
+            arrangement.userRepository.insertSelfIncompleteUserWithOnlyEmail(eq(email))
+        }.wasInvoked(exactly = 1)
+    }
+
+    inner class Arrangement {
+
+        @Mock
+        val userRepository: UserRepository = mock(UserRepository::class)
+
+        val useCase by lazy {
+            PersistSelfUserEmailUseCaseImpl(userRepository = userRepository)
+        }
+
+        suspend fun withSuccess() = apply {
+            coEvery {
+                userRepository.insertSelfIncompleteUserWithOnlyEmail(any())
+            }.returns(Either.Right(Unit))
+        }
+
+        suspend fun withFailure() = apply {
+            coEvery {
+                userRepository.insertSelfIncompleteUserWithOnlyEmail(any())
+            }.returns(Either.Left(StorageFailure.Generic(RuntimeException("DB failed"))))
+        }
+
+        fun arrange() = this to useCase
+    }
+}

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Users.sq
@@ -137,9 +137,9 @@ insertOrIgnoreUserId:
 INSERT OR IGNORE INTO User(qualified_id, incomplete_metadata)
 VALUES(?, 1);
 
-insertOrIgnoreUserIdWithConnectionStatus:
-INSERT OR IGNORE INTO User(qualified_id, connection_status)
-VALUES(?, ?);
+insertOrIgnoreUserIdWithEmail:
+INSERT OR IGNORE INTO User(qualified_id, email, incomplete_metadata)
+VALUES(?, ?, 1);
 
 upsertUserConnectionStatus:
 INSERT INTO User(qualified_id, connection_status)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAO.kt
@@ -279,6 +279,7 @@ interface UserDAO {
     suspend fun updateUserAvailabilityStatus(qualifiedID: QualifiedIDEntity, status: UserAvailabilityStatusEntity)
     fun observeUsersDetailsNotInConversation(conversationId: QualifiedIDEntity): Flow<List<UserDetailsEntity>>
     suspend fun insertOrIgnoreIncompleteUsers(userIds: List<QualifiedIDEntity>)
+    suspend fun insertOrIgnoreIncompleteUserWithOnlyEmail(userId: QualifiedIDEntity, email: String)
     suspend fun getUsersDetailsNotInConversationByNameOrHandleOrEmail(
         conversationId: QualifiedIDEntity,
         searchQuery: String,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserDAOImpl.kt
@@ -430,6 +430,11 @@ class UserDAOImpl internal constructor(
             }
         }
 
+    override suspend fun insertOrIgnoreIncompleteUserWithOnlyEmail(userId: QualifiedIDEntity, email: String) =
+        withContext(queriesContext) {
+            userQueries.insertOrIgnoreUserIdWithEmail(userId, email)
+        }
+
     override suspend fun observeAllUsersDetailsByConnectionStatus(connectionState: ConnectionEntity.State): Flow<List<UserDetailsEntity>> =
         withContext(queriesContext) {
             userQueries.selectAllUsersWithConnectionStatus(connectionState)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/UserDAOTest.kt
@@ -1131,6 +1131,40 @@ class UserDAOTest : BaseDatabaseTest() {
         assertEquals(3, result)
     }
 
+    @Test
+    fun givenUserNotYetStored_whenInsertingOrIgnoringUserIdWithEmail_thenItShouldBeSavedWithIncompleteData() = runTest(dispatcher) {
+        // Given
+        val email = "user@email.com"
+        val userId = UserIDEntity("user", "domain")
+
+        // When
+        db.userDAO.insertOrIgnoreIncompleteUserWithOnlyEmail(userId, email)
+
+        // Then
+        val result = db.userDAO.observeUserDetailsByQualifiedID(userId).first()
+        assertNotNull(result)
+        assertEquals(true, result.hasIncompleteMetadata)
+        assertEquals(email, result.email)
+    }
+
+    @Test
+    fun givenUserWithCompleteDataAlreadyStored_whenInsertingOrIgnoringUserIdWithEmail_thenJustIgnore() = runTest(dispatcher) {
+        // Given
+        val email = "user@email.com"
+        val userId = UserIDEntity("user", "domain")
+        val user = USER_ENTITY_1.copy(id = userId, email = email, hasIncompleteMetadata = false)
+        db.userDAO.upsertUser(user)
+
+        // When
+        db.userDAO.insertOrIgnoreIncompleteUserWithOnlyEmail(userId, email)
+
+        // Then
+        val result = db.userDAO.observeUserDetailsByQualifiedID(userId).first()
+        assertNotNull(result)
+        assertEquals(false, result.hasIncompleteMetadata)
+    }
+
+
     private companion object {
         val USER_ENTITY_1 = newUserEntity(QualifiedIDEntity("1", "wire.com"))
         val USER_ENTITY_2 = newUserEntity(QualifiedIDEntity("2", "wire.com"))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16573" title="WPB-16573" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16573</a>  [Android] Invalid information alert received although login is valid
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When registering device with 2fa, the code is saved from login so that it can be reused, but it uses email as the key.
Currently, the app doesn't know self user's email until initial sync is performed (only then `fetchSelfUser` is executed) so when trying to get email during device registration, it returns null and 2fa code cannot be retrieved resulting in error.

### Solutions

Persist self user email (in User table but with flag informing that this user's data is incomplete) right after login and when the user session is created so that it can be used during client registration.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Login with email on account that requires 2FA.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
