### PR TITLE
fix: ProteusSyncWorker is being executed too often [WPB-17160]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/proteus/ProteusSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/proteus/ProteusSyncWorker.kt
@@ -28,8 +28,10 @@ import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.datetime.Clock
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.ZERO
 import kotlin.time.Duration.Companion.days
 
 /**
@@ -66,14 +68,14 @@ internal class ProteusSyncWorkerImpl(
             .collectLatest { lastRefill ->
                 val now = Clock.System.now()
                 val nextCheckTime = lastRefill?.plus(minIntervalBetweenRefills) ?: now
-                val delayUntilNextCheck = nextCheckTime - now
+                val delayUntilNextCheck = (nextCheckTime - now).coerceIn(ZERO, minIntervalBetweenRefills)
                 logger.logStructuredJson(
                     level = KaliumLogLevel.DEBUG,
                     leadingMessage = "Delaying until next check",
                     jsonStringKeyValues = mapOf(
                         "lastRefillPerformedAt" to lastRefill?.toIsoDateTimeString(),
                         "nextCheckTimeAt" to nextCheckTime.toIsoDateTimeString(),
-                        "delayingFor" to delayUntilNextCheck
+                        "delayingFor" to delayUntilNextCheck.toString(),
                     )
                 )
                 delay(delayUntilNextCheck)
@@ -86,7 +88,8 @@ internal class ProteusSyncWorkerImpl(
         logger.i("Waiting until live to refill prekeys if needed")
         incrementalSyncRepository.incrementalSyncState
             .filter { it is IncrementalSyncStatus.Live }
-            .collect {
+            .firstOrNull()
+            ?.let {
                 logger.i("Refilling prekeys if needed")
                 proteusPreKeyRefiller.refillIfNeeded()
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17160" title="WPB-17160" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17160</a>  [Android] Excessive frequency of fetching proteus prekeys
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

`ProteusSyncWorker` is being executed hundreds of times per each day instead of once every 24h.

### Causes (Optional)

It delays until next interval passes but then it collects incremental sync state flow to run when it's "live", but this flow never ends so it collects indefinitely instead of once and then delay to wait for next interval to pass.

### Solutions

Change `waitUntilLiveAndRefillPreKeysIfNeeded` to wait only for first "live" state and then finish.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
