### PR TITLE
fix: no learn more link on federation system message [WPB-16881]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
@@ -471,7 +471,7 @@ internal class ConversationGroupRepositoryImpl(
         return if (canRetryOnce) {
             extractValidUsersForRetryableError(apiResult.value, userIdList)
                 .flatMap { (validUsers, failedUsers, failType) ->
-                    when (failedUsers.isNotEmpty()) {
+                    when (failedUsers.isNotEmpty() && validUsers.isNotEmpty()) {
                         true -> tryAddMembersToCloudAndStorage(validUsers, conversationId, LastUsersAttempt.Failed(failedUsers, failType))
                         false -> {
                             newGroupConversationSystemMessagesCreator.value.conversationFailedToAddMembers(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
@@ -1326,6 +1326,47 @@ class ConversationGroupRepositoryTest {
         }
 
     @Test
+    fun givenAConversationFailsWithUnreachableAndNoValidExtractedUsers_whenAddingMembers_thenRetryIsNotExecutedAndCreateSysMessage() =
+        runTest {
+            val failedDomain = "unstableDomain1.com"
+            val conversation = TestConversation.CONVERSATION.copy(id = ConversationId("valueConvo", "domainConvo"))
+            // given
+            val (arrangement, conversationGroupRepository) = Arrangement()
+                .withConversationDetailsById(conversation)
+                .withProtocolInfoById(PROTEUS_PROTOCOL_INFO)
+                .withFetchUsersIfUnknownByIdsSuccessful()
+                .withAddMemberAPIFailsFirstWithUnreachableThenSucceed(
+                    arrayOf(FEDERATION_ERROR_UNREACHABLE_DOMAINS, FEDERATION_ERROR_UNREACHABLE_DOMAINS)
+                )
+                .withSuccessfulHandleMemberJoinEvent()
+                .withInsertFailedToAddSystemMessageSuccess()
+                .arrange()
+
+            // when
+            val expectedInitialUsers = listOf(
+                TestConversation.USER_1.copy(domain = failedDomain) // only failed domain user so after extracting there are no valid ones
+            )
+            conversationGroupRepository.addMembers(expectedInitialUsers, TestConversation.ID).shouldFail()
+
+            // then
+            coVerify {
+                arrangement.conversationApi.addMember(any(), any())
+            }.wasInvoked(exactly = once)
+
+            coVerify {
+                arrangement.memberJoinEventHandler.handle(any())
+            }.wasNotInvoked()
+
+            coVerify {
+                arrangement.newGroupConversationSystemMessagesCreator.conversationFailedToAddMembers(
+                    conversationId = conversation.id,
+                    userIdList = expectedInitialUsers,
+                    type = MessageContent.MemberChange.FailedToAdd.Type.Federation
+                )
+            }.wasInvoked(once)
+        }
+
+    @Test
     fun givenAConversationFailsWithUnreachableAndNotFromUsersInRequest_whenAddingMembers_thenRetryIsNotExecutedAndCreateSysMessage() =
         runTest {
             val conversation = TestConversation.CONVERSATION.copy(id = ConversationId("valueConvo", "domainConvo"))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16881" title="WPB-16881" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16881</a>  [Android] Learn more link not shown when I try to add a user to a group who does not federate with another user after group creation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Learn more link not shown when I try to add a user to a group who does not federate with another user after group creation.

### Causes (Optional)

When there are only users that don't federate on a list to be added, the retry mechanism removes them before executing the request again with only valid users, but in this case it removes all of them so the request is being done with empty list which ends up with an error because it's an invalid request.

### Solutions

Check whether the list after removing invalid users is empty and don't execute the request again in that case but just return failure.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Try to add a user to a group who does not federate with another user (but select only that one user).

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
