### PR TITLE
feat: improve SQL views and indexes for conversation details and unread events [WPB-17782]

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Calls.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Calls.sq
@@ -10,12 +10,13 @@ CREATE TABLE Call (
     conversation_type TEXT AS ConversationEntity.Type NOT NULL,
     created_at TEXT NOT NULL,
     type TEXT AS CallEntity.Type NOT NULL DEFAULT 'UNKNOWN',
-    PRIMARY KEY (conversation_id, id)
+    PRIMARY KEY (id, conversation_id)
 );
+
 CREATE INDEX call_date_index ON Call(created_at);
-CREATE INDEX call_conversation_index ON Call(conversation_id);
 CREATE INDEX call_caller_index ON Call(caller_id);
 CREATE INDEX call_status ON Call(status);
+CREATE INDEX Call_idx_conversation_created_at ON Call(conversation_id, created_at DESC);
 
 insertCall:
 INSERT INTO Call(conversation_id, id, status, caller_id, conversation_type, created_at, type)

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationDetailsWithEvents.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationDetailsWithEvents.sq
@@ -1,117 +1,6 @@
 CREATE VIEW IF NOT EXISTS ConversationDetailsWithEvents AS
 SELECT
-    Conversation.qualified_id AS qualifiedId,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN  User.name
-        WHEN 'CONNECTION_PENDING' THEN connection_user.name
-        ELSE Conversation.name
-    END AS name,
-    Conversation.type,
-    Call.status AS callStatus,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN  User.preview_asset_id
-        WHEN 'CONNECTION_PENDING' THEN connection_user.preview_asset_id
-    END AS previewAssetId,
-    Conversation.muted_status AS mutedStatus,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN User.team
-        ELSE Conversation.team_id
-    END AS teamId,
-    CASE (Conversation.type)
-        WHEN 'CONNECTION_PENDING' THEN Connection.last_update_date
-        ELSE Conversation.last_modified_date
-    END AS lastModifiedDate,
-    Conversation.last_read_date AS lastReadDate,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN  User.user_availability_status
-        WHEN 'CONNECTION_PENDING' THEN connection_user.user_availability_status
-    END AS userAvailabilityStatus,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN  User.user_type
-        WHEN 'CONNECTION_PENDING' THEN connection_user.user_type
-    END AS userType,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN  User.bot_service
-        WHEN 'CONNECTION_PENDING' THEN connection_user.bot_service
-    END AS botService,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN  User.deleted
-        WHEN 'CONNECTION_PENDING' THEN connection_user.deleted
-    END AS userDeleted,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN  User.defederated
-        WHEN 'CONNECTION_PENDING' THEN connection_user.defederated
-    END AS userDefederated,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN  User.supported_protocols
-        WHEN 'CONNECTION_PENDING' THEN connection_user.supported_protocols
-    END AS userSupportedProtocols,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN  User.connection_status
-        WHEN 'CONNECTION_PENDING' THEN connection_user.connection_status
-    END AS connectionStatus,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN  User.qualified_id
-        WHEN 'CONNECTION_PENDING' THEN connection_user.qualified_id
-    END AS otherUserId,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN User.active_one_on_one_conversation_id
-        WHEN 'CONNECTION_PENDING' THEN connection_user.active_one_on_one_conversation_id
-    END AS otherUserActiveConversationId,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN coalesce(User.active_one_on_one_conversation_id = Conversation.qualified_id, 0)
-        ELSE 1
-    END AS isActive,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN User.accent_id
-        ELSE 0
-    END AS accentId,
-    Conversation.last_notified_date AS lastNotifiedMessageDate,
-    memberRole. role AS selfRole,
-    Conversation.protocol,
-    Conversation.mls_cipher_suite,
-    Conversation.mls_epoch,
-    Conversation.mls_group_id,
-    Conversation.mls_last_keying_material_update_date,
-    Conversation.mls_group_state,
-    Conversation.access_list,
-    Conversation.access_role_list,
-    Conversation.mls_proposal_timer,
-    Conversation.muted_time,
-    Conversation.creator_id,
-    Conversation.receipt_mode,
-    Conversation.message_timer,
-    Conversation.user_message_timer,
-    Conversation.incomplete_metadata,
-    Conversation.archived,
-    Conversation.archived_date_time,
-    Conversation.verification_status AS mls_verification_status,
-    Conversation.proteus_verification_status,
-    Conversation.legal_hold_status,
-    Conversation.is_channel,
-    Conversation.channel_access,
-    Conversation.channel_add_permission,
-    SelfUser.id AS selfUserId,
-    CASE
-        WHEN Conversation.type = 'GROUP' THEN
-            CASE
-                WHEN memberRole.role IS NOT NULL THEN 1
-                ELSE 0
-            END
-        WHEN Conversation.type = 'ONE_ON_ONE' THEN
-            CASE
-                WHEN User.defederated = 1 THEN 0
-                WHEN User.deleted = 1 THEN 0
-                WHEN User.connection_status = 'BLOCKED' THEN 0
-                WHEN Conversation.legal_hold_status = 'DEGRADED' THEN 0
-                ELSE 1
-            END
-        ELSE 0
-    END AS interactionEnabled,
-    LabeledConversation.folder_id IS NOT NULL AS isFavorite,
-    CurrentFolder.id AS folderId,
-    CurrentFolder.name AS folderName,
-    Conversation.wire_cell AS wireCell,
+    ConversationDetails.*,
     -- unread events
     UnreadEventCountsGrouped.knocksCount AS unreadKnocksCount,
     UnreadEventCountsGrouped.missedCallsCount AS unreadMissedCallsCount,
@@ -119,17 +8,17 @@ SELECT
     UnreadEventCountsGrouped.repliesCount AS unreadRepliesCount,
     UnreadEventCountsGrouped.messagesCount AS unreadMessagesCount,
     CASE
-        WHEN Call.status = 'STILL_ONGOING' AND Conversation.type = 'GROUP' THEN 1 -- if ongoing call in a group, move it to the top
-        WHEN Conversation.muted_status = 'ALL_ALLOWED' THEN
+        WHEN ConversationDetails.callStatus = 'STILL_ONGOING' AND ConversationDetails.type = 'GROUP' THEN 1 -- if ongoing call in a group, move it to the top
+        WHEN ConversationDetails.mutedStatus = 'ALL_ALLOWED' THEN
            CASE
                 WHEN (UnreadEventCountsGrouped.knocksCount + UnreadEventCountsGrouped.missedCallsCount + UnreadEventCountsGrouped.mentionsCount + UnreadEventCountsGrouped.repliesCount + UnreadEventCountsGrouped.messagesCount) > 0 THEN 1 -- if any unread events, move it to the top
-                WHEN Conversation.type = 'CONNECTION_PENDING' AND connection_user.connection_status = 'PENDING' THEN 1 -- if received connection request, move it to the top
+                WHEN ConversationDetails.type = 'CONNECTION_PENDING' AND ConversationDetails.connectionStatus = 'PENDING' THEN 1 -- if received connection request, move it to the top
                 ELSE 0
             END
-        WHEN Conversation.muted_status = 'ONLY_MENTIONS_AND_REPLIES_ALLOWED' THEN
+        WHEN ConversationDetails.mutedStatus = 'ONLY_MENTIONS_AND_REPLIES_ALLOWED' THEN
             CASE
                 WHEN (UnreadEventCountsGrouped.mentionsCount + UnreadEventCountsGrouped.repliesCount) > 0 THEN 1 -- only if unread mentions or replies, move it to the top
-                WHEN Conversation.type = 'CONNECTION_PENDING' AND connection_user.connection_status = 'PENDING' THEN 1 -- if received connection request, move it to the top
+                WHEN ConversationDetails.type = 'CONNECTION_PENDING' AND ConversationDetails.connectionStatus = 'PENDING' THEN 1 -- if received connection request, move it to the top
                 ELSE 0
             END
         ELSE 0
@@ -149,82 +38,46 @@ SELECT
     User.name AS lastMessageSenderName,
     User.connection_status AS lastMessageSenderConnectionStatus,
     User.deleted AS lastMessageSenderIsDeleted,
-    (Message.sender_user_id IS NOT NULL AND Message.sender_user_id == SelfUser.id) AS lastMessageIsSelfMessage,
+    (Message.sender_user_id IS NOT NULL AND Message.sender_user_id == ConversationDetails.selfUserId) AS lastMessageIsSelfMessage,
     MemberChangeContent.member_change_list AS lastMessageMemberChangeList,
     MemberChangeContent.member_change_type AS lastMessageMemberChangeType,
     ConversationNameChangedContent.conversation_name AS lastMessageUpdateConversationName,
-    EXISTS(
-        SELECT 1 FROM MessageMention mm
-        WHERE mm.message_id = LastMessage.message_id
-            AND mm.user_id = SelfUser.id
-    ) AS lastMessageIsMentioningSelfUser,
+    COUNT(Mention.user_id) > 0 AS lastMessageIsMentioningSelfUser,
     TextContent.is_quoting_self AS lastMessageIsQuotingSelfUser,
     TextContent.text_body AS lastMessageText,
     AssetContent.asset_mime_type AS lastMessageAssetMimeType
-FROM Conversation
-LEFT JOIN SelfUser
+FROM ConversationDetails
 LEFT JOIN UnreadEventCountsGrouped
-    ON UnreadEventCountsGrouped.conversationId = Conversation.qualified_id
+    ON UnreadEventCountsGrouped.conversationId = ConversationDetails.qualifiedId
 LEFT JOIN MessageDraft
