### PR TITLE
fix: can not enrol e2ei cert during login [WPB-16869]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1949,7 +1949,8 @@ class UserSessionScope internal constructor(
             checkRevocationList,
             syncFeatureConfigsUseCase,
             userScopedLogger,
-            getTeamUrlUseCase
+            getTeamUrlUseCase,
+            this,
         )
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
@@ -89,6 +89,7 @@ import com.wire.kalium.logic.feature.user.typingIndicator.PersistTypingIndicator
 import com.wire.kalium.logic.sync.SyncManager
 import com.wire.kalium.network.session.SessionManager
 import com.wire.kalium.persistence.dao.MetadataDAO
+import kotlinx.coroutines.CoroutineScope
 
 @Suppress("LongParameterList")
 class UserScope internal constructor(
@@ -121,7 +122,8 @@ class UserScope internal constructor(
     private val checkRevocationList: RevocationListChecker,
     private val syncFeatureConfigs: SyncFeatureConfigsUseCase,
     private val userScopedLogger: KaliumLogger,
-    private val teamUrlUseCase: GetTeamUrlUseCase
+    private val teamUrlUseCase: GetTeamUrlUseCase,
+    private val userCoroutineScope: CoroutineScope,
 ) {
     private val validateUserHandleUseCase: ValidateUserHandleUseCase get() = ValidateUserHandleUseCaseImpl()
     val getSelfUser: GetSelfUserUseCase get() = GetSelfUserUseCaseImpl(userRepository)
@@ -132,7 +134,12 @@ class UserScope internal constructor(
     val persistSelfUserEmail: PersistSelfUserEmailUseCase get() = PersistSelfUserEmailUseCaseImpl(userRepository)
 
     val getPublicAsset: GetAvatarAssetUseCase get() = GetAvatarAssetUseCaseImpl(assetRepository, userRepository)
-    val enrollE2EI: EnrollE2EIUseCase get() = EnrollE2EIUseCaseImpl(e2EIRepository)
+    val enrollE2EI: EnrollE2EIUseCase
+        get() = EnrollE2EIUseCaseImpl(
+            e2EIRepository = e2EIRepository,
+            userRepository = userRepository,
+            coroutineScope = userCoroutineScope,
+        )
     val getTeamUrl: GetTeamUrlUseCase get() = teamUrlUseCase
 
     val finalizeMLSClientAfterE2EIEnrollment: FinalizeMLSClientAfterE2EIEnrollment

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/EnrollE2EICertificateUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/EnrollE2EICertificateUseCaseTest.kt
@@ -1042,7 +1042,7 @@ class EnrollE2EICertificateUseCaseTest {
     }
 
     @Test
-    fun givenCertEnrollForNewClient_whenEnrolling_thenUpdateSelfUserInf() = coroutineScope.runTest {
+    fun givenCertEnrollForNewClient_whenEnrolling_thenUpdateSelfUserInfo() = coroutineScope.runTest {
         val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange(coroutineScope) {
             // given
             withInitializingE2EIClientSucceed()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/EnrollE2EICertificateUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/EnrollE2EICertificateUseCaseTest.kt
@@ -31,6 +31,9 @@ import com.wire.kalium.logic.feature.e2ei.usecase.EnrollE2EIUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.EnrollE2EIUseCaseImpl
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.left
+import com.wire.kalium.common.functional.right
+import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangementImpl
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.authenticated.e2ei.AccessTokenResponse
@@ -43,10 +46,16 @@ import io.mockative.coEvery
 import io.mockative.coVerify
 import io.mockative.mock
 import io.mockative.once
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -54,15 +63,27 @@ import kotlin.test.assertIs
 @ExperimentalCoroutinesApi
 class EnrollE2EICertificateUseCaseTest {
 
-    @Test
-    fun givenLoadACMEDirectoriesFails_whenInvokeUseCase_thenReturnFailure() = runTest {
-        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange()
+    private lateinit var coroutineScope: TestScope
 
-        // given
-        arrangement.withInitializingE2EIClientSucceed()
-        arrangement.withLoadTrustAnchorsResulting(Either.Right(Unit))
-        arrangement.withFetchFederationCertificateChainResulting(Either.Right(Unit))
-        arrangement.withLoadACMEDirectoriesResulting(E2EIFailure.AcmeDirectories(TEST_CORE_FAILURE).left())
+    @BeforeTest
+    fun setup() {
+        coroutineScope = TestScope()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        coroutineScope.cancel()
+    }
+
+    @Test
+    fun givenLoadACMEDirectoriesFails_whenInvokeUseCase_thenReturnFailure() = coroutineScope.runTest {
+        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange(coroutineScope) {
+            // given
+            withInitializingE2EIClientSucceed()
+            withLoadTrustAnchorsResulting(Either.Right(Unit))
+            withFetchFederationCertificateChainResulting(Either.Right(Unit))
+            withLoadACMEDirectoriesResulting(E2EIFailure.AcmeDirectories(TEST_CORE_FAILURE).left())
+        }
 
         // when
         val result = enrollE2EICertificateUseCase.initialEnrollment()
@@ -126,15 +147,15 @@ class EnrollE2EICertificateUseCaseTest {
     }
 
     @Test
-    fun givenGetACMENonceFails_whenInvokeUseCase_thenReturnFailure() = runTest {
-        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange()
-
-        // given
-        arrangement.withInitializingE2EIClientSucceed()
-        arrangement.withLoadTrustAnchorsResulting(Either.Right(Unit))
-        arrangement.withFetchFederationCertificateChainResulting(Either.Right(Unit))
-        arrangement.withLoadACMEDirectoriesResulting(Either.Right(ACME_DIRECTORIES))
-        arrangement.withGetACMENonceResulting(E2EIFailure.AcmeNonce(TEST_CORE_FAILURE).left())
+    fun givenGetACMENonceFails_whenInvokeUseCase_thenReturnFailure() = coroutineScope.runTest {
+        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange(coroutineScope) {
+            // given
+            withInitializingE2EIClientSucceed()
+            withLoadTrustAnchorsResulting(Either.Right(Unit))
+            withFetchFederationCertificateChainResulting(Either.Right(Unit))
+            withLoadACMEDirectoriesResulting(Either.Right(ACME_DIRECTORIES))
+            withGetACMENonceResulting(E2EIFailure.AcmeNonce(TEST_CORE_FAILURE).left())
+        }
 
         // when
         val result = enrollE2EICertificateUseCase.initialEnrollment()
@@ -196,16 +217,16 @@ class EnrollE2EICertificateUseCaseTest {
     }
 
     @Test
-    fun givenCreateNewAccountFails_whenInvokeUseCase_thenReturnFailure() = runTest {
-        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange()
-
-        // given
-        arrangement.withInitializingE2EIClientSucceed()
-        arrangement.withLoadTrustAnchorsResulting(Either.Right(Unit))
-        arrangement.withFetchFederationCertificateChainResulting(Either.Right(Unit))
-        arrangement.withLoadACMEDirectoriesResulting(Either.Right(ACME_DIRECTORIES))
-        arrangement.withGetACMENonceResulting(Either.Right(RANDOM_NONCE))
-        arrangement.withCreateNewAccountResulting(E2EIFailure.AcmeNewAccount(TEST_CORE_FAILURE).left())
+    fun givenCreateNewAccountFails_whenInvokeUseCase_thenReturnFailure() = coroutineScope.runTest {
+        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange(coroutineScope) {
+            // given
+            withInitializingE2EIClientSucceed()
+            withLoadTrustAnchorsResulting(Either.Right(Unit))
+            withFetchFederationCertificateChainResulting(Either.Right(Unit))
+            withLoadACMEDirectoriesResulting(Either.Right(ACME_DIRECTORIES))
+            withGetACMENonceResulting(Either.Right(RANDOM_NONCE))
+            withCreateNewAccountResulting(E2EIFailure.AcmeNewAccount(TEST_CORE_FAILURE).left())
+        }
 
         // when
         val result = enrollE2EICertificateUseCase.initialEnrollment()
@@ -271,17 +292,17 @@ class EnrollE2EICertificateUseCaseTest {
     }
 
     @Test
-    fun givenUseCase_whenCreateNewOrderFailing_thenReturnFailure() = runTest {
-        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange()
-
-        // given
-        arrangement.withInitializingE2EIClientSucceed()
-        arrangement.withLoadTrustAnchorsResulting(Either.Right(Unit))
-        arrangement.withFetchFederationCertificateChainResulting(Either.Right(Unit))
-        arrangement.withLoadACMEDirectoriesResulting(Either.Right(ACME_DIRECTORIES))
-        arrangement.withGetACMENonceResulting(Either.Right(RANDOM_NONCE))
-        arrangement.withCreateNewAccountResulting(Either.Right(RANDOM_NONCE))
-        arrangement.withCreateNewOrderResulting(E2EIFailure.AcmeNewOrder(TEST_CORE_FAILURE).left())
+    fun givenUseCase_whenCreateNewOrderFailing_thenReturnFailure() = coroutineScope.runTest {
+        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange(coroutineScope) {
+            // given
+            withInitializingE2EIClientSucceed()
+            withLoadTrustAnchorsResulting(Either.Right(Unit))
+            withFetchFederationCertificateChainResulting(Either.Right(Unit))
+            withLoadACMEDirectoriesResulting(Either.Right(ACME_DIRECTORIES))
+            withGetACMENonceResulting(Either.Right(RANDOM_NONCE))
+            withCreateNewAccountResulting(Either.Right(RANDOM_NONCE))
+            withCreateNewOrderResulting(E2EIFailure.AcmeNewOrder(TEST_CORE_FAILURE).left())
+        }
 
         // when
         val result = enrollE2EICertificateUseCase.initialEnrollment()
@@ -348,18 +369,18 @@ class EnrollE2EICertificateUseCaseTest {
     }
 
     @Test
-    fun givenUseCase_whenCreateAuthorizationsFailing_thenReturnFailure() = runTest {
-        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange()
-
-        // given
-        arrangement.withInitializingE2EIClientSucceed()
-        arrangement.withLoadTrustAnchorsResulting(Either.Right(Unit))
-        arrangement.withFetchFederationCertificateChainResulting(Either.Right(Unit))
-        arrangement.withLoadACMEDirectoriesResulting(Either.Right(ACME_DIRECTORIES))
-        arrangement.withGetACMENonceResulting(Either.Right(RANDOM_NONCE))
-        arrangement.withCreateNewAccountResulting(Either.Right(RANDOM_NONCE))
-        arrangement.withCreateNewOrderResulting(Either.Right(Triple(ACME_ORDER, RANDOM_NONCE, RANDOM_LOCATION)))
-        arrangement.withGettingChallenges(E2EIFailure.AcmeAuthorizations.left())
+    fun givenUseCase_whenCreateAuthorizationsFailing_thenReturnFailure() = coroutineScope.runTest {
+        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange(coroutineScope) {
+            // given
+            withInitializingE2EIClientSucceed()
+            withLoadTrustAnchorsResulting(Either.Right(Unit))
+            withFetchFederationCertificateChainResulting(Either.Right(Unit))
+            withLoadACMEDirectoriesResulting(Either.Right(ACME_DIRECTORIES))
+            withGetACMENonceResulting(Either.Right(RANDOM_NONCE))
+            withCreateNewAccountResulting(Either.Right(RANDOM_NONCE))
+            withCreateNewOrderResulting(Either.Right(Triple(ACME_ORDER, RANDOM_NONCE, RANDOM_LOCATION)))
+            withGettingChallenges(E2EIFailure.AcmeAuthorizations.left())
+        }
 
         // when
         val result = enrollE2EICertificateUseCase.initialEnrollment()
@@ -427,21 +448,21 @@ class EnrollE2EICertificateUseCaseTest {
     }
 
     @Test
-    fun givenUseCase_whenCallingInitialization_thenReturnInitializationResult() = runTest {
-        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange()
+    fun givenUseCase_whenCallingInitialization_thenReturnInitializationResult() = coroutineScope.runTest {
+        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange(coroutineScope) {
+            // given
+            withInitializingE2EIClientSucceed()
+            withLoadTrustAnchorsResulting(Either.Right(Unit))
+            withFetchFederationCertificateChainResulting(Either.Right(Unit))
+            withLoadACMEDirectoriesResulting(Either.Right(ACME_DIRECTORIES))
+            withGetACMENonceResulting(Either.Right(RANDOM_NONCE))
+            withCreateNewAccountResulting(Either.Right(RANDOM_NONCE))
+            withCreateNewOrderResulting(Either.Right(Triple(ACME_ORDER, RANDOM_NONCE, RANDOM_LOCATION)))
+            withGettingRefreshTokenSucceeding()
+            withGettingChallenges(Either.Right(AUTHORIZATIONS))
+        }
 
         val expected = INITIALIZATION_RESULT
-
-        // given
-        arrangement.withInitializingE2EIClientSucceed()
-        arrangement.withLoadTrustAnchorsResulting(Either.Right(Unit))
-        arrangement.withFetchFederationCertificateChainResulting(Either.Right(Unit))
-        arrangement.withLoadACMEDirectoriesResulting(Either.Right(ACME_DIRECTORIES))
-        arrangement.withGetACMENonceResulting(Either.Right(RANDOM_NONCE))
-        arrangement.withCreateNewAccountResulting(Either.Right(RANDOM_NONCE))
-        arrangement.withCreateNewOrderResulting(Either.Right(Triple(ACME_ORDER, RANDOM_NONCE, RANDOM_LOCATION)))
-        arrangement.withGettingRefreshTokenSucceeding()
-        arrangement.withGettingChallenges(Either.Right(AUTHORIZATIONS))
 
         // when
         val result = enrollE2EICertificateUseCase.initialEnrollment()
@@ -515,11 +536,11 @@ class EnrollE2EICertificateUseCaseTest {
     }
 
     @Test
-    fun givenUseCase_whenGetWireNonceFailing_thenReturnFailure() = runTest {
-        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange()
-
-        // given
-        arrangement.withGetWireNonceResulting(E2EIFailure.WireNonce(TEST_CORE_FAILURE).left())
+    fun givenUseCase_whenGetWireNonceFailing_thenReturnFailure() = coroutineScope.runTest {
+        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange(coroutineScope) {
+            // given
+            withGetWireNonceResulting(E2EIFailure.WireNonce(TEST_CORE_FAILURE).left())
+        }
 
         // when
         val result = enrollE2EICertificateUseCase.finalizeEnrollment(RANDOM_ID_TOKEN, REFRESH_TOKEN, INITIALIZATION_RESULT)
@@ -558,12 +579,12 @@ class EnrollE2EICertificateUseCaseTest {
     }
 
     @Test
-    fun givenUseCase_whenGetDPoPTokenFailing_thenReturnFailure() = runTest {
-        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange()
-
-        // given
-        arrangement.withGetWireNonceResulting(Either.Right(RANDOM_NONCE))
-        arrangement.withGetDPoPTokenResulting(E2EIFailure.DPoPToken(TEST_CORE_FAILURE).left())
+    fun givenUseCase_whenGetDPoPTokenFailing_thenReturnFailure() = coroutineScope.runTest {
+        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange(coroutineScope) {
+            // given
+            withGetWireNonceResulting(Either.Right(RANDOM_NONCE))
+            withGetDPoPTokenResulting(E2EIFailure.DPoPToken(TEST_CORE_FAILURE).left())
+        }
 
         // when
         val result = enrollE2EICertificateUseCase.finalizeEnrollment(RANDOM_ID_TOKEN, REFRESH_TOKEN, INITIALIZATION_RESULT)
@@ -604,13 +625,13 @@ class EnrollE2EICertificateUseCaseTest {
     }
 
     @Test
-    fun givenUseCase_whenGetWireAccessTokenFailing_thenReturnFailure() = runTest {
-        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange()
-
-        // given
-        arrangement.withGetWireNonceResulting(Either.Right(RANDOM_NONCE))
-        arrangement.withGetDPoPTokenResulting(Either.Right(RANDOM_DPoP_TOKEN))
-        arrangement.withGetWireAccessTokenResulting(E2EIFailure.DPoPChallenge(TEST_CORE_FAILURE).left())
+    fun givenUseCase_whenGetWireAccessTokenFailing_thenReturnFailure() = coroutineScope.runTest {
+        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange(coroutineScope) {
+            // given
+            withGetWireNonceResulting(Either.Right(RANDOM_NONCE))
+            withGetDPoPTokenResulting(Either.Right(RANDOM_DPoP_TOKEN))
+            withGetWireAccessTokenResulting(E2EIFailure.DPoPChallenge(TEST_CORE_FAILURE).left())
+        }
 
         // when
         val result = enrollE2EICertificateUseCase.finalizeEnrollment(RANDOM_ID_TOKEN, REFRESH_TOKEN, INITIALIZATION_RESULT)
@@ -651,14 +672,16 @@ class EnrollE2EICertificateUseCaseTest {
     }
 
     @Test
-    fun givenUseCase_whenValidateDPoPChallengeFailing_thenReturnFailure() = runTest {
-        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange()
+    fun givenUseCase_whenValidateDPoPChallengeFailing_thenReturnFailure() = coroutineScope.runTest {
+        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange(coroutineScope) {
+            // given
+            withGetWireNonceResulting(Either.Right(RANDOM_NONCE))
+            withGetDPoPTokenResulting(Either.Right(RANDOM_DPoP_TOKEN))
+            withGetWireAccessTokenResulting(Either.Right(WIRE_ACCESS_TOKEN))
+            withValidateDPoPChallengeResulting(E2EIFailure.DPoPChallenge(TEST_CORE_FAILURE).left())
 
-        // given
-        arrangement.withGetWireNonceResulting(Either.Right(RANDOM_NONCE))
-        arrangement.withGetDPoPTokenResulting(Either.Right(RANDOM_DPoP_TOKEN))
-        arrangement.withGetWireAccessTokenResulting(Either.Right(WIRE_ACCESS_TOKEN))
-        arrangement.withValidateDPoPChallengeResulting(E2EIFailure.DPoPChallenge(TEST_CORE_FAILURE).left())
+        }
+
 
         // when
         val result = enrollE2EICertificateUseCase.finalizeEnrollment(RANDOM_ID_TOKEN, REFRESH_TOKEN, INITIALIZATION_RESULT)
@@ -700,15 +723,16 @@ class EnrollE2EICertificateUseCaseTest {
     }
 
     @Test
-    fun givenUseCase_whenValidateOIDCChallengeFailing_thenReturnFailure() = runTest {
-        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange()
+    fun givenUseCase_whenValidateOIDCChallengeFailing_thenReturnFailure() = coroutineScope.runTest {
+        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange(coroutineScope) {
+            // given
+            withGetWireNonceResulting(Either.Right(RANDOM_NONCE))
+            withGetDPoPTokenResulting(Either.Right(RANDOM_DPoP_TOKEN))
+            withGetWireAccessTokenResulting(Either.Right(WIRE_ACCESS_TOKEN))
+            withValidateDPoPChallengeResulting(Either.Right(ACME_CHALLENGE_RESPONSE))
+            withValidateOIDCChallengeResulting(E2EIFailure.OIDCChallenge(TEST_CORE_FAILURE).left())
+        }
 
-        // given
-        arrangement.withGetWireNonceResulting(Either.Right(RANDOM_NONCE))
-        arrangement.withGetDPoPTokenResulting(Either.Right(RANDOM_DPoP_TOKEN))
-        arrangement.withGetWireAccessTokenResulting(Either.Right(WIRE_ACCESS_TOKEN))
-        arrangement.withValidateDPoPChallengeResulting(Either.Right(ACME_CHALLENGE_RESPONSE))
-        arrangement.withValidateOIDCChallengeResulting(E2EIFailure.OIDCChallenge(TEST_CORE_FAILURE).left())
 
         // when
         val result = enrollE2EICertificateUseCase.finalizeEnrollment(RANDOM_ID_TOKEN, REFRESH_TOKEN, INITIALIZATION_RESULT)
@@ -750,16 +774,16 @@ class EnrollE2EICertificateUseCaseTest {
     }
 
     @Test
-    fun givenUseCase_whenCheckOrderRequestFailing_thenReturnFailure() = runTest {
-        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange()
-
-        // given
-        arrangement.withGetWireNonceResulting(Either.Right(RANDOM_NONCE))
-        arrangement.withGetDPoPTokenResulting(Either.Right(RANDOM_DPoP_TOKEN))
-        arrangement.withGetWireAccessTokenResulting(Either.Right(WIRE_ACCESS_TOKEN))
-        arrangement.withValidateDPoPChallengeResulting(Either.Right(ACME_CHALLENGE_RESPONSE))
-        arrangement.withValidateOIDCChallengeResulting(Either.Right(ACME_CHALLENGE_RESPONSE))
-        arrangement.withCheckOrderRequestResulting(E2EIFailure.CheckOrderRequest(TEST_CORE_FAILURE).left())
+    fun givenUseCase_whenCheckOrderRequestFailing_thenReturnFailure() = coroutineScope.runTest {
+        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange(coroutineScope) {
+            // given
+            withGetWireNonceResulting(Either.Right(RANDOM_NONCE))
+            withGetDPoPTokenResulting(Either.Right(RANDOM_DPoP_TOKEN))
+            withGetWireAccessTokenResulting(Either.Right(WIRE_ACCESS_TOKEN))
+            withValidateDPoPChallengeResulting(Either.Right(ACME_CHALLENGE_RESPONSE))
+            withValidateOIDCChallengeResulting(Either.Right(ACME_CHALLENGE_RESPONSE))
+            withCheckOrderRequestResulting(E2EIFailure.CheckOrderRequest(TEST_CORE_FAILURE).left())
+        }
 
         // when
         val result = enrollE2EICertificateUseCase.finalizeEnrollment(RANDOM_ID_TOKEN, REFRESH_TOKEN, INITIALIZATION_RESULT)
@@ -802,17 +826,17 @@ class EnrollE2EICertificateUseCaseTest {
     }
 
     @Test
-    fun givenUseCase_whenFinalizeFailing_thenReturnFailure() = runTest {
-        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange()
-
-        // given
-        arrangement.withGetWireNonceResulting(Either.Right(RANDOM_NONCE))
-        arrangement.withGetDPoPTokenResulting(Either.Right(RANDOM_DPoP_TOKEN))
-        arrangement.withGetWireAccessTokenResulting(Either.Right(WIRE_ACCESS_TOKEN))
-        arrangement.withValidateDPoPChallengeResulting(Either.Right(ACME_CHALLENGE_RESPONSE))
-        arrangement.withValidateOIDCChallengeResulting(Either.Right(ACME_CHALLENGE_RESPONSE))
-        arrangement.withCheckOrderRequestResulting(Either.Right((ACME_RESPONSE to RANDOM_LOCATION)))
-        arrangement.withFinalizeResulting(E2EIFailure.FinalizeRequest(TEST_CORE_FAILURE).left())
+    fun givenUseCase_whenFinalizeFailing_thenReturnFailure() = coroutineScope.runTest {
+        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange(coroutineScope) {
+            // given
+            withGetWireNonceResulting(Either.Right(RANDOM_NONCE))
+            withGetDPoPTokenResulting(Either.Right(RANDOM_DPoP_TOKEN))
+            withGetWireAccessTokenResulting(Either.Right(WIRE_ACCESS_TOKEN))
+            withValidateDPoPChallengeResulting(Either.Right(ACME_CHALLENGE_RESPONSE))
+            withValidateOIDCChallengeResulting(Either.Right(ACME_CHALLENGE_RESPONSE))
+            withCheckOrderRequestResulting(Either.Right((ACME_RESPONSE to RANDOM_LOCATION)))
+            withFinalizeResulting(E2EIFailure.FinalizeRequest(TEST_CORE_FAILURE).left())
+        }
 
         // when
         val result = enrollE2EICertificateUseCase.finalizeEnrollment(RANDOM_ID_TOKEN, REFRESH_TOKEN, INITIALIZATION_RESULT)
@@ -853,19 +877,19 @@ class EnrollE2EICertificateUseCaseTest {
     }
 
     @Test
-    fun givenUseCase_whenCertificateRequestFailing_thenReturnFailure() = runTest {
-        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange()
-
-        // given
-        arrangement.withGetWireNonceResulting(Either.Right(RANDOM_NONCE))
-        arrangement.withGetDPoPTokenResulting(Either.Right(RANDOM_DPoP_TOKEN))
-        arrangement.withGetWireAccessTokenResulting(Either.Right(WIRE_ACCESS_TOKEN))
-        arrangement.withValidateDPoPChallengeResulting(Either.Right(ACME_CHALLENGE_RESPONSE))
-        arrangement.withValidateOIDCChallengeResulting(Either.Right(ACME_CHALLENGE_RESPONSE))
-        arrangement.withCheckOrderRequestResulting(Either.Right((ACME_RESPONSE to RANDOM_LOCATION)))
-        arrangement.withFinalizeResulting(Either.Right((ACME_RESPONSE to RANDOM_LOCATION)))
-        arrangement.withRotateKeysAndMigrateConversations(Either.Right(Unit))
-        arrangement.withCertificateRequestResulting(E2EIFailure.Certificate(TEST_CORE_FAILURE).left())
+    fun givenUseCase_whenCertificateRequestFailing_thenReturnFailure() = coroutineScope.runTest {
+        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange(coroutineScope) {
+            // given
+            withGetWireNonceResulting(Either.Right(RANDOM_NONCE))
+            withGetDPoPTokenResulting(Either.Right(RANDOM_DPoP_TOKEN))
+            withGetWireAccessTokenResulting(Either.Right(WIRE_ACCESS_TOKEN))
+            withValidateDPoPChallengeResulting(Either.Right(ACME_CHALLENGE_RESPONSE))
+            withValidateOIDCChallengeResulting(Either.Right(ACME_CHALLENGE_RESPONSE))
+            withCheckOrderRequestResulting(Either.Right((ACME_RESPONSE to RANDOM_LOCATION)))
+            withFinalizeResulting(Either.Right((ACME_RESPONSE to RANDOM_LOCATION)))
+            withRotateKeysAndMigrateConversations(Either.Right(Unit))
+            withCertificateRequestResulting(E2EIFailure.Certificate(TEST_CORE_FAILURE).left())
+        }
 
         // when
         val result = enrollE2EICertificateUseCase.finalizeEnrollment(RANDOM_ID_TOKEN, REFRESH_TOKEN, INITIALIZATION_RESULT)
@@ -910,19 +934,19 @@ class EnrollE2EICertificateUseCaseTest {
     }
 
     @Test
-    fun givenUseCase_whenRotatingKeysAndMigratingConversationsFailing_thenReturnFailure() = runTest {
-        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange()
-
-        // given
-        arrangement.withGetWireNonceResulting(Either.Right(RANDOM_NONCE))
-        arrangement.withGetDPoPTokenResulting(Either.Right(RANDOM_DPoP_TOKEN))
-        arrangement.withGetWireAccessTokenResulting(Either.Right(WIRE_ACCESS_TOKEN))
-        arrangement.withValidateDPoPChallengeResulting(Either.Right(ACME_CHALLENGE_RESPONSE))
-        arrangement.withValidateOIDCChallengeResulting(Either.Right(ACME_CHALLENGE_RESPONSE))
-        arrangement.withCheckOrderRequestResulting(Either.Right((ACME_RESPONSE to RANDOM_LOCATION)))
-        arrangement.withFinalizeResulting(Either.Right((ACME_RESPONSE to RANDOM_LOCATION)))
-        arrangement.withCertificateRequestResulting(Either.Right(ACME_RESPONSE))
-        arrangement.withRotateKeysAndMigrateConversations(E2EIFailure.RotationAndMigration(TEST_CORE_FAILURE).left())
+    fun givenUseCase_whenRotatingKeysAndMigratingConversationsFailing_thenReturnFailure() = coroutineScope.runTest {
+        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange(coroutineScope) {
+            // given
+            withGetWireNonceResulting(Either.Right(RANDOM_NONCE))
+            withGetDPoPTokenResulting(Either.Right(RANDOM_DPoP_TOKEN))
+            withGetWireAccessTokenResulting(Either.Right(WIRE_ACCESS_TOKEN))
+            withValidateDPoPChallengeResulting(Either.Right(ACME_CHALLENGE_RESPONSE))
+            withValidateOIDCChallengeResulting(Either.Right(ACME_CHALLENGE_RESPONSE))
+            withCheckOrderRequestResulting(Either.Right((ACME_RESPONSE to RANDOM_LOCATION)))
+            withFinalizeResulting(Either.Right((ACME_RESPONSE to RANDOM_LOCATION)))
+            withCertificateRequestResulting(Either.Right(ACME_RESPONSE))
+            withRotateKeysAndMigrateConversations(E2EIFailure.RotationAndMigration(TEST_CORE_FAILURE).left())
+        }
 
         // when
         val result = enrollE2EICertificateUseCase.finalizeEnrollment(RANDOM_ID_TOKEN, REFRESH_TOKEN, INITIALIZATION_RESULT)
@@ -960,19 +984,19 @@ class EnrollE2EICertificateUseCaseTest {
     }
 
     @Test
-    fun givenUseCase_whenEveryStepSucceed_thenShouldSucceed() = runTest {
-        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange()
-
-        // given
-        arrangement.withGetWireNonceResulting(Either.Right(RANDOM_NONCE))
-        arrangement.withGetDPoPTokenResulting(Either.Right(RANDOM_DPoP_TOKEN))
-        arrangement.withGetWireAccessTokenResulting(Either.Right(WIRE_ACCESS_TOKEN))
-        arrangement.withValidateDPoPChallengeResulting(Either.Right(ACME_CHALLENGE_RESPONSE))
-        arrangement.withValidateOIDCChallengeResulting(Either.Right(ACME_CHALLENGE_RESPONSE))
-        arrangement.withCheckOrderRequestResulting(Either.Right((ACME_RESPONSE to RANDOM_LOCATION)))
-        arrangement.withFinalizeResulting(Either.Right((ACME_RESPONSE to RANDOM_LOCATION)))
-        arrangement.withCertificateRequestResulting(Either.Right(ACME_RESPONSE))
-        arrangement.withRotateKeysAndMigrateConversations(Either.Right(Unit))
+    fun givenUseCase_whenEveryStepSucceed_thenShouldSucceed() = coroutineScope.runTest {
+        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange(coroutineScope) {
+            // given
+            withGetWireNonceResulting(Either.Right(RANDOM_NONCE))
+            withGetDPoPTokenResulting(Either.Right(RANDOM_DPoP_TOKEN))
+            withGetWireAccessTokenResulting(Either.Right(WIRE_ACCESS_TOKEN))
+            withValidateDPoPChallengeResulting(Either.Right(ACME_CHALLENGE_RESPONSE))
+            withValidateOIDCChallengeResulting(Either.Right(ACME_CHALLENGE_RESPONSE))
+            withCheckOrderRequestResulting(Either.Right((ACME_RESPONSE to RANDOM_LOCATION)))
+            withFinalizeResulting(Either.Right((ACME_RESPONSE to RANDOM_LOCATION)))
+            withCertificateRequestResulting(Either.Right(ACME_RESPONSE))
+            withRotateKeysAndMigrateConversations(Either.Right(Unit))
+        }
 
         // when
         val result = enrollE2EICertificateUseCase.finalizeEnrollment(RANDOM_ID_TOKEN, REFRESH_TOKEN, INITIALIZATION_RESULT)
@@ -1017,7 +1041,34 @@ class EnrollE2EICertificateUseCaseTest {
         }.wasInvoked(exactly = once)
     }
 
-    private class Arrangement {
+    @Test
+    fun givenCertEnrollForNewClient_whenEnrolling_thenUpdateSelfUserInf() = coroutineScope.runTest {
+        val (arrangement, enrollE2EICertificateUseCase) = Arrangement().arrange(coroutineScope) {
+            // given
+            withInitializingE2EIClientSucceed()
+            withLoadTrustAnchorsResulting(Either.Right(Unit))
+            withFetchFederationCertificateChainResulting(Either.Right(Unit))
+            withLoadACMEDirectoriesResulting(Either.Right(ACME_DIRECTORIES))
+            withGetACMENonceResulting(Either.Right(RANDOM_NONCE))
+            withCreateNewAccountResulting(Either.Right(RANDOM_NONCE))
+            withCreateNewOrderResulting(Either.Right(Triple(ACME_ORDER, RANDOM_NONCE, RANDOM_LOCATION)))
+            withGettingRefreshTokenSucceeding()
+            withGettingChallenges(Either.Right(AUTHORIZATIONS))
+            withFetchSelfUser(Unit.right())
+        }
+
+        // when
+        val result = enrollE2EICertificateUseCase.initialEnrollment(true)
+
+        // then
+        result.shouldSucceed()
+        advanceUntilIdle()
+        coVerify {
+            arrangement.userRepository.fetchSelfUser()
+        }.wasInvoked(exactly = once)
+    }
+
+    private class Arrangement: UserRepositoryArrangement by UserRepositoryArrangementImpl() {
 
         @Mock
         val e2EIRepository = mock(E2EIRepository::class)
@@ -1130,7 +1181,12 @@ class EnrollE2EICertificateUseCaseTest {
             }.returns(result)
         }
 
-        fun arrange(): Pair<Arrangement, EnrollE2EIUseCase> = this to EnrollE2EIUseCaseImpl(e2EIRepository)
+        suspend fun arrange(coroutineScope: CoroutineScope, block: suspend Arrangement.() -> Unit): Pair<Arrangement, EnrollE2EIUseCase> =
+            apply {
+                block()
+            }.let {
+                this to EnrollE2EIUseCaseImpl(e2EIRepository, userRepository = userRepository, coroutineScope = coroutineScope)
+            }
     }
 
     companion object {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/UserRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/UserRepositoryArrangement.kt
@@ -102,12 +102,20 @@ internal interface UserRepositoryArrangement {
         userId: Matcher<UserId> = AnyMatcher(valueOf()),
         clientId: Matcher<ClientId> = AnyMatcher(valueOf())
     )
+
+    suspend fun withFetchSelfUser(result: Either<CoreFailure, Unit>)
 }
 
 @Suppress("INAPPLICABLE_JVM_NAME")
 internal open class UserRepositoryArrangementImpl : UserRepositoryArrangement {
     @Mock
     override val userRepository: UserRepository = mock(UserRepository::class)
+
+    override suspend fun withFetchSelfUser(result: Either<CoreFailure, Unit>) {
+        coEvery {
+            userRepository.fetchSelfUser()
+        }.returns(result)
+    }
 
     override suspend fun withDefederateUser(
         result: Either<CoreFailure, Unit>,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16869" title="WPB-16869" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16869</a>  [Android] Can not create e2ei certificates if e2ei was enabled for my team before I logged in
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

can not enrol e2ei cert during login

### Causes (Optional)

self user info is required for this step and at this point it would not have been fetched yet

### Solutions

if the cert is for a new client then fetch self user info

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
