### PR TITLE
fix: Allow guests toggle reverts to ON after channel creation (WPB-16958)

### DIFF
--- a/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/conversation/CreateConversationRequestJson.kt
+++ b/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/conversation/CreateConversationRequestJson.kt
@@ -41,7 +41,7 @@ object CreateConversationRequestJson {
         conversationRole = "WIRE_MEMBER",
         protocol = ConvProtocol.PROTEUS,
         creatorClient = null,
-        groupConversationType = GroupConversationType.REGULAR_GROUP
+        groupConversationType = GroupConversationType.CHANNEL,
     )
 
     val v0 = ValidJsonProvider(
@@ -74,7 +74,7 @@ object CreateConversationRequestJson {
         |   }
         |}
         """.trimMargin()
-        }
+    }
 
     fun v3(accessRole: List<ConversationAccessRoleDTO>? = null) = ValidJsonProvider(
         createConversationRequest.copy(
@@ -109,4 +109,33 @@ object CreateConversationRequestJson {
         """.trimMargin()
     }
 
+    fun v8() = ValidJsonProvider(createConversationRequest) {
+        """
+        |{
+        |   "qualified_users": [
+        |       {
+        |           "id": "${it.qualifiedUsers?.get(0)?.value}",
+        |           "domain": "${it.qualifiedUsers?.get(0)?.domain}"
+        |       }
+        |   ],
+        |   "name": "${it.name}",
+        |   "access": [
+        |       "${it.access?.get(0)}"
+        |   ],
+        |   "access_role": [
+        |       "${it.accessRole?.get(0)}"
+        |   ],
+        |   "group_conv_type": "${it.groupConversationType?.name?.lowercase()}",
+        |   "team": {
+        |       "managed": false,
+        |       "teamid": "${it.convTeamInfo?.teamId}"
+        |   },
+        |   "message_timer": ${it.messageTimer},
+        |   "protocol": "${it.protocol}",
+        |   "add_permission": "${it.channelAddPermissionTypeDTO.name.lowercase()}",
+        |   "receipt_mode": ${it.receiptMode.value},
+        |   "conversation_role": "${it.conversationRole}"
+        |}
+        """.trimMargin()
+    }
 }

