### PR TITLE
fix: mls self conversation join [WPB-17115]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationUseCase.kt
@@ -189,20 +189,10 @@ internal class JoinExistingMLSConversationUseCaseImpl(
 
             type == Conversation.Type.Self -> {
                 kaliumLogger.d("$TAG: Establish Self MLS Conversation ${conversation.id.toLogString()}")
-                clientRepository.getClientsByConversationId(conversation.id)
-                    .flatMap { clients ->
-                        if ((clients[selfUserId]?.size ?: 0) > 1) {
-                            mlsConversationRepository.establishMLSGroup(
-                                protocol.groupId,
-                                listOf(selfUserId)
-                            )
-                        } else {
-                            mlsConversationRepository.establishMLSGroup(
-                                protocol.groupId,
-                                listOf()
-                            )
-                        }
-                    }
+                mlsConversationRepository.establishMLSGroup(
+                    protocol.groupId,
+                    listOf(selfUserId)
+                )
                     .onSuccess {
                         kaliumLogger.logStructuredJson(
                             level = KaliumLogLevel.INFO,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationUseCase.kt
@@ -18,15 +18,10 @@
 
 package com.wire.kalium.logic.data.conversation
 
-import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.common.error.StorageFailure
-import com.wire.kalium.logic.data.client.ClientRepository
-import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.id.toApi
-import com.wire.kalium.logic.data.mls.MLSPublicKeys
-import com.wire.kalium.logic.featureFlags.FeatureSupport
+import com.wire.kalium.common.error.wrapApiRequest
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
 import com.wire.kalium.common.functional.flatMapLeft
@@ -36,9 +31,15 @@ import com.wire.kalium.common.functional.map
 import com.wire.kalium.common.functional.onSuccess
 import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.common.logger.logStructuredJson
+import com.wire.kalium.logger.KaliumLogLevel
+import com.wire.kalium.logic.data.client.ClientRepository
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.toApi
+import com.wire.kalium.logic.data.mls.MLSPublicKeys
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.featureFlags.FeatureSupport
 import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageFailureHandler
 import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageFailureResolution
-import com.wire.kalium.common.error.wrapApiRequest
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.exceptions.isMlsMissingGroupInfo
@@ -62,6 +63,7 @@ internal class JoinExistingMLSConversationUseCaseImpl(
     private val clientRepository: ClientRepository,
     private val conversationRepository: ConversationRepository,
     private val mlsConversationRepository: MLSConversationRepository,
+    private val selfUserId: UserId,
     kaliumDispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) : JoinExistingMLSConversationUseCase {
     private val dispatcher = kaliumDispatcher.io
@@ -187,21 +189,32 @@ internal class JoinExistingMLSConversationUseCaseImpl(
 
             type == Conversation.Type.Self -> {
                 kaliumLogger.d("$TAG: Establish Self MLS Conversation ${conversation.id.toLogString()}")
-                mlsConversationRepository.establishMLSGroup(
-                    protocol.groupId,
-                    emptyList()
-                ).onSuccess {
-                    kaliumLogger.logStructuredJson(
-                        level = KaliumLogLevel.INFO,
-                        leadingMessage = "Establish Group",
-                        jsonStringKeyValues = mapOf(
-                            "conversationId" to conversation.id.toLogString(),
-                            "conversationType" to type,
-                            "protocol" to ConversationOptions.Protocol.MLS.name,
-                            "protocolInfo" to conversation.protocol.toLogMap(),
+                clientRepository.getClientsByConversationId(conversation.id)
+                    .flatMap { clients ->
+                        if ((clients[selfUserId]?.size ?: 0) > 1) {
+                            mlsConversationRepository.establishMLSGroup(
+                                protocol.groupId,
+                                listOf(selfUserId)
+                            )
+                        } else {
+                            mlsConversationRepository.establishMLSGroup(
+                                protocol.groupId,
+                                listOf()
+                            )
+                        }
+                    }
+                    .onSuccess {
+                        kaliumLogger.logStructuredJson(
+                            level = KaliumLogLevel.INFO,
+                            leadingMessage = "Establish Group",
+                            jsonStringKeyValues = mapOf(
+                                "conversationId" to conversation.id.toLogString(),
+                                "conversationType" to type,
+                                "protocol" to ConversationOptions.Protocol.MLS.name,
+                                "protocolInfo" to conversation.protocol.toLogMap(),
+                            )
                         )
-                    )
-                }.map { Unit }
+                    }.map { Unit }
             }
 
             type == Conversation.Type.OneOnOne -> {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1036,7 +1036,8 @@ class UserSessionScope internal constructor(
             authenticatedNetworkContainer.conversationApi,
             clientRepository,
             conversationRepository,
-            mlsConversationRepository
+            mlsConversationRepository,
+            userId
         )
 
     private val registerMLSClientUseCase: RegisterMLSClientUseCase


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17115" title="WPB-17115" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17115</a>  [Android] Second client in a Self MLS conversation stuck on connecting
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
- When a second client (belonging to the same user) attempted to join a self-type MLS conversation, the app would get stuck in a `connecting` state. After a restart, the conversation list was displayed, but the user could not send messages.
- A `409 InvalidRequestError` was thrown due to the second client trying to establish a brand-new self MLS conversation instead of joining the existing one.

### Causes
- In the original code, any zero-epoch `SELF` conversation would always call `establishMLSGroup` with an empty list of members, regardless of whether the user already had an existing MLS group for that conversation.
- This mismatch caused MLS conflicts, preventing the second client from syncing properly.

### Solutions
- **Modified `JoinExistingMLSConversationUseCaseImpl`:**
  - For a `SELF` conversation with zero epoch, we now check the number of clients mapped to the current user in that conversation:
    - If there is only one client, we call `establishMLSGroup` with an empty list (original behavior).
    - If there are more, we call `establishMLSGroup` with a list containing the user ID, effectively “adding” the new client to the existing MLS group.
