### PR TITLE
chore: show server error message for non stranded response

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/utils/NetworkUtils.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/utils/NetworkUtils.kt
@@ -204,7 +204,10 @@ internal suspend fun handleUnsuccessfulResponse(
         result.body()
     } catch (_: NoTransformationFoundException) {
         // When the backend returns something that is not a JSON for whatever reason.
-        ErrorResponse(status.value, status.description, "")
+        ErrorResponse(code = status.value, label = status.description, message = result.bodyAsText())
+    } catch (_: SerializationException) {
+        // When the backend returns a JSON that cannot be parsed.
+        ErrorResponse(code = status.value, label = status.description, message = result.bodyAsText())
     }
 
     val federationException = errorResponse.isFederationError().let {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

show server error message for non stranded response

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
