### PR TITLE
chore(sync): improve event logging [WPB-8645]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.logic.data.conversation.Conversation.Member
 import com.wire.kalium.logic.data.conversation.Conversation.Protocol
 import com.wire.kalium.logic.data.conversation.Conversation.ReceiptMode
 import com.wire.kalium.logic.data.conversation.Conversation.TypingIndicatorMode
+import com.wire.kalium.logic.data.conversation.ConversationDetails.Group.Channel.ChannelAddPermission
 import com.wire.kalium.logic.data.conversation.FolderWithConversations
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.featureConfig.AppLockModel
@@ -52,7 +53,6 @@ import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import com.wire.kalium.util.serialization.toJsonElement
 import kotlinx.datetime.Instant
 import kotlinx.serialization.json.JsonNull
-import com.wire.kalium.logic.data.conversation.ConversationDetails.Group.Channel.ChannelAddPermission
 
 /**
  * A wrapper that joins [Event] with its [EventDeliveryInfo].
@@ -392,16 +392,20 @@ sealed class Event(open val id: String) {
             val uri: String?,
             val isPasswordProtected: Boolean,
         ) : Conversation(id, conversationId) {
-            override fun toLogMap(): Map<String, Any?> =
-                mapOf(typeKey to "Conversation.CodeUpdated")
+            override fun toLogMap(): Map<String, Any?> = mapOf(
+                idKey to id.obfuscateId(),
+                typeKey to "Conversation.CodeUpdated"
+            )
         }
 
         data class CodeDeleted(
             override val id: String,
             override val conversationId: ConversationId,
         ) : Conversation(id, conversationId) {
-            override fun toLogMap(): Map<String, Any?> =
-                mapOf(typeKey to "Conversation.CodeDeleted")
+            override fun toLogMap(): Map<String, Any?> = mapOf(
+                idKey to id.obfuscateId(),
+                typeKey to "Conversation.CodeDeleted"
+            )
         }
 
         data class TypingIndicator(
@@ -412,6 +416,7 @@ sealed class Event(open val id: String) {
             val typingIndicatorMode: TypingIndicatorMode,
         ) : Conversation(id, conversationId) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
+                idKey to id.obfuscateId(),
                 typeKey to "Conversation.TypingIndicator",
                 conversationIdKey to conversationId.toLogString(),
                 "typingIndicatorMode" to typingIndicatorMode.name,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
@@ -130,9 +130,9 @@ internal class EventGathererImpl(
     private suspend fun FlowCollector<EventEnvelope>.onWebSocketEventReceived(
         webSocketEvent: WebSocketEvent.BinaryPayloadReceived<EventEnvelope>
     ) {
-        logger.i("Websocket Received binary payload")
         val envelope = webSocketEvent.payload
         val obfuscatedId = envelope.event.id.obfuscateId()
+        logger.i("Websocket Received payload: ${envelope.event.toLogString()}")
         if (offlineEventBuffer.contains(envelope.event)) {
             if (offlineEventBuffer.clearHistoryIfLastEventEquals(envelope.event)) {
                 // Really live
@@ -161,7 +161,7 @@ internal class EventGathererImpl(
             .filterIsInstance<Either.Right<EventEnvelope>>()
             .map { offlineEvent -> offlineEvent.value }
             .collect {
-                logger.i("Collecting offline event: ${it.event.id.obfuscateId()}")
+                logger.i("Collecting offline event: ${it.event.toLogString()}")
                 offlineEventBuffer.add(it.event)
                 emit(it)
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessor.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessor.kt
@@ -91,6 +91,7 @@ internal class EventProcessorImpl(
             logger.w("Skipping processing of ${event.toLogString()} due to debug option")
             Either.Right(Unit)
         } else {
+            logger.i("Starting processing of event: ${event.toLogString()}")
             withContext(NonCancellable) {
                 doProcess(event, deliveryInfo, eventEnvelope)
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8645" title="WPB-8645" target="_blank"><img alt="Epic" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10807?size=medium" />WPB-8645</a>  [Android] Infrastructure code and developer experience
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Did you know we have came this far without logging "Event processing started: eventData"?
We only had logs for "offline events".

### Solutions

Added informational logging at event processing start for better traceability.

Enhanced `toLogMap()` implementations to include obfuscated IDs in events where it was missing.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
