### PR TITLE
fix: prevent multiple sync jobs in parallel [WPB-17145]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncExceptionHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncExceptionHandler.kt
@@ -24,12 +24,12 @@ import com.wire.kalium.common.logger.kaliumLogger
 import kotlinx.coroutines.CancellationException
 
 internal class SyncExceptionHandler(
-    private val onCancellation: () -> Unit,
-    private val onFailure: (exception: CoreFailure) -> Unit
+    private val onCancellation: suspend () -> Unit,
+    private val onFailure: suspend (exception: CoreFailure) -> Unit
 ) {
     private val logger = kaliumLogger.withFeatureId(SYNC)
 
-    fun handleException(exception: Throwable) {
+    suspend fun handleException(exception: Throwable) {
         when (exception) {
             is CancellationException -> {
                 logger.w("Sync job was cancelled", exception)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManagerTest.kt
@@ -23,7 +23,6 @@ import com.wire.kalium.logic.data.sync.InMemoryIncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.common.logger.kaliumLogger
-import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import com.wire.kalium.logic.util.ExponentialDurationHelper
 import com.wire.kalium.logic.util.flowThatFailsOnFirstTime
 import com.wire.kalium.network.NetworkState
@@ -57,7 +56,7 @@ import kotlin.time.Duration.Companion.seconds
 class IncrementalSyncManagerTest {
 
     @Test
-    fun givenDefaultState_whenStartingIncrementalManager_thenShouldStartWorker() = runTest(TestKaliumDispatcher.default) {
+    fun givenDefaultState_whenStartingIncrementalManager_thenShouldStartWorker() = runTest {
         val sharedFlow = MutableSharedFlow<EventSource>()
 
         val (arrangement, incrementalSyncManager) = Arrangement()
@@ -77,7 +76,7 @@ class IncrementalSyncManagerTest {
     }
 
     @Test
-    fun givenDefaultState_whenStartingIncrementalSync_thenShouldResetRetryTimer() = runTest(TestKaliumDispatcher.default) {
+    fun givenDefaultState_whenStartingIncrementalSync_thenShouldResetRetryTimer() = runTest {
         val sharedFlow = MutableSharedFlow<EventSource>()
 
         val (arrangement, incrementalSyncManager) = Arrangement()
@@ -95,7 +94,7 @@ class IncrementalSyncManagerTest {
     }
 
     @Test
-    fun givenNormalOperation_whenWorkerEmitsSources_thenShouldUpdateRepositoryWithState() = runTest(TestKaliumDispatcher.default) {
+    fun givenNormalOperation_whenWorkerEmitsSources_thenShouldUpdateRepositoryWithState() = runTest {
         val sourceFlow = Channel<EventSource>(Channel.UNLIMITED)
 
         val (arrangement, incrementalSyncManager) = Arrangement()
@@ -116,7 +115,7 @@ class IncrementalSyncManagerTest {
     }
 
     @Test
-    fun givenWorkerThrows_whenPerformingSync_thenShouldUpdateRepositoryWithFailedState() = runTest(TestKaliumDispatcher.default) {
+    fun givenWorkerThrows_whenPerformingSync_thenShouldUpdateRepositoryWithFailedState() = runTest {
         val (arrangement, incrementalSyncManager) = Arrangement()
             .withWorkerReturning(flowThatFailsOnFirstTime())
             .arrange()
@@ -129,7 +128,7 @@ class IncrementalSyncManagerTest {
     }
 
     @Test
-    fun givenWorkerThrowsNonCancellation_whenPerformingSync_thenShouldRetry() = runTest(TestKaliumDispatcher.default) {
+    fun givenWorkerThrowsNonCancellation_whenPerformingSync_thenShouldRetry() = runTest {
         val (arrangement, incrementalSyncManager) = Arrangement()
             .withWorkerReturning(flowThatFailsOnFirstTime())
             .withRecoveringFromFailure()
@@ -149,7 +148,7 @@ class IncrementalSyncManagerTest {
     }
 
     @Test
-    fun givenWorkerThrowsCancellation_whenPerformingSync_thenShouldNotRetry() = runTest(TestKaliumDispatcher.default) {
+    fun givenWorkerThrowsCancellation_whenPerformingSync_thenShouldNotRetry() = runTest {
         val (arrangement, incrementalSyncManager) = Arrangement()
             .withWorkerReturning(flowThatFailsOnFirstTime(CancellationException("Cancelled")))
             .withRecoveringFromFailure()
@@ -171,7 +170,7 @@ class IncrementalSyncManagerTest {
 
     @Test
     fun givenDefaultState_whenCancellingSync_thenShouldUpdateIncrementalSyncStatusToPendingAgain() =
-        runTest(TestKaliumDispatcher.default) {
+        runTest {
 
             val (arrangement, incrementalSyncManager) = Arrangement()
                 .withWorkerReturning(emptyFlow())
@@ -186,7 +185,7 @@ class IncrementalSyncManagerTest {
         }
 
     @Test
-    fun givenSyncIsLive_whenWorkerEmitsSources_thenShouldResetExponentialDuration() = runTest(TestKaliumDispatcher.default) {
+    fun givenSyncIsLive_whenWorkerEmitsSources_thenShouldResetExponentialDuration() = runTest {
         val sourceFlow = Channel<EventSource>(Channel.UNLIMITED)
 
         val (arrangement, incrementalSyncManager) = Arrangement()
@@ -206,7 +205,7 @@ class IncrementalSyncManagerTest {
     }
 
     @Test
-    fun givenWorkerFailure_whenPerformingSync_thenShouldCalculateNextExponentialDelay() = runTest(TestKaliumDispatcher.default) {
+    fun givenWorkerFailure_whenPerformingSync_thenShouldCalculateNextExponentialDelay() = runTest {
         val (arrangement, incrementalSyncManager) = Arrangement()
             .withWorkerReturning(flowThatFailsOnFirstTime())
             .withRecoveringFromFailure()
@@ -224,7 +223,7 @@ class IncrementalSyncManagerTest {
     }
 
     @Test
-    fun givenDefaultState_whenStartingSync_thenShouldResetExponentialDuration() = runTest(TestKaliumDispatcher.default) {
+    fun givenDefaultState_whenStartingSync_thenShouldResetExponentialDuration() = runTest {
         val sourceFlow = Channel<EventSource>(Channel.UNLIMITED)
 
         val (arrangement, incrementalSyncManager) = Arrangement()
@@ -294,7 +293,6 @@ class IncrementalSyncManagerTest {
             incrementalSyncRepository = incrementalSyncRepository,
             incrementalSyncRecoveryHandler = incrementalSyncRecoveryHandler,
             networkStateObserver = networkStateObserver,
-            kaliumDispatcher = TestKaliumDispatcher,
             exponentialDurationHelper = exponentialDurationHelper,
             userScopedLogger = kaliumLogger
         )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManagerTest.kt
@@ -70,7 +70,7 @@ import kotlin.time.Duration.Companion.seconds
 class SlowSyncManagerTest {
 
     @Test
-    fun givenCriteriaAreMet_whenManagerIsCreated_thenShouldStartSlowSync() = runTest(TestKaliumDispatcher.default) {
+    fun givenCriteriaAreMet_whenManagerIsCreated_thenShouldStartSlowSync() = runTest {
         var isCollected = false
         val stepFlow = flow<SlowSyncStep> { isCollected = true }
         val (arrangement, slowSyncManager) = Arrangement().arrange {
@@ -93,7 +93,7 @@ class SlowSyncManagerTest {
     }
 
     @Test
-    fun givenCriteriaAreMet_whenWorkerThrowsNonCancellation_thenShouldRetry() = runTest(TestKaliumDispatcher.default) {
+    fun givenCriteriaAreMet_whenWorkerThrowsNonCancellation_thenShouldRetry() = runTest {
         val (arrangement, slowSyncManager) = Arrangement().arrange {
             withSatisfiedCriteria()
             withSlowSyncWorkerReturning(flowThatFailsOnFirstTime())
@@ -111,7 +111,7 @@ class SlowSyncManagerTest {
     }
 
     @Test
-    fun givenCriteriaAreMet_whenWorkerThrowsCancellation_thenShouldNotRetry() = runTest(TestKaliumDispatcher.default) {
+    fun givenCriteriaAreMet_whenWorkerThrowsCancellation_thenShouldNotRetry() = runTest {
         val (arrangement, slowSyncManager) = Arrangement().arrange {
             withSatisfiedCriteria()
             withSlowSyncWorkerReturning(flowThatFailsOnFirstTime(CancellationException("Cancelled")))
@@ -128,7 +128,7 @@ class SlowSyncManagerTest {
     }
 
     @Test
-    fun givenCriteriaAreMet_whenStepsAreOver_thenShouldUpdateStateInRepository() = runTest(TestKaliumDispatcher.default) {
+    fun givenCriteriaAreMet_whenStepsAreOver_thenShouldUpdateStateInRepository() = runTest {
         val (arrangement, slowSyncManager) = Arrangement().arrange {
             withSatisfiedCriteria()
             withSlowSyncWorkerReturning(emptyFlow())
@@ -145,7 +145,7 @@ class SlowSyncManagerTest {
     }
 
     @Test
-    fun givenCriteriaAreMet_whenStepsAreOver_thenShouldUpdateLastCompletedDate() = runTest(TestKaliumDispatcher.default) {
+    fun givenCriteriaAreMet_whenStepsAreOver_thenShouldUpdateLastCompletedDate() = runTest {
         val initialTime = DateTimeUtil.currentInstant()
 
         val (arrangement, slowSyncManager) = Arrangement().arrange {
@@ -173,7 +173,7 @@ class SlowSyncManagerTest {
     }
 
     @Test
-    fun givenItWasCompletedRecently_whenCriteriaAreMet_thenShouldNotUpdateLastCompletedDate() = runTest(TestKaliumDispatcher.default) {
+    fun givenItWasCompletedRecently_whenCriteriaAreMet_thenShouldNotUpdateLastCompletedDate() = runTest {
         val initialTime = DateTimeUtil.currentInstant()
 
         val (arrangement, slowSyncManager) = Arrangement().arrange {
@@ -190,7 +190,7 @@ class SlowSyncManagerTest {
 
     @Test
     fun givenItWasCompletedRecentlyAndVersionIsOutdated_whenCriteriaAreMet_thenShouldUpdateSlowSyncVersion() =
-        runTest(TestKaliumDispatcher.default) {
+        runTest {
             val (arrangement, slowSyncManager) = Arrangement().arrange {
                 withSatisfiedCriteria()
                 withLastSlowSyncPerformedAt(flowOf(DateTimeUtil.currentInstant()))
@@ -211,7 +211,7 @@ class SlowSyncManagerTest {
 
     @Test
     fun givenItWasCompletedRecentlyAndVersionIsUpToDate_whenCriteriaAreMet_thenShouldNotUpdateSlowSyncVersion() =
-        runTest(TestKaliumDispatcher.default) {
+        runTest {
             val (arrangement, slowSyncManager) = Arrangement().arrange {
                 withSatisfiedCriteria()
                 withLastSlowSyncPerformedAt(flowOf(DateTimeUtil.currentInstant()))
@@ -227,7 +227,7 @@ class SlowSyncManagerTest {
         }
 
     @Test
-    fun givenCriteriaAreMet_whenWorkerEmitsAStep_thenShouldUpdateStateInRepository() = runTest(TestKaliumDispatcher.default) {
+    fun givenCriteriaAreMet_whenWorkerEmitsAStep_thenShouldUpdateStateInRepository() = runTest {
         val stepChannel = Channel<SlowSyncStep>(Channel.UNLIMITED)
         val (arrangement, slowSyncManager) = Arrangement().arrange {
             withSatisfiedCriteria()
@@ -250,7 +250,7 @@ class SlowSyncManagerTest {
     }
 
     @Test
-    fun givenCriteriaAreMet_whenCriteriaAreBroken_thenShouldCancelCollection() = runTest(TestKaliumDispatcher.default) {
+    fun givenCriteriaAreMet_whenCriteriaAreBroken_thenShouldCancelCollection() = runTest {
         val criteriaChannel = Channel<SyncCriteriaResolution>(Channel.UNLIMITED)
         val stepSharedFlow = MutableSharedFlow<SlowSyncStep>()
         val (_, slowSyncManager) = Arrangement().arrange {
@@ -274,7 +274,7 @@ class SlowSyncManagerTest {
     }
 
     @Test
-    fun givenItWasPerformedRecently_whenCriteriaAreMet_thenShouldNotStartSlowSync() = runTest(TestKaliumDispatcher.default) {
+    fun givenItWasPerformedRecently_whenCriteriaAreMet_thenShouldNotStartSlowSync() = runTest {
         val criteriaChannel = Channel<SyncCriteriaResolution>(Channel.UNLIMITED)
         val stepSharedFlow = MutableSharedFlow<SlowSyncStep>(extraBufferCapacity = 1)
         stepSharedFlow.emit(SlowSyncStep.CONVERSATIONS)
@@ -297,7 +297,7 @@ class SlowSyncManagerTest {
     }
 
     @Test
-    fun givenItWasPerformedRecently_whenLastPerformedIsCleared_thenShouldStartSlowSyncAgain() = runTest(TestKaliumDispatcher.default) {
+    fun givenItWasPerformedRecently_whenLastPerformedIsCleared_thenShouldStartSlowSyncAgain() = runTest {
         val criteriaChannel = Channel<SyncCriteriaResolution>(Channel.UNLIMITED)
         criteriaChannel.send(SyncCriteriaResolution.Ready)
 
@@ -336,7 +336,7 @@ class SlowSyncManagerTest {
 
     @Test
     fun givenItWasPerformedLongAgoAndCriteriaAreMet_whenWorkerEmitsAStep_thenShouldUpdateStateInRepository() =
-        runTest(TestKaliumDispatcher.default) {
+        runTest {
             val stepChannel = Channel<SlowSyncStep>(Channel.UNLIMITED)
             val (arrangement, slowSyncManager) = Arrangement().arrange {
                 withSatisfiedCriteria()
@@ -363,7 +363,7 @@ class SlowSyncManagerTest {
         }
 
     @Test
-    fun givenCriteriaAreNotMet_whenManagerIsCreated_thenShouldNotStartSlowSync() = runTest(TestKaliumDispatcher.default) {
+    fun givenCriteriaAreNotMet_whenManagerIsCreated_thenShouldNotStartSlowSync() = runTest {
         var isCollected = false
         val stepFlow = flow<SlowSyncStep> { isCollected = true }
         val (_, slowSyncManager) = Arrangement().arrange {
@@ -380,7 +380,7 @@ class SlowSyncManagerTest {
     }
 
     @Test
-    fun givenCriteriaAreMet_whenStepsAreOver_thenShouldResetExponentialDuration() = runTest(TestKaliumDispatcher.default) {
+    fun givenCriteriaAreMet_whenStepsAreOver_thenShouldResetExponentialDuration() = runTest {
         val (arrangement, slowSyncManager) = Arrangement().arrange {
             withSatisfiedCriteria()
             withSlowSyncWorkerReturning(emptyFlow())
@@ -397,7 +397,7 @@ class SlowSyncManagerTest {
     }
 
     @Test
-    fun givenCriteriaAreMet_whenRecovers_thenShouldRetry() = runTest(TestKaliumDispatcher.default) {
+    fun givenCriteriaAreMet_whenRecovers_thenShouldRetry() = runTest {
         val (arrangement, slowSyncManager) = Arrangement().arrange {
             withSatisfiedCriteria()
             withSlowSyncWorkerReturning(flowThatFailsOnFirstTime())
@@ -500,7 +500,6 @@ class SlowSyncManagerTest {
             slowSyncWorker = slowSyncWorker,
             slowSyncRecoveryHandler = slowSyncRecoveryHandler,
             networkStateObserver = networkStateObserver,
-            kaliumDispatcher = TestKaliumDispatcher,
             exponentialDurationHelper = exponentialDurationHelper,
             syncMigrationStepsProvider = { syncMigrationStepsProvider },
             userScopedLogger = kaliumLogger


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17145" title="WPB-17145" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17145</a>  [Android] stuck on sync
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some users are stuck on sync. 
Our log lines seem to have spiked.
Battery consumption is higher recently...

### Causes

Me?

Launching sync retries on a different coroutine scope caused a bug, where multiple retries could be left hanging in this different scope. 

When stopping/starting from the outside (when app goes foreground → background → foreground, for example), sync would restart, but that "retry" attempt would still keep on living.


### Solutions

There is absolutely _no need_ to launch stuff on a different scope when retrying sync.
This _used_ to work before the recent changes in Sync, but it should've been removed as well :)

### Testing

Manually tested.
I'm working on writing tests for it ASAP.

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
