### PR TITLE
fix(MLS): use current client ID when refreshing token [WPB-16726]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -599,6 +599,7 @@ class UserSessionScope internal constructor(
         sessionRepository = globalScope.sessionRepository,
         accessTokenRefresherFactory = accessTokenRefresherFactory,
         userId = userId,
+        currentClientIdProvider = clientIdProvider,
         tokenStorage = globalPreferences.authTokenStorage,
         logout = { logoutReason -> logout(reason = logoutReason, waitUntilCompletes = true) }
     )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/UpgradeCurrentSessionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/UpgradeCurrentSessionUseCase.kt
@@ -44,7 +44,7 @@ internal class UpgradeCurrentSessionUseCaseImpl(
     override suspend operator fun invoke(clientId: ClientId): Either<CoreFailure, Unit> =
         wrapStorageRequest { sessionManager.session()?.refreshToken }
             .flatMap { currentRefreshToken ->
-                accessTokenRefresher.refreshTokenAndPersistSession(currentRefreshToken, clientId.value)
+                accessTokenRefresher.refreshTokenAndPersistSession(currentRefreshToken, clientId)
             }.map {
                 authenticatedNetworkContainer.clearCachedToken()
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/token/AccessTokenRefresher.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/token/AccessTokenRefresher.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.logic.data.session.token.AccessTokenRepository
 import com.wire.kalium.logic.data.auth.AccountTokens
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.logic.data.conversation.ClientId
 
 internal interface AccessTokenRefresher {
     /**
@@ -33,7 +34,7 @@ internal interface AccessTokenRefresher {
      */
     suspend fun refreshTokenAndPersistSession(
         currentRefreshToken: String,
-        clientId: String? = null,
+        clientId: ClientId? = null,
     ): Either<CoreFailure, AccountTokens>
 }
 
@@ -42,11 +43,11 @@ internal class AccessTokenRefresherImpl(
 ) : AccessTokenRefresher {
     override suspend fun refreshTokenAndPersistSession(
         currentRefreshToken: String,
-        clientId: String?
+        clientId: ClientId?
     ): Either<CoreFailure, AccountTokens> {
         return repository.getNewAccessToken(
             refreshToken = currentRefreshToken,
-            clientId = clientId
+            clientId = clientId?.value
         ).flatMap { result ->
             repository.persistTokens(result.accessToken, result.refreshToken)
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/network/SessionManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/network/SessionManagerTest.kt
@@ -19,6 +19,7 @@ package com.wire.kalium.logic.network
 
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.NetworkFailure
+import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.logic.configuration.server.ServerConfigMapper
 import com.wire.kalium.logic.data.auth.AccountTokens
 import com.wire.kalium.logic.data.logout.LogoutReason
@@ -28,6 +29,7 @@ import com.wire.kalium.logic.feature.session.token.AccessTokenRefresher
 import com.wire.kalium.logic.feature.session.token.AccessTokenRefresherFactory
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.network.api.base.authenticated.AccessTokenApi
 import com.wire.kalium.network.api.model.QualifiedID
 import com.wire.kalium.network.api.model.SessionDTO
@@ -60,7 +62,7 @@ class SessionManagerTest {
         }
 
         assertFailsWith<FailureToRefreshTokenException> {
-            sessionManager.updateToken(arrangement.accessTokenApi, "egal", "egal")
+            sessionManager.updateToken(arrangement.accessTokenApi, "egal")
         }
     }
 
@@ -93,15 +95,43 @@ class SessionManagerTest {
             withTokenRefresherResult(Either.Right(TEST_ACCOUNT_TOKENS))
         }
 
-        val accessToken = "egal"
         val refreshToken = "refreshToken"
-        sessionManager.updateToken(arrangement.accessTokenApi, accessToken, refreshToken)
+        sessionManager.updateToken(arrangement.accessTokenApi, refreshToken)
 
         coVerify {
+            arrangement.accessTokenRefresher.refreshTokenAndPersistSession(eq(refreshToken), any())
+        }.wasInvoked()
+    }
 
-            arrangement.accessTokenRefresher.refreshTokenAndPersistSession(eq(accessToken), eq(refreshToken))
-
+    @Test
+    fun givenCurrentClientId_whenUpdatingToken_thenItShouldCallTokenRefresherWithCurrentClientId() = runTest {
+        val currentClientId = ClientId("currentClientId")
+        val (arrangement, sessionManager) = arrange {
+            currentClientIdResponse = Either.Right(currentClientId)
+            withTokenRefresherResult(Either.Right(TEST_ACCOUNT_TOKENS))
         }
+
+        val refreshToken = "refreshToken"
+        sessionManager.updateToken(arrangement.accessTokenApi, refreshToken)
+
+        coVerify {
+            arrangement.accessTokenRefresher.refreshTokenAndPersistSession(any(), eq(currentClientId))
+        }.wasInvoked()
+    }
+
+    @Test
+    fun givenNoCurrentClientId_whenUpdatingToken_thenItShouldCallTokenRefresherWithNullClientId() = runTest {
+        val (arrangement, sessionManager) = arrange {
+            currentClientIdResponse = Either.Left(StorageFailure.DataNotFound)
+            withTokenRefresherResult(Either.Right(TEST_ACCOUNT_TOKENS))
+        }
+
+        val refreshToken = "refreshToken"
+        sessionManager.updateToken(arrangement.accessTokenApi, refreshToken)
+
+        coVerify {
+            arrangement.accessTokenRefresher.refreshTokenAndPersistSession(refreshToken, null)
+        }.wasInvoked()
     }
 
     @Test
@@ -172,12 +202,15 @@ class SessionManagerTest {
 
         private val sessionMapper = MapperProvider.sessionMapper()
 
+        var currentClientIdResponse: Either<CoreFailure, ClientId> = Either.Right(ClientId("testClientId"))
+
         suspend fun arrange(): Pair<Arrangement, SessionManager> = run {
             configure()
             this@Arrangement to SessionManagerImpl(
                 sessionRepository = sessionRepository,
                 accessTokenRefresherFactory = accessTokenRefresherFactory,
                 userId = userId,
+                currentClientIdProvider = { currentClientIdResponse },
                 tokenStorage = tokenStorage,
                 logout = logout,
                 serverConfigMapper = serverConfigMapper,

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/networkContainer/AuthenticatedNetworkContainer.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/networkContainer/AuthenticatedNetworkContainer.kt
@@ -253,7 +253,6 @@ internal class AuthenticatedHttpClientProviderImpl(
         }
         val newSession = sessionManager.updateToken(
             accessTokenApi = accessTokenApi(client),
-            oldAccessToken = oldTokens!!.accessToken,
             oldRefreshToken = oldTokens!!.refreshToken
         )
         BearerTokens(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/session/SessionManager.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/session/SessionManager.kt
@@ -48,12 +48,11 @@ interface SessionManager {
      * In case of failure to refresh the access token, an exception can be thrown.
      *
      * @param accessTokenApi The AccessTokenApi interface used to retrieve the new access token.
-     * @param oldAccessToken The old access token to be replaced.
      * @param oldRefreshToken The old refresh token to be replaced.
      * @return The updated SessionDTO object.
      * @see FailureToRefreshTokenException
      */
-    suspend fun updateToken(accessTokenApi: AccessTokenApi, oldAccessToken: String, oldRefreshToken: String): SessionDTO
+    suspend fun updateToken(accessTokenApi: AccessTokenApi, oldRefreshToken: String): SessionDTO
     fun proxyCredentials(): ProxyCredentialsDTO?
 }
 

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/ApiTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/ApiTest.kt
@@ -72,7 +72,6 @@ internal abstract class ApiTest {
         get() = {
             val newSession = TEST_SESSION_MANAGER.updateToken(
                 accessTokenApi = AccessTokenApiV0(client),
-                oldAccessToken = oldTokens!!.accessToken,
                 oldRefreshToken = oldTokens!!.refreshToken
             )
             newSession.let {

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/TestSessionManagerV0.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/TestSessionManagerV0.kt
@@ -33,7 +33,6 @@ class TestSessionManagerV0 : SessionManager {
     override fun serverConfig(): ServerConfigDTO = serverConfig
     override suspend fun updateToken(
         accessTokenApi: AccessTokenApi,
-        oldAccessToken: String,
         oldRefreshToken: String
     ): SessionDTO {
         TODO("Not yet implemented")

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/common/SessionManagerIntegrationTest.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/common/SessionManagerIntegrationTest.kt
@@ -72,7 +72,6 @@ class SessionManagerIntegrationTest {
         val refreshToken: suspend RefreshTokensParams.() -> BearerTokens? = {
             val newSession = sessionManager.updateToken(
                 accessTokenApi = AccessTokenApiV0(client),
-                oldAccessToken = oldTokens!!.accessToken,
                 oldRefreshToken = oldTokens!!.refreshToken
             )
             newSession.let {
@@ -119,7 +118,6 @@ class SessionManagerIntegrationTest {
         val refreshToken: suspend RefreshTokensParams.() -> BearerTokens? = {
             val newSession = sessionManager.updateToken(
                 accessTokenApi = AccessTokenApiV0(client),
-                oldAccessToken = oldTokens!!.accessToken,
                 oldRefreshToken = oldTokens!!.refreshToken
             )
             newSession.let {
@@ -158,7 +156,6 @@ class SessionManagerIntegrationTest {
         val refreshToken: suspend RefreshTokensParams.() -> BearerTokens? = {
             val newSession = sessionManager.updateToken(
                 AccessTokenApiV0(client),
-                oldTokens!!.accessToken,
                 oldTokens!!.refreshToken
             )
             newSession.let {
@@ -252,7 +249,6 @@ class SessionManagerIntegrationTest {
         override fun serverConfig(): ServerConfigDTO = TEST_BACKEND_CONFIG
         override suspend fun updateToken(
             accessTokenApi: AccessTokenApi,
-            oldAccessToken: String,
             oldRefreshToken: String
         ): SessionDTO = testCredentials.copy(accessToken = UPDATED_ACCESS_TOKEN)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16726" title="WPB-16726" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16726</a>  [Android] Client not being able to send MLS messages, but receive them
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some clients have their auth sessions without an associated client ID _somehow_.

### Causes

We are not sure yet. Might have been a bug we had in the past and it's fixed now. But this was dormant for more than a year until now that MLS is coming out, as MLS requests _require_ an "upgraded" session - _i.e._ an associated client ID.

### Solutions

Send the client ID every time we refresh the auth token. This is a broad safety net, in case the auth session wasn't upgraded to have an associated client ID.

This should recover the faulty clients with some delay, and cover our asses in case we break the proper planned upgrade after client registration. Currently the auth token has a 15min expiration on Wire Cloud, so within 15min of an app upgrade, all clients should recover.

On a side-note: Removed `oldAccessToken` from the `SessionManager` refresh process as it wasn't used at all.

Ideally, we should also investigate further to possibly catch the root cause.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