-    ON Conversation.qualified_id = MessageDraft.conversation_id AND Conversation.archived = 0 -- only return message draft for non-archived conversations
+    ON ConversationDetails.qualifiedId = MessageDraft.conversation_id AND ConversationDetails.archived = 0 -- only return message draft for non-archived conversations
 LEFT JOIN LastMessage
-    ON LastMessage.conversation_id = Conversation.qualified_id AND Conversation.archived = 0 -- only return last message for non-archived conversations
+    ON LastMessage.conversation_id = ConversationDetails.qualifiedId AND ConversationDetails.archived = 0 -- only return last message for non-archived conversations
 LEFT JOIN Message
     ON LastMessage.message_id = Message.id AND LastMessage.conversation_id = Message.conversation_id
 LEFT JOIN User
     ON Message.sender_user_id = User.qualified_id
 LEFT JOIN MessageMemberChangeContent AS MemberChangeContent
     ON LastMessage.message_id = MemberChangeContent.message_id AND LastMessage.conversation_id = MemberChangeContent.conversation_id
--- LEFT JOIN MessageMention AS Mention
---     ON LastMessage.message_id == Mention.message_id AND SelfUser.id == Mention.user_id
+LEFT JOIN MessageMention AS Mention
+    ON LastMessage.message_id == Mention.message_id AND ConversationDetails.selfUserId == Mention.user_id
 LEFT JOIN MessageConversationChangedContent AS ConversationNameChangedContent
     ON LastMessage.message_id = ConversationNameChangedContent.message_id AND LastMessage.conversation_id = ConversationNameChangedContent.conversation_id
 LEFT JOIN MessageAssetContent AS AssetContent
     ON LastMessage.message_id = AssetContent.message_id AND LastMessage.conversation_id = AssetContent.conversation_id
 LEFT JOIN MessageTextContent AS TextContent
     ON LastMessage.message_id = TextContent.message_id AND LastMessage.conversation_id = TextContent.conversation_id
-LEFT JOIN Connection ON Connection.qualified_conversation = Conversation.qualified_id
-LEFT JOIN User AS connection_user ON Connection.qualified_to = connection_user.qualified_id
-LEFT JOIN Call ON Call.id IS (SELECT id FROM Call WHERE Call.conversation_id = Conversation.qualified_id AND Call.status IS 'STILL_ONGOING' ORDER BY created_at DESC LIMIT 1)
-LEFT JOIN Member AS memberRole ON Conversation.qualified_id = memberRole.conversation
-    AND memberRole.user IS SelfUser.id
-LEFT JOIN ConversationFolder AS FavoriteFolder ON FavoriteFolder.folder_type IS 'FAVORITE'
-LEFT JOIN LabeledConversation ON LabeledConversation.conversation_id = Conversation.qualified_id AND LabeledConversation.folder_id = FavoriteFolder.id
-LEFT JOIN LabeledConversation AS ConversationLabel ON ConversationLabel.conversation_id = Conversation.qualified_id AND ConversationLabel.folder_id IS NOT FavoriteFolder.id
-LEFT JOIN ConversationFolder AS CurrentFolder ON CurrentFolder.id = ConversationLabel.folder_id AND CurrentFolder.folder_type IS NOT 'FAVORITE'
 WHERE
-    Conversation.type IS NOT 'SELF'
+    ConversationDetails.type IS NOT 'SELF'
     AND (
-        Conversation.type IS 'GROUP'
-        OR (Conversation.type IS 'ONE_ON_ONE' AND (
-            CASE (Conversation.type)
-                WHEN 'ONE_ON_ONE' THEN  User.name
-                WHEN 'CONNECTION_PENDING' THEN connection_user.name
-                ELSE Conversation.name
-            END IS NOT NULL
-            AND CASE (Conversation.type)
-                WHEN 'ONE_ON_ONE' THEN  User.qualified_id
-                WHEN 'CONNECTION_PENDING' THEN connection_user.qualified_id
-            END IS NOT NULL
-        )) -- show 1:1 convos if they have user metadata
-        OR (Conversation.type IS 'ONE_ON_ONE' AND (
-            CASE (Conversation.type)
-                WHEN 'ONE_ON_ONE' THEN  User.deleted
-                WHEN 'CONNECTION_PENDING' THEN connection_user.deleted
-            END = 1)) -- show deleted 1:1 convos to maintain prev, logic
-        OR (Conversation.type IS 'CONNECTION_PENDING' AND (
-            CASE (Conversation.type)
-                WHEN 'ONE_ON_ONE' THEN  User.qualified_id
-                WHEN 'CONNECTION_PENDING' THEN connection_user.qualified_id
-            END IS NOT NULL)) -- show connection requests even without metadata
+        ConversationDetails.type IS 'GROUP'
+        OR (ConversationDetails.type IS 'ONE_ON_ONE' AND (ConversationDetails.name IS NOT NULL AND ConversationDetails.otherUserId IS NOT NULL)) -- show 1:1 convos if they have user metadata
+        OR (ConversationDetails.type IS 'ONE_ON_ONE' AND ConversationDetails.userDeleted = 1) -- show deleted 1:1 convos to maintain prev, logic
+        OR (ConversationDetails.type IS 'CONNECTION_PENDING' AND ConversationDetails.otherUserId IS NOT NULL) -- show connection requests even without metadata
     )
-    AND (Conversation.protocol IS 'PROTEUS' OR Conversation.protocol IS 'MIXED' OR (Conversation.protocol IS 'MLS' AND Conversation.mls_group_state IS 'ESTABLISHED'))
-    AND (
-        CASE (Conversation.type)
-            WHEN 'ONE_ON_ONE' THEN coalesce(User.active_one_on_one_conversation_id = Conversation.qualified_id, 0)
-            ELSE 1
-        END
-    );
+    AND (ConversationDetails.protocol IS 'PROTEUS' OR ConversationDetails.protocol IS 'MIXED' OR (ConversationDetails.protocol IS 'MLS' AND ConversationDetails.mls_group_state IS 'ESTABLISHED'))
+    AND ConversationDetails.isActive
+GROUP BY ConversationDetails.qualifiedId;
 
 selectAllConversationDetailsWithEvents:
 SELECT * FROM ConversationDetailsWithEvents

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationDetailsWithEvents.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationDetailsWithEvents.sq
@@ -225,3 +225,119 @@ WHERE
             ELSE 1
         END
     );
