### PR TITLE
fix: Call Not Connect When SFT 1-1 Is Enabled on Proteus with MLS backend [WPB-17404]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -618,7 +618,7 @@ fun ConversationEntity.ChannelAccess.toModelChannelAccess(): ChannelAccess = whe
     ConversationEntity.ChannelAccess.PUBLIC -> ChannelAccess.PUBLIC
 }
 
-private fun ConversationEntity.Type.fromDaoModelToType(isChannel: Boolean): Conversation.Type = when (this) {
+fun ConversationEntity.Type.fromDaoModelToType(isChannel: Boolean): Conversation.Type = when (this) {
     ConversationEntity.Type.SELF -> Conversation.Type.Self
     ConversationEntity.Type.ONE_ON_ONE -> Conversation.Type.OneOnOne
     ConversationEntity.Type.GROUP -> {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMetaDataRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMetaDataRepository.kt
@@ -25,18 +25,20 @@ import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.persistence.dao.conversation.ConversationMetaDataDAO
 
-
 interface ConversationMetaDataRepository {
-    suspend fun getConversationTypeAndProtocolInfo(conversationId: ConversationId): Either<StorageFailure, Pair<Conversation.Type, Conversation.ProtocolInfo>>
+    suspend fun getConversationTypeAndProtocolInfo(
+        conversationId: ConversationId
+    ): Either<StorageFailure, Pair<Conversation.Type, Conversation.ProtocolInfo>>
 }
 
-internal class ConversationMetaDataDataSource internal  constructor(
+internal class ConversationMetaDataDataSource internal constructor(
     private val conversationMetaDataDAO: ConversationMetaDataDAO,
     private val protocolInfoMapper: ProtocolInfoMapper = MapperProvider.protocolInfoMapper(),
 ) : ConversationMetaDataRepository {
 
-
-    override suspend fun getConversationTypeAndProtocolInfo(conversationId: ConversationId): Either<StorageFailure, Pair<Conversation.Type, Conversation.ProtocolInfo>> =
+    override suspend fun getConversationTypeAndProtocolInfo(
+        conversationId: ConversationId
+    ): Either<StorageFailure, Pair<Conversation.Type, Conversation.ProtocolInfo>> =
         wrapStorageRequest {
             conversationMetaDataDAO.typeAndProtocolInfo(conversationId.toDao())?.let {
                 Pair(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMetaDataRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMetaDataRepository.kt
@@ -1,0 +1,49 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.conversation
+
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.error.wrapStorageRequest
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.toDao
+import com.wire.kalium.logic.di.MapperProvider
+import com.wire.kalium.persistence.dao.conversation.ConversationMetaDataDAO
+
+
+interface ConversationMetaDataRepository {
+    suspend fun getConversationTypeAndProtocolInfo(conversationId: ConversationId): Either<StorageFailure, Pair<Conversation.Type, Conversation.ProtocolInfo>>
+}
+
+internal class ConversationMetaDataDataSource internal  constructor(
+    private val conversationMetaDataDAO: ConversationMetaDataDAO,
+    private val protocolInfoMapper: ProtocolInfoMapper = MapperProvider.protocolInfoMapper(),
+) : ConversationMetaDataRepository {
+
+
+    override suspend fun getConversationTypeAndProtocolInfo(conversationId: ConversationId): Either<StorageFailure, Pair<Conversation.Type, Conversation.ProtocolInfo>> =
+        wrapStorageRequest {
+            conversationMetaDataDAO.typeAndProtocolInfo(conversationId.toDao())?.let {
+                Pair(
+                    it.type.fromDaoModelToType(it.isChannel),
+                    protocolInfoMapper.fromEntity(it.protocolInfo)
+                )
+            }
+        }
+
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -100,7 +100,6 @@ interface ConversationRepository {
     suspend fun observeConversationById(conversationId: ConversationId): Flow<Either<StorageFailure, Conversation>>
     suspend fun observeConversationDetailsById(conversationID: ConversationId): Flow<Either<StorageFailure, ConversationDetails>>
     suspend fun getConversationById(conversationId: ConversationId): Either<StorageFailure, Conversation>
-    suspend fun getConversationTypeById(conversationId: ConversationId): Either<StorageFailure, Conversation.Type>
 
     // endregion
 
@@ -385,14 +384,6 @@ internal class ConversationDataSource internal constructor(
             conversationMapper.fromDaoModel(it)
         }
     }
-
-    override suspend fun getConversationTypeById(conversationId: ConversationId): Either<StorageFailure, Conversation.Type> =
-        wrapStorageRequest {
-            conversationDAO.getConversationTypeById(conversationId.toDao())?.let {
-                val isChannel = conversationDAO.isAChannel(conversationId.toDao())
-                conversationMapper.fromConversationEntityType(it, isChannel)
-            }
-        }
 
     override suspend fun observeConversationDetailsById(conversationID: ConversationId): Flow<Either<StorageFailure, ConversationDetails>> =
         conversationDAO.observeConversationDetailsById(conversationID.toDao())

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/e2ei/RevocationListChecker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/e2ei/RevocationListChecker.kt
@@ -62,7 +62,7 @@ internal class RevocationListCheckerImpl(
         } else Either.Left(E2EIFailure.Disabled)
     }
 
-    private fun getIsE2EIEnabled() = userConfigRepository.getE2EISettings().flatMap { settings ->
+    private suspend fun getIsE2EIEnabled() = userConfigRepository.getE2EISettings().flatMap { settings ->
         userConfigRepository.isMLSEnabled()
             .map {
                 it && settings.isRequired && featureSupport.isMLSSupported

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -73,6 +73,8 @@ import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.ConversationDataSource
 import com.wire.kalium.logic.data.conversation.ConversationGroupRepository
 import com.wire.kalium.logic.data.conversation.ConversationGroupRepositoryImpl
+import com.wire.kalium.logic.data.conversation.ConversationMetaDataDataSource
+import com.wire.kalium.logic.data.conversation.ConversationMetaDataRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.EpochChangesObserver
 import com.wire.kalium.logic.data.conversation.EpochChangesObserverImpl
@@ -751,6 +753,11 @@ class UserSessionScope internal constructor(
             userStorage.database.metadataDAO,
         )
 
+    private val conversationMetaDataRepository: ConversationMetaDataRepository
+        get () = ConversationMetaDataDataSource(
+            userStorage.database.conversationMetaDataDAO,
+        )
+
     private val conversationFolderRepository: ConversationFolderRepository
         get() = ConversationFolderDataSource(
             userStorage.database.conversationFolderDAO,
@@ -1348,8 +1355,7 @@ class UserSessionScope internal constructor(
     private val getCallConversationType: GetCallConversationTypeProvider by lazy {
         GetCallConversationTypeProviderImpl(
             userConfigRepository = userConfigRepository,
-            conversationRepository = conversationRepository,
-            callMapper = callMapper
+            conversationMetaDataRepository = conversationMetaDataRepository,
         )
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -754,7 +754,7 @@ class UserSessionScope internal constructor(
         )
 
     private val conversationMetaDataRepository: ConversationMetaDataRepository
-        get () = ConversationMetaDataDataSource(
+        get() = ConversationMetaDataDataSource(
             userStorage.database.conversationMetaDataDAO,
         )
 
@@ -1260,28 +1260,30 @@ class UserSessionScope internal constructor(
         lazy { users.timestampKeyRepository }
     )
 
-    val keyingMaterialsManager: KeyingMaterialsManager get() = KeyingMaterialsManager(
-        featureSupport,
-        syncStateObserver,
-        lazy { clientRepository },
-        lazy { conversations.updateMLSGroupsKeyingMaterials },
-        lazy { users.timestampKeyRepository },
-        this,
-    )
+    val keyingMaterialsManager: KeyingMaterialsManager
+        get() = KeyingMaterialsManager(
+            featureSupport,
+            syncStateObserver,
+            lazy { clientRepository },
+            lazy { conversations.updateMLSGroupsKeyingMaterials },
+            lazy { users.timestampKeyRepository },
+            this,
+        )
 
-    val mlsClientManager: MLSClientManager get() = MLSClientManager(
-        clientIdProvider,
-        isAllowedToRegisterMLSClient,
-        syncStateObserver,
-        lazy { slowSyncRepository },
-        lazy { clientRepository },
-        lazy {
-            RegisterMLSClientUseCaseImpl(
-                mlsClientProvider, clientRepository, keyPackageRepository, keyPackageLimitsProvider, userConfigRepository
-            )
-        },
-        this,
-    )
+    val mlsClientManager: MLSClientManager
+        get() = MLSClientManager(
+            clientIdProvider,
+            isAllowedToRegisterMLSClient,
+            syncStateObserver,
+            lazy { slowSyncRepository },
+            lazy { clientRepository },
+            lazy {
+                RegisterMLSClientUseCaseImpl(
+                    mlsClientProvider, clientRepository, keyPackageRepository, keyPackageLimitsProvider, userConfigRepository
+                )
+            },
+            this,
+        )
 
     private val mlsMigrationWorker
         get() = MLSMigrationWorkerImpl(
@@ -1292,15 +1294,16 @@ class UserSessionScope internal constructor(
             mlsMigrator,
         )
 
-    val mlsMigrationManager: MLSMigrationManager get() = MLSMigrationManager(
-        kaliumConfigs,
-        isMLSEnabled,
-        syncStateObserver,
-        lazy { clientRepository },
-        lazy { users.timestampKeyRepository },
-        lazy { mlsMigrationWorker },
-        this,
-    )
+    val mlsMigrationManager: MLSMigrationManager
+        get() = MLSMigrationManager(
+            kaliumConfigs,
+            isMLSEnabled,
+            syncStateObserver,
+            lazy { clientRepository },
+            lazy { users.timestampKeyRepository },
+            lazy { mlsMigrationWorker },
+            this,
+        )
 
     private val mlsPublicKeysRepository: MLSPublicKeysRepository
         get() = MLSPublicKeysRepositoryImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetCallConversationTypeProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetCallConversationTypeProvider.kt
@@ -62,7 +62,9 @@ internal class GetCallConversationTypeProviderImpl(
             )
     }
 
-    private fun handleGroupConversation(protocolInfo: Conversation.ProtocolInfo): Either.Right<ConversationTypeCalling> = when (protocolInfo) {
+    private fun handleGroupConversation(
+        protocolInfo: Conversation.ProtocolInfo
+    ): Either.Right<ConversationTypeCalling> = when (protocolInfo) {
         is Conversation.ProtocolInfo.MLS -> ConversationTypeCalling.ConferenceMls
         is Conversation.ProtocolInfo.Proteus,
         is Conversation.ProtocolInfo.Mixed -> ConversationTypeCalling.Conference

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/IsE2EIEnabledUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/IsE2EIEnabledUseCase.kt
@@ -28,7 +28,7 @@ interface IsE2EIEnabledUseCase {
     /**
      * @return true if E2EI and MLS is enabled, false otherwise.
      */
-    operator fun invoke(): Boolean
+    suspend operator fun invoke(): Boolean
 }
 
 internal class IsE2EIEnabledUseCaseImpl(
@@ -36,7 +36,7 @@ internal class IsE2EIEnabledUseCaseImpl(
     private val isMLSEnabledUseCase: IsMLSEnabledUseCase
 ) : IsE2EIEnabledUseCase {
 
-    override operator fun invoke(): Boolean =
+    override suspend operator fun invoke(): Boolean =
         userConfigRepository.getE2EISettings().fold({
             false
         }, {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/IsMLSEnabledUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/IsMLSEnabledUseCase.kt
@@ -29,7 +29,7 @@ interface IsMLSEnabledUseCase {
     /**
      * @return true if MLS is enabled, false otherwise.
      */
-    operator fun invoke(): Boolean
+    suspend operator fun invoke(): Boolean
 }
 
 internal class IsMLSEnabledUseCaseImpl(
@@ -37,7 +37,7 @@ internal class IsMLSEnabledUseCaseImpl(
     private val userConfigRepository: UserConfigRepository
 ) : IsMLSEnabledUseCase {
 
-    override operator fun invoke(): Boolean =
+    override suspend operator fun invoke(): Boolean =
         userConfigRepository.isMLSEnabled().fold({
             false
         }, {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallHelperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallHelperTest.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.data.mls.CipherSuite
 import com.wire.kalium.common.functional.Either
 import io.mockative.Mock
 import io.mockative.classOf
+import io.mockative.coEvery
 import io.mockative.every
 import io.mockative.mock
 import kotlinx.coroutines.test.runTest
@@ -116,9 +117,9 @@ class CallHelperTest {
 
         fun arrange() = this to mLSCallHelper
 
-        fun withShouldUseSFTForOneOnOneCallsReturning(result: Either<StorageFailure, Boolean>) =
+        suspend fun withShouldUseSFTForOneOnOneCallsReturning(result: Either<StorageFailure, Boolean>) =
             apply {
-                every { userConfigRepository.shouldUseSFTForOneOnOneCalls() }.returns(result)
+                coEvery { userConfigRepository.shouldUseSFTForOneOnOneCalls() }.returns(result)
             }
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/MLSClientProviderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/MLSClientProviderTest.kt
@@ -76,7 +76,7 @@ class MLSClientProviderTest {
             assertEquals(expected.supportedCipherSuite, it)
         }
 
-        verify { arrangement.userConfigRepository.isMLSEnabled() }
+        coVerify { arrangement.userConfigRepository.isMLSEnabled() }
             .wasInvoked(exactly = once)
 
         coVerify { arrangement.userConfigRepository.getSupportedCipherSuite() }
@@ -106,7 +106,7 @@ class MLSClientProviderTest {
             assertEquals(expected, it)
         }
 
-        verify { arrangement.userConfigRepository.isMLSEnabled() }
+        coVerify { arrangement.userConfigRepository.isMLSEnabled() }
             .wasInvoked(exactly = once)
 
         coVerify {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/e2ei/RevocationListCheckerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/e2ei/RevocationListCheckerTest.kt
@@ -266,12 +266,12 @@ class RevocationListCheckerTest {
             }.returns(CrlRegistration(true, EXPIRATION))
         }
 
-        fun withE2EIEnabledAndMLSEnabled(result: Boolean) = apply {
+        suspend fun withE2EIEnabledAndMLSEnabled(result: Boolean) = apply {
             every {
                 featureSupport.isMLSSupported
             }.returns(result)
 
-            every {
+            coEvery {
                 userConfigRepository.isMLSEnabled()
             }.returns(result.right())
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/GetCallConversationTypeProviderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/GetCallConversationTypeProviderTest.kt
@@ -1,259 +1,280 @@
-/*
- * Wire
- * Copyright (C) 2024 Wire Swiss GmbH
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see http://www.gnu.org/licenses/.
- */
 package com.wire.kalium.logic.feature.call.usecase
 
 import com.wire.kalium.calling.ConversationTypeCalling
 import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.logic.configuration.UserConfigRepository
-import com.wire.kalium.logic.data.call.ConversationTypeForCall
-import com.wire.kalium.logic.data.call.mapper.CallMapper
 import com.wire.kalium.logic.data.conversation.Conversation
-import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.ConversationMetaDataRepository
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.mls.CipherSuite
-import com.wire.kalium.logic.framework.TestConversation
-import com.wire.kalium.common.functional.Either
 import io.mockative.Mock
 import io.mockative.any
 import io.mockative.coEvery
-import io.mockative.eq
-import io.mockative.every
+import io.mockative.coVerify
 import io.mockative.mock
+import io.mockative.once
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.Clock
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class GetCallConversationTypeProviderTest {
 
     @Test
-    fun givenShouldUseSFTForOneOnOneCallsAndMLSEnabled_whenRunningUseCase_thenReturnConferenceMls() =
-        runTest {
-            val conversationId = TestConversation.ID
-            val groupId = GroupID("groupid")
-
-            val (arrangement, getCallConversationType) = Arrangement()
-                .withGetConversationTypeByIdSuccess(conversationId, Conversation.Type.OneOnOne)
-                .withGetConversationProtocolInfoSuccess(
-                    conversationId,
-                    Conversation.ProtocolInfo.MLS(
-                        groupId,
-                        Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED,
-                        1UL,
-                        Clock.System.now(),
-                        CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
-                    )
+    fun givenGroupConversationWithMLSProtocol_whenGettingCallType_thenReturnConferenceMls() = runTest {
+        // Given
+        val (arrangement, provider) = arrange {
+            withGetConversationTypeAndProtocolInfoSuccess(
+                type = Conversation.Type.Group.Regular,
+                protocolInfo = Conversation.ProtocolInfo.MLS(
+                    groupId = GroupID("groupId"),
+                    groupState = Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED,
+                    epoch = 1.toULong(),
+                    cipherSuite = CipherSuite.Companion.fromTag(1),
+                    keyingMaterialLastUpdate = kotlinx.datetime.Instant.DISTANT_PAST
                 )
-                .withMlsConferenceCallMapping()
-                .withShouldUseSFTForOneOnOneCalls()
-                .withMLSEnabled()
-                .arrange()
-
-            val result = getCallConversationType.invoke(conversationId)
-
-            assertEquals(ConversationTypeCalling.ConferenceMls, result)
+            )
         }
+
+        // When
+        val result = provider(ConversationId("some-id", "some-domain"))
+
+        // Then
+        assertEquals(ConversationTypeCalling.ConferenceMls, result)
+        coVerify { arrangement.conversationMetaDataRepository.getConversationTypeAndProtocolInfo(any()) }.wasInvoked(exactly = once)
+        coVerify { arrangement.userConfigRepository.shouldUseSFTForOneOnOneCalls() }.wasNotInvoked()
+    }
 
     @Test
-    fun givenShouldUseSFTForOneOnOneCallsAndMLSDisabled_whenRunningUseCase_thenReturnConference() =
-        runTest {
-            val conversationId = TestConversation.ID
-
-            val (_, getCallConversationType) = Arrangement()
-                .withGetConversationTypeByIdSuccess(conversationId, Conversation.Type.Group.Regular)
-                .withGetConversationProtocolInfoSuccess(
-                    conversationId,
-                    Conversation.ProtocolInfo.Proteus
-                )
-                .withConferenceCallMapping()
-                .withShouldUseSFTForOneOnOneCalls()
-                .withMLSDisabled()
-                .arrange()
-
-            val result = getCallConversationType(conversationId)
-
-            assertEquals(ConversationTypeCalling.Conference, result)
+    fun givenOneOnOneConversationWithSFTDisabled_whenGettingCallType_thenReturnOneOnOne() = runTest {
+        // Given
+        val (arrangement, provider) = arrange {
+            withGetConversationTypeAndProtocolInfoSuccess(
+                type = Conversation.Type.OneOnOne,
+                protocolInfo = Conversation.ProtocolInfo.Proteus
+            )
+            withShouldNotUseSFTForOneOnOneCalls()
         }
+
+        // When
+        val result = provider(ConversationId("some-id", "some-domain"))
+
+        // Then
+        assertEquals(ConversationTypeCalling.OneOnOne, result)
+        coVerify { arrangement.conversationMetaDataRepository.getConversationTypeAndProtocolInfo(any()) }.wasInvoked(exactly = once)
+        coVerify { arrangement.userConfigRepository.shouldUseSFTForOneOnOneCalls() }.wasInvoked(exactly = once)
+    }
 
     @Test
-    fun givenShouldNotUseSFTForOneOnOneCallsAndOneOnOneConversation_whenRunningUseCase_thenReturnOneOnOneType() =
-        runTest {
-            val conversationId = TestConversation.ID
-
-            val (_, getCallConversationType) = Arrangement()
-                .withShouldNotUseSFTForOneOnOneCalls()
-                .withGetConversationTypeByIdSuccess(conversationId, Conversation.Type.OneOnOne)
-                .withGetConversationProtocolInfoSuccess(
-                    conversationId,
-                    Conversation.ProtocolInfo.Proteus
-                )
-                .withOneOnOneCallMapping()
-                .arrange()
-
-            val result = getCallConversationType.invoke(conversationId)
-
-            assertEquals(ConversationTypeCalling.OneOnOne, result)
+    fun givenProteusOneOnOneConversationWithSFTEnabled_whenGettingCallType_thenReturnConference() = runTest {
+        // Given
+        val (arrangement, provider) = arrange {
+            withGetConversationTypeAndProtocolInfoSuccess(
+                type = Conversation.Type.OneOnOne,
+                protocolInfo = Conversation.ProtocolInfo.Proteus
+            )
+            withShouldUseSFTForOneOnOneCalls()
         }
+
+        // When
+        val result = provider(ConversationId("some-id", "some-domain"))
+
+        // Then
+        assertEquals(ConversationTypeCalling.Conference, result)
+        coVerify { arrangement.conversationMetaDataRepository.getConversationTypeAndProtocolInfo(any()) }.wasInvoked(exactly = once)
+        coVerify { arrangement.userConfigRepository.shouldUseSFTForOneOnOneCalls() }.wasInvoked(exactly = once)
+    }
 
     @Test
-    fun givenUserConfigRepositoryReturnsFailure_whenRunningUseCase_thenReturnConversationType() =
-        runTest {
-            val conversationId = TestConversation.ID
-
-            val (_, getCallConversationType) = Arrangement()
-                .withShouldUseSFTForOneOnOneCallsFailure()
-                .withGetConversationTypeByIdSuccess(conversationId, Conversation.Type.Group.Regular)
-                .withGetConversationProtocolInfoSuccess(
-                    conversationId,
-                    Conversation.ProtocolInfo.Proteus
-                )
-                .withConferenceCallMapping()
-                .arrange()
-
-            val result = getCallConversationType.invoke(conversationId)
-
-            assertEquals(ConversationTypeCalling.Conference, result)
+    fun givenSelfConversation_whenGettingCallType_thenReturnUnknown() = runTest {
+        // Given
+        val (arrangement, provider) = arrange {
+            withGetConversationTypeAndProtocolInfoSuccess(
+                type = Conversation.Type.Self,
+                protocolInfo = Conversation.ProtocolInfo.Proteus
+            )
         }
+
+        // When
+        val result = provider(ConversationId("some-id", "some-domain"))
+
+        // Then
+        assertEquals(ConversationTypeCalling.Unknown, result)
+        coVerify { arrangement.conversationMetaDataRepository.getConversationTypeAndProtocolInfo(any()) }.wasInvoked(exactly = once)
+        coVerify { arrangement.userConfigRepository.shouldUseSFTForOneOnOneCalls() }.wasNotInvoked()
+    }
 
     @Test
-    fun givenShouldNotUseSFTAndConversationRepositoryFailure_whenRunningUseCase_thenReturnUnknown() =
-        runTest {
-            val conversationId = TestConversation.ID
-
-            val (_, getCallConversationType) = Arrangement()
-                .withShouldNotUseSFTForOneOnOneCalls()
-                .withGetConversationTypeByIdFailure(conversationId)
-                .withUnknownCallMapping()
-                .arrange()
-
-            val result = getCallConversationType.invoke(conversationId)
-
-            assertEquals(ConversationTypeCalling.Unknown, result)
+    fun givenOneOnOneConversationWithSFTEnabledButSFTCheckFails_whenGettingCallType_thenReturnUnknown() = runTest {
+        // Given
+        val (arrangement, provider) = arrange {
+            withGetConversationTypeAndProtocolInfoSuccess(
+                type = Conversation.Type.OneOnOne,
+                protocolInfo = Conversation.ProtocolInfo.Proteus
+            )
+            withSFTCheckFailure()
         }
+
+        // When
+        val result = provider(ConversationId("some-id", "some-domain"))
+
+        // Then
+        assertEquals(ConversationTypeCalling.Unknown, result)
+        coVerify { arrangement.conversationMetaDataRepository.getConversationTypeAndProtocolInfo(any()) }.wasInvoked(exactly = once)
+        coVerify { arrangement.userConfigRepository.shouldUseSFTForOneOnOneCalls() }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenConnectionPendingConversation_whenGettingCallType_thenReturnUnknown() = runTest {
+        // Given
+        val (arrangement, provider) = arrange {
+            withGetConversationTypeAndProtocolInfoSuccess(
+                type = Conversation.Type.ConnectionPending,
+                protocolInfo = Conversation.ProtocolInfo.Proteus
+            )
+        }
+
+        // When
+        val result = provider(ConversationId("some-id", "some-domain"))
+
+        // Then
+        assertEquals(ConversationTypeCalling.Unknown, result)
+        coVerify { arrangement.conversationMetaDataRepository.getConversationTypeAndProtocolInfo(any()) }.wasInvoked(exactly = once)
+        coVerify { arrangement.userConfigRepository.shouldUseSFTForOneOnOneCalls() }.wasNotInvoked()
+    }
+
+    @Test
+    fun givenGroupConversationWithMixedProtocol_whenGettingCallType_thenReturnConference() = runTest {
+        // Given
+        val (arrangement, provider) = arrange {
+            withGetConversationTypeAndProtocolInfoSuccess(
+                type = Conversation.Type.Group.Regular,
+                protocolInfo = Conversation.ProtocolInfo.Mixed(
+                    groupId = GroupID("groupId"),
+                    groupState = Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED,
+                    epoch = 1.toULong(),
+                    cipherSuite = CipherSuite.Companion.fromTag(1),
+                    keyingMaterialLastUpdate = kotlinx.datetime.Instant.DISTANT_PAST
+                )
+            )
+        }
+
+        // When
+        val result = provider(ConversationId("some-id", "some-domain"))
+
+        // Then
+        assertEquals(ConversationTypeCalling.Conference, result)
+        coVerify { arrangement.conversationMetaDataRepository.getConversationTypeAndProtocolInfo(any()) }.wasInvoked(exactly = once)
+        coVerify { arrangement.userConfigRepository.shouldUseSFTForOneOnOneCalls() }.wasNotInvoked()
+    }
+
+    @Test
+    fun givenGroupConversationWithProteusProtocol_whenGettingCallType_thenReturnConference() = runTest {
+        val (arrangement, getCallConversationType) = arrange {
+            withGetConversationTypeAndProtocolInfoSuccess(
+                type = Conversation.Type.Group.Regular,
+                protocolInfo = Conversation.ProtocolInfo.Proteus
+            )
+        }
+
+        val result = getCallConversationType(ConversationId("some-id", "some-domain"))
+
+        assertEquals(ConversationTypeCalling.Conference, result)
+    }
+
+    @Test
+    fun givenChannelWithProteusProtocol_whenGettingCallType_thenReturnConference() = runTest {
+        val (arrangement, getCallConversationType) = arrange {
+            withGetConversationTypeAndProtocolInfoSuccess(
+                type = Conversation.Type.Group.Channel,
+                protocolInfo = Conversation.ProtocolInfo.Proteus
+            )
+        }
+
+        val result = getCallConversationType(ConversationId("some-id", "some-domain"))
+
+        assertEquals(ConversationTypeCalling.Conference, result)
+    }
+
+    @Test
+    fun givenOneOnOneMLSConversationWithSFTEnabled_whenGettingCallType_thenReturnConferenceMls() = runTest {
+        val (arrangement, getCallConversationType) = arrange {
+            withGetConversationTypeAndProtocolInfoSuccess(
+                type = Conversation.Type.OneOnOne,
+                protocolInfo = Conversation.ProtocolInfo.MLS(
+                    groupId = GroupID("groupId"),
+                    groupState = Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED,
+                    epoch = 1.toULong(),
+                    cipherSuite = CipherSuite.Companion.fromTag(1),
+                    keyingMaterialLastUpdate = kotlinx.datetime.Instant.DISTANT_PAST
+                )
+            )
+            withShouldUseSFTForOneOnOneCalls()
+        }
+
+        val result = getCallConversationType(ConversationId("some-id", "some-domain"))
+
+        assertEquals(ConversationTypeCalling.ConferenceMls, result)
+    }
+
+    @Test
+    fun givenGetConversationTypeAndProtocolInfoFails_whenGettingCallType_thenReturnUnknown() = runTest {
+        val (arrangement, getCallConversationType) = arrange {
+            withGetConversationTypeAndProtocolInfoFailure(Either.Left(StorageFailure.DataNotFound))
+        }
+
+        val result = getCallConversationType(ConversationId("some-id", "some-domain"))
+
+        assertEquals(ConversationTypeCalling.Unknown, result)
+    }
+
 
     private class Arrangement {
-
         @Mock
         val userConfigRepository = mock(UserConfigRepository::class)
 
         @Mock
-        val conversationRepository = mock(ConversationRepository::class)
-
-        @Mock
-        val callMapper = mock(CallMapper::class)
+        val conversationMetaDataRepository = mock(ConversationMetaDataRepository::class)
 
         private val getCallConversationType = GetCallConversationTypeProviderImpl(
             userConfigRepository = userConfigRepository,
-            conversationRepository = conversationRepository,
-            callMapper = callMapper
+            conversationMetaDataRepository = conversationMetaDataRepository
         )
 
+        suspend fun withShouldUseSFTForOneOnOneCalls() = apply {
+            coEvery { userConfigRepository.shouldUseSFTForOneOnOneCalls() }.returns(Either.Right(true))
+        }
+
+        suspend fun withShouldNotUseSFTForOneOnOneCalls() = apply {
+            coEvery { userConfigRepository.shouldUseSFTForOneOnOneCalls() }.returns(Either.Right(false))
+        }
+
+        suspend fun withGetConversationTypeAndProtocolInfoSuccess(
+            type: Conversation.Type,
+            protocolInfo: Conversation.ProtocolInfo
+        ) = apply {
+            coEvery {
+                conversationMetaDataRepository.getConversationTypeAndProtocolInfo(any())
+            }.returns(Either.Right(Pair(type, protocolInfo)))
+        }
+
+        suspend fun withSFTCheckFailure() = apply {
+            coEvery {
+                userConfigRepository.shouldUseSFTForOneOnOneCalls()
+            }.returns(Either.Left(StorageFailure.DataNotFound))
+        }
+
+        suspend fun withGetConversationTypeAndProtocolInfoFailure(result: Either.Left<StorageFailure>) {
+            coEvery {
+                conversationMetaDataRepository.getConversationTypeAndProtocolInfo(any())
+            }.returns(result)
+        }
+
+
         fun arrange() = this to getCallConversationType
-
-        fun withMLSEnabled() = apply {
-            every {
-                userConfigRepository.isMLSEnabled()
-            }.returns(Either.Right(true))
-        }
-
-        fun withMLSDisabled() = apply {
-            every {
-                userConfigRepository.isMLSEnabled()
-            }.returns(Either.Right(false))
-        }
-
-        fun withShouldUseSFTForOneOnOneCalls() = apply {
-            every {
-                userConfigRepository.shouldUseSFTForOneOnOneCalls()
-            }.returns(Either.Right(true))
-        }
-
-        fun withShouldNotUseSFTForOneOnOneCalls() = apply {
-            every {
-                userConfigRepository.shouldUseSFTForOneOnOneCalls()
-            }.returns(Either.Right(false))
-        }
-
-        fun withShouldUseSFTForOneOnOneCallsFailure() = apply {
-            every {
-                userConfigRepository.shouldUseSFTForOneOnOneCalls()
-            }.returns(Either.Left(StorageFailure.DataNotFound))
-        }
-
-        suspend fun withGetConversationTypeByIdSuccess(
-            conversationId: ConversationId,
-            result: Conversation.Type
-        ) = apply {
-            coEvery {
-                conversationRepository.getConversationTypeById(eq(conversationId))
-            }.returns(Either.Right(result))
-        }
-
-        suspend fun withGetConversationTypeByIdFailure(conversationId: ConversationId) = apply {
-            coEvery {
-                conversationRepository.getConversationTypeById(eq(conversationId))
-            }.returns(Either.Left(StorageFailure.DataNotFound))
-        }
-
-        suspend fun withGetConversationProtocolInfoSuccess(
-            conversationId: ConversationId,
-            protocolResult: Conversation.ProtocolInfo
-        ) = apply {
-            coEvery {
-                conversationRepository.getConversationProtocolInfo(eq(conversationId))
-            }.returns(Either.Right(protocolResult))
-        }
-
-        fun withOneOnOneCallMapping() = apply {
-            every {
-                callMapper.fromConversationTypeToConversationTypeForCall(any(), any())
-            }.returns(ConversationTypeForCall.OneOnOne)
-
-            every {
-                callMapper.toConversationTypeCalling(any())
-            }.returns(ConversationTypeCalling.OneOnOne)
-        }
-
-        fun withConferenceCallMapping() = apply {
-            every {
-                callMapper.fromConversationTypeToConversationTypeForCall(any(), any())
-            }.returns(ConversationTypeForCall.Conference)
-
-            every {
-                callMapper.toConversationTypeCalling(any())
-            }.returns(ConversationTypeCalling.Conference)
-        }
-
-        fun withMlsConferenceCallMapping() = apply {
-            every {
-                callMapper.fromConversationTypeToConversationTypeForCall(any(), any())
-            }.returns(ConversationTypeForCall.ConferenceMls)
-
-            every {
-                callMapper.toConversationTypeCalling(any())
-            }.returns(ConversationTypeCalling.ConferenceMls)
-        }
-
-        fun withUnknownCallMapping() = apply {
-            every {
-                callMapper.toConversationTypeCalling(eq(ConversationTypeForCall.Unknown))
-            }.returns(ConversationTypeCalling.Unknown)
-        }
     }
+
+    private fun arrange(block: suspend Arrangement.() -> Unit) = Arrangement().apply { runBlocking { block() } }.arrange()
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/IsAllowedToRegisterMLSClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/IsAllowedToRegisterMLSClientUseCaseTest.kt
@@ -131,14 +131,14 @@ class IsAllowedToRegisterMLSClientUseCaseTest {
             }.returns(enabled)
         }
 
-        fun withUserConfigMlsEnabled(enabled: Boolean) = apply {
-            every {
+        suspend fun withUserConfigMlsEnabled(enabled: Boolean) = apply {
+            coEvery {
                 userConfigRepository.isMLSEnabled()
             }.returns(Either.Right(enabled))
         }
 
-        fun withUserConfigDataNotFound() = apply {
-            every {
+        suspend fun withUserConfigDataNotFound() = apply {
+            coEvery {
                 userConfigRepository.isMLSEnabled()
             }.returns(Either.Left(StorageFailure.DataNotFound))
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/keypackage/MLSKeyPackageCountUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/keypackage/MLSKeyPackageCountUseCaseTest.kt
@@ -132,7 +132,7 @@ class MLSKeyPackageCountUseCaseTest {
 
         val actual = keyPackageCountUseCase()
 
-        verify {
+         coVerify {
             arrangement.userConfigRepository.isMLSEnabled()
         }.wasInvoked(once)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationManagerTest.kt
@@ -168,8 +168,8 @@ class MLSMigrationManagerTest {
             }.returns(Either.Right(Unit))
         }
 
-        fun withIsMLSSupported(supported: Boolean) = apply {
-            every {
+        suspend fun withIsMLSSupported(supported: Boolean) = apply {
+            coEvery {
                 isMLSEnabledUseCase()
             }.returns(supported)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/mls/IsE2EIEnabledUseCaseArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/mls/IsE2EIEnabledUseCaseArrangement.kt
@@ -19,21 +19,22 @@ package com.wire.kalium.logic.util.arrangement.mls
 
 import com.wire.kalium.logic.feature.user.IsE2EIEnabledUseCase
 import io.mockative.Mock
+import io.mockative.coEvery
 import io.mockative.every
 import io.mockative.mock
 
 interface IsE2EIEnabledUseCaseArrangement {
     val isE2EIEnabledUseCase: IsE2EIEnabledUseCase
 
-    fun withE2EIEnabledAndMLSEnabled(result: Boolean)
+    suspend fun withE2EIEnabledAndMLSEnabled(result: Boolean)
 }
 
 class IsE2EIEnabledUseCaseArrangementImpl : IsE2EIEnabledUseCaseArrangement {
     @Mock
     override val isE2EIEnabledUseCase: IsE2EIEnabledUseCase = mock(IsE2EIEnabledUseCase::class)
 
-    override fun withE2EIEnabledAndMLSEnabled(result: Boolean) {
-        every {
+    override suspend fun withE2EIEnabledAndMLSEnabled(result: Boolean) {
+        coEvery {
             isE2EIEnabledUseCase.invoke()
         }.returns(result)
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/UserConfigRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/UserConfigRepositoryArrangement.kt
@@ -39,7 +39,7 @@ internal interface UserConfigRepositoryArrangement {
     fun withSetDefaultProtocolSuccessful()
     fun withGetDefaultProtocolReturning(result: Either<StorageFailure, SupportedProtocol>)
     fun withSetMLSEnabledSuccessful()
-    fun withGetMLSEnabledReturning(result: Either<StorageFailure, Boolean>)
+    suspend fun withGetMLSEnabledReturning(result: Either<StorageFailure, Boolean>)
     suspend fun withSetMigrationConfigurationSuccessful()
     suspend fun withGetMigrationConfigurationReturning(result: Either<StorageFailure, MLSMigrationModel>)
     suspend fun withSetSupportedCipherSuite(result: Either<StorageFailure, Unit>)
@@ -87,8 +87,8 @@ internal class UserConfigRepositoryArrangementImpl : UserConfigRepositoryArrange
         }.returns(Either.Right(Unit))
     }
 
-    override fun withGetMLSEnabledReturning(result: Either<StorageFailure, Boolean>) {
-        every {
+    override suspend fun withGetMLSEnabledReturning(result: Either<StorageFailure, Boolean>) {
+        coEvery {
             userConfigRepository.isMLSEnabled()
         }.returns(result)
     }

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/scenario/OnParticipantListChangedTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/scenario/OnParticipantListChangedTest.kt
@@ -156,8 +156,8 @@ class OnParticipantListChangedTest {
             callingScope = testScope,
         )
 
-        fun withUserConfigRepositoryReturning(result: Either<StorageFailure, Boolean>) = apply {
-            every {
+        suspend fun withUserConfigRepositoryReturning(result: Either<StorageFailure, Boolean>) = apply {
+            coEvery {
                 userConfigRepository.shouldUseSFTForOneOnOneCalls()
             }.returns(result)
         }

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationMetadata.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationMetadata.sq
@@ -1,0 +1,14 @@
+typeAndProtocolInfo:
+SELECT type, is_channel, protocol, mls_group_id, mls_group_state, mls_epoch , mls_last_keying_material_update_date, mls_cipher_suite
+    FROM Conversation
+    WHERE qualified_id = ?;
+
+
+isInformedAboutDegradedMLSVerification:
+SELECT mls_degraded_notified FROM Conversation
+WHERE qualified_id = :qualified_id;
+
+updateInformedAboutDegradedMLSVerification:
+UPDATE Conversation
+SET mls_degraded_notified = ?
+WHERE qualified_id = :qualified_id;

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -161,15 +161,6 @@ UPDATE Conversation
 SET last_read_date = :last_read_date
 WHERE qualified_id = :qualified_id;
 
-isInformedAboutDegradedMLSVerification:
-SELECT mls_degraded_notified FROM Conversation
-WHERE qualified_id = :qualified_id;
-
-updateInformedAboutDegradedMLSVerification:
-UPDATE Conversation
-SET mls_degraded_notified = ?
-WHERE qualified_id = :qualified_id;
-
 updateDegradedConversationNotifiedFlag:
 UPDATE Conversation
 SET degraded_conversation_notified = ?
@@ -226,9 +217,6 @@ SELECT qualified_id FROM Conversation WHERE mls_group_id = ?;
 
 selectConversationIds:
 SELECT qualified_id FROM Conversation WHERE protocol = :protocol AND type = :type AND (:teamId IS NULL OR team_id = :teamId);
-
-getConversationTypeById:
-SELECT type FROM Conversation WHERE qualified_id = ?;
 
 updateConversationMutingStatus:
 UPDATE Conversation

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
@@ -68,7 +68,6 @@ interface ConversationDAO {
         protocol: ConversationEntity.Protocol,
         teamId: String? = null
     ): List<QualifiedIDEntity>
-    suspend fun getConversationTypeById(conversationId: QualifiedIDEntity): ConversationEntity.Type?
 
     suspend fun getTeamConversationIdsReadyToCompleteMigration(teamId: String): List<QualifiedIDEntity>
     suspend fun getOneOnOneConversationIdsWithOtherUser(

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
@@ -262,11 +262,6 @@ internal class ConversationDAOImpl internal constructor(
         }
     }
 
-    override suspend fun getConversationTypeById(conversationId: QualifiedIDEntity): ConversationEntity.Type? =
-        withContext(coroutineContext) {
-            conversationQueries.getConversationTypeById(conversationId).executeAsOneOrNull()
-        }
-
     override suspend fun getTeamConversationIdsReadyToCompleteMigration(teamId: String): List<QualifiedIDEntity> {
         return withContext(coroutineContext) {
             conversationQueries.selectAllTeamProteusConversationsReadyForMigration(teamId)

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationMetaDataDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationMetaDataDAO.kt
@@ -22,4 +22,5 @@ import com.wire.kalium.persistence.dao.QualifiedIDEntity
 interface ConversationMetaDataDAO {
     suspend fun isInformedAboutDegradedMLSVerification(conversationId: QualifiedIDEntity): Boolean
     suspend fun setInformedAboutDegradedMLSVerificationFlag(conversationId: QualifiedIDEntity, isInformed: Boolean)
+    suspend fun typeAndProtocolInfo(conversationId: QualifiedIDEntity): ConversationTypeAndProtocolInfo?
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationMetaDataDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationMetaDataDAOImpl.kt
@@ -18,7 +18,6 @@
 package com.wire.kalium.persistence.dao.conversation
 
 import com.wire.kalium.persistence.ConversationMetadataQueries
-import com.wire.kalium.persistence.ConversationsQueries
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
@@ -28,7 +27,9 @@ class ConversationMetaDataDAOImpl internal constructor(
     private val coroutineContext: CoroutineContext,
     private val conversationMapper: ConversationMapper = ConversationMapper,
 ) : ConversationMetaDataDAO {
-    override suspend fun isInformedAboutDegradedMLSVerification(conversationId: QualifiedIDEntity): Boolean = withContext(coroutineContext) {
+    override suspend fun isInformedAboutDegradedMLSVerification(
+        conversationId: QualifiedIDEntity
+    ): Boolean = withContext(coroutineContext) {
         conversationMetadataQueries.isInformedAboutDegradedMLSVerification(conversationId).executeAsOne()
     }
 
@@ -38,7 +39,9 @@ class ConversationMetaDataDAOImpl internal constructor(
         }
     }
 
-    override suspend fun typeAndProtocolInfo(conversationId: QualifiedIDEntity): ConversationTypeAndProtocolInfo? = withContext(coroutineContext) {
+    override suspend fun typeAndProtocolInfo(
+        conversationId: QualifiedIDEntity
+    ): ConversationTypeAndProtocolInfo? = withContext(coroutineContext) {
         conversationMetadataQueries.typeAndProtocolInfo(conversationId).executeAsOneOrNull()?.let {
             ConversationTypeAndProtocolInfo(
                 type = it.type,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
@@ -325,7 +325,7 @@ class UserDatabaseBuilder internal constructor(
     val searchDAO: SearchDAO get() = SearchDAOImpl(database.searchQueries, queriesContext)
     val conversationMetaDataDAO: ConversationMetaDataDAO
         get() = ConversationMetaDataDAOImpl(
-            database.conversationsQueries,
+            database.conversationMetadataQueries,
             queriesContext
         )
 


### PR DESCRIPTION
### Issues
The call connection was failing when trying to establish 1-1 calls between users when Secure Forwarding Trust (SFT) was enabled on Proteus protocol. This affected users trying to make direct calls in these specific protocol conditions.

### Solutions
Introduced `ConversationMetaDataRepository` to provide a clean way to retrieve conversation type and protocol details. This new component:

1. Streamlines call type determination based on conversation metadata
2. Simplifies MLS protocol integration in conversation handling
3. Provides a consistent way to access conversation properties needed for call establishment

This change allows the calling code to properly identify the protocol being used and apply the appropriate connection logic when SFT is enabled, ensuring calls connect successfully in all protocol configurations.

### Testing
The fix was tested by:
1. Setting up test accounts with SFT for 1:1 enabled on Proteus with MLS client created and no migration
2. Attempting 1-1 calls between these accounts
3. Verifying call connection and audio/video transmission worked properly

After implementing the fix, calls connected successfully in all tested scenarios where they previously failed.