### PR TITLE
fix: keep and fetch MLS public keys every 24h [WPB-17161]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mls/MLSPublicKeysSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/mls/MLSPublicKeysSyncWorker.kt
@@ -1,0 +1,101 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.mls
+
+import com.wire.kalium.common.logger.logStructuredJson
+import com.wire.kalium.logger.KaliumLogLevel
+import com.wire.kalium.logger.KaliumLogger
+import com.wire.kalium.logic.data.mlspublickeys.MLSPublicKeysRepository
+import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
+import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
+import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.ZERO
+import kotlin.time.Duration.Companion.days
+
+/**
+ * Worker that periodically syncs MLS public keys.
+ * It will wait until the interval passes and incremental sync is live and then fetch MLS public keys.
+ */
+interface MLSPublicKeysSyncWorker {
+    suspend fun schedule()
+    suspend fun executeImmediately()
+}
+
+internal class MLSPublicKeysSyncWorkerImpl(
+    private val incrementalSyncRepository: IncrementalSyncRepository,
+    private val mlsPublicKeysRepository: MLSPublicKeysRepository,
+    private val minIntervalBetweenRefills: Duration = MIN_INTERVAL_BETWEEN_REFILLS,
+    private val lastFetchInstantFlow: MutableStateFlow<Instant> = MutableStateFlow(Instant.DISTANT_PAST),
+    kaliumLogger: KaliumLogger,
+) : MLSPublicKeysSyncWorker {
+
+    private val logger = kaliumLogger.withTextTag("MLSPublicKeysSyncWorker")
+    override suspend fun schedule() {
+        logger.d("Starting to monitor")
+        lastFetchInstantFlow
+            .onCompletion {
+                logger.i("Stopping to monitor")
+            }
+            .collectLatest { lastFetch ->
+                val now = Clock.System.now()
+                val nextCheckTime = lastFetch.plus(minIntervalBetweenRefills)
+                val delayUntilNextCheck = (nextCheckTime - now).coerceIn(ZERO, minIntervalBetweenRefills)
+                logger.logStructuredJson(
+                    level = KaliumLogLevel.DEBUG,
+                    leadingMessage = "Delaying until next fetch",
+                    jsonStringKeyValues = mapOf(
+                        "lastFetchPerformedAt" to lastFetch.toIsoDateTimeString(),
+                        "nextFetchTimeAt" to nextCheckTime.toIsoDateTimeString(),
+                        "delayingFor" to delayUntilNextCheck.toString(),
+                    )
+                )
+                delay(delayUntilNextCheck)
+                waitUntilLiveAndFetchMLSPublicKeys()
+            }
+    }
+
+    override suspend fun executeImmediately() {
+        logger.d("Executing immediately")
+        waitUntilLiveAndFetchMLSPublicKeys()
+    }
+
+    private suspend fun waitUntilLiveAndFetchMLSPublicKeys() {
+        logger.i("Waiting until live to fetch MLS public keys")
+        incrementalSyncRepository.incrementalSyncState
+            .filter { it is IncrementalSyncStatus.Live }
+            .firstOrNull()
+            ?.let {
+                logger.i("Fetching MLS public keys")
+                mlsPublicKeysRepository.fetchKeys()
+                lastFetchInstantFlow.value = Clock.System.now()
+            }
+    }
+
+    private companion object {
+        val MIN_INTERVAL_BETWEEN_REFILLS = 1.days
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
@@ -70,6 +70,7 @@ import com.wire.kalium.logic.feature.featureConfig.FeatureFlagSyncWorkerImpl
 import com.wire.kalium.logic.feature.featureConfig.FeatureFlagsSyncWorker
 import com.wire.kalium.logic.feature.featureConfig.SyncFeatureConfigsUseCase
 import com.wire.kalium.logic.feature.message.MessageSender
+import com.wire.kalium.logic.feature.mls.MLSPublicKeysSyncWorker
 import com.wire.kalium.logic.feature.personaltoteamaccount.CanMigrateFromPersonalToTeamUseCase
 import com.wire.kalium.logic.feature.personaltoteamaccount.CanMigrateFromPersonalToTeamUseCaseImpl
 import com.wire.kalium.logic.feature.publicuser.GetAllContactsUseCase
@@ -123,6 +124,7 @@ class UserScope internal constructor(
     private val syncFeatureConfigs: SyncFeatureConfigsUseCase,
     private val userScopedLogger: KaliumLogger,
     private val teamUrlUseCase: GetTeamUrlUseCase,
+    val mlsPublicKeysSyncWorker: MLSPublicKeysSyncWorker,
     private val userCoroutineScope: CoroutineScope,
 ) {
     private val validateUserHandleUseCase: ValidateUserHandleUseCase get() = ValidateUserHandleUseCaseImpl()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/mlspublickeys/MLSPublicKeysRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/mlspublickeys/MLSPublicKeysRepositoryTest.kt
@@ -1,0 +1,210 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.mlspublickeys
+
+import com.wire.kalium.common.error.NetworkFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.mls.CipherSuite
+import com.wire.kalium.logic.data.mls.MLSPublicKeys
+import com.wire.kalium.network.api.authenticated.serverpublickey.MLSPublicKeysDTO
+import com.wire.kalium.network.api.base.authenticated.serverpublickey.MLSPublicKeyApi
+import com.wire.kalium.network.api.model.ErrorResponse
+import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.network.utils.NetworkResponse
+import io.ktor.util.decodeBase64Bytes
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.coEvery
+import io.mockative.coVerify
+import io.mockative.every
+import io.mockative.mock
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class MLSPublicKeysRepositoryTest {
+
+    @Test
+    fun givenNoKeysStored_whenGettingKeys_thenFetchAndReturnKeys() = runTest {
+        // given
+        val mlsPublicKeys = MLSPublicKeys(mapOf("keySignature" to "key"))
+        val response = NetworkResponse.Success(MLSPublicKeysDTO(mlsPublicKeys.removal), mapOf(), 200)
+        val (arrangement, repository) = Arrangement(initialPublicKeys = null)
+            .withGetMLSPublicKeysApiReturning(response)
+            .arrange()
+        // when
+        repository.getKeys()
+        // then
+        coVerify {
+            arrangement.mlsPublicKeyApi.getMLSPublicKeys()
+        }.wasInvoked(exactly = 1)
+        assertIs<Either.Right<MLSPublicKeys>>(repository.getKeys()).let {
+            assertEquals(mlsPublicKeys, it.value)
+        }
+    }
+
+    @Test
+    fun givenKeysAlreadyStored_whenGettingKeys_thenDoNotFetchAndReturnKeys() = runTest {
+        // given
+        val mlsPublicKeys = MLSPublicKeys(mapOf())
+        val (arrangement, repository) = Arrangement(initialPublicKeys = mlsPublicKeys)
+            .arrange()
+        // when
+        val result = repository.getKeys()
+        // then
+        coVerify {
+            arrangement.mlsPublicKeyApi.getMLSPublicKeys()
+        }.wasNotInvoked()
+        assertIs<Either.Right<MLSPublicKeys>>(result).let {
+            assertEquals(mlsPublicKeys, it.value)
+        }
+    }
+
+    @Test
+    fun givenNoKeysStoredAndFailedFetch_whenGettingKeys_thenReturnFailure() = runTest {
+        // given
+        val error = KaliumException.ServerError(ErrorResponse(500, "error_message", "error_label"))
+        val response = NetworkResponse.Error(error)
+        val (arrangement, repository) = Arrangement(initialPublicKeys = null)
+            .withGetMLSPublicKeysApiReturning(response)
+            .arrange()
+        // when
+        val result = repository.getKeys()
+        // then
+        coVerify {
+            arrangement.mlsPublicKeyApi.getMLSPublicKeys()
+        }.wasInvoked(exactly = 1)
+        assertIs<Either.Left<NetworkFailure.ServerMiscommunication>>(result).let {
+            assertEquals(error, it.value.kaliumException)
+        }
+    }
+
+    @Test
+    fun givenNoKeysStored_whenGettingKeyForCipherSuite_thenFetchAndReturnKey() = runTest {
+        // given
+        val cipherSuite = CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+        val keySignature = MLSPublicKeyType.ED25519
+        val key = "some-key"
+        val response = NetworkResponse.Success(MLSPublicKeysDTO(mapOf(keySignature.value to key)), mapOf(), 200)
+        val (arrangement, repository) = Arrangement(initialPublicKeys = null)
+            .withGetMLSPublicKeysApiReturning(response)
+            .withMapperFromCipherSuiteReturning(keySignature)
+            .arrange()
+        // when
+        val result = repository.getKeyForCipherSuite(cipherSuite)
+        // then
+        coVerify {
+            arrangement.mlsPublicKeyApi.getMLSPublicKeys()
+        }.wasInvoked(exactly = 1)
+        assertIs<Either.Right<ByteArray>>(result).let {
+            assertContentEquals(key.decodeBase64Bytes(), it.value)
+        }
+    }
+
+    @Test
+    fun givenKeysAlreadyStoredWithKeyForGivenCipherSuite_whenGettingKeyForCipherSuite_thenDoNotFetchKeysAndReturnKey() = runTest {
+        // given
+        val cipherSuite = CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+        val keySignature = MLSPublicKeyType.ED25519
+        val key = "some-key"
+        val mlsPublicKeys = MLSPublicKeys(mapOf(keySignature.value to key))
+        val (arrangement, repository) = Arrangement(initialPublicKeys = mlsPublicKeys)
+            .withMapperFromCipherSuiteReturning(keySignature)
+            .withMapperFromCipherSuiteReturning(keySignature)
+            .arrange()
+        // when
+        val result = repository.getKeyForCipherSuite(cipherSuite)
+        // then
+        coVerify {
+            arrangement.mlsPublicKeyApi.getMLSPublicKeys()
+        }.wasNotInvoked()
+        assertIs<Either.Right<ByteArray>>(result).let {
+            assertContentEquals(key.decodeBase64Bytes(), it.value)
+        }
+    }
+
+    @Test
+    fun givenKeysAlreadyStoredWithoutKeyForGivenCipherSuite_whenGettingKeyForCipherSuite_thenFetchKeysAgainAndReturnKey() = runTest {
+        // given
+        val cipherSuite = CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+        val keySignature = MLSPublicKeyType.ED25519
+        val key = "some-key"
+        val mlsPublicKeysWithoutKey = MLSPublicKeys(mapOf())
+        val mlsPublicKeysWithKey = MLSPublicKeys(mapOf(keySignature.value to key))
+        val response = NetworkResponse.Success(MLSPublicKeysDTO(mlsPublicKeysWithKey.removal), mapOf(), 200)
+        val (arrangement, repository) = Arrangement(initialPublicKeys = mlsPublicKeysWithoutKey)
+            .withGetMLSPublicKeysApiReturning(response)
+            .withMapperFromCipherSuiteReturning(keySignature)
+            .arrange()
+        // when
+        val result = repository.getKeyForCipherSuite(cipherSuite)
+        // then
+        coVerify {
+            arrangement.mlsPublicKeyApi.getMLSPublicKeys()
+        }.wasInvoked(exactly = 1)
+        assertIs<Either.Right<ByteArray>>(result).let {
+            assertContentEquals(key.decodeBase64Bytes(), it.value)
+        }
+    }
+
+    @Test
+    fun givenKeysNotStoredAndFailedFetching_whenGettingKeyForCipherSuite_thenReturnFailure() = runTest {
+        // given
+        val cipherSuite = CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+        val keySignature = MLSPublicKeyType.ED25519
+        val error = KaliumException.ServerError(ErrorResponse(500, "error_message", "error_label"))
+        val response = NetworkResponse.Error(error)
+        val (arrangement, repository) = Arrangement(initialPublicKeys = null)
+            .withGetMLSPublicKeysApiReturning(response)
+            .withMapperFromCipherSuiteReturning(keySignature)
+            .arrange()
+        // when
+        val result = repository.getKeyForCipherSuite(cipherSuite)
+        // then
+        coVerify {
+            arrangement.mlsPublicKeyApi.getMLSPublicKeys()
+        }.wasInvoked(exactly = 1)
+        assertIs<Either.Left<NetworkFailure.ServerMiscommunication>>(result).let {
+            assertEquals(error, it.value.kaliumException)
+        }
+    }
+
+    inner class Arrangement(private val initialPublicKeys: MLSPublicKeys? = null) {
+        @Mock
+        internal val mlsPublicKeyApi: MLSPublicKeyApi = mock(MLSPublicKeyApi::class)
+
+        @Mock
+        internal val mlsPublicKeysMapper: MLSPublicKeysMapper = mock(MLSPublicKeysMapper::class)
+
+        internal suspend fun withGetMLSPublicKeysApiReturning(result: NetworkResponse<MLSPublicKeysDTO>) = apply {
+            coEvery {
+                mlsPublicKeyApi.getMLSPublicKeys()
+            }.returns(result)
+        }
+
+        internal fun withMapperFromCipherSuiteReturning(result: MLSPublicKeyType) = apply {
+            every {
+                mlsPublicKeysMapper.fromCipherSuite(any())
+            }.returns(result)
+        }
+
+        internal fun arrange() = this to MLSPublicKeysRepositoryImpl(mlsPublicKeyApi, mlsPublicKeysMapper, initialPublicKeys)
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mls/MLSPublicKeysSyncWorkerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mls/MLSPublicKeysSyncWorkerTest.kt
@@ -1,0 +1,319 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.mls
+
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.logger.kaliumLogger
+import com.wire.kalium.logic.data.mls.MLSPublicKeys
+import com.wire.kalium.logic.data.mlspublickeys.MLSPublicKeysRepository
+import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
+import com.wire.kalium.logic.util.arrangement.IncrementalSyncRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.IncrementalSyncRepositoryArrangementImpl
+import io.mockative.Mock
+import io.mockative.coEvery
+import io.mockative.coVerify
+import io.mockative.mock
+import io.mockative.once
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MLSPublicKeysSyncWorkerTest {
+
+    @Test
+    fun givenLastCheckWasRecentAndSyncIsLive_whenScheduling_thenNotAttemptToFetchKeys() = runTest {
+        val lastCheck = Clock.System.now() - 1.hours
+        val (arrangement, mlsPublicKeysSyncWorker) = arrange {
+            minIntervalBetweenRefills = 24.hours
+            lastFetchInstantFlow = MutableStateFlow(lastCheck)
+            withIncrementalSyncState(flowOf(IncrementalSyncStatus.Live))
+        }
+
+        val workerJob = launch {
+            mlsPublicKeysSyncWorker.schedule()
+        }
+        advanceTimeBy(1.minutes)
+
+        coVerify {
+            arrangement.mlsPublicKeysRepository.fetchKeys()
+        }.wasNotInvoked()
+
+        workerJob.cancel()
+    }
+
+    @Test
+    fun givenLastCheckWasLongAgoAndSyncIsLive_whenScheduling_thenAttemptToFetchKeys() = runTest {
+        val lastCheck = Clock.System.now() - 25.hours
+        val (arrangement, mlsPublicKeysSyncWorker) = arrange {
+            minIntervalBetweenRefills = 24.hours
+            lastFetchInstantFlow = MutableStateFlow(lastCheck)
+            withIncrementalSyncState(flowOf(IncrementalSyncStatus.Live))
+        }
+
+        val workerJob = launch {
+            mlsPublicKeysSyncWorker.schedule()
+        }
+        advanceTimeBy(1.minutes)
+
+        coVerify {
+            arrangement.mlsPublicKeysRepository.fetchKeys()
+        }.wasInvoked(exactly = once)
+
+        workerJob.cancel()
+    }
+
+    @Test
+    fun givenLastCheckWasLongAgoAndSyncIsNotLive_whenScheduling_thenAttemptToFetchKeysAfterSyncBecomesLive() = runTest {
+        val lastCheck = Clock.System.now() - 25.hours
+        val incrementalSyncStateFlow = MutableStateFlow<IncrementalSyncStatus>(IncrementalSyncStatus.Pending)
+        val (arrangement, mlsPublicKeysSyncWorker) = arrange {
+            minIntervalBetweenRefills = 24.hours
+            lastFetchInstantFlow = MutableStateFlow(lastCheck)
+            withIncrementalSyncState(incrementalSyncStateFlow)
+        }
+
+        val workerJob = launch {
+            mlsPublicKeysSyncWorker.schedule()
+        }
+        advanceTimeBy(1.minutes)
+
+        coVerify {
+            arrangement.mlsPublicKeysRepository.fetchKeys()
+        }.wasNotInvoked() // Sync is not live yet
+
+        incrementalSyncStateFlow.value = IncrementalSyncStatus.Live // Change sync state to live
+        advanceTimeBy(1.minutes)
+
+        coVerify {
+            arrangement.mlsPublicKeysRepository.fetchKeys()
+        }.wasInvoked(exactly = once) // Sync is now live
+
+        workerJob.cancel()
+    }
+
+    @Test
+    fun givenLastCheckWasRecentAndSyncIsLive_whenSchedulingAndTimeElapses_thenAttemptToFetchKeys() = runTest {
+        val lastCheck = Clock.System.now() - 1.hours
+        val (arrangement, mlsPublicKeysSyncWorker) = arrange {
+            minIntervalBetweenRefills = 24.hours
+            lastFetchInstantFlow = MutableStateFlow(lastCheck)
+            withIncrementalSyncState(flowOf(IncrementalSyncStatus.Live))
+        }
+
+        val workerJob = launch {
+            mlsPublicKeysSyncWorker.schedule()
+        }
+
+        coVerify {
+            arrangement.mlsPublicKeysRepository.fetchKeys()
+        }.wasNotInvoked()
+
+        // Advance time until it's time to refill
+        advanceTimeBy(23.hours + 1.minutes)
+
+        coVerify {
+            arrangement.mlsPublicKeysRepository.fetchKeys()
+        }.wasInvoked(exactly = once)
+
+        workerJob.cancel()
+    }
+
+    @Test
+    fun givenLastCheckWasLongAgoAndSyncIsLive_whenSchedulingAndSyncChangesToLiveAgainBeforeNextIntervalPasses_thenFetchKeys() = runTest {
+        val lastCheck = Clock.System.now() - 25.hours
+        val lastCheckStateFlow = MutableStateFlow(lastCheck)
+        val incrementalSyncStateFlow = MutableStateFlow<IncrementalSyncStatus>(IncrementalSyncStatus.Live)
+        val (arrangement, mlsPublicKeysSyncWorker) = arrange {
+            minIntervalBetweenRefills = 24.hours
+            lastFetchInstantFlow = lastCheckStateFlow
+            withIncrementalSyncState(incrementalSyncStateFlow)
+        }
+
+        val workerJob = launch {
+            mlsPublicKeysSyncWorker.schedule()
+        }
+        advanceTimeBy(1.minutes)
+
+        coVerify {
+            arrangement.mlsPublicKeysRepository.fetchKeys()
+        }.wasInvoked(exactly = once)
+        lastCheckStateFlow.value = Clock.System.now()
+
+        incrementalSyncStateFlow.value = IncrementalSyncStatus.Pending // Change sync state to not live
+        incrementalSyncStateFlow.value = IncrementalSyncStatus.Live // Change sync state back to live
+        advanceTimeBy(23.hours) // This should not trigger a refill since the interval hasn't elapsed
+
+        coVerify {
+            arrangement.mlsPublicKeysRepository.fetchKeys()
+        }.wasNotInvoked()
+
+        workerJob.cancel()
+    }
+
+    @Test
+    fun givenLastCheckWasLongAgoAndSyncIsLive_whenSchedulingAndSyncChangesToLiveAgainAndNextIntervalPasses_thenFetchKeysAgain() = runTest {
+        val lastCheck = Clock.System.now() - 25.hours
+        val lastCheckStateFlow = MutableStateFlow(lastCheck)
+        val incrementalSyncStateFlow = MutableStateFlow<IncrementalSyncStatus>(IncrementalSyncStatus.Live)
+        val (arrangement, mlsPublicKeysSyncWorker) = arrange {
+            minIntervalBetweenRefills = 24.hours
+            lastFetchInstantFlow = lastCheckStateFlow
+            withIncrementalSyncState(incrementalSyncStateFlow)
+        }
+
+        val workerJob = launch {
+            mlsPublicKeysSyncWorker.schedule()
+        }
+        advanceTimeBy(1.minutes)
+
+        coVerify {
+            arrangement.mlsPublicKeysRepository.fetchKeys()
+        }.wasInvoked(exactly = once)
+        lastCheckStateFlow.value = Clock.System.now()
+
+        incrementalSyncStateFlow.value = IncrementalSyncStatus.Pending // Change sync state to not live
+        incrementalSyncStateFlow.value = IncrementalSyncStatus.Live // Change sync state back to live
+        advanceTimeBy(24.hours + 1.minutes) // This should  trigger a refill since the interval elapsed
+
+        coVerify {
+            arrangement.mlsPublicKeysRepository.fetchKeys()
+        }.wasInvoked(exactly = once)
+
+        workerJob.cancel()
+    }
+
+    @Test
+    fun givenLastCheckWasLongAgoAndSyncIsLive_whenSchedulingAndNextIntervalPasses_thenFetchKeysAgainOnlyAfterSyncIsLiveAgain() = runTest {
+        val lastCheck = Clock.System.now() - 25.hours
+        val lastCheckStateFlow = MutableStateFlow(lastCheck)
+        val incrementalSyncStateFlow = MutableStateFlow<IncrementalSyncStatus>(IncrementalSyncStatus.Live)
+        val (arrangement, mlsPublicKeysSyncWorker) = arrange {
+            minIntervalBetweenRefills = 24.hours
+            lastFetchInstantFlow = lastCheckStateFlow
+            withIncrementalSyncState(incrementalSyncStateFlow)
+        }
+
+        val workerJob = launch {
+            mlsPublicKeysSyncWorker.schedule()
+        }
+        advanceTimeBy(1.minutes)
+
+        coVerify {
+            arrangement.mlsPublicKeysRepository.fetchKeys()
+        }.wasInvoked(exactly = once)
+        lastCheckStateFlow.value = Clock.System.now()
+
+        incrementalSyncStateFlow.value = IncrementalSyncStatus.Pending // Change sync state to not live
+        advanceTimeBy(24.hours + 1.minutes) // Next interval elapses, trigger refill when sync becomes live again
+
+        coVerify {
+            arrangement.mlsPublicKeysRepository.fetchKeys()
+        }.wasNotInvoked() // Should not refill yet since sync is not live
+
+        incrementalSyncStateFlow.value = IncrementalSyncStatus.Live // Change sync state back to live
+        advanceTimeBy(1.minutes)
+
+        coVerify {
+            arrangement.mlsPublicKeysRepository.fetchKeys()
+        }.wasInvoked(exactly = once) // Should refill now since sync is live again
+
+        workerJob.cancel()
+    }
+
+    @Test
+    fun givenSyncIsLive_whenExecutingImmediately_thenFetchKeys() = runTest {
+        val incrementalSyncStateFlow = MutableStateFlow<IncrementalSyncStatus>(IncrementalSyncStatus.Live)
+        val (arrangement, mlsPublicKeysSyncWorker) = arrange {
+            withIncrementalSyncState(incrementalSyncStateFlow)
+        }
+
+        val workerJob = launch {
+            mlsPublicKeysSyncWorker.executeImmediately()
+        }
+        advanceTimeBy(1.minutes)
+
+        coVerify {
+            arrangement.mlsPublicKeysRepository.fetchKeys()
+        }.wasInvoked(exactly = once)
+
+        workerJob.cancel()
+    }
+
+    @Test
+    fun givenSyncIsNotLive_whenExecutingImmediately_thenFetchKeysAfterSyncBecomesLive() = runTest {
+        val incrementalSyncStateFlow = MutableStateFlow<IncrementalSyncStatus>(IncrementalSyncStatus.Pending)
+        val (arrangement, mlsPublicKeysSyncWorker) = arrange {
+            withIncrementalSyncState(incrementalSyncStateFlow)
+        }
+
+        val workerJob = launch {
+            mlsPublicKeysSyncWorker.executeImmediately()
+        }
+        advanceTimeBy(1.minutes)
+
+        coVerify {
+            arrangement.mlsPublicKeysRepository.fetchKeys()
+        }.wasNotInvoked() // Sync is not live yet
+
+        incrementalSyncStateFlow.value = IncrementalSyncStatus.Live // Change sync state to live
+        advanceTimeBy(1.minutes)
+        coVerify {
+            arrangement.mlsPublicKeysRepository.fetchKeys()
+        }.wasInvoked(exactly = once) // Sync is now live
+
+        workerJob.cancel()
+    }
+
+    private class Arrangement(private val configure: suspend Arrangement.() -> Unit) :
+        IncrementalSyncRepositoryArrangement by IncrementalSyncRepositoryArrangementImpl() {
+
+        @Mock
+        val mlsPublicKeysRepository = mock(MLSPublicKeysRepository::class)
+        var minIntervalBetweenRefills: Duration = 1.days
+        var lastFetchInstantFlow = MutableStateFlow(Instant.DISTANT_PAST)
+        
+        suspend fun arrange(): Pair<Arrangement, MLSPublicKeysSyncWorker> = run {
+            coEvery {
+                mlsPublicKeysRepository.fetchKeys()
+            }.returns(Either.Right(MLSPublicKeys(emptyMap())))
+            configure()
+            this@Arrangement to MLSPublicKeysSyncWorkerImpl(
+                incrementalSyncRepository = incrementalSyncRepository,
+                mlsPublicKeysRepository = mlsPublicKeysRepository,
+                minIntervalBetweenRefills = minIntervalBetweenRefills,
+                lastFetchInstantFlow = lastFetchInstantFlow,
+                kaliumLogger = kaliumLogger
+            )
+        }
+    }
+
+    private companion object {
+        suspend fun arrange(configure: suspend Arrangement.() -> Unit) = Arrangement(configure).arrange()
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently we do not keep the MLS public keys, they are being fetched every time.
MLS public keys should be treated the same way as feature-config and api-version, so should be fetched once every 24h and when the app is put into foreground (cannot be done in kalium itself, but the worker is provided to do it on the specific platform).

### Solutions

Keep MLS public keys in-memory. 
Create a worker to fetch them once every 24h.
Update repository to be thread safe and try to fetch keys when cannot be found for the given cipherSuite.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