+
+selectAllConversationDetailsWithEvents:
+SELECT * FROM ConversationDetailsWithEvents
+WHERE archived = :fromArchive
+    AND CASE WHEN :onlyInteractionsEnabled THEN interactionEnabled = 1 ELSE 1 END
+ORDER BY
+    CASE WHEN :newActivitiesOnTop THEN hasNewActivitiesToShow ELSE 0 END DESC,
+    lastModifiedDate DESC,
+    name IS NULL,
+    name COLLATE NOCASE ASC;
+
+selectConversationDetailsWithEvents:
+SELECT * FROM ConversationDetailsWithEvents
+WHERE
+    archived = :fromArchive
+    AND CASE
+        -- When filter is ALL, do not apply additional filters on conversation type
+        WHEN :conversationFilter = 'ALL' THEN 1 = 1
+        -- When filter is GROUPS, filter only group conversations
+        WHEN :conversationFilter = 'GROUPS' THEN (type = 'GROUP' AND is_channel = 0)
+        -- When filter is ONE_ON_ONE, filter only one-on-one conversations
+        WHEN :conversationFilter = 'ONE_ON_ONE' THEN type = 'ONE_ON_ONE'
+        WHEN :conversationFilter = 'CHANNELS' THEN type = 'GROUP' AND is_channel = 1
+        -- When filter is FAVORITES (future implementation)
+
+        ELSE 1 = 0
+    END
+    AND CASE WHEN :onlyInteractionsEnabled THEN interactionEnabled = 1 ELSE 1 END
+    ORDER BY
+        CASE WHEN :newActivitiesOnTop THEN hasNewActivitiesToShow ELSE 0 END DESC,
+        lastModifiedDate DESC,
+        name IS NULL,
+        name COLLATE NOCASE ASC
+    LIMIT :limit
+    OFFSET :offset;
+
+selectConversationDetailsWithEventsFromSearch:
+SELECT * FROM ConversationDetailsWithEvents
+WHERE
+    archived = :fromArchive
+    AND CASE
+        -- When filter is ALL, do not apply additional filters on conversation type
+        WHEN :conversationFilter = 'ALL' THEN 1 = 1
+        -- When filter is GROUPS, filter only group conversations
+        WHEN :conversationFilter = 'GROUPS' THEN (type = 'GROUP' AND is_channel = 0)
+        -- When filter is ONE_ON_ONE, filter only one-on-one conversations
+        WHEN :conversationFilter = 'ONE_ON_ONE' THEN type = 'ONE_ON_ONE'
+        WHEN :conversationFilter = 'CHANNELS' THEN type = 'GROUP' AND is_channel = 1
+
+        -- When filter is FAVORITES (future implementation)
+        ELSE 1 = 0
+    END
+    AND CASE WHEN :onlyInteractionsEnabled THEN interactionEnabled = 1 ELSE 1 END
+    AND name LIKE ('%' || :searchQuery || '%')
+ORDER BY
+    CASE WHEN :newActivitiesOnTop THEN hasNewActivitiesToShow ELSE 0 END DESC,
+    lastModifiedDate DESC,
+    name IS NULL,
+    name COLLATE NOCASE ASC
+LIMIT :limit
+OFFSET :offset;
+
+countConversationDetailsWithEvents:
+SELECT COUNT(*) FROM ConversationDetails
+WHERE
+    ConversationDetails.type IS NOT 'SELF'
+    AND (
+        ConversationDetails.type IS 'GROUP'
+        OR (ConversationDetails.type IS 'ONE_ON_ONE' AND (ConversationDetails.name IS NOT NULL AND ConversationDetails.otherUserId IS NOT NULL)) -- show 1:1 convos if they have user metadata
+        OR (ConversationDetails.type IS 'ONE_ON_ONE' AND ConversationDetails.userDeleted = 1) -- show deleted 1:1 convos to maintain prev, logic
+        OR (ConversationDetails.type IS 'CONNECTION_PENDING' AND ConversationDetails.otherUserId IS NOT NULL) -- show connection requests even without metadata
+    )
+    AND (ConversationDetails.protocol IS 'PROTEUS' OR ConversationDetails.protocol IS 'MIXED' OR (ConversationDetails.protocol IS 'MLS' AND ConversationDetails.mls_group_state IS 'ESTABLISHED'))
+    AND ConversationDetails.isActive
+    AND archived = :fromArchive
+    AND CASE
+        -- When filter is ALL, do not apply additional filters on conversation type
+        WHEN :conversationFilter = 'ALL' THEN 1 = 1
+        -- When filter is GROUPS, filter only group conversations
+        WHEN :conversationFilter = 'GROUPS' THEN (type = 'GROUP' AND is_channel = 0)
+        -- When filter is ONE_ON_ONE, filter only one-on-one conversations
+        WHEN :conversationFilter = 'ONE_ON_ONE' THEN type = 'ONE_ON_ONE'
+        WHEN :conversationFilter = 'CHANNELS' THEN type = 'GROUP' AND is_channel = 1
+
+        -- When filter is FAVORITES (future implementation)
+        ELSE 1 = 0
+    END
+    AND CASE WHEN :onlyInteractionsEnabled THEN interactionEnabled = 1 ELSE 1 END;
+
+countConversationDetailsWithEventsFromSearch:
+SELECT COUNT(*) FROM ConversationDetails
+WHERE
+    ConversationDetails.type IS NOT 'SELF'
+    AND (
+        ConversationDetails.type IS 'GROUP'
+        OR (ConversationDetails.type IS 'ONE_ON_ONE' AND (ConversationDetails.name IS NOT NULL AND ConversationDetails.otherUserId IS NOT NULL)) -- show 1:1 convos if they have user metadata
+        OR (ConversationDetails.type IS 'ONE_ON_ONE' AND ConversationDetails.userDeleted = 1) -- show deleted 1:1 convos to maintain prev, logic
+        OR (ConversationDetails.type IS 'CONNECTION_PENDING' AND ConversationDetails.otherUserId IS NOT NULL) -- show connection requests even without metadata
+    )
+    AND (ConversationDetails.protocol IS 'PROTEUS' OR ConversationDetails.protocol IS 'MIXED' OR (ConversationDetails.protocol IS 'MLS' AND ConversationDetails.mls_group_state IS 'ESTABLISHED'))
+    AND ConversationDetails.isActive
+    AND archived = :fromArchive
+    AND CASE
+        -- When filter is ALL, do not apply additional filters on conversation type
+        WHEN :conversationFilter = 'ALL' THEN 1 = 1
+        -- When filter is GROUPS, filter only group conversations
+        WHEN :conversationFilter = 'GROUPS' THEN (type = 'GROUP' AND is_channel = 0)
+        -- When filter is ONE_ON_ONE, filter only one-on-one conversations
+        WHEN :conversationFilter = 'ONE_ON_ONE' THEN type = 'ONE_ON_ONE'
+        WHEN :conversationFilter = 'CHANNELS' THEN type = 'GROUP' AND is_channel = 1
+
+        -- When filter is FAVORITES (future implementation)
+        ELSE 1 = 0
+    END
+    AND CASE WHEN :onlyInteractionsEnabled THEN interactionEnabled = 1 ELSE 1 END
+    AND name LIKE ('%' || :searchQuery || '%');

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationFolders.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationFolders.sq
@@ -6,6 +6,7 @@ CREATE TABLE ConversationFolder (
     name TEXT NOT NULL,
     folder_type TEXT AS ConversationFolderTypeEntity NOT NULL
 );
