### PR TITLE
fix: E2EE info system message when adding users and creating MLS 1:1 [WPB-17287][WPB-17202]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/NewGroupConversationSystemMessagesCreator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/NewGroupConversationSystemMessagesCreator.kt
@@ -19,6 +19,8 @@ package com.wire.kalium.logic.data.conversation
 
 import com.benasher44.uuid.uuid4
 import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.fold
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.id.SelfTeamIdProvider
@@ -27,12 +29,11 @@ import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.common.functional.Either
-import com.wire.kalium.common.functional.fold
 import com.wire.kalium.network.api.authenticated.conversation.ConversationResponse
 import com.wire.kalium.network.api.authenticated.conversation.ReceiptMode
 import com.wire.kalium.persistence.dao.ConversationIDEntity
 import com.wire.kalium.persistence.dao.conversation.ConversationEntity
+import com.wire.kalium.persistence.dao.message.LocalId
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 
@@ -201,7 +202,7 @@ internal class NewGroupConversationSystemMessagesCreatorImpl(
     ): Either<CoreFailure, Unit> =
         persistMessage(
             Message.System(
-                uuid4().toString(),
+                LocalId.generate(),
                 MessageContent.ConversationStartedUnverifiedWarning,
                 conversationId,
                 instant,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/SystemMessageInserter.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/SystemMessageInserter.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.common.functional.Either
+import com.wire.kalium.persistence.dao.message.LocalId
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 
@@ -43,6 +44,8 @@ internal interface SystemMessageInserter {
     )
 
     suspend fun insertLostCommitSystemMessage(conversationId: ConversationId, instant: Instant): Either<CoreFailure, Unit>
+
+    suspend fun insertConversationStartedUnverifiedWarning(conversationId: ConversationId)
 }
 
 internal class SystemMessageInserterImpl(
@@ -116,5 +119,20 @@ internal class SystemMessageInserterImpl(
             expirationData = null
         )
         return persistMessage(mlsEpochWarningMessage)
+    }
+
+    override suspend fun insertConversationStartedUnverifiedWarning(conversationId: ConversationId) {
+        persistMessage(
+            Message.System(
+                id = LocalId.generate(),
+                content = MessageContent.ConversationStartedUnverifiedWarning,
+                conversationId = conversationId,
+                date = Clock.System.now(),
+                senderUserId = selfUserId,
+                status = Message.Status.Sent,
+                visibility = Message.Visibility.VISIBLE,
+                expirationData = null
+            )
+        )
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1489,6 +1489,7 @@ class UserSessionScope internal constructor(
             persistMessage = persistMessage,
             legalHoldHandler = legalHoldHandler,
             newGroupConversationSystemMessagesCreator = newGroupConversationSystemMessagesCreator,
+            selfUserId = userId,
         )
     private val memberLeaveHandler: MemberLeaveEventHandler
         get() = MemberLeaveEventHandlerImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneMigrator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneMigrator.kt
@@ -112,6 +112,7 @@ internal class OneOnOneMigratorImpl(
                         ).map {
                             mlsConversation
                         }.also {
+                            systemMessageInserter.insertConversationStartedUnverifiedWarning(mlsConversation)
                             systemMessageInserter.insertProtocolChangedSystemMessage(
                                 conversationId = mlsConversation,
                                 senderUserId = user.id,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneMigratorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneMigratorTest.kt
@@ -139,6 +139,10 @@ class OneOnOneMigratorTest {
         }.wasNotInvoked()
 
         coVerify {
+            arrangement.systemMessageInserter.insertConversationStartedUnverifiedWarning(any())
+        }.wasNotInvoked()
+
+        coVerify {
             arrangement.systemMessageInserter.insertProtocolChangedSystemMessage(any(), any(), any())
         }.wasNotInvoked()
     }
@@ -179,6 +183,10 @@ class OneOnOneMigratorTest {
 
         coVerify {
             arrangement.userRepository.updateActiveOneOnOneConversation(any(), any())
+        }.wasNotInvoked()
+
+        coVerify {
+            arrangement.systemMessageInserter.insertConversationStartedUnverifiedWarning(any())
         }.wasNotInvoked()
 
         coVerify {
@@ -231,6 +239,10 @@ class OneOnOneMigratorTest {
         }.wasInvoked(exactly = once)
 
         coVerify {
+            arrangement.systemMessageInserter.insertConversationStartedUnverifiedWarning(eq(resolvedConversationId))
+        }.wasInvoked(exactly = once)
+
+        coVerify {
             arrangement.systemMessageInserter.insertProtocolChangedSystemMessage(any(), any(), any())
         }.wasInvoked(exactly = once)
     }
@@ -256,6 +268,10 @@ class OneOnOneMigratorTest {
 
         coVerify {
             arrangement.userRepository.updateActiveOneOnOneConversation(eq(user.id), eq(resolvedConversationId))
+        }.wasInvoked(exactly = once)
+
+        coVerify {
+            arrangement.systemMessageInserter.insertConversationStartedUnverifiedWarning(eq(resolvedConversationId))
         }.wasInvoked(exactly = once)
 
         coVerify {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17287" title="WPB-17287" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17287</a>  [Android] E2EE info system message when adding users and creating MLS 1:1
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There are two found cases when this E2EE initial system message behaves wrongly:

- it’s being added every time when adding someone else to a group - it should be added only if you are being added to a group and you haven’t been in that group yet (so that this message is added only once initially)

- it’s not being added when you create 1:1 MLS conversation with someone from your contacts (so that there is no connection request needed, e.g. from your team)

Also, there's a problem with our inserting message logic - for this particular type of message it should check whether such message already exists for the given conversation and not add it again, but looks like it's not working properly.

### Solutions

- use `LocalId.generate()` to create system message with id having "local" prefix so that our inserting message logic can check whether such message already exists - we check only messages with local ids to not mess up any message from remote and this message type was being created with non-local id so our logic of checking for duplicate was failing
- for adding someone to the conversation, check if the user being added is self user and add this system message only in that case
- for creating MLS 1:1 conversation, add it right after migration - if it's a newly created conversation then it will add, otherwise, if it's migrated with all other messages from proteus conversation then our logic of checking for duplicates for this specific type of message will prevent from adding it again

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

- create a conversation and add someone else to it - this system message should be added only once at the beginning of the conversation
- create a 1:1 MLS conversation with someone new from your contacts - this system message should be added at the beginning of the conversation just like for proteus conversations

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
