### PR TITLE
fix: OrphanWelcome error handling on process welcome message [WPB-17186]

### DIFF
--- a/common/src/commonJvmAndroid/kotlin/com/wire/kalium/common/error/CoreCryptoExceptionMapper.kt
+++ b/common/src/commonJvmAndroid/kotlin/com/wire/kalium/common/error/CoreCryptoExceptionMapper.kt
@@ -43,7 +43,7 @@ actual fun mapMLSException(exception: Exception): MLSFailure =
                 }
             }
 
-            is MlsException.OrphanWelcome -> MLSFailure.Generic(exception)
+            is MlsException.OrphanWelcome -> MLSFailure.OrphanWelcome
         }
     } else {
         MLSFailure.Generic(exception)

--- a/common/src/commonMain/kotlin/com/wire/kalium/common/error/CoreFailure.kt
+++ b/common/src/commonMain/kotlin/com/wire/kalium/common/error/CoreFailure.kt
@@ -202,6 +202,7 @@ sealed interface MLSFailure : CoreFailure {
     data object Disabled : MLSFailure
     data object Other : MLSFailure
     data object CommitForMissingProposal : MLSFailure
+    data object OrphanWelcome : MLSFailure
     data class Generic(val rootCause: Throwable) : MLSFailure
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1499,7 +1499,8 @@ class UserSessionScope internal constructor(
             oneOnOneResolver = oneOnOneResolver,
             refillKeyPackages = client.refillKeyPackages,
             revocationListChecker = checkRevocationList,
-            certificateRevocationListRepository = certificateRevocationListRepository
+            certificateRevocationListRepository = certificateRevocationListRepository,
+            joinExistingMLSConversation = joinExistingMLSConversationUseCase,
         )
 
     private val renamedConversationHandler: RenamedConversationEventHandler

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageFailureHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageFailureHandler.kt
@@ -50,6 +50,7 @@ internal object MLSMessageFailureHandler {
             is MLSFailure.InternalErrors,
             is MLSFailure.Disabled,
             MLSFailure.CommitForMissingProposal,
+            MLSFailure.OrphanWelcome,
             is CoreFailure.DevelopmentAPINotAllowedOnProduction -> MLSMessageFailureResolution.Ignore
 
             MLSFailure.ConversationAlreadyExists,
@@ -73,7 +74,6 @@ internal object MLSMessageFailureHandler {
             StorageFailure.DataNotFound,
             is StorageFailure.Generic,
             is CoreFailure.Unknown -> MLSMessageFailureResolution.InformUser
-
         }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandlerTest.kt
@@ -17,24 +17,25 @@
  */
 package com.wire.kalium.logic.sync.receiver.conversation
 
-import com.wire.kalium.cryptography.MLSClient
-import com.wire.kalium.cryptography.MLSGroupId
-import com.wire.kalium.cryptography.WelcomeBundle
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.cryptography.MLSClient
+import com.wire.kalium.cryptography.MLSGroupId
+import com.wire.kalium.cryptography.WelcomeBundle
 import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCase
 import com.wire.kalium.logic.data.e2ei.CertificateRevocationListRepository
+import com.wire.kalium.logic.data.e2ei.RevocationListChecker
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.id.GroupID
-import com.wire.kalium.logic.data.e2ei.RevocationListChecker
 import com.wire.kalium.logic.feature.keypackage.RefillKeyPackagesResult
 import com.wire.kalium.logic.feature.keypackage.RefillKeyPackagesUseCase
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestConversationDetails
 import com.wire.kalium.logic.framework.TestUser
-import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.util.arrangement.mls.OneOnOneResolverArrangement
 import com.wire.kalium.logic.util.arrangement.mls.OneOnOneResolverArrangementImpl
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
@@ -270,6 +271,9 @@ class MLSWelcomeEventHandlerTest {
         @Mock
         val certificateRevocationListRepository: CertificateRevocationListRepository = mock(CertificateRevocationListRepository::class)
 
+        @Mock
+        val joinExistingMLSConversation: JoinExistingMLSConversationUseCase = mock(JoinExistingMLSConversationUseCase::class)
+
         suspend fun withMLSClientProviderReturningMLSClient() = apply {
             coEvery {
                 mlsClientProvider.getMLSClient(any())
@@ -300,6 +304,12 @@ class MLSWelcomeEventHandlerTest {
             }.returns(result)
         }
 
+        suspend fun withJoinExistingMLSConversationReturning(result: Either<CoreFailure, Unit>) = apply {
+            coEvery {
+                joinExistingMLSConversation(conversationId = any())
+            }.returns(result)
+        }
+
         suspend fun arrange() = run {
             withMLSClientProviderReturningMLSClient()
             block()
@@ -309,7 +319,8 @@ class MLSWelcomeEventHandlerTest {
                 oneOnOneResolver = oneOnOneResolver,
                 refillKeyPackages = refillKeyPackagesUseCase,
                 revocationListChecker = checkRevocationList,
-                certificateRevocationListRepository = certificateRevocationListRepository
+                certificateRevocationListRepository = certificateRevocationListRepository,
+                joinExistingMLSConversation = joinExistingMLSConversation
             )
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17186" title="WPB-17186" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17186</a>  [Android] Failed to decrypt message after receiving welcome message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- Fixed an issue where the client was unable to decrypt messages after receiving an MLS welcome message due to an unhandled `MlsException.OrphanWelcome`.

### Causes (Optional)

- The `OrphanWelcome` error was not handled during `processWelcomeMessage`, which occurs when the KeyPackage used to create the Welcome message has already been claimed by another client.  
- As a result, the client failed to properly join the group, leaving it unable to decrypt subsequent messages.

### Solutions

- Added explicit handling of `MlsException.OrphanWelcome` by invoking `joinExistingMLSConversation`, allowing the client to recover and join the MLS group via an external commit.
