### PR TITLE
fix: run database operations on IO thread (WPB-15730)

### DIFF
--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
@@ -243,12 +243,13 @@ internal class ConversationDAOImpl internal constructor(
             .flowOn(coroutineContext)
     }
 
-    override suspend fun setWireCell(conversationId: QualifiedIDEntity, wireCell: String?) {
+    override suspend fun setWireCell(conversationId: QualifiedIDEntity, wireCell: String?) = withContext(coroutineContext) {
         conversationQueries.updateWireCell(wireCell, conversationId)
     }
 
-    override suspend fun getCellName(conversationId: QualifiedIDEntity): String? =
+    override suspend fun getCellName(conversationId: QualifiedIDEntity): String? = withContext(coroutineContext) {
         conversationQueries.getCellName(conversationId).executeAsOneOrNull()?.wire_cell
+    }
 
     override suspend fun getConversationIds(
         type: ConversationEntity.Type,
@@ -300,8 +301,8 @@ internal class ConversationDAOImpl internal constructor(
             conversationQueries.selectProtocolInfoByQualifiedId(qualifiedID, conversationMapper::mapProtocolInfo).executeAsOneOrNull()
         }
 
-    override suspend fun getConversationByGroupID(groupID: String): ConversationEntity? {
-        return conversationQueries.selectByGroupId(groupID, mapper = conversationMapper::toConversationEntity)
+    override suspend fun getConversationByGroupID(groupID: String): ConversationEntity? = withContext(coroutineContext) {
+        conversationQueries.selectByGroupId(groupID, mapper = conversationMapper::toConversationEntity)
             .executeAsOneOrNull()
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15730" title="WPB-15730" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15730</a>  [Android] ANR when opening conversation from notification
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some database calls are being invoked on Main thread

### Solutions

Switch context to run on IO

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
