### PR TITLE
fix: check mls call participants before removing [WPB-17304]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinSubconversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinSubconversationUseCase.kt
@@ -58,8 +58,8 @@ internal class JoinSubconversationUseCaseImpl(
     override suspend operator fun invoke(
         conversationId: ConversationId,
         subconversationId: SubconversationId
-    ): Either<CoreFailure, Unit> =
-        joinOrEstablishSubconversationAndRetry(conversationId, subconversationId)
+    ): Either<CoreFailure, Unit> = joinOrEstablishSubconversationAndRetry(conversationId, subconversationId)
+
     private suspend fun joinOrEstablishSubconversation(
         conversationId: ConversationId,
         subconversationId: SubconversationId


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17304" title="WPB-17304" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17304</a>  [Android]User appears in "Connecting" state to others after leaving a group call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

During removing stale participant from mls call there was an error
` "MLSException": "exception=com.wire.crypto.MlsException$Other: An empty list of KeyPackage references was provided.,"`


### Solutions

Check if members exists in mls group before trying to remove them
