### PR TITLE
feat: improve SQL views and indexes for conversation details and unread events

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -64,8 +64,8 @@ CREATE INDEX conversation_notified_date_index ON Conversation(last_notified_date
 CREATE INDEX conversation_read_date_index ON Conversation(last_read_date);
 CREATE INDEX conversation_creator_index ON Conversation(creator_id);
 CREATE INDEX conversation_verification_status ON Conversation(verification_status);
-CREATE INDEX conversation_archiverd_index ON Conversation(archived);
 CREATE INDEX conversation_muted_status_index ON Conversation(muted_status);
+CREATE INDEX conversation_archived_type_channel_index ON Conversation(archived, type, is_channel);
 
 conversationIDByGroupId:
 SELECT qualified_id, verification_status FROM Conversation WHERE mls_group_id = :groupId;

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/UnreadEvents.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/UnreadEvents.sq
@@ -11,9 +11,8 @@ CREATE TABLE UnreadEvent (
     FOREIGN KEY (id, conversation_id) REFERENCES Message(id, conversation_id) ON DELETE CASCADE ON UPDATE CASCADE,
     PRIMARY KEY (id, conversation_id)
 );
-CREATE INDEX unread_event_conversation ON UnreadEvent(conversation_id);
 CREATE INDEX unread_event_date ON UnreadEvent(creation_date);
-CREATE INDEX unread_event_type ON UnreadEvent(type);
+CREATE INDEX unread_event_conv_tyoe ON UnreadEvent(conversation_id, type);
 
 deleteUnreadEvent:
 DELETE FROM UnreadEvent WHERE id = ? AND conversation_id = ?;

--- a/persistence/src/commonMain/db_user/migrations/104.sqm
+++ b/persistence/src/commonMain/db_user/migrations/104.sqm
@@ -1,3 +1,11 @@
+CREATE INDEX conversation_archived_type_channel_index ON Conversation(archived, type, is_channel);
+CREATE INDEX unread_event_conv_tyoe ON UnreadEvent(conversation_id, type);
+
+DROP INDEX IF EXISTS conversation_archiverd_index;
+DROP INDEX IF EXISTS unread_event_conversation;
+DROP INDEX IF EXISTS  unread_event_type;
+DROP VIEW IF EXISTS ConversationDetailsWithEvents;
+
 CREATE VIEW IF NOT EXISTS ConversationDetailsWithEvents AS
 SELECT
     Conversation.qualified_id AS qualifiedId,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Conversation list feels sluggish on large accounts with older devices.

### Causes (Optional)

missing indexes and large views with a lot of joins
us not repeat ourselves 

### Solutions

1. join the ConversationDetails and the ConversationDetailsWithEvents tables together in one view 
2. add missing indexes 
3. replace  
```sql
COUNT(Mention.user_id) > 0 AS lastMessageIsMentioningSelfUser,
```
with 
```sql
    EXISTS(
        SELECT 1 FROM MessageMention mm
        WHERE mm.message_id = LastMessage.message_id
            AND mm.user_id = SelfUser.id
    ) AS lastMessageIsMentioningSelfUser, <- yes it did make a big dirrance somehow 
```

i did run a small benchmark are running on SQLite 3.49.2 CLI on macbook with an obfuscated version of an actual prod database 
the following options are always used .timer ON and .stats stmt 

and did test 3 versions 
1. old query with 2 indexes added one for the Conversation, and another in UnreadEvent table
2. same as 1 but did rewrite the view to use EXSITS instead of count in the VIEW
3. merged the 2 views together so i can reorder JOINS as i want 
And the results 

version | wall-clock (s) | VM steps | page-cache misses
-- | -- | -- | --
v1 | 0.170 | 311 936 | 2 547
v2 | 0.172 | 226 763 | 2 534
**v3** | **0.164** | **186 467** | **2 205**

this is really nice 40% fewer VM steps which leads to fewer CPU cycles 

but there is more 
i used sqlite .expert with v3 to see if there are any missing indexes and it spits out 
```
    CREATE INDEX LabeledConversation_idx_69c24eb3 ON LabeledConversation(conversation_id, folder_id);
CREATE INDEX ConversationFolder_idx_06fcba25 ON ConversationFolder(folder_type);
CREATE INDEX Call_idx_8cf6e116 ON Call(conversation_id, created_at DESC);
CREATE INDEX Call_idx_00000415 ON Call(id);
CREATE INDEX Conversation_idx_9973027c ON Conversation(archived, protocol);
```
added those and theresults 


version | wall-clock time – s | VM steps | full-scan steps | page-cache misses | peak mem – MB
-- | -- | -- | -- | -- | --
v1 | 0.170 | 311 936 | 1 741 | 2 547 | 2.98
v2 | 0.172 | 226 763 | 881 | 2 534 | 2.98
v3 | 0.164 | 186 467 | 955 | 2 205 | 3.00
v4 | 0.132 ⟵ -20 % vs v3 | 177 812 ⟵ -5 % | 955 | 1 872 ⟵ -15 % | 4.21


Highlights

    ⏱ Fastest yet – shaves another 32 ms from the view load, a full 20 % over v3.

    🧮 Fewest VM opcodes – down 5 % more; now -43 % vs the original.

    📚 Least I/O – 1 872 page misses (-26 % vs v1).

    🪣 Almost zero auto-indexes – only 4 inserts, so the planner is now using the real indexes you added instead of building throw-away ones.

    🗄 Memory – peak rises to 4.2 MB, still tiny for mobile.

also asked chatgpt if this results still holds when using sqlcipher and the result


factor | what SQLCipher changes | why v4 keeps the edge
-- | -- | --
Per-page CPU cost | Every page read/write is AES-GCM/CTR decrypted/encrypted. This adds a few µs of CPU per page miss or spill, independent of the SQL text. | v4 triggers the fewest page-cache misses (1 872) and almost no temp-B-tree writes, so it amortises the encryption tax better than the others.
Memory footprint | SQLCipher allocates a small extra buffer per page, but overall heap use grows by only a few hundred KB for a 4 MB cache. | v4’s peak rose to 4.2 MB, still trivial on modern iOS/Android devices.
Virtual-machine steps | Unaffected by encryption. | v4 already does -43 % VM steps vs v1, and that advantage stays intact.
I/O strategy | mmap is disabled, so all page traffic goes through the pager. | The fewer misses v4 has, the bigger the relative win when each miss is costlier.
Temp files | Temp B-trees are not encrypted by SQLCipher unless you enable PRAGMA cipher_temp_store = 2. | v4 barely writes to temp anyway (4 auto-index inserts).

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
