### PR TITLE
feat: use LoginDomainPath.Default for server 503 error

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/GetLoginFlowForDomainUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/GetLoginFlowForDomainUseCase.kt
@@ -108,8 +108,8 @@ internal fun GetLoginFlowForDomainUseCase(
                 leadingMessage = "Get domain registration",
                 jsonStringKeyValues = mapOf("error" to "EnterpriseServiceNotEnabled")
             )
-            // if enterprise service is not enabled, the app should treat it as "no-registration" and continue
-            LoginDomainPath.NoRegistration.right()
+            // if enterprise service is not enabled, the app should treat it as "Default" and continue
+            LoginDomainPath.Default.right()
 
         } else {
             it.left()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/GetLoginFlowForDomainUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/GetLoginFlowForDomainUseCaseTest.kt
@@ -49,7 +49,7 @@ class GetLoginFlowForDomainUseCaseTest {
         val result = useCase(Arrangement.EMAIL)
 
         coVerify { arrangement.loginRepository.getDomainRegistration(eq(Arrangement.EMAIL)) }
-        assertEquals(result, EnterpriseLoginResult.Success(LoginRedirectPath.Default))
+        assertEquals(EnterpriseLoginResult.Success(LoginRedirectPath.Default), result)
     }
 
     @Test
@@ -61,7 +61,7 @@ class GetLoginFlowForDomainUseCaseTest {
         val result = useCase(Arrangement.EMAIL)
 
         coVerify { arrangement.loginRepository.getDomainRegistration(eq(Arrangement.EMAIL)) }
-        assertEquals(result::class, EnterpriseLoginResult.Failure.Generic::class)
+        assertEquals(EnterpriseLoginResult.Failure.Generic::class, result::class)
     }
 
     @Test
@@ -73,7 +73,7 @@ class GetLoginFlowForDomainUseCaseTest {
         val result = useCase(Arrangement.EMAIL)
 
         coVerify { arrangement.loginRepository.getDomainRegistration(eq(Arrangement.EMAIL)) }
-        assertEquals(result, EnterpriseLoginResult.Failure.NotSupported)
+        assertEquals(EnterpriseLoginResult.Failure.NotSupported, result)
     }
 
     @Test
@@ -92,8 +92,8 @@ class GetLoginFlowForDomainUseCaseTest {
         coVerify { arrangement.loginRepository.fetchDomainRedirectCustomBackendConfig(backendConfigUrl) }
         coVerify { arrangement.customServerConfigRepository.fetchRemoteConfig(configJsonUrl) }
         assertEquals(
+            EnterpriseLoginResult.Success(LoginRedirectPath.CustomBackend(ServerConfig.DUMMY)),
             result,
-            EnterpriseLoginResult.Success(LoginRedirectPath.CustomBackend(ServerConfig.DUMMY))
         )
     }
 
@@ -107,7 +107,7 @@ class GetLoginFlowForDomainUseCaseTest {
         val result = useCase(Arrangement.EMAIL)
 
         coVerify { arrangement.loginRepository.getDomainRegistration(eq(Arrangement.EMAIL)) }
-        assertEquals(result, EnterpriseLoginResult.Success(LoginRedirectPath.NoRegistration))
+        assertEquals(EnterpriseLoginResult.Success(LoginRedirectPath.Default), result)
     }
 
     private class Arrangement {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

se LoginDomainPath.Default for server 503 error

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
