### PR TITLE
chore(MLS): add transaction identifiers for logging [WPB-17522]

### DIFF
--- a/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/CoreCryptoCentral.kt
+++ b/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/CoreCryptoCentral.kt
@@ -102,7 +102,7 @@ class CoreCryptoCentralImpl(
                 }
             })
 
-            cc.transaction { context ->
+            cc.transaction("initMLS") { context ->
                 context.mlsInit(
                     ClientId(clientId.toString()),
                     Ciphersuites(allowedCipherSuites.map { it.toCrypto() }.toSet()),
@@ -146,7 +146,7 @@ class CoreCryptoCentralImpl(
             }
         })
 
-        cc.transaction {
+        cc.transaction("e2eiMlsInitOnly") {
             it.e2eiMlsInitOnly(
                 (enrollment as E2EIClientImpl).wireE2eIdentity,
                 certificateChain,
@@ -178,7 +178,7 @@ class CoreCryptoCentralImpl(
         expiry: Duration,
         defaultCipherSuite: MLSCiphersuite
     ): E2EIClient {
-        return cc.transaction {
+        return cc.transaction("newAcmeEnrollment") {
             E2EIClientImpl(
                 it.e2eiNewEnrollment(
                     clientId.toString(),
@@ -194,7 +194,7 @@ class CoreCryptoCentralImpl(
 
     override suspend fun registerTrustAnchors(pem: CertificateChain) {
         try {
-            cc.transaction {
+            cc.transaction("registerTrustAnchors") {
                 it.e2eiRegisterAcmeCA(pem)
             }
         } catch (e: CryptographyException) {
@@ -204,7 +204,7 @@ class CoreCryptoCentralImpl(
 
     @Suppress("TooGenericExceptionCaught")
     override suspend fun registerCrl(url: String, crl: JsonRawData): CrlRegistration = try {
-        cc.transaction {
+        cc.transaction("registerCrl") {
             it.e2eiRegisterCRL(url, crl).toCryptography()
         }
     } catch (exception: Exception) {
@@ -218,7 +218,7 @@ class CoreCryptoCentralImpl(
     @Suppress("TooGenericExceptionCaught")
     override suspend fun registerIntermediateCa(pem: CertificateChain) {
         try {
-            cc.transaction {
+            cc.transaction("registerIntermediateCa") {
                 it.e2eiRegisterIntermediateCA(pem)
             }
         } catch (exception: Exception) {

--- a/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/CoreCryptoTransactionExt.kt
+++ b/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/CoreCryptoTransactionExt.kt
@@ -1,0 +1,61 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.cryptography
+
+import com.wire.crypto.CoreCrypto
+import com.wire.crypto.CoreCryptoContext
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Performs a work using a CC Transaction, returning its result, exactly like the regular withLock function.
+ * However, this will monitor the work and log warnings using the provided [workIdentifier]
+ * every 10 seconds, while the work isn't completed.
+ */
+@Suppress("MagicNumber")
+internal suspend fun <T> CoreCrypto.transaction(
+    workIdentifier: String,
+    block: suspend (context: CoreCryptoContext) -> T
+): T = coroutineScope {
+    val asyncLockWork = async {
+        transaction {
+            block(it)
+        }
+    }
+    val startInstant = Clock.System.now()
+    val waitJob = launch {
+        while (asyncLockWork.isActive) {
+            delay(10.seconds)
+            if (asyncLockWork.isActive) {
+                val currentInstant = Clock.System.now()
+                val elapsedTime = currentInstant.minus(startInstant)
+                kaliumLogger.w(
+                    "Waiting for CC Transaction Work '$workIdentifier' to complete for a long time! Elapsed time: $elapsedTime."
+                )
+            }
+        }
+    }
+    asyncLockWork.invokeOnCompletion {
+        waitJob.cancel()
+    }
+    asyncLockWork.await()
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -65,14 +65,22 @@ import com.wire.kalium.network.api.base.authenticated.client.ClientApi
 import com.wire.kalium.persistence.dao.conversation.ConversationDAO
 import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 import com.wire.kalium.util.DateTimeUtil
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
 import io.ktor.util.decodeBase64Bytes
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.datetime.Clock
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 data class ApplicationMessage(
     val message: ByteArray,
@@ -225,31 +233,47 @@ internal class MLSConversationDataSource(
     private val certificateRevocationListRepository: CertificateRevocationListRepository,
     private val mutex: Mutex,
     private val idMapper: IdMapper = MapperProvider.idMapper(),
-    private val conversationMapper: ConversationMapper = MapperProvider.conversationMapper(selfUserId)
+    private val conversationMapper: ConversationMapper = MapperProvider.conversationMapper(selfUserId),
+    private val dispatchers: KaliumDispatcher = KaliumDispatcherImpl
 ) : MLSConversationRepository {
 
-    /**
-     * A dispatcher with limited parallelism of 1.
-     * This means using this dispatcher only a single coroutine will be processed at a time.
-     *
-     * This used for operations where ordering is important. For example when sending commit to
-     * add client to a group, this a two-step operation:
-     *
-     * 1. Create pending commit and send to distribution server
-     * 2. Merge pending commit when accepted by distribution server
-     *
-     * Here's it's critical that no other operation like `decryptMessage` is performed
-     * between step 1 and 2. We enforce this by dispatching all `decrypt` and `commit` operations
-     * onto this serial dispatcher.
-     */
     private val logger = kaliumLogger.withTextTag("MLSConversationDataSource")
+
+    /**
+     * Performs a work using the Mutex lock returning its result, exactly like the regular withLock function.
+     * However, this will monitor the work and log warnings using the provided [workIdentifier]
+     * every 10 seconds, while the work isn't completed.
+     */
+    @Suppress("MagicNumber")
+    private suspend fun <T> Mutex.withLock(workIdentifier: String, block: suspend () -> T): T = coroutineScope {
+        val asyncLockWork = async {
+            withLock {
+                block()
+            }
+        }
+        val startInstant = Clock.System.now()
+        val waitJob = launch(dispatchers.default) {
+            while (asyncLockWork.isActive) {
+                delay(10.seconds)
+                if (asyncLockWork.isActive) {
+                    val currentInstant = Clock.System.now()
+                    val elapsedTime = currentInstant.minus(startInstant)
+                    logger.w("Waiting for Mutex work '$workIdentifier' to complete for a long time! Elapsed time: $elapsedTime.")
+                }
+            }
+        }
+        asyncLockWork.invokeOnCompletion {
+            waitJob.cancel()
+        }
+        asyncLockWork.await()
+    }
 
     override suspend fun decryptMessage(
         message: ByteArray,
         groupID: GroupID
     ): Either<CoreFailure, List<DecryptedMessageBundle>> {
         logger.d("Decrypting message for group ${groupID.toLogString()}")
-        return mutex.withLock {
+        return mutex.withLock("decryptMessage") {
             mlsClientProvider.getMLSClient().flatMap { mlsClient ->
                 wrapMLSRequest {
                     mlsClient.decryptMessage(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17522" title="WPB-17522" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17522</a>  [Android] Stuck while processing MLS messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

It seems that some MLS operations might be stuck and possibly locking other operations indeterminately.

### Causes

Still unknown. But we have seen that `mlsClient.decrypt` is not running / running for ages. So this is either the `mlsMutex` in `MLSConversationDataSource`, or the actual `coreCrypto.transaction` that is making it stuck.

### Solutions

For now, introduced unique identifiers to `CoreCrypto.transaction` and `mlsMutex.withLock` calls for improved monitoring and tracking via logs. Enhanced warnings are emitted when transactions take longer than 10 seconds, aiding debugging and performance insights.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