+CREATE INDEX ConversationFolder_idx_type ON ConversationFolder(folder_type);
 
 CREATE TABLE LabeledConversation (
       conversation_id TEXT AS QualifiedIDEntity NOT NULL,
@@ -13,7 +14,7 @@ CREATE TABLE LabeledConversation (
 
       FOREIGN KEY (folder_id) REFERENCES ConversationFolder(id) ON DELETE CASCADE ON UPDATE CASCADE,
 
-      PRIMARY KEY (folder_id, conversation_id)
+      PRIMARY KEY (conversation_id, folder_id)
 );
 
 getFolders:

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -64,8 +64,8 @@ CREATE INDEX conversation_notified_date_index ON Conversation(last_notified_date
 CREATE INDEX conversation_read_date_index ON Conversation(last_read_date);
 CREATE INDEX conversation_creator_index ON Conversation(creator_id);
 CREATE INDEX conversation_verification_status ON Conversation(verification_status);
-CREATE INDEX conversation_archiverd_index ON Conversation(archived);
 CREATE INDEX conversation_muted_status_index ON Conversation(muted_status);
+CREATE INDEX conversation_archived_type_channel_index ON Conversation(archived, type, is_channel);
 
 conversationIDByGroupId:
 SELECT qualified_id, verification_status FROM Conversation WHERE mls_group_id = :groupId;

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -66,6 +66,7 @@ CREATE INDEX conversation_creator_index ON Conversation(creator_id);
 CREATE INDEX conversation_verification_status ON Conversation(verification_status);
 CREATE INDEX conversation_muted_status_index ON Conversation(muted_status);
 CREATE INDEX conversation_archived_type_channel_index ON Conversation(archived, type, is_channel);
+CREATE INDEX Conversation_idx_archived_protocol ON Conversation(archived, protocol);
 
 conversationIDByGroupId:
 SELECT qualified_id, verification_status FROM Conversation WHERE mls_group_id = :groupId;

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Members.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Members.sq
@@ -10,7 +10,7 @@ CREATE TABLE Member (
     FOREIGN KEY (user) REFERENCES User(qualified_id) ON DELETE CASCADE
 );
 
-CREATE INDEX member_conversation_index ON Member(conversation);
+CREATE INDEX Member_idx_conversation_user ON Member(conversation, user);
 
 insertMember:
 INSERT OR IGNORE INTO Member(user, conversation, role)

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/UnreadEvents.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/UnreadEvents.sq
@@ -11,9 +11,8 @@ CREATE TABLE UnreadEvent (
     FOREIGN KEY (id, conversation_id) REFERENCES Message(id, conversation_id) ON DELETE CASCADE ON UPDATE CASCADE,
     PRIMARY KEY (id, conversation_id)
 );
-CREATE INDEX unread_event_conversation ON UnreadEvent(conversation_id);
 CREATE INDEX unread_event_date ON UnreadEvent(creation_date);
-CREATE INDEX unread_event_type ON UnreadEvent(type);
+CREATE INDEX unread_event_conv_tyoe ON UnreadEvent(conversation_id, type);
 
 deleteUnreadEvent:
 DELETE FROM UnreadEvent WHERE id = ? AND conversation_id = ?;

--- a/persistence/src/commonMain/db_user/migrations/104.sqm
+++ b/persistence/src/commonMain/db_user/migrations/104.sqm
@@ -268,3 +268,5 @@ WHERE
     AND (ConversationDetails.protocol IS 'PROTEUS' OR ConversationDetails.protocol IS 'MIXED' OR (ConversationDetails.protocol IS 'MLS' AND ConversationDetails.mls_group_state IS 'ESTABLISHED'))
     AND ConversationDetails.isActive
 GROUP BY ConversationDetails.qualifiedId;
+
+PRAGMA optimize;

--- a/persistence/src/commonMain/db_user/migrations/104.sqm
+++ b/persistence/src/commonMain/db_user/migrations/104.sqm
@@ -1,3 +1,11 @@
+CREATE INDEX conversation_archived_type_channel_index ON Conversation(archived, type, is_channel);
+CREATE INDEX unread_event_conv_tyoe ON UnreadEvent(conversation_id, type);
+
+DROP INDEX IF EXISTS conversation_archiverd_index;
+DROP INDEX IF EXISTS unread_event_conversation;
+DROP INDEX IF EXISTS  unread_event_type;
+DROP VIEW IF EXISTS ConversationDetailsWithEvents;
+
 CREATE VIEW IF NOT EXISTS ConversationDetailsWithEvents AS
 SELECT
     Conversation.qualified_id AS qualifiedId,

--- a/persistence/src/commonMain/db_user/migrations/104.sqm
+++ b/persistence/src/commonMain/db_user/migrations/104.sqm
@@ -1,5 +1,4 @@
 PRAGMA foreign_keys = 0;
-BEGIN TRANSACTION;
 
 CREATE TABLE Call_new (
     conversation_id   TEXT AS QualifiedIDEntity   NOT NULL,
@@ -47,7 +46,7 @@ CREATE INDEX unread_event_conv_tyoe ON UnreadEvent(conversation_id, type);
 
 DROP INDEX IF EXISTS conversation_archiverd_index;
 DROP INDEX IF EXISTS unread_event_conversation;
-DROP INDEX IF EXISTS  unread_event_type;
+DROP INDEX IF EXISTS unread_event_type;
 DROP INDEX IF EXISTS call_conversation_index;
 
 CREATE INDEX Call_idx_conversation_created_at ON Call(conversation_id, created_at DESC);

--- a/persistence/src/commonMain/db_user/migrations/104.sqm
+++ b/persistence/src/commonMain/db_user/migrations/104.sqm
@@ -6,34 +6,29 @@ DROP VIEW IF EXISTS ConversationDetailsWithEvents;
 DROP VIEW IF EXISTS ConversationDetails;
 
 CREATE TABLE Call_new (
-    conversation_id   TEXT  NOT NULL,
-    id                TEXT                        NOT NULL,
-    status            TEXT   NOT NULL,
-    caller_id         TEXT                        NOT NULL,
-    conversation_type TEXT NOT NULL,
-    created_at        TEXT                        NOT NULL,
-    type              TEXT     NOT NULL DEFAULT 'UNKNOWN',
+    conversation_id TEXT AS QualifiedIDEntity NOT NULL,
+    id TEXT NOT NULL,
+    status TEXT AS CallEntity.Status NOT NULL,
+    caller_id TEXT NOT NULL,
+    conversation_type TEXT AS ConversationEntity.Type NOT NULL,
+    created_at TEXT NOT NULL,
+    type TEXT AS CallEntity.Type NOT NULL DEFAULT 'UNKNOWN',
     PRIMARY KEY (id, conversation_id)
 );
-INSERT INTO Call_new (conversation_id, id, status, caller_id,
-                      conversation_type, created_at, type)
-SELECT conversation_id, id, status, caller_id,
-       conversation_type, created_at, type
+INSERT INTO Call_new (conversation_id, id, status, caller_id, conversation_type, created_at, type)
+SELECT conversation_id, id, status, caller_id, conversation_type, created_at, type
 FROM   Call;
 
 DROP TABLE Call;
 ALTER TABLE Call_new RENAME TO Call;
 
 CREATE TABLE LabeledConversation_new (
-    conversation_id TEXT NOT NULL,
-    folder_id       TEXT                      NOT NULL,
+      conversation_id TEXT AS QualifiedIDEntity NOT NULL,
+      folder_id TEXT NOT NULL,
 
-    FOREIGN KEY (folder_id)
-        REFERENCES ConversationFolder(id)
-        ON DELETE CASCADE
-        ON UPDATE CASCADE,
+      FOREIGN KEY (folder_id) REFERENCES ConversationFolder(id) ON DELETE CASCADE ON UPDATE CASCADE,
 
-    PRIMARY KEY (conversation_id, folder_id)
+      PRIMARY KEY (conversation_id, folder_id)
 );
 
 INSERT INTO LabeledConversation_new (conversation_id, folder_id)

--- a/persistence/src/commonMain/db_user/migrations/104.sqm
+++ b/persistence/src/commonMain/db_user/migrations/104.sqm
@@ -1,4 +1,4 @@
-PRAGMA foreign_keys = OFF;
+PRAGMA foreign_keys = 0;
 BEGIN TRANSACTION;
 
 CREATE TABLE Call_new (
@@ -40,7 +40,7 @@ FROM   LabeledConversation;
 DROP TABLE LabeledConversation;
 ALTER TABLE LabeledConversation_new RENAME TO LabeledConversation;
 
-PRAGMA foreign_keys = ON;
+PRAGMA foreign_keys = 1;
 
 CREATE INDEX conversation_archived_type_channel_index ON Conversation(archived, type, is_channel);
 CREATE INDEX unread_event_conv_tyoe ON UnreadEvent(conversation_id, type);

--- a/persistence/src/commonMain/db_user/migrations/104.sqm
+++ b/persistence/src/commonMain/db_user/migrations/104.sqm
@@ -1,9 +1,59 @@
+PRAGMA foreign_keys = OFF;
+BEGIN TRANSACTION;
+
+CREATE TABLE Call_new (
+    conversation_id   TEXT AS QualifiedIDEntity   NOT NULL,
+    id                TEXT                        NOT NULL,
+    status            TEXT AS CallEntity.Status   NOT NULL,
+    caller_id         TEXT                        NOT NULL,
+    conversation_type TEXT AS ConversationEntity.Type NOT NULL,
+    created_at        TEXT                        NOT NULL,
+    type              TEXT AS CallEntity.Type     NOT NULL DEFAULT 'UNKNOWN',
+    PRIMARY KEY (id, conversation_id)
+);
+INSERT INTO Call_new (conversation_id, id, status, caller_id,
+                      conversation_type, created_at, type)
+SELECT conversation_id, id, status, caller_id,
+       conversation_type, created_at, type
+FROM   Call;
+
+DROP TABLE Call;
+ALTER TABLE Call_new RENAME TO Call;
+
+
+CREATE TABLE LabeledConversation_new (
+    conversation_id TEXT AS QualifiedIDEntity NOT NULL,
+    folder_id       TEXT                      NOT NULL,
+
+    FOREIGN KEY (folder_id)
+        REFERENCES ConversationFolder(id)
+        ON DELETE CASCADE
+        ON UPDATE CASCADE,
+
+    PRIMARY KEY (conversation_id, folder_id)
+);
+
+INSERT INTO LabeledConversation_new (conversation_id, folder_id)
+SELECT conversation_id, folder_id
+FROM   LabeledConversation;
+
+DROP TABLE LabeledConversation;
+ALTER TABLE LabeledConversation_new RENAME TO LabeledConversation;
+
+PRAGMA foreign_keys = ON;
+
 CREATE INDEX conversation_archived_type_channel_index ON Conversation(archived, type, is_channel);
 CREATE INDEX unread_event_conv_tyoe ON UnreadEvent(conversation_id, type);
 
 DROP INDEX IF EXISTS conversation_archiverd_index;
 DROP INDEX IF EXISTS unread_event_conversation;
 DROP INDEX IF EXISTS  unread_event_type;
+DROP INDEX IF EXISTS call_conversation_index;
+
+CREATE INDEX Call_idx_conversation_created_at ON Call(conversation_id, created_at DESC);
+CREATE INDEX ConversationFolder_idx_type ON ConversationFolder(folder_type);
+CREATE INDEX Conversation_idx_archived_protocol ON Conversation(archived, protocol);
+
 DROP VIEW IF EXISTS ConversationDetailsWithEvents;
 
 CREATE VIEW IF NOT EXISTS ConversationDetailsWithEvents AS

--- a/persistence/src/commonMain/db_user/migrations/104.sqm
+++ b/persistence/src/commonMain/db_user/migrations/104.sqm
@@ -38,20 +38,22 @@ FROM   LabeledConversation;
 DROP TABLE LabeledConversation;
 ALTER TABLE LabeledConversation_new RENAME TO LabeledConversation;
 
-PRAGMA foreign_keys = 1;
-
-CREATE INDEX conversation_archived_type_channel_index ON Conversation(archived, type, is_channel);
-CREATE INDEX unread_event_conv_tyoe ON UnreadEvent(conversation_id, type);
+CREATE INDEX IF NOT EXISTS conversation_archived_type_channel_index ON Conversation(archived, type, is_channel);
+CREATE INDEX IF NOT EXISTS unread_event_conv_tyoe ON UnreadEvent(conversation_id, type);
 
 DROP INDEX IF EXISTS conversation_archiverd_index;
 DROP INDEX IF EXISTS unread_event_conversation;
 DROP INDEX IF EXISTS unread_event_type;
 DROP INDEX IF EXISTS call_conversation_index;
 
-CREATE INDEX Call_idx_conversation_created_at ON Call(conversation_id, created_at DESC);
-CREATE INDEX ConversationFolder_idx_type ON ConversationFolder(folder_type);
-CREATE INDEX Conversation_idx_archived_protocol ON Conversation(archived, protocol);
-CREATE INDEX Member_idx_conversation_user ON Member(conversation, user);
+CREATE INDEX IF NOT EXISTS call_date_index ON Call(created_at);
+CREATE INDEX IF NOT EXISTS call_caller_index ON Call(caller_id);
+CREATE INDEX IF NOT EXISTS call_status ON Call(status);
+CREATE INDEX IF NOT EXISTS Call_idx_conversation_created_at ON Call(conversation_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS ConversationFolder_idx_type ON ConversationFolder(folder_type);
+CREATE INDEX IF NOT EXISTS Conversation_idx_archived_protocol ON Conversation(archived, protocol);
+CREATE INDEX IF NOT EXISTS Member_idx_conversation_user ON Member(conversation, user);
 DROP INDEX member_conversation_index;
 
 CREATE VIEW IF NOT EXISTS ConversationDetails AS
@@ -268,5 +270,6 @@ WHERE
     AND (ConversationDetails.protocol IS 'PROTEUS' OR ConversationDetails.protocol IS 'MIXED' OR (ConversationDetails.protocol IS 'MLS' AND ConversationDetails.mls_group_state IS 'ESTABLISHED'))
     AND ConversationDetails.isActive
 GROUP BY ConversationDetails.qualifiedId;
+PRAGMA foreign_keys = 1;
 
 PRAGMA optimize;

--- a/persistence/src/commonMain/db_user/migrations/104.sqm
+++ b/persistence/src/commonMain/db_user/migrations/104.sqm
@@ -1,13 +1,18 @@
 PRAGMA foreign_keys = 0;
+-- since tables that uses those views will be droped we need to drop the views first
+-- but this have 0 changes to the views
+
+DROP VIEW IF EXISTS ConversationDetailsWithEvents;
+DROP VIEW IF EXISTS ConversationDetails;
 
 CREATE TABLE Call_new (
-    conversation_id   TEXT AS QualifiedIDEntity   NOT NULL,
+    conversation_id   TEXT  NOT NULL,
     id                TEXT                        NOT NULL,
-    status            TEXT AS CallEntity.Status   NOT NULL,
+    status            TEXT   NOT NULL,
     caller_id         TEXT                        NOT NULL,
-    conversation_type TEXT AS ConversationEntity.Type NOT NULL,
+    conversation_type TEXT NOT NULL,
     created_at        TEXT                        NOT NULL,
-    type              TEXT AS CallEntity.Type     NOT NULL DEFAULT 'UNKNOWN',
+    type              TEXT     NOT NULL DEFAULT 'UNKNOWN',
     PRIMARY KEY (id, conversation_id)
 );
 INSERT INTO Call_new (conversation_id, id, status, caller_id,
@@ -19,9 +24,8 @@ FROM   Call;
 DROP TABLE Call;
 ALTER TABLE Call_new RENAME TO Call;
 
-
 CREATE TABLE LabeledConversation_new (
-    conversation_id TEXT AS QualifiedIDEntity NOT NULL,
+    conversation_id TEXT NOT NULL,
     folder_id       TEXT                      NOT NULL,
 
     FOREIGN KEY (folder_id)
@@ -52,123 +56,146 @@ DROP INDEX IF EXISTS call_conversation_index;
 CREATE INDEX Call_idx_conversation_created_at ON Call(conversation_id, created_at DESC);
 CREATE INDEX ConversationFolder_idx_type ON ConversationFolder(folder_type);
 CREATE INDEX Conversation_idx_archived_protocol ON Conversation(archived, protocol);
+CREATE INDEX Member_idx_conversation_user ON Member(conversation, user);
+DROP INDEX member_conversation_index;
 
-DROP VIEW IF EXISTS ConversationDetailsWithEvents;
+CREATE VIEW IF NOT EXISTS ConversationDetails AS
+SELECT
+Conversation.qualified_id AS qualifiedId,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.name
+    WHEN 'CONNECTION_PENDING' THEN connection_user.name
+    ELSE Conversation.name
+END AS name,
+Conversation.type,
+Call.status AS callStatus,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.preview_asset_id
+    WHEN 'CONNECTION_PENDING' THEN connection_user.preview_asset_id
+END AS previewAssetId,
+Conversation.muted_status AS mutedStatus,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN User.team
+    ELSE Conversation.team_id
+END AS teamId,
+CASE (Conversation.type)
+    WHEN 'CONNECTION_PENDING' THEN Connection.last_update_date
+    ELSE Conversation.last_modified_date
+END AS lastModifiedDate,
+Conversation.last_read_date AS lastReadDate,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.user_availability_status
+    WHEN 'CONNECTION_PENDING' THEN connection_user.user_availability_status
+END AS userAvailabilityStatus,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.user_type
+    WHEN 'CONNECTION_PENDING' THEN connection_user.user_type
+END AS userType,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.bot_service
+    WHEN 'CONNECTION_PENDING' THEN connection_user.bot_service
+END AS botService,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.deleted
+    WHEN 'CONNECTION_PENDING' THEN connection_user.deleted
+END AS userDeleted,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.defederated
+    WHEN 'CONNECTION_PENDING' THEN connection_user.defederated
+END AS userDefederated,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.supported_protocols
+    WHEN 'CONNECTION_PENDING' THEN connection_user.supported_protocols
+END AS userSupportedProtocols,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.connection_status
+    WHEN 'CONNECTION_PENDING' THEN connection_user.connection_status
+END AS connectionStatus,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.qualified_id
+    WHEN 'CONNECTION_PENDING' THEN connection_user.qualified_id
+END AS otherUserId,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN User.active_one_on_one_conversation_id
+    WHEN 'CONNECTION_PENDING' THEN connection_user.active_one_on_one_conversation_id
+END AS otherUserActiveConversationId,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN coalesce(User.active_one_on_one_conversation_id = Conversation.qualified_id, 0)
+    ELSE 1
+END AS isActive,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN User.accent_id
+    ELSE 0
+END AS accentId,
+Conversation.last_notified_date AS lastNotifiedMessageDate,
+memberRole. role AS selfRole,
+Conversation.protocol,
+Conversation.mls_cipher_suite,
+Conversation.mls_epoch,
+Conversation.mls_group_id,
+Conversation.mls_last_keying_material_update_date,
+Conversation.mls_group_state,
+Conversation.access_list,
+Conversation.access_role_list,
+Conversation.mls_proposal_timer,
+Conversation.muted_time,
+Conversation.creator_id,
+Conversation.receipt_mode,
+Conversation.message_timer,
+Conversation.user_message_timer,
+Conversation.incomplete_metadata,
+Conversation.archived,
+Conversation.archived_date_time,
+Conversation.verification_status AS mls_verification_status,
+Conversation.proteus_verification_status,
+Conversation.legal_hold_status,
+Conversation.is_channel,
+Conversation.channel_access,
+Conversation.channel_add_permission,
+SelfUser.id AS selfUserId,
+CASE
+    WHEN Conversation.type = 'GROUP' THEN
+        CASE
+            WHEN memberRole.role IS NOT NULL THEN 1
+            ELSE 0
+        END
+    WHEN Conversation.type = 'ONE_ON_ONE' THEN
+        CASE
+            WHEN User.defederated = 1 THEN 0
+            WHEN User.deleted = 1 THEN 0
+            WHEN User.connection_status = 'BLOCKED' THEN 0
+            WHEN Conversation.legal_hold_status = 'DEGRADED' THEN 0
+            ELSE 1
+        END
+    ELSE 0
+END AS interactionEnabled,
+LabeledConversation.folder_id IS NOT NULL AS isFavorite,
+CurrentFolder.id AS folderId,
+CurrentFolder.name AS folderName,
+Conversation.wire_cell AS wireCell
+FROM Conversation
+LEFT JOIN SelfUser
+LEFT JOIN Member ON Conversation.qualified_id = Member.conversation
+    AND Conversation.type IS 'ONE_ON_ONE'
+    AND Member.user IS NOT SelfUser.id
+LEFT JOIN Member AS memberRole ON Conversation.qualified_id = memberRole.conversation
+    AND memberRole.user IS SelfUser.id
+LEFT JOIN User ON User.qualified_id = Member.user
+LEFT JOIN Connection ON Connection.qualified_conversation = Conversation.qualified_id
+    AND (Connection.status = 'SENT'
+         OR Connection.status = 'PENDING'
+         OR Connection.status = 'NOT_CONNECTED'
+         AND Conversation.type IS 'CONNECTION_PENDING')
+LEFT JOIN User AS connection_user ON Connection.qualified_to = connection_user.qualified_id
+LEFT JOIN Call ON Call.id IS (SELECT id FROM Call WHERE Call.conversation_id = Conversation.qualified_id AND Call.status IS 'STILL_ONGOING' ORDER BY created_at DESC LIMIT 1)
+LEFT JOIN ConversationFolder AS FavoriteFolder ON FavoriteFolder.folder_type IS 'FAVORITE'
+LEFT JOIN LabeledConversation ON LabeledConversation.conversation_id = Conversation.qualified_id AND LabeledConversation.folder_id = FavoriteFolder.id
+LEFT JOIN LabeledConversation AS ConversationLabel ON ConversationLabel.conversation_id = Conversation.qualified_id AND ConversationLabel.folder_id IS NOT FavoriteFolder.id
+LEFT JOIN ConversationFolder AS CurrentFolder ON CurrentFolder.id = ConversationLabel.folder_id AND CurrentFolder.folder_type IS NOT 'FAVORITE';
 
 CREATE VIEW IF NOT EXISTS ConversationDetailsWithEvents AS
 SELECT
-    Conversation.qualified_id AS qualifiedId,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN  User.name
-        WHEN 'CONNECTION_PENDING' THEN connection_user.name
-        ELSE Conversation.name
-    END AS name,
-    Conversation.type,
-    Call.status AS callStatus,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN  User.preview_asset_id
-        WHEN 'CONNECTION_PENDING' THEN connection_user.preview_asset_id
-    END AS previewAssetId,
-    Conversation.muted_status AS mutedStatus,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN User.team
-        ELSE Conversation.team_id
-    END AS teamId,
-    CASE (Conversation.type)
-        WHEN 'CONNECTION_PENDING' THEN Connection.last_update_date
-        ELSE Conversation.last_modified_date
-    END AS lastModifiedDate,
-    Conversation.last_read_date AS lastReadDate,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN  User.user_availability_status
-        WHEN 'CONNECTION_PENDING' THEN connection_user.user_availability_status
-    END AS userAvailabilityStatus,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN  User.user_type
-        WHEN 'CONNECTION_PENDING' THEN connection_user.user_type
-    END AS userType,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN  User.bot_service
-        WHEN 'CONNECTION_PENDING' THEN connection_user.bot_service
-    END AS botService,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN  User.deleted
-        WHEN 'CONNECTION_PENDING' THEN connection_user.deleted
-    END AS userDeleted,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN  User.defederated
-        WHEN 'CONNECTION_PENDING' THEN connection_user.defederated
-    END AS userDefederated,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN  User.supported_protocols
-        WHEN 'CONNECTION_PENDING' THEN connection_user.supported_protocols
-    END AS userSupportedProtocols,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN  User.connection_status
-        WHEN 'CONNECTION_PENDING' THEN connection_user.connection_status
-    END AS connectionStatus,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN  User.qualified_id
-        WHEN 'CONNECTION_PENDING' THEN connection_user.qualified_id
-    END AS otherUserId,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN User.active_one_on_one_conversation_id
-        WHEN 'CONNECTION_PENDING' THEN connection_user.active_one_on_one_conversation_id
-    END AS otherUserActiveConversationId,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN coalesce(User.active_one_on_one_conversation_id = Conversation.qualified_id, 0)
-        ELSE 1
-    END AS isActive,
-    CASE (Conversation.type)
-        WHEN 'ONE_ON_ONE' THEN User.accent_id
-        ELSE 0
-    END AS accentId,
-    Conversation.last_notified_date AS lastNotifiedMessageDate,
-    memberRole. role AS selfRole,
-    Conversation.protocol,
-    Conversation.mls_cipher_suite,
-    Conversation.mls_epoch,
-    Conversation.mls_group_id,
-    Conversation.mls_last_keying_material_update_date,
-    Conversation.mls_group_state,
-    Conversation.access_list,
-    Conversation.access_role_list,
-    Conversation.mls_proposal_timer,
-    Conversation.muted_time,
-    Conversation.creator_id,
-    Conversation.receipt_mode,
-    Conversation.message_timer,
-    Conversation.user_message_timer,
-    Conversation.incomplete_metadata,
-    Conversation.archived,
-    Conversation.archived_date_time,
-    Conversation.verification_status AS mls_verification_status,
-    Conversation.proteus_verification_status,
-    Conversation.legal_hold_status,
-    Conversation.is_channel,
-    Conversation.channel_access,
-    Conversation.channel_add_permission,
-    SelfUser.id AS selfUserId,
-    CASE
-        WHEN Conversation.type = 'GROUP' THEN
-            CASE
-                WHEN memberRole.role IS NOT NULL THEN 1
-                ELSE 0
-            END
-        WHEN Conversation.type = 'ONE_ON_ONE' THEN
-            CASE
-                WHEN User.defederated = 1 THEN 0
-                WHEN User.deleted = 1 THEN 0
-                WHEN User.connection_status = 'BLOCKED' THEN 0
-                WHEN Conversation.legal_hold_status = 'DEGRADED' THEN 0
-                ELSE 1
-            END
-        ELSE 0
-    END AS interactionEnabled,
-    LabeledConversation.folder_id IS NOT NULL AS isFavorite,
-    CurrentFolder.id AS folderId,
-    CurrentFolder.name AS folderName,
-    Conversation.wire_cell AS wireCell,
+    ConversationDetails.*,
     -- unread events
     UnreadEventCountsGrouped.knocksCount AS unreadKnocksCount,
     UnreadEventCountsGrouped.missedCallsCount AS unreadMissedCallsCount,
@@ -176,17 +203,17 @@ SELECT
     UnreadEventCountsGrouped.repliesCount AS unreadRepliesCount,
     UnreadEventCountsGrouped.messagesCount AS unreadMessagesCount,
     CASE
-        WHEN Call.status = 'STILL_ONGOING' AND Conversation.type = 'GROUP' THEN 1 -- if ongoing call in a group, move it to the top
-        WHEN Conversation.muted_status = 'ALL_ALLOWED' THEN
+        WHEN ConversationDetails.callStatus = 'STILL_ONGOING' AND ConversationDetails.type = 'GROUP' THEN 1 -- if ongoing call in a group, move it to the top
+        WHEN ConversationDetails.mutedStatus = 'ALL_ALLOWED' THEN
            CASE
                 WHEN (UnreadEventCountsGrouped.knocksCount + UnreadEventCountsGrouped.missedCallsCount + UnreadEventCountsGrouped.mentionsCount + UnreadEventCountsGrouped.repliesCount + UnreadEventCountsGrouped.messagesCount) > 0 THEN 1 -- if any unread events, move it to the top
-                WHEN Conversation.type = 'CONNECTION_PENDING' AND connection_user.connection_status = 'PENDING' THEN 1 -- if received connection request, move it to the top
+                WHEN ConversationDetails.type = 'CONNECTION_PENDING' AND ConversationDetails.connectionStatus = 'PENDING' THEN 1 -- if received connection request, move it to the top
                 ELSE 0
             END
-        WHEN Conversation.muted_status = 'ONLY_MENTIONS_AND_REPLIES_ALLOWED' THEN
+        WHEN ConversationDetails.mutedStatus = 'ONLY_MENTIONS_AND_REPLIES_ALLOWED' THEN
             CASE
                 WHEN (UnreadEventCountsGrouped.mentionsCount + UnreadEventCountsGrouped.repliesCount) > 0 THEN 1 -- only if unread mentions or replies, move it to the top
-                WHEN Conversation.type = 'CONNECTION_PENDING' AND connection_user.connection_status = 'PENDING' THEN 1 -- if received connection request, move it to the top
+                WHEN ConversationDetails.type = 'CONNECTION_PENDING' AND ConversationDetails.connectionStatus = 'PENDING' THEN 1 -- if received connection request, move it to the top
                 ELSE 0
             END
         ELSE 0
@@ -206,79 +233,43 @@ SELECT
     User.name AS lastMessageSenderName,
     User.connection_status AS lastMessageSenderConnectionStatus,
     User.deleted AS lastMessageSenderIsDeleted,
-    (Message.sender_user_id IS NOT NULL AND Message.sender_user_id == SelfUser.id) AS lastMessageIsSelfMessage,
+    (Message.sender_user_id IS NOT NULL AND Message.sender_user_id == ConversationDetails.selfUserId) AS lastMessageIsSelfMessage,
     MemberChangeContent.member_change_list AS lastMessageMemberChangeList,
     MemberChangeContent.member_change_type AS lastMessageMemberChangeType,
     ConversationNameChangedContent.conversation_name AS lastMessageUpdateConversationName,
-    EXISTS(
-        SELECT 1 FROM MessageMention mm
-        WHERE mm.message_id = LastMessage.message_id
-            AND mm.user_id = SelfUser.id
-    ) AS lastMessageIsMentioningSelfUser,
+    COUNT(Mention.user_id) > 0 AS lastMessageIsMentioningSelfUser,
     TextContent.is_quoting_self AS lastMessageIsQuotingSelfUser,
     TextContent.text_body AS lastMessageText,
     AssetContent.asset_mime_type AS lastMessageAssetMimeType
-FROM Conversation
-LEFT JOIN SelfUser
+FROM ConversationDetails
 LEFT JOIN UnreadEventCountsGrouped
-    ON UnreadEventCountsGrouped.conversationId = Conversation.qualified_id
+    ON UnreadEventCountsGrouped.conversationId = ConversationDetails.qualifiedId
 LEFT JOIN MessageDraft
-    ON Conversation.qualified_id = MessageDraft.conversation_id AND Conversation.archived = 0 -- only return message draft for non-archived conversations
+    ON ConversationDetails.qualifiedId = MessageDraft.conversation_id AND ConversationDetails.archived = 0 -- only return message draft for non-archived conversations
 LEFT JOIN LastMessage
-    ON LastMessage.conversation_id = Conversation.qualified_id AND Conversation.archived = 0 -- only return last message for non-archived conversations
+    ON LastMessage.conversation_id = ConversationDetails.qualifiedId AND ConversationDetails.archived = 0 -- only return last message for non-archived conversations
 LEFT JOIN Message
     ON LastMessage.message_id = Message.id AND LastMessage.conversation_id = Message.conversation_id
 LEFT JOIN User
     ON Message.sender_user_id = User.qualified_id
 LEFT JOIN MessageMemberChangeContent AS MemberChangeContent
     ON LastMessage.message_id = MemberChangeContent.message_id AND LastMessage.conversation_id = MemberChangeContent.conversation_id
--- LEFT JOIN MessageMention AS Mention
---     ON LastMessage.message_id == Mention.message_id AND SelfUser.id == Mention.user_id
+LEFT JOIN MessageMention AS Mention
+    ON LastMessage.message_id == Mention.message_id AND ConversationDetails.selfUserId == Mention.user_id
 LEFT JOIN MessageConversationChangedContent AS ConversationNameChangedContent
     ON LastMessage.message_id = ConversationNameChangedContent.message_id AND LastMessage.conversation_id = ConversationNameChangedContent.conversation_id
 LEFT JOIN MessageAssetContent AS AssetContent
     ON LastMessage.message_id = AssetContent.message_id AND LastMessage.conversation_id = AssetContent.conversation_id
 LEFT JOIN MessageTextContent AS TextContent
     ON LastMessage.message_id = TextContent.message_id AND LastMessage.conversation_id = TextContent.conversation_id
-LEFT JOIN Connection ON Connection.qualified_conversation = Conversation.qualified_id
-LEFT JOIN User AS connection_user ON Connection.qualified_to = connection_user.qualified_id
-LEFT JOIN Call ON Call.id IS (SELECT id FROM Call WHERE Call.conversation_id = Conversation.qualified_id AND Call.status IS 'STILL_ONGOING' ORDER BY created_at DESC LIMIT 1)
-LEFT JOIN Member AS memberRole ON Conversation.qualified_id = memberRole.conversation
-    AND memberRole.user IS SelfUser.id
-LEFT JOIN ConversationFolder AS FavoriteFolder ON FavoriteFolder.folder_type IS 'FAVORITE'
-LEFT JOIN LabeledConversation ON LabeledConversation.conversation_id = Conversation.qualified_id AND LabeledConversation.folder_id = FavoriteFolder.id
-LEFT JOIN LabeledConversation AS ConversationLabel ON ConversationLabel.conversation_id = Conversation.qualified_id AND ConversationLabel.folder_id IS NOT FavoriteFolder.id
-LEFT JOIN ConversationFolder AS CurrentFolder ON CurrentFolder.id = ConversationLabel.folder_id AND CurrentFolder.folder_type IS NOT 'FAVORITE'
 WHERE
-    Conversation.type IS NOT 'SELF'
+    ConversationDetails.type IS NOT 'SELF'
     AND (
-        Conversation.type IS 'GROUP'
-        OR (Conversation.type IS 'ONE_ON_ONE' AND (
-            CASE (Conversation.type)
-                WHEN 'ONE_ON_ONE' THEN  User.name
-                WHEN 'CONNECTION_PENDING' THEN connection_user.name
-                ELSE Conversation.name
-            END IS NOT NULL
-            AND CASE (Conversation.type)
-                WHEN 'ONE_ON_ONE' THEN  User.qualified_id
-                WHEN 'CONNECTION_PENDING' THEN connection_user.qualified_id
-            END IS NOT NULL
-        )) -- show 1:1 convos if they have user metadata
-        OR (Conversation.type IS 'ONE_ON_ONE' AND (
-            CASE (Conversation.type)
-                WHEN 'ONE_ON_ONE' THEN  User.deleted
-                WHEN 'CONNECTION_PENDING' THEN connection_user.deleted
-            END = 1)) -- show deleted 1:1 convos to maintain prev, logic
-        OR (Conversation.type IS 'CONNECTION_PENDING' AND (
-            CASE (Conversation.type)
-                WHEN 'ONE_ON_ONE' THEN  User.qualified_id
-                WHEN 'CONNECTION_PENDING' THEN connection_user.qualified_id
-            END IS NOT NULL)) -- show connection requests even without metadata
+        ConversationDetails.type IS 'GROUP'
+        OR (ConversationDetails.type IS 'ONE_ON_ONE' AND (ConversationDetails.name IS NOT NULL AND ConversationDetails.otherUserId IS NOT NULL)) -- show 1:1 convos if they have user metadata
+        OR (ConversationDetails.type IS 'ONE_ON_ONE' AND ConversationDetails.userDeleted = 1) -- show deleted 1:1 convos to maintain prev, logic
+        OR (ConversationDetails.type IS 'CONNECTION_PENDING' AND ConversationDetails.otherUserId IS NOT NULL) -- show connection requests even without metadata
     )
-    AND (Conversation.protocol IS 'PROTEUS' OR Conversation.protocol IS 'MIXED' OR (Conversation.protocol IS 'MLS' AND Conversation.mls_group_state IS 'ESTABLISHED'))
-    AND (
-        CASE (Conversation.type)
-            WHEN 'ONE_ON_ONE' THEN coalesce(User.active_one_on_one_conversation_id = Conversation.qualified_id, 0)
-            ELSE 1
-        END
-    );
+    AND (ConversationDetails.protocol IS 'PROTEUS' OR ConversationDetails.protocol IS 'MIXED' OR (ConversationDetails.protocol IS 'MLS' AND ConversationDetails.mls_group_state IS 'ESTABLISHED'))
+    AND ConversationDetails.isActive
+GROUP BY ConversationDetails.qualifiedId;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17782" title="WPB-17782" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17782</a>  [Android] improve conversation list loading
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Conversation list feels sluggish on large accounts with older devices.

### Causes (Optional)

missing indexes and large views with a lot of joins
us not repeat ourselves 

### Solutions


# SQLite Performance Metrics Reference

## Environment
These snapshots were captured on **macOS** using the stock `sqlite3` CLI (v3.x) against an unen­crypted DB.  
Production runs **SQLCipher 4.x** on iOS / Android devices (encrypted, different page size & flash I/O), so *absolute* numbers will differ — we rely on the **delta** between runs to decide whether a change is beneficial.

---

## Baseline (before index additions) — captured 2025‑05‑20
### Key figures
| Metric | Value |
| --- | --- |
| Real runtime | **0.180 s** |
| VM steps | 311 790 |
| Sort ops | 545 |
| Full‑scan steps | 1 741 |
| Memory used | 2 783 824 B |
| Peak memory | 3 117 632 B |
| Largest allocation | 65 536 B |
| Page‑cache writes | 0 |

<details>
<summary>Raw metrics (click to expand)</summary>

```text
Memory Used:                         2783824 (max 3117632) bytes
Number of Outstanding Allocations:   4279 (max 4963)
Number of Pcache Overflow Bytes:     2225664 (max 2515968) bytes
Largest Allocation:                  65536 bytes
Largest Pcache Allocation:           4368 bytes
Lookaside Slots Used:                91 (max 168)
Successful lookaside attempts:       1331
Lookaside failures due to size:      17
Lookaside failures due to OOM:       20023
Pager Heap Usage:                    2102752 bytes
Page cache hits:                     9597
Page cache misses:                   2607
Page cache writes:                   0
Page cache spills:                   0
Schema Heap Usage:                   374592 bytes
Statement Heap/Lookaside Usage:      116288 bytes
Fullscan Steps:                      1741
Sort Operations:                     545
Autoindex Inserts:                   530
Virtual Machine Steps:               311790
Reprepare operations:                0
Number of times run:                 1
Memory used by prepared stmt:        116288
Run Time: real 0.180 user 0.014232 sys 0.018217
```

```text
QUERY PLAN
|--CO-ROUTINE ConversationDetailsWithEvents
|  |--MATERIALIZE UnreadEventCountsGrouped
|  |  `--SCAN UnreadEvent USING INDEX unread_event_conversation
|  |--SCAN Conversation USING INDEX sqlite_autoindex_Conversation_1
|  |--SCAN SelfUser LEFT-JOIN
|  |--SEARCH Member USING INDEX member_conversation_index (conversation=?) LEFT-JOIN
|  |--SEARCH memberRole USING INDEX sqlite_autoindex_Member_1 (user=? AND conversation=?) LEFT-JOIN
|  |--SEARCH User USING INDEX sqlite_autoindex_User_1 (qualified_id=?) LEFT-JOIN
|  |--SCAN Connection LEFT-JOIN
|  |--SEARCH connection_user USING INDEX sqlite_autoindex_User_1 (qualified_id=?) LEFT-JOIN
|  |--SEARCH Call USING AUTOMATIC COVERING INDEX (id=?) LEFT-JOIN
|  |--CORRELATED SCALAR SUBQUERY 4
|  |  |--SEARCH Call USING INDEX call_status (status=?)
|  |  `--USE TEMP B-TREE FOR ORDER BY
|  |--SEARCH FavoriteFolder USING AUTOMATIC PARTIAL COVERING INDEX (folder_type=?) LEFT-JOIN
|  |--SEARCH LabeledConversation USING COVERING INDEX sqlite_autoindex_LabeledConversation_1 (folder_id=? AND conversation_id=?) LEFT-JOIN
|  |--SEARCH ConversationLabel USING AUTOMATIC COVERING INDEX (conversation_id=?) LEFT-JOIN
|  |--SEARCH CurrentFolder USING INDEX sqlite_autoindex_ConversationFolder_1 (id=?) LEFT-JOIN
|  |--SEARCH UnreadEventCountsGrouped USING AUTOMATIC COVERING INDEX (conversationId=?) LEFT-JOIN
|  |--SEARCH MessageDraft USING INDEX sqlite_autoindex_MessageDraft_1 (conversation_id=?) LEFT-JOIN
|  |--SEARCH LastMessage USING INDEX sqlite_autoindex_LastMessage_1 (conversation_id=?) LEFT-JOIN
|  |--SEARCH Message USING INDEX sqlite_autoindex_Message_1 (id=? AND conversation_id=?) LEFT-JOIN
|  |--SEARCH User USING INDEX sqlite_autoindex_User_1 (qualified_id=?) LEFT-JOIN
|  |--SEARCH MemberChangeContent USING INDEX sqlite_autoindex_MessageMemberChangeContent_1 (message_id=? AND conversation_id=?) LEFT-JOIN
|  |--SEARCH Mention USING COVERING INDEX message_mentioned_user_id_and_message_index (user_id=? AND message_id=?) LEFT-JOIN
|  |--SEARCH ConversationNameChangedContent USING INDEX sqlite_autoindex_MessageConversationChangedContent_1 (message_id=? AND conversation_id=?) LEFT-JOIN
|  |--SEARCH AssetContent USING INDEX sqlite_autoindex_MessageAssetContent_1 (message_id=? AND conversation_id=?) LEFT-JOIN
|  `--SEARCH TextContent USING INDEX sqlite_autoindex_MessageTextContent_1 (message_id=? AND conversation_id=?) LEFT-JOIN
|--SCAN ConversationDetailsWithEvents
`--USE TEMP B-TREE FOR ORDER BY
```
</details>

---

## Change 1 (extra indexes only)
### Key figures
| Metric | Value |
| --- | --- |
| Real runtime | **0.101 s** |
| VM steps | 308 938 |
| Sort ops | 1 |
| Full‑scan steps | 2 829 |
| Memory used | 2 753 664 B |
| Peak memory | 3 561 984 B |
| Largest allocation | 1 048 576 B |
| Page‑cache writes | 204 |

<details>
<summary>Raw metrics (click to expand)</summary>

```text
Memory Used:                         2753664 (max 3561984) bytes
Number of Outstanding Allocations:   3968 (max 5099)
Number of Pcache Overflow Bytes:     2243072 (max 2429440) bytes
Largest Allocation:                  1048576 bytes
Largest Pcache Allocation:           4368 bytes
Lookaside Slots Used:                91 (max 168)
Successful lookaside attempts:       5970
Lookaside failures due to size:      140
Lookaside failures due to OOM:       19524
Pager Heap Usage:                    2112016 bytes
Page cache hits:                     15694
Page cache misses:                   3348
Page cache writes:                   204
Page cache spills:                   0
Schema Heap Usage:                   323984 bytes
Statement Heap/Lookaside Usage:      116256 bytes
Fullscan Steps:                      2829
Sort Operations:                     1
Autoindex Inserts:                   4
Virtual Machine Steps:               308938
Reprepare operations:                0
Number of times run:                 1
Memory used by prepared stmt:        116256
Run Time: real 0.101 user 0.011412 sys 0.013010
```

```text
QUERY PLAN
|--CO-ROUTINE ConversationDetailsWithEvents
|  |--MATERIALIZE UnreadEventCountsGrouped
|  |  `--SCAN UnreadEvent USING COVERING INDEX unread_event_conv_tyoe
|  |--SCAN Conversation USING INDEX sqlite_autoindex_Conversation_1
|  |--SCAN SelfUser LEFT-JOIN
|  |--SEARCH Member USING COVERING INDEX Member_idx_ddd34dc6 (conversation=?) LEFT-JOIN
|  |--SEARCH memberRole USING INDEX Member_idx_ddd34dc6 (conversation=? AND user=?) LEFT-JOIN
|  |--SEARCH User USING INDEX sqlite_autoindex_User_1 (qualified_id=?) LEFT-JOIN
|  |--SCAN Connection LEFT-JOIN
|  |--SEARCH connection_user USING INDEX sqlite_autoindex_User_1 (qualified_id=?) LEFT-JOIN
|  |--SEARCH Call USING INDEX sqlite_autoindex_Call_1 (id=?) LEFT-JOIN
|  |--CORRELATED SCALAR SUBQUERY 4
|  |  `--SEARCH Call USING INDEX Call_idx_conversation_created_at (conversation_id=?)
|  |--SCAN FavoriteFolder LEFT-JOIN
|  |--SEARCH LabeledConversation USING COVERING INDEX sqlite_autoindex_LabeledConversation_1 (conversation_id=? AND folder_id=?) LEFT-JOIN
|  |--SEARCH ConversationLabel USING COVERING INDEX sqlite_autoindex_LabeledConversation_1 (conversation_id=?) LEFT-JOIN
|  |--SEARCH CurrentFolder USING INDEX sqlite_autoindex_ConversationFolder_1 (id=?) LEFT-JOIN
|  |--SEARCH UnreadEventCountsGrouped USING AUTOMATIC COVERING INDEX (conversationId=?) LEFT-JOIN
|  |--SEARCH MessageDraft USING INDEX sqlite_autoindex_MessageDraft_1 (conversation_id=?) LEFT-JOIN
|  |--SEARCH LastMessage USING INDEX sqlite_autoindex_LastMessage_1 (conversation_id=?) LEFT-JOIN
|  |--SEARCH Message USING INDEX sqlite_autoindex_Message_1 (id=? AND conversation_id=?) LEFT-JOIN
|  |--SEARCH User USING INDEX sqlite_autoindex_User_1 (qualified_id=?) LEFT-JOIN
|  |--SEARCH MemberChangeContent USING INDEX sqlite_autoindex_MessageMemberChangeContent_1 (message_id=? AND conversation_id=?) LEFT-JOIN
|  |--SEARCH Mention USING COVERING INDEX message_mentioned_user_id_and_message_index (user_id=? AND message_id=?) LEFT-JOIN
|  |--SEARCH ConversationNameChangedContent USING INDEX sqlite_autoindex_MessageConversationChangedContent_1 (message_id=? AND conversation_id=?) LEFT-JOIN
|  |--SEARCH AssetContent USING INDEX sqlite_autoindex_MessageAssetContent_1 (message_id=? AND conversation_id=?) LEFT-JOIN
|  `--SEARCH TextContent USING INDEX sqlite_autoindex_MessageTextContent_1 (message_id=? AND conversation_id=?) LEFT-JOIN
|--SCAN ConversationDetailsWithEvents
`--USE TEMP B-TREE FOR ORDER BY
```
</details>

---

## Delta & observations
* **Runtime:** ↓ ~44 % (0.180 s → 0.101 s) — excellent improvement.  
* **Sort ops eliminated:** 545 → 1 (major disk/RAM win).  
* **Page‑cache writes:** 0 → 204 (writes introduced by new indexes; monitor flash wear).  
* **Largest allocation:** 64 KiB → 1 MiB (index buffers). Peak memory up, steady‑state flat.  
* **Full‑scan steps:** ↑ 62 % — acceptable given latency gain; investigate if needed.  

### NOTE REVERTED THOSE AND ONLY DID THE INDEX
1. join the ConversationDetails and the ConversationDetailsWithEvents tables together in one view 
2. add missing indexes 
3. replace  
```sql
COUNT(Mention.user_id) > 0 AS lastMessageIsMentioningSelfUser,
```
with 
```sql
    EXISTS(
        SELECT 1 FROM MessageMention mm
        WHERE mm.message_id = LastMessage.message_id
            AND mm.user_id = SelfUser.id
    ) AS lastMessageIsMentioningSelfUser, <- yes it did make a big dirrance somehow 
```

i did run a small benchmark are running on SQLite 3.49.2 CLI on macbook with an obfuscated version of an actual prod database 
the following options are always used .timer ON and .stats stmt 


and did test 3 versions 
1. old query with 2 indexes added one for the Conversation, and another in UnreadEvent table
2. same as 1 but did rewrite the view to use EXSITS instead of count in the VIEW
3. merged the 2 views together so i can reorder JOINS as i want 
And the results 

version | wall-clock (s) | VM steps | page-cache misses
-- | -- | -- | --
v1 | 0.170 | 311 936 | 2 547
v2 | 0.172 | 226 763 | 2 534
**v3** | **0.164** | **186 467** | **2 205**

this is really nice 40% fewer VM steps which leads to fewer CPU cycles 

but there is more 
i used sqlite .expert with v3 to see if there are any missing indexes and it spits out 
```
    CREATE INDEX LabeledConversation_idx_69c24eb3 ON LabeledConversation(conversation_id, folder_id);
CREATE INDEX ConversationFolder_idx_06fcba25 ON ConversationFolder(folder_type);
CREATE INDEX Call_idx_8cf6e116 ON Call(conversation_id, created_at DESC);
CREATE INDEX Call_idx_00000415 ON Call(id);
CREATE INDEX Conversation_idx_9973027c ON Conversation(archived, protocol);
```
added those and theresults 


version | wall-clock time – s | VM steps | full-scan steps | page-cache misses | peak mem – MB
-- | -- | -- | -- | -- | --
v1 | 0.170 | 311 936 | 1 741 | 2 547 | 2.98
v2 | 0.172 | 226 763 | 881 | 2 534 | 2.98
v3 | 0.164 | 186 467 | 955 | 2 205 | 3.00
v4 | 0.132 ⟵ -20 % vs v3 | 177 812 ⟵ -5 % | 955 | 1 872 ⟵ -15 % | 4.21


Highlights

    ⏱ Fastest yet – shaves another 32 ms from the view load, a full 20 % over v3.

    🧮 Fewest VM opcodes – down 5 % more; now -43 % vs the original.

    📚 Least I/O – 1 872 page misses (-26 % vs v1).

    🪣 Almost zero auto-indexes – only 4 inserts, so the planner is now using the real indexes you added instead of building throw-away ones.

    🗄 Memory – peak rises to 4.2 MB, still tiny for mobile.

also asked chatgpt if this results still holds when using sqlcipher and the result


factor | what SQLCipher changes | why v4 keeps the edge
-- | -- | --
Per-page CPU cost | Every page read/write is AES-GCM/CTR decrypted/encrypted. This adds a few µs of CPU per page miss or spill, independent of the SQL text. | v4 triggers the fewest page-cache misses (1 872) and almost no temp-B-tree writes, so it amortises the encryption tax better than the others.
Memory footprint | SQLCipher allocates a small extra buffer per page, but overall heap use grows by only a few hundred KB for a 4 MB cache. | v4’s peak rose to 4.2 MB, still trivial on modern iOS/Android devices.
Virtual-machine steps | Unaffected by encryption. | v4 already does -43 % VM steps vs v1, and that advantage stays intact.
I/O strategy | mmap is disabled, so all page traffic goes through the pager. | The fewer misses v4 has, the bigger the relative win when each miss is costlier.
Temp files | Temp B-trees are not encrypted by SQLCipher unless you enable PRAGMA cipher_temp_store = 2. | v4 barely writes to temp anyway (4 auto-index inserts).

## WHAT TO DO NEXT 
now that the view is sepeated from the ConversationDetails that is used in other places, we are free to slim it down and remove any data that is not needed for the main conversation list 
Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