--- a/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/conversation/CreateConversationRequestJson.kt
+++ b/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/conversation/CreateConversationRequestJson.kt
@@ -94,7 +94,7 @@ object CreateConversationRequestJson {
         |   "message_timer": ${it.messageTimer},
         |   "name": "${it.name}",
         |   "protocol": "${it.protocol}",
-        |   "group_conv_type": "group_conversation",
+        |   "group_conv_type": "channel",
         |   "qualified_users": [
         |       {
         |           "domain": "${it.qualifiedUsers?.get(0)?.domain}",

--- a/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/conversation/CreateConversationRequestJson.kt
+++ b/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/conversation/CreateConversationRequestJson.kt
@@ -60,7 +60,7 @@ object CreateConversationRequestJson {
         |   "message_timer": ${it.messageTimer},
         |   "name": "${it.name}",
         |   "protocol": "${it.protocol}",
-        |   "group_conv_type": "group_conversation",
+        |   "group_conv_type": "channel",
         |   "add_permission": "admins",
         |   "qualified_users": [
         |       {

--- a/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/conversation/CreateConversationRequestJson.kt
+++ b/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/conversation/CreateConversationRequestJson.kt
@@ -42,6 +42,7 @@ object CreateConversationRequestJson {
         protocol = ConvProtocol.PROTEUS,
         creatorClient = null,
         groupConversationType = GroupConversationType.CHANNEL,
+        cellEnabled = null
     )
 
     val v0 = ValidJsonProvider(

--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/conversation/ConversationPagingResponse.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/conversation/ConversationPagingResponse.kt
@@ -42,3 +42,10 @@ data class ConversationResponseDTOV3(
     @SerialName("not_found") val conversationsNotFound: List<ConversationId>,
     @SerialName("failed") val conversationsFailed: List<ConversationId>,
 )
+
+@Serializable
+data class ConversationResponseDTOV8(
+    @SerialName("found") val conversationsFound: List<ConversationResponseV8>,
+    @SerialName("not_found") val conversationsNotFound: List<ConversationId>,
+    @SerialName("failed") val conversationsFailed: List<ConversationId>,
+)

--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/conversation/ConversationResponse.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/conversation/ConversationResponse.kt
@@ -243,7 +243,6 @@ data class ConversationResponseV8(
     val channelAddUserPermissionTypeDTO: ChannelAddPermissionTypeDTO? = null
 )
 
-
 @Serializable
 data class ConversationResponseV6(
     @SerialName("conversation")

--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/conversation/ConversationResponse.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/conversation/ConversationResponse.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.network.api.authenticated.conversation
 
+import com.wire.kalium.network.api.authenticated.conversation.ConversationResponse.GroupType
 import com.wire.kalium.network.api.authenticated.serverpublickey.MLSPublicKeysDTO
 import com.wire.kalium.network.api.model.ConversationAccessDTO
 import com.wire.kalium.network.api.model.ConversationAccessRoleDTO
@@ -125,9 +126,6 @@ data class ConversationResponse(
         @SerialName("channel")
         CHANNEL,
     }
-
-    fun toV6(): ConversationResponseV6 =
-        ConversationResponseV6(this, publicKeys ?: MLSPublicKeysDTO(null))
 }
 
 @Serializable
@@ -180,6 +178,64 @@ data class ConversationResponseV3(
     @SerialName("receipt_mode")
     val receiptMode: ReceiptMode,
 )
+
+@Serializable
+data class ConversationResponseV8(
+    @SerialName("creator")
+    val creator: String?,
+
+    @SerialName("members")
+    val members: ConversationMembersResponse,
+
+    @SerialName("name")
+    val name: String?,
+
+    @SerialName("qualified_id")
+    val id: ConversationId,
+
+    @SerialName("group_id")
+    val groupId: String?,
+
+    @SerialName("epoch")
+    val epoch: ULong?,
+
+    @Serializable(with = ConversationTypeSerializer::class)
+    val type: ConversationResponse.Type,
+
+    @SerialName("message_timer")
+    val messageTimer: Long?,
+
+    @SerialName("team")
+    val teamId: TeamId?,
+
+    @SerialName("protocol")
+    val protocol: ConvProtocol,
+
+    @SerialName("last_event_time")
+    val lastEventTime: String,
+
+    @SerialName("cipher_suite")
+    val mlsCipherSuiteTag: Int?,
+
+    @SerialName("access")
+    val access: Set<ConversationAccessDTO>,
+
+    @SerialName("access_role")
+    val accessRole: Set<ConversationAccessRoleDTO>?,
+
+    @SerialName("receipt_mode")
+    val receiptMode: ReceiptMode,
+
+    @SerialName("public_keys")
+    val publicKeys: MLSPublicKeysDTO? = null,
+
+    @SerialName("group_conv_type")
+    val conversationGroupType: GroupType? = null,
+
+    @SerialName("add_permission")
+    val channelAddUserPermissionTypeDTO: ChannelAddPermissionTypeDTO? = null
+)
+
 
 @Serializable
 data class ConversationResponseV6(

--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/conversation/ConversationResponse.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/conversation/ConversationResponse.kt
@@ -240,7 +240,10 @@ data class ConversationResponseV8(
     val conversationGroupType: GroupType? = null,
 
     @SerialName("add_permission")
-    val channelAddUserPermissionTypeDTO: ChannelAddPermissionTypeDTO? = null
+    val channelAddUserPermissionTypeDTO: ChannelAddPermissionTypeDTO? = null,
+
+    @SerialName("cells_state")
+    val cellsState: String? = null,
 )
 
 @Serializable
@@ -249,46 +252,6 @@ data class ConversationResponseV6(
     val conversation: ConversationResponse,
     @SerialName("public_keys")
     val publicKeys: MLSPublicKeysDTO
-)
-
-@Serializable
-data class ConversationResponseV8(
-    @SerialName("creator")
-    val creator: String?,
-    @SerialName("members")
-    val members: ConversationMembersResponse,
-    @SerialName("name")
-    val name: String?,
-    @SerialName("qualified_id")
-    val id: ConversationId,
-    @SerialName("group_id")
-    val groupId: String?,
-    @SerialName("epoch")
-    val epoch: ULong?,
-    @Serializable(with = ConversationTypeSerializer::class)
-    val type: ConversationResponse.Type,
-    @SerialName("message_timer")
-    val messageTimer: Long?,
-    @SerialName("team")
-    val teamId: TeamId?,
-    @SerialName("protocol")
-    val protocol: ConvProtocol,
-    @SerialName("last_event_time")
-    val lastEventTime: String,
-    @SerialName("cipher_suite")
-    val mlsCipherSuiteTag: Int?,
-    @SerialName("access")
-    val access: Set<ConversationAccessDTO>,
-    @SerialName("access_role")
-    val accessRole: Set<ConversationAccessRoleDTO>?,
-    @SerialName("access_role_v2")
-    val accessRoleV2: Set<ConversationAccessRoleDTO>?,
-    @SerialName("receipt_mode")
-    val receiptMode: ReceiptMode,
-    @SerialName("group_conv_type")
-    val conversationGroupType: GroupType? = null,
-    @SerialName("cells_state")
-    val cellsState: String? = null,
 )
 
 @Serializable

--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/conversation/CreateConversationRequest.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/conversation/CreateConversationRequest.kt
@@ -103,40 +103,6 @@ data class CreateConversationRequestV8(
     val accessRole: List<ConversationAccessRoleDTO>?,
     @SerialName("group_conv_type")
     val groupConversationType: GroupConversationType?,
-    @SerialName("team")
-    val convTeamInfo: ConvTeamInfo?,
-    @SerialName("message_timer")
-    val messageTimer: Long?, // Per-conversation message time
-    // Receipt mode, controls if read receipts are enabled for the conversation.
-    // Any positive value is interpreted as enabled.
-    @SerialName("receipt_mode")
-    val receiptMode: ReceiptMode,
-    // Role name, between 2 and 128 chars, 'wire_' prefix is reserved for roles
-    // designed by Wire (i.e., no custom roles can have the same prefix)
-    @SerialName("conversation_role")
-    val conversationRole: String?,
-    @SerialName("protocol")
-    val protocol: ConvProtocol?,
-    // Only needed for MLS conversations
-    @SerialName("creator_client")
-    val creatorClient: String?,
-    @SerialName("cells")
-    val cellEnabled: Boolean?
-)
-
-
-@Serializable
-data class CreateConversationRequestV8(
-    @SerialName("qualified_users")
-    val qualifiedUsers: List<UserId>?,
-    @SerialName("name")
-    val name: String?,
-    @SerialName("access")
-    val access: List<ConversationAccessDTO>?,
-    @SerialName("access_role")
-    val accessRole: List<ConversationAccessRoleDTO>?,
-    @SerialName("group_conv_type")
-    val groupConversationType: GroupConversationType?,
     @SerialName("add_permission")
     val channelAddPermissionTypeDTO: ChannelAddPermissionTypeDTO = ChannelAddPermissionTypeDTO.ADMINS,
     @SerialName("team")
@@ -156,6 +122,8 @@ data class CreateConversationRequestV8(
     // Only needed for MLS conversations
     @SerialName("creator_client")
     val creatorClient: String?,
+    @SerialName("cells")
+    val cellEnabled: Boolean?
 )
 
 @Serializable

--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/conversation/CreateConversationRequest.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/conversation/CreateConversationRequest.kt
@@ -89,6 +89,40 @@ data class CreateConversationRequestV3(
     val creatorClient: String?
 )
 
+
+@Serializable
+data class CreateConversationRequestV8(
+    @SerialName("qualified_users")
+    val qualifiedUsers: List<UserId>?,
+    @SerialName("name")
+    val name: String?,
+    @SerialName("access")
+    val access: List<ConversationAccessDTO>?,
+    @SerialName("access_role")
+    val accessRole: List<ConversationAccessRoleDTO>?,
+    @SerialName("group_conv_type")
+    val groupConversationType: GroupConversationType?,
+    @SerialName("add_permission")
+    val channelAddPermissionTypeDTO: ChannelAddPermissionTypeDTO = ChannelAddPermissionTypeDTO.ADMINS,
+    @SerialName("team")
+    val convTeamInfo: ConvTeamInfo?,
+    @SerialName("message_timer")
+    val messageTimer: Long?, // Per-conversation message time
+    // Receipt mode, controls if read receipts are enabled for the conversation.
+    // Any positive value is interpreted as enabled.
+    @SerialName("receipt_mode")
+    val receiptMode: ReceiptMode,
+    // Role name, between 2 and 128 chars, 'wire_' prefix is reserved for roles
+    // designed by Wire (i.e., no custom roles can have the same prefix)
+    @SerialName("conversation_role")
+    val conversationRole: String?,
+    @SerialName("protocol")
+    val protocol: ConvProtocol?,
+    // Only needed for MLS conversations
+    @SerialName("creator_client")
+    val creatorClient: String?,
+)
+
 @Serializable
 enum class ConvProtocol {
     @SerialName("proteus")

--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/model/ApiModelMapper.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/model/ApiModelMapper.kt
@@ -38,7 +38,6 @@ interface ApiModelMapper {
     fun toApiV3(request: UpdateConversationAccessRequest): UpdateConversationAccessRequestV3
     fun fromApiV3(response: ConversationResponseV3): ConversationResponse
     fun fromApiV6(response: ConversationResponseV6): ConversationResponse
-    fun toApiV8(request: CreateConversationRequest): CreateConversationRequestV8
     fun fromApiV8(response: ConversationResponseV8): ConversationResponse
 }
 
@@ -72,7 +71,8 @@ class ApiModelMapperImpl : ApiModelMapper {
             receiptMode = request.receiptMode,
             conversationRole = request.conversationRole,
             protocol = request.protocol,
-            creatorClient = request.creatorClient
+            creatorClient = request.creatorClient,
+            cellEnabled = request.cellEnabled
         )
 
     override fun toApiV3(request: UpdateConversationAccessRequest): UpdateConversationAccessRequestV3 =
@@ -119,22 +119,6 @@ class ApiModelMapperImpl : ApiModelMapper {
             receiptMode = response.conversation.receiptMode,
             publicKeys = response.publicKeys,
             conversationGroupType = response.conversation.conversationGroupType
-        )
-
-    override fun toApiV8(request: CreateConversationRequest): CreateConversationRequestV8 =
-        CreateConversationRequestV8(
-            request.qualifiedUsers,
-            request.name,
-            request.access,
-            request.accessRole,
-            request.groupConversationType,
-            request.convTeamInfo,
-            request.messageTimer,
-            request.receiptMode,
-            request.conversationRole,
-            request.protocol,
-            request.creatorClient,
-            request.cellEnabled,
         )
 
     override fun fromApiV8(response: ConversationResponseV8): ConversationResponse =

--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/model/ApiModelMapper.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/model/ApiModelMapper.kt
@@ -21,8 +21,10 @@ package com.wire.kalium.network.api.model
 import com.wire.kalium.network.api.authenticated.conversation.ConversationResponse
 import com.wire.kalium.network.api.authenticated.conversation.ConversationResponseV3
 import com.wire.kalium.network.api.authenticated.conversation.ConversationResponseV6
+import com.wire.kalium.network.api.authenticated.conversation.ConversationResponseV8
 import com.wire.kalium.network.api.authenticated.conversation.CreateConversationRequest
 import com.wire.kalium.network.api.authenticated.conversation.CreateConversationRequestV3
+import com.wire.kalium.network.api.authenticated.conversation.CreateConversationRequestV8
 import com.wire.kalium.network.api.authenticated.conversation.UpdateConversationAccessRequest
 import com.wire.kalium.network.api.authenticated.conversation.UpdateConversationAccessRequestV3
 
@@ -32,9 +34,11 @@ import com.wire.kalium.network.api.authenticated.conversation.UpdateConversation
 interface ApiModelMapper {
 
     fun toApiV3(request: CreateConversationRequest): CreateConversationRequestV3
+    fun toApiV8(request: CreateConversationRequest): CreateConversationRequestV8
     fun toApiV3(request: UpdateConversationAccessRequest): UpdateConversationAccessRequestV3
     fun fromApiV3(response: ConversationResponseV3): ConversationResponse
     fun fromApiV6(response: ConversationResponseV6): ConversationResponse
+    fun fromApiV8(response: ConversationResponseV8): ConversationResponse
 }
 
 class ApiModelMapperImpl : ApiModelMapper {
@@ -52,6 +56,22 @@ class ApiModelMapperImpl : ApiModelMapper {
             request.conversationRole,
             request.protocol,
             request.creatorClient
+        )
+
+    override fun toApiV8(request: CreateConversationRequest): CreateConversationRequestV8 =
+        CreateConversationRequestV8(
+            qualifiedUsers = request.qualifiedUsers,
+            name = request.name,
+            access = request.access,
+            accessRole = request.accessRole,
+            groupConversationType = request.groupConversationType,
+            channelAddPermissionTypeDTO = request.channelAddPermissionTypeDTO,
+            convTeamInfo = request.convTeamInfo,
+            messageTimer = request.messageTimer,
+            receiptMode = request.receiptMode,
+            conversationRole = request.conversationRole,
+            protocol = request.protocol,
+            creatorClient = request.creatorClient
         )
 
     override fun toApiV3(request: UpdateConversationAccessRequest): UpdateConversationAccessRequestV3 =
@@ -98,5 +118,27 @@ class ApiModelMapperImpl : ApiModelMapper {
             receiptMode = response.conversation.receiptMode,
             publicKeys = response.publicKeys,
             conversationGroupType = response.conversation.conversationGroupType
+        )
+
+    override fun fromApiV8(response: ConversationResponseV8): ConversationResponse =
+        ConversationResponse(
+            creator = response.creator,
+            members = response.members,
+            name = response.name,
+            id = response.id,
+            groupId = response.groupId,
+            epoch = response.epoch,
+            type = response.type,
+            messageTimer = response.messageTimer,
+            teamId = response.teamId,
+            protocol = response.protocol,
+            lastEventTime = response.lastEventTime,
+            mlsCipherSuiteTag = response.mlsCipherSuiteTag,
+            access = response.access,
+            accessRole = response.accessRole,
+            receiptMode = response.receiptMode,
+            publicKeys = response.publicKeys,
+            conversationGroupType = response.conversationGroupType,
+            channelAddUserPermissionTypeDTO = response.channelAddUserPermissionTypeDTO
         )
 }

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v8/ConversationApiV8Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v8/ConversationApiV8Test.kt
@@ -21,13 +21,36 @@ import com.wire.kalium.api.ApiTest
 import com.wire.kalium.mocks.extensions.toJsonString
 import com.wire.kalium.mocks.mocks.conversation.ConversationMocks
 import com.wire.kalium.mocks.responses.conversation.ConversationDetailsResponse
+import com.wire.kalium.mocks.responses.conversation.ConversationResponseJson
+import com.wire.kalium.mocks.responses.conversation.CreateConversationRequestJson
+import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
 import com.wire.kalium.network.api.model.ConversationId
 import com.wire.kalium.network.api.v8.authenticated.ConversationApiV8
+import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertTrue
 
 internal class ConversationApiV8Test : ApiTest() {
+
+    @Test
+    fun givenACreateNewConversationRequest_whenCallingCreateNewConversation_thenTheRequestShouldBeConfiguredOK() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(
+            CREATE_CONVERSATION_RESPONSE,
+            statusCode = HttpStatusCode.Created,
+            assertion = {
+                assertJson()
+                assertPost()
+                assertPathEqual(PATH_CONVERSATIONS)
+                assertJsonBodyContent(CREATE_CONVERSATION_REQUEST.rawJson)
+            }
+        )
+        val conversationApi: ConversationApi = ConversationApiV8(networkClient)
+        val result = conversationApi.createNewConversation(CREATE_CONVERSATION_REQUEST.serializableData)
+
+        assertTrue(result.isSuccessful())
+    }
 
     @Test
     fun givenFetchConversationsDetails_whenCallingFetchWithIdList_thenTheRequestShouldBeConfiguredOK() = runTest {
@@ -54,10 +77,13 @@ internal class ConversationApiV8Test : ApiTest() {
 
     private companion object {
         const val PATH_CONVERSATIONS_LIST = "/conversations/list"
+        const val PATH_CONVERSATIONS = "/conversations"
         val CREATE_CONVERSATION_IDS_REQUEST = ConversationMocks.conversationsDetailsRequest
         val CONVERSATION_DETAILS_RESPONSE = ConversationDetailsResponse.validGetDetailsForIds.copy(
             jsonProvider = ConversationDetailsResponseV8.jsonProvider
         )
+        val CREATE_CONVERSATION_RESPONSE = ConversationResponseJson.v8.rawJson
+        val CREATE_CONVERSATION_REQUEST = CreateConversationRequestJson.v8()
     }
 }
 
@@ -175,5 +201,4 @@ object ConversationDetailsResponseV8 {
         |}
         """.trimIndent()
     }
-
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
@@ -159,7 +159,8 @@ internal class ConversationDAOImpl internal constructor(
                 access_list = access,
                 access_role_list = accessRole,
                 last_read_date = lastReadDate,
-                mls_last_keying_material_update_date = if (protocolInfo is ConversationEntity.ProtocolInfo.MLSCapable) protocolInfo.keyingMaterialLastUpdate
+                mls_last_keying_material_update_date = if (protocolInfo is ConversationEntity.ProtocolInfo.MLSCapable)
+                    protocolInfo.keyingMaterialLastUpdate
                 else Instant.fromEpochMilliseconds(MLS_DEFAULT_LAST_KEY_MATERIAL_UPDATE_MILLI),
                 mls_cipher_suite = if (protocolInfo is ConversationEntity.ProtocolInfo.MLSCapable) protocolInfo.cipherSuite
                 else MLS_DEFAULT_CIPHER_SUITE,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
@@ -136,30 +136,30 @@ internal class ConversationDAOImpl internal constructor(
     private fun nonSuspendingInsertConversation(conversationEntity: ConversationEntity) {
         with(conversationEntity) {
             conversationQueries.insertConversation(
-                id,
-                name,
-                type,
-                teamId,
-                if (protocolInfo is ConversationEntity.ProtocolInfo.MLSCapable) protocolInfo.groupId
+                qualified_id = id,
+                name = name,
+                type = type,
+                team_id = teamId,
+                mls_group_id = if (protocolInfo is ConversationEntity.ProtocolInfo.MLSCapable) protocolInfo.groupId
                 else null,
-                if (protocolInfo is ConversationEntity.ProtocolInfo.MLSCapable) protocolInfo.groupState
+                mls_group_state = if (protocolInfo is ConversationEntity.ProtocolInfo.MLSCapable) protocolInfo.groupState
                 else ConversationEntity.GroupState.ESTABLISHED,
-                if (protocolInfo is ConversationEntity.ProtocolInfo.MLSCapable) protocolInfo.epoch.toLong()
+                mls_epoch = if (protocolInfo is ConversationEntity.ProtocolInfo.MLSCapable) protocolInfo.epoch.toLong()
                 else MLS_DEFAULT_EPOCH,
-                when (protocolInfo) {
+                protocol = when (protocolInfo) {
                     is ConversationEntity.ProtocolInfo.MLS -> ConversationEntity.Protocol.MLS
                     is ConversationEntity.ProtocolInfo.Mixed -> ConversationEntity.Protocol.MIXED
                     is ConversationEntity.ProtocolInfo.Proteus -> ConversationEntity.Protocol.PROTEUS
                 },
-                mutedStatus,
-                mutedTime,
-                creatorId,
-                lastModifiedDate,
-                lastNotificationDate,
-                access,
-                accessRole,
+                muted_status = mutedStatus,
+                muted_time = mutedTime,
+                creator_id = creatorId,
+                last_modified_date = lastModifiedDate,
+                last_notified_date = lastNotificationDate,
+                access_list = access,
+                access_role_list = accessRole,
                 last_read_date = lastReadDate,
-                if (protocolInfo is ConversationEntity.ProtocolInfo.MLSCapable) protocolInfo.keyingMaterialLastUpdate
+                mls_last_keying_material_update_date = if (protocolInfo is ConversationEntity.ProtocolInfo.MLSCapable) protocolInfo.keyingMaterialLastUpdate
                 else Instant.fromEpochMilliseconds(MLS_DEFAULT_LAST_KEY_MATERIAL_UPDATE_MILLI),
                 mls_cipher_suite = if (protocolInfo is ConversationEntity.ProtocolInfo.MLSCapable) protocolInfo.cipherSuite
                 else MLS_DEFAULT_CIPHER_SUITE,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16958" title="WPB-16958" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16958</a>  [Android]Allow guests toggle reverts to ON after channel creation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Allow guests toggle reverts to ON after channel creation

### Causes (Optional)

We are not parsing `access_role` value when we fetch conversation details endpoint as it's annotated with `access_role_v2` in COnversationResponse.
Causing to persist default values in database, which are TEAM_MEMEBR, NON_TEAM_MEMBER and SERVICE, every time we create a conversation.

### Solutions

Created a separate data class with valid annotations for V8

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
