### PR TITLE
feat(backup): add backup comparison tool [WPB-17821]

### DIFF
--- a/backup-verification/build.gradle.kts
+++ b/backup-verification/build.gradle.kts
@@ -1,0 +1,44 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+plugins {
+    kotlin("jvm")
+    alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.compose.jetbrains)
+}
+
+dependencies {
+    implementation(project(":backup"))
+    implementation(compose.desktop.currentOs)
+    implementation(compose.materialIconsExtended)
+    implementation(kotlin("reflect"))
+    implementation(libs.compose.fileKit.core)
+    implementation(libs.compose.fileKit.compose)
+    implementation(libs.coroutines.core)
+    implementation(libs.ktxSerialization)
+}
+
+compose.desktop {
+    application {
+        mainClass = "MainKt"
+        nativeDistributions {
+            linux {
+                modules("jdk.security.auth")
+            }
+        }
+    }
+}

--- a/backup-verification/src/main/kotlin/AppScreen.kt
+++ b/backup-verification/src/main/kotlin/AppScreen.kt
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2024 Wire Swiss GmbH
+ * Copyright (C) 2025 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,22 +15,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-
-package com.wire.backup.data
-
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-import kotlin.js.JsExport
-
-@JsExport
-@Serializable
-public data class BackupMetadata(
-    @SerialName("version")
-    val version: String,
-    @SerialName("userId")
-    val userId: BackupQualifiedId,
-    @SerialName("creationTime")
-    val creationTime: BackupDateTime,
-    @SerialName("clientId")
-    val clientId: String?
-)
+// Define which screen is currently active
+enum class AppScreen {
+    FILE_SELECTION,
+    COMPARISON_RESULT
+}

--- a/backup-verification/src/main/kotlin/ComparisonResultScreen.kt
+++ b/backup-verification/src/main/kotlin/ComparisonResultScreen.kt
@@ -1,0 +1,136 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material.Button
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Tab
+import androidx.compose.material.TabRow
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.wire.backup.verification.DifferentItemsTab
+import com.wire.backup.verification.EqualItemsTab
+import com.wire.backup.verification.MissingItemsTab
+
+@Composable
+fun ComparisonResultScreen(
+    comparisonState: ComparisonScreenState?,
+    onBackClick: () -> Unit
+) {
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        // Header with back button
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = onBackClick) {
+                Icon(
+                    Icons.AutoMirrored.Default.ArrowBack,
+                    contentDescription = "Back to file selection"
+                )
+            }
+
+            Text(
+                "Backup Comparison Results",
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(start = 8.dp)
+            )
+        }
+
+        Spacer(Modifier.size(16.dp))
+
+        when (comparisonState) {
+            is ComparisonScreenState.AnalyzingFiles -> {
+                AnalyzingFilesScreen()
+            }
+
+            is ComparisonScreenState.ResultAvailable -> {
+                // Comparison tabs
+                val tabs = listOf("Equal Items", "Missing Items", "Different Items")
+                var selectedTabIndex by remember { mutableStateOf(0) }
+
+                // Display tabs
+                TabRow(selectedTabIndex = selectedTabIndex) {
+                    tabs.forEachIndexed { index, title ->
+                        Tab(
+                            selected = selectedTabIndex == index,
+                            onClick = { selectedTabIndex = index }
+                        ) {
+                            Text(title, modifier = Modifier.padding(16.dp))
+                        }
+                    }
+                }
+
+                // Display tab content
+                SelectionContainer {
+                    when (selectedTabIndex) {
+                        0 -> EqualItemsTab(comparisonState.result)
+                        1 -> MissingItemsTab(comparisonState.result)
+                        2 -> DifferentItemsTab(comparisonState.result)
+                    }
+                }
+            }
+
+            else -> {
+                // This shouldn't happen, but handle it gracefully
+                Text("No comparison data available")
+
+                Spacer(Modifier.size(16.dp))
+
+                Button(onClick = onBackClick) {
+                    Text("Back to file selection")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AnalyzingFilesScreen() {
+    Box(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text("Comparing backup files...", fontSize = 18.sp)
+            Spacer(Modifier.size(16.dp))
+            CircularProgressIndicator(modifier = Modifier.size(48.dp))
+        }
+    }
+}

--- a/backup-verification/src/main/kotlin/ComparisonScreenState.kt
+++ b/backup-verification/src/main/kotlin/ComparisonScreenState.kt
@@ -1,0 +1,60 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+import com.wire.backup.ingest.BackupPeekResult
+import com.wire.backup.verification.CompleteBackupComparisonResult
+import java.io.File
+
+data class ScreenState(
+    val peekScreenState: PeekScreenState,
+    val comparisonScreenState: ComparisonScreenState? = null
+)
+
+sealed interface ComparisonScreenState {
+    /**
+     * State when files are being analyzed for comparison
+     */
+    data class AnalyzingFiles(val fileNames: List<String>) : ComparisonScreenState
+
+    /**
+     * State when comparison results are available
+     */
+    data class ResultAvailable(
+        val peekResult: PeekScreenState.ResultAvailable,
+        val result: CompleteBackupComparisonResult.Success
+    ) : ComparisonScreenState
+}
+
+/**
+ * State for backup peek operation
+ */
+sealed interface PeekScreenState {
+    /**
+     * Initial state when no files are selected for peeking
+     */
+    data object WaitingForFileSelection : PeekScreenState
+
+    /**
+     * State when peek results are available
+     */
+    data class ResultAvailable(
+        val result: Map<File, BackupPeekResult>,
+        val filePasswords: Map<String, String> = emptyMap(),
+        val failedFiles: Set<File> = emptySet()
+    ) : PeekScreenState
+}

--- a/backup-verification/src/main/kotlin/FileSelectionScreen.kt
+++ b/backup-verification/src/main/kotlin/FileSelectionScreen.kt
@@ -1,0 +1,400 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Button
+import androidx.compose.material.Card
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.wire.backup.ingest.BackupPeekResult
+import com.wire.backup.verification.peekBackupFiles
+import io.github.vinceglb.filekit.FileKit
+import io.github.vinceglb.filekit.dialogs.FileKitMode
+import io.github.vinceglb.filekit.dialogs.FileKitType
+import io.github.vinceglb.filekit.dialogs.openFilePicker
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.io.File
+import java.nio.file.Paths
+
+@Composable
+fun FileSelectionScreen(
+    screenState: ScreenState,
+    onScreenStateChange: (ScreenState) -> Unit,
+    onCompare: (peekState: PeekScreenState.ResultAvailable, files: List<File>) -> Unit
+) {
+    val peekState = screenState.peekScreenState
+
+    Column(modifier = Modifier.padding(16.dp)) {
+        // Display header and basic app info
+        Text(
+            "Wire Backup Verifier",
+            fontSize = 24.sp,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+
+        Text(
+            "This tool compares Wire backup files (.wbu) to identify differences in messages between backups.",
+            fontSize = 16.sp,
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+
+        // Display the file selection card
+        FileSelectionCard(
+            screenState = screenState,
+            peekState = peekState,
+            onScreenStateChange = onScreenStateChange,
+            onPasswordChange = { filePath, password ->
+                if (peekState is PeekScreenState.ResultAvailable) {
+                    // Create a new map with the updated password
+                    val updatedPasswords = peekState.filePasswords.toMutableMap().apply {
+                        put(filePath, password)
+                    }
+
+                    // Update the screen state with the new passwords, preserving failedFiles
+                    onScreenStateChange(
+                        screenState.copy(
+                            peekScreenState = peekState.copy(
+                                filePasswords = updatedPasswords
+                                // failedFiles will be preserved by copy()
+                            )
+                        )
+                    )
+                }
+            }
+        )
+
+        // Show compare button if we have results with at least 2 files
+        if (peekState is PeekScreenState.ResultAvailable) {
+            SelectedFilesList(peekState, onCompare)
+        }
+    }
+}
+
+@Suppress("CyclomaticComplexMethod")
+@Composable
+private fun FileSelectionCard(
+    screenState: ScreenState,
+    peekState: PeekScreenState,
+    onScreenStateChange: (ScreenState) -> Unit,
+    onPasswordChange: (String, String) -> Unit
+) {
+    val scope = rememberCoroutineScope()
+
+    // Function to peek backup files and update the state
+    fun peekFiles(files: List<File>) {
+        scope.launch(Dispatchers.IO) {
+            val peekResults = peekBackupFiles(files)
+
+            // Preserve existing passwords and failed files when updating peek results
+            val (existingPasswords, existingFailedFiles) = if (peekState is PeekScreenState.ResultAvailable) {
+                peekState.filePasswords to peekState.failedFiles
+            } else {
+                emptyMap<String, String>() to emptySet<File>()
+            }
+
+            onScreenStateChange(
+                screenState.copy(
+                    peekScreenState = PeekScreenState.ResultAvailable(
+                        result = peekResults,
+                        filePasswords = existingPasswords,
+                        failedFiles = existingFailedFiles
+                    )
+                )
+            )
+        }
+    }
+
+    // Function to add new backup files
+    fun addFiles() {
+        scope.launch(Dispatchers.IO) {
+            val result = FileKit.openFilePicker(
+                type = FileKitType.File(listOf("wbu")),
+                FileKitMode.Multiple()
+            )
+            result?.let { fileResults ->
+                if (fileResults.isNotEmpty()) {
+                    val newFiles = fileResults.map { it.file }
+
+                    // Get current selected files
+                    val currentFiles = when (val currentPeekState = screenState.peekScreenState) {
+                        is PeekScreenState.ResultAvailable -> currentPeekState.result.keys.toList()
+                        else -> emptyList()
+                    }
+
+                    val updatedFiles = (currentFiles + newFiles).distinct()
+
+                    if (updatedFiles.isNotEmpty()) {
+                        peekFiles(updatedFiles)
+                    }
+                }
+            }
+        }
+    }
+
+    // Function to remove a backup file
+    fun removeFile(file: File) {
+        // Get current files
+        val currentPeekState = screenState.peekScreenState
+        if (currentPeekState is PeekScreenState.ResultAvailable) {
+            val updatedFiles = currentPeekState.result.keys.toList().filter { it != file }
+
+            if (updatedFiles.isNotEmpty()) {
+                peekFiles(updatedFiles)
+            } else {
+                // No files left, reset to waiting state
+                onScreenStateChange(
+                    screenState.copy(
+                        peekScreenState = PeekScreenState.WaitingForFileSelection,
+                        comparisonScreenState = null // Clear comparison state when no files
+                    )
+                )
+            }
+        }
+    }
+
+    Card(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+        elevation = 4.dp
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    "Selected Backup Files",
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold
+                )
+
+                Button(onClick = { addFiles() }) {
+                    Text("Add Files")
+                }
+            }
+
+            Spacer(Modifier.size(8.dp))
+
+            // Get files from peek state if available
+            val selectedFiles = if (peekState is PeekScreenState.ResultAvailable) {
+                peekState.result.keys.toList()
+            } else {
+                emptyList()
+            }
+
+            if (selectedFiles.isEmpty()) {
+                Text(
+                    "No backup files selected. Please add backup files to continue.",
+                    color = Color.Gray,
+                    modifier = Modifier.padding(vertical = 8.dp)
+                )
+            } else {
+                FileList(
+                    selectedFiles = selectedFiles,
+                    onRemoveFile = { removeFile(it) },
+                    peekState = peekState,
+                    onPasswordChange = onPasswordChange,
+                    failedFiles = if (peekState is PeekScreenState.ResultAvailable) peekState.failedFiles else emptySet()
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SelectedFilesList(
+    peekState: PeekScreenState.ResultAvailable,
+    onCompare: (peekState: PeekScreenState.ResultAvailable, files: List<File>) -> Unit
+) {
+    val fileCount = peekState.result.keys.size
+    if (fileCount >= 2) {
+        Spacer(Modifier.size(16.dp))
+        Button(
+            onClick = {
+                onCompare(peekState, peekState.result.keys.toList())
+            },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Run Backup Comparison", fontSize = 16.sp)
+        }
+    } else {
+        Text(
+            "Add at least two backup files to compare",
+            color = Color.Gray,
+            modifier = Modifier.padding(vertical = 8.dp)
+        )
+    }
+}
+
+@Composable
+private fun FileList(
+    selectedFiles: List<File>,
+    onRemoveFile: (File) -> Unit,
+    peekState: PeekScreenState,
+    onPasswordChange: (String, String) -> Unit,
+    failedFiles: Set<File> = emptySet()
+) {
+    LazyColumn(modifier = Modifier.fillMaxWidth()) {
+        items(selectedFiles) { file ->
+            FileItem(selectedFiles, file, failedFiles, onRemoveFile, peekState, onPasswordChange)
+        }
+    }
+}
+
+@Composable
+private fun FileItem(
+    selectedFiles: List<File>,
+    file: File,
+    failedFiles: Set<File>,
+    onRemoveFile: (File) -> Unit,
+    peekState: PeekScreenState,
+    onPasswordChange: (String, String) -> Unit
+) {
+    if (selectedFiles.indexOf(file) > 0) {
+        Spacer(modifier = Modifier.size(8.dp))
+        Divider(thickness = 2.dp)
+        Spacer(modifier = Modifier.size(8.dp))
+    }
+
+    val fileName = Paths.get(file.absolutePath).fileName.toString()
+    val filePath = file.absolutePath
+
+    Column(modifier = Modifier.padding(12.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    // Check if this file is in the failedFiles set
+                    if (failedFiles.contains(file)) {
+                        Icon(
+                            Icons.AutoMirrored.Default.ArrowBack,
+                            contentDescription = "Import failed",
+                            tint = Color.Red,
+                            modifier = Modifier.size(24.dp)
+                        )
+                        Spacer(modifier = Modifier.size(8.dp))
+                    }
+                    Text(
+                        fileName,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+                Text(
+                    filePath,
+                    fontSize = 12.sp,
+                    color = Color.Gray
+                )
+            }
+
+            IconButton(
+                onClick = { onRemoveFile(file) },
+                modifier = Modifier.size(32.dp)
+            ) {
+                Icon(
+                    Icons.Default.Close,
+                    contentDescription = "Remove file",
+                    tint = Color.Red
+                )
+            }
+        }
+
+        // Show file details if available
+        if (peekState is PeekScreenState.ResultAvailable) {
+            val fileResult = peekState.result[file]
+            if (fileResult != null) {
+                Spacer(Modifier.size(8.dp))
+                Divider()
+                Spacer(Modifier.size(8.dp))
+
+                when (fileResult) {
+                    is BackupPeekResult.Success -> {
+                        Row(modifier = Modifier.padding(vertical = 2.dp)) {
+                            Text("Version: ", fontWeight = FontWeight.Medium)
+                            Text(fileResult.version)
+                        }
+                        Row(modifier = Modifier.padding(vertical = 2.dp)) {
+                            Text("Encrypted: ", fontWeight = FontWeight.Medium)
+                            Text(fileResult.isEncrypted.toString())
+                        }
+
+                        // Add password field if the file is encrypted
+                        if (fileResult.isEncrypted) {
+                            Spacer(Modifier.size(8.dp))
+
+                            // Get current password or empty string if not set
+                            val currentPassword = peekState.filePasswords[filePath] ?: ""
+
+                            OutlinedTextField(
+                                value = currentPassword,
+                                onValueChange = { newPassword ->
+                                    onPasswordChange(filePath, newPassword)
+                                },
+                                label = { Text("Password") },
+                                placeholder = { Text("Enter password for this backup") },
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                        }
+                    }
+
+                    is BackupPeekResult.Failure.UnsupportedVersion -> {
+                        Text(
+                            "Unsupported Version: ${fileResult.backupVersion}",
+                            color = Color.Red
+                        )
+                    }
+
+                    is BackupPeekResult.Failure.UnknownFormat -> {
+                        Text(
+                            "Unknown Format",
+                            color = Color.Red
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/backup-verification/src/main/kotlin/Main.kt
+++ b/backup-verification/src/main/kotlin/Main.kt
@@ -1,0 +1,124 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+import androidx.compose.ui.window.rememberWindowState
+import com.wire.backup.verification.CompleteBackupComparisonResult
+import com.wire.backup.verification.compareBackupFiles
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.io.File
+
+fun main(): Unit = application {
+    var screenState by remember {
+        mutableStateOf(
+            ScreenState(peekScreenState = PeekScreenState.WaitingForFileSelection)
+        )
+    }
+    val coroutineScope = rememberCoroutineScope()
+    // Track which screen is currently active
+    var currentScreen by remember { mutableStateOf(AppScreen.FILE_SELECTION) }
+
+    fun compareFiles(peekResult: PeekScreenState.ResultAvailable, files: List<File>) {
+        // Clear any previously failed files before starting a new comparison
+        val updatedPeekResult = peekResult.copy(failedFiles = emptySet())
+
+        // Update state with analysing files status and clear failed files
+        screenState = screenState.copy(
+            peekScreenState = updatedPeekResult,
+            comparisonScreenState = ComparisonScreenState.AnalyzingFiles(files.map { it.absolutePath })
+        )
+
+        // Notify to navigate to comparison screen
+        currentScreen = AppScreen.COMPARISON_RESULT
+
+        coroutineScope.launch(Dispatchers.IO) {
+            val result = compareBackupFiles(files, updatedPeekResult.filePasswords)
+            when (result) {
+                is CompleteBackupComparisonResult.Success -> {
+                    screenState = screenState.copy(
+                        comparisonScreenState = ComparisonScreenState.ResultAvailable(
+                            // Use the updated peekResult with cleared failedFiles
+                            peekResult = (screenState.peekScreenState as PeekScreenState.ResultAvailable),
+                            result = result
+                        )
+                    )
+                }
+
+                is CompleteBackupComparisonResult.Failure -> {
+                    // Return to file selection screen with failed files info
+                    currentScreen = AppScreen.FILE_SELECTION
+
+                    // Update the peek result to include failed files
+                    val updatedPeekState = when (val currentPeekState = screenState.peekScreenState) {
+                        is PeekScreenState.ResultAvailable -> currentPeekState.copy(
+                            failedFiles = result.errors.toSet()
+                        )
+
+                        else -> currentPeekState
+                    }
+
+                    screenState = screenState.copy(
+                        peekScreenState = updatedPeekState,
+                        comparisonScreenState = null
+                    )
+                }
+            }
+        }
+    }
+
+    Window(
+        onCloseRequest = ::exitApplication,
+        title = "Wire Backup Verifier",
+        state = rememberWindowState(
+            width = 1024.dp,
+            height = 768.dp
+        )
+    ) {
+        // Switch between screens based on currentScreen
+        when (currentScreen) {
+            AppScreen.FILE_SELECTION -> {
+                FileSelectionScreen(
+                    screenState = screenState,
+                    onScreenStateChange = { newState ->
+                        screenState = newState
+                    },
+                    onCompare = { peekState, files ->
+                        compareFiles(peekState, files)
+                    }
+                )
+            }
+
+            AppScreen.COMPARISON_RESULT -> {
+                ComparisonResultScreen(
+                    comparisonState = screenState.comparisonScreenState,
+                    onBackClick = {
+                        currentScreen = AppScreen.FILE_SELECTION
+                    }
+                )
+            }
+        }
+    }
+}

--- a/backup-verification/src/main/kotlin/com/wire/backup/verification/BackupId.kt
+++ b/backup-verification/src/main/kotlin/com/wire/backup/verification/BackupId.kt
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2024 Wire Swiss GmbH
+ * Copyright (C) 2025 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,22 +15,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
+package com.wire.backup.verification
 
-package com.wire.backup.data
-
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-import kotlin.js.JsExport
-
-@JsExport
-@Serializable
-public data class BackupMetadata(
-    @SerialName("version")
-    val version: String,
-    @SerialName("userId")
-    val userId: BackupQualifiedId,
-    @SerialName("creationTime")
-    val creationTime: BackupDateTime,
-    @SerialName("clientId")
-    val clientId: String?
-)
+data class BackupId(val id: String)

--- a/backup-verification/src/main/kotlin/com/wire/backup/verification/BackupVerification.kt
+++ b/backup-verification/src/main/kotlin/com/wire/backup/verification/BackupVerification.kt
@@ -1,0 +1,155 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.backup.verification
+
+import com.wire.backup.data.BackupConversation
+import com.wire.backup.data.BackupMessage
+import com.wire.backup.data.BackupUser
+import com.wire.backup.ingest.BackupImportResult
+import com.wire.backup.ingest.BackupPeekResult
+import com.wire.backup.ingest.ImportResultPager
+import com.wire.backup.ingest.MPBackupImporter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileInputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.zip.ZipInputStream
+import kotlin.io.path.absolutePathString
+
+private val tempDir by lazy {
+    Files.createTempDirectory("wireBackupVerification").toFile().also {
+        it.deleteOnExit()
+    }
+}
+
+suspend fun compareBackupFiles(
+    backupFiles: List<File>,
+    passwords: Map<String, String> = emptyMap()
+): CompleteBackupComparisonResult = coroutineScope {
+    tempDir.listFiles().forEach { it.deleteRecursively() }
+    withContext(Dispatchers.IO) {
+        var failures = mutableListOf<File>()
+        val imports = backupFiles.map { file ->
+            async {
+                // Use file-specific password if available, otherwise use empty string
+                val filePassword = passwords[file.absolutePath] ?: ""
+                val importResult = importBackup(file.absolutePath, filePassword)
+                if (importResult == null) {
+                    failures.add(file)
+                }
+                importResult
+            }
+        }.awaitAll()
+        val successList = imports.filterNotNull()
+        if (successList.size == imports.size) {
+            compareBackupMessages(successList)
+        } else {
+            CompleteBackupComparisonResult.Failure(failures)
+        }
+    }
+}
+
+suspend fun peekBackupFiles(backupFiles: List<File>): Map<File, BackupPeekResult> = coroutineScope {
+    withContext(Dispatchers.IO) {
+        backupFiles.map { file ->
+            async {
+                file to importerForFile(file).peekBackupFile(file.absolutePath)
+            }
+        }.awaitAll().toMap()
+    }
+}
+
+class BackupImport(val backupId: BackupId, private val importResult: ImportResultPager) {
+    val allMessages: List<BackupMessage> by lazy {
+        val pager = importResult.messagesPager
+        val content = mutableListOf<BackupMessage>()
+        while (pager.hasMorePages()) {
+            val currentPage = pager.nextPage()
+            content.addAll(currentPage)
+        }
+        content
+    }
+
+    val allConversations: List<BackupConversation> by lazy {
+        val pager = importResult.conversationsPager
+        val content = mutableListOf<BackupConversation>()
+        while (pager.hasMorePages()) {
+            val currentPage = pager.nextPage()
+            content.addAll(currentPage)
+        }
+        content
+    }
+
+    val allUsers: List<BackupUser> by lazy {
+        val pager = importResult.usersPager
+        val content = mutableListOf<BackupUser>()
+        while (pager.hasMorePages()) {
+            val currentPage = pager.nextPage()
+            content.addAll(currentPage)
+        }
+        content
+    }
+}
+
+internal suspend fun importBackup(
+    importFilePath: String,
+    importPassword: String
+): BackupImport? {
+    val importFile = File(importFilePath)
+    val importer = importerForFile(importFile)
+    return when (val result = importer.importFromFile(importFile.absolutePath, importPassword)) {
+        is BackupImportResult.Failure -> {
+            null
+        }
+
+        is BackupImportResult.Success -> {
+            BackupImport(BackupId(importFile.nameWithoutExtension), result.pager)
+        }
+    }
+}
+
+private fun importerForFile(
+    importFile: File
+): MPBackupImporter {
+    val unzipDir = File(tempDir, "unzipped-${importFile.name}")
+    unzipDir.mkdirs()
+    val unzipPath = unzipDir.toPath()
+    val workPath = File(tempDir, "work-${importFile.name}")
+    val importer = MPBackupImporter(workPath.absolutePath) { path ->
+        ZipInputStream(FileInputStream(path)).use { zipInputStream ->
+            var ze = zipInputStream.nextEntry
+            while (ze != null) {
+                val resolvedPath: Path = unzipPath.resolve(ze.name).normalize()
+                if (ze.isDirectory) {
+                    Files.createDirectories(resolvedPath)
+                } else {
+                    Files.createDirectories(resolvedPath.parent)
+                    Files.copy(zipInputStream, resolvedPath)
+                }
+                ze = zipInputStream.nextEntry
+            }
+        }
+        unzipPath.absolutePathString()
+    }
+    return importer
+}

--- a/backup-verification/src/main/kotlin/com/wire/backup/verification/DifferentItem.kt
+++ b/backup-verification/src/main/kotlin/com/wire/backup/verification/DifferentItem.kt
@@ -1,0 +1,108 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.backup.verification
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Divider
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun DifferentItemsTab(result: CompleteBackupComparisonResult.Success) = LazyColumn {
+    item { Text("Conversations", fontSize = 20.sp, modifier = Modifier.padding(vertical = 8.dp)) }
+    items(result.conversations.differentItems) { conversation ->
+        Column {
+            Text("Different conversation: ${conversation.itemId}", fontSize = 20.sp)
+            DiffItem(compareConversationAcrossSources(conversation.itemsBySource))
+        }
+        Divider(modifier = Modifier.padding(vertical = 8.dp))
+    }
+    item { Text("Users", fontSize = 20.sp, modifier = Modifier.padding(vertical = 8.dp)) }
+    items(result.users.differentItems) { user ->
+        Column {
+            Text("Different user: ${user.itemId}", fontSize = 20.sp)
+            DiffItem(compareUserAcrossSources(user.itemsBySource))
+        }
+        Divider(modifier = Modifier.padding(vertical = 8.dp))
+    }
+    item { Text("Messages", fontSize = 20.sp, modifier = Modifier.padding(vertical = 8.dp)) }
+    items(result.messages.differentItems) { message ->
+        Column {
+            Text("Different message: ${message.itemId}", fontSize = 20.sp)
+            DiffItem(compareMessageAcrossSources(message.itemsBySource))
+        }
+        Divider(modifier = Modifier.padding(vertical = 8.dp))
+    }
+}
+
+@Composable
+fun DiffItem(node: Node, level: Int = 0) {
+    val padding = (level * 16).dp
+
+    // Determine background colour based on agreement status
+    val backgroundColor = if (!node.allSourcesAgree && node.textValue.isNotEmpty()) {
+        Color.Red.copy(alpha = 0.2f)
+    } else {
+        Color.Transparent
+    }
+
+    Column(modifier = Modifier.padding(start = padding)) {
+        // Display the node key and any text values
+        Column(
+            modifier = Modifier
+                .background(backgroundColor)
+                .padding(vertical = 2.dp)
+        ) {
+            // Display text values from different sources
+            if (node.allSourcesAgree && node.hasDisplayableTextValue) {
+                Text(
+                    text = "${node.key}: ${node.textValue.values.first()}",
+                    fontSize = 16.sp,
+                    color = Color.Black
+                )
+            } else {
+                Text(
+                    text = node.key,
+                    fontSize = 16.sp,
+                    color = Color.Black
+                )
+                // If sources disagree, show each source's value
+                node.textValue.forEach { (sourceId, value) ->
+                    Text(
+                        text = "${sourceId.id}: $value",
+                        fontSize = 14.sp,
+                        modifier = Modifier.padding(start = 16.dp)
+                    )
+                }
+            }
+        }
+
+        // Recursively display all child nodes with increased indentation
+        node.children.forEach { (_, childNode) ->
+            DiffItem(childNode, level + 1)
+        }
+    }
+}

--- a/backup-verification/src/main/kotlin/com/wire/backup/verification/EqualItem.kt
+++ b/backup-verification/src/main/kotlin/com/wire/backup/verification/EqualItem.kt
@@ -1,0 +1,48 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.backup.verification
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun EqualItemsTab(result: CompleteBackupComparisonResult.Success) = LazyColumn {
+    item { Text("Conversations", fontSize = 20.sp, modifier = Modifier.padding(vertical = 8.dp)) }
+    items(result.conversations.equalItems) { conversation ->
+        Text("Equal conversation: ${conversation.itemId} in sources: ${conversation.sources.joinToString { it.id }}")
+        Spacer(Modifier.size(8.dp))
+    }
+    item { Text("Users", fontSize = 20.sp, modifier = Modifier.padding(vertical = 8.dp)) }
+    items(result.users.equalItems) { user ->
+        Text("Equal user: ${user.itemId} in sources: ${user.sources.joinToString { it.id }}")
+        Spacer(Modifier.size(8.dp))
+    }
+    item { Text("Messages", fontSize = 20.sp, modifier = Modifier.padding(vertical = 8.dp)) }
+    items(result.messages.equalItems) { message ->
+        Text("Equal message: ${message.itemId} in sources: ${message.sources.joinToString { it.id }}")
+        Spacer(Modifier.size(8.dp))
+    }
+}

--- a/backup-verification/src/main/kotlin/com/wire/backup/verification/MessageComparator.kt
+++ b/backup-verification/src/main/kotlin/com/wire/backup/verification/MessageComparator.kt
@@ -1,0 +1,209 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.backup.verification
+
+import com.wire.backup.data.BackupConversation
+import com.wire.backup.data.BackupMessage
+import com.wire.backup.data.BackupUser
+import java.io.File
+
+/**
+ * A generic class that compares items from multiple sources and categorizes them
+ * based on equality, presence, and differences.
+ */
+abstract class Comparator<T> {
+    /**
+     * Represents the result of comparing items across different sources
+     *
+     * @param equalItems Items that are exactly the same across sources
+     * @param missingItems Items that are missing in some sources
+     * @param differentItems Items that exist in multiple sources but have differences
+     */
+    data class ComparisonResult<T>(
+        val equalItems: List<ItemMatch<T>> = emptyList(),
+        val missingItems: List<ItemMissing<T>> = emptyList(),
+        val differentItems: List<ItemDifference<T>> = emptyList()
+    )
+
+    /**
+     * Represents an item that matches exactly across sources
+     *
+     * @param itemId The unique identifier of the item
+     * @param item The item object itself
+     * @param sources The sources where this exact item was found
+     */
+    data class ItemMatch<T>(
+        val itemId: String,
+        val item: T,
+        val sources: Set<BackupId>
+    )
+
+    /**
+     * Represents an item that is missing in some sources
+     *
+     * @param itemId The unique identifier of the item
+     * @param presentIn Map of sources to the item found in that source
+     * @param missingFrom List of sources where the item is missing
+     */
+    data class ItemMissing<T>(
+        val itemId: String,
+        val presentIn: Map<BackupId, T>,
+        val missingFrom: List<BackupId>
+    )
+
+    /**
+     * Represents an item that exists in multiple sources but has differences
+     *
+     * @param itemId The unique identifier of the item
+     * @param itemsBySource Map of sources to their version of the item
+     */
+    data class ItemDifference<T>(
+        val itemId: String,
+        val itemsBySource: Map<BackupId, T>
+    )
+
+    /**
+     * Gets the ID of an item
+     */
+    protected abstract fun getItemId(item: T): String
+
+    /**
+     * Gets all items from a backup import
+     */
+    protected abstract fun getAllItems(backupImport: BackupImport): List<T>
+
+    /**
+     * Checks if all items are equal
+     */
+    private fun areAllItemsEqual(items: List<T>): Boolean {
+        if (items.isEmpty()) return true
+        val first = items.first()
+        return items.all { it == first }
+    }
+
+    /**
+     * Compares items from different sources and categorizes them
+     *
+     * @return A ComparisonResult containing categorized items
+     */
+    fun compare(backupImports: List<BackupImport>): ComparisonResult<T> {
+        val allSources = backupImports.map { it.backupId }
+        val allItemIds = backupImports
+            .flatMap { getAllItems(it) }
+            .map { getItemId(it) }
+            .toSet()
+
+        val equalItems = mutableListOf<ItemMatch<T>>()
+        val missingItems = mutableListOf<ItemMissing<T>>()
+        val differentItems = mutableListOf<ItemDifference<T>>()
+
+        for (itemId in allItemIds) {
+            val matchingItemsForId = backupImports.associate { import ->
+                import.backupId to getAllItems(import).filter { item ->
+                    getItemId(item) == itemId
+                }
+            }
+
+            val sourcesWithItem = matchingItemsForId.filter { it.value.isNotEmpty() }
+            val sourcesWithoutItem = allSources - sourcesWithItem.keys
+
+            when {
+                // Item is present in all sources and identical
+                sourcesWithItem.size == backupImports.size &&
+                        areAllItemsEqual(sourcesWithItem.values.map { it.first() }) -> {
+                    equalItems.add(
+                        ItemMatch(
+                            itemId = itemId,
+                            item = sourcesWithItem.values.first().first(),
+                            sources = sourcesWithItem.keys.toSet()
+                        )
+                    )
+                }
+                // Item is missing in some sources
+                sourcesWithoutItem.isNotEmpty() -> {
+                    missingItems.add(
+                        ItemMissing(
+                            itemId = itemId,
+                            presentIn = sourcesWithItem.mapValues { it.value.first() },
+                            missingFrom = sourcesWithoutItem.toList()
+                        )
+                    )
+                }
+                // Item exists in multiple sources but has differences
+                else -> {
+                    differentItems.add(
+                        ItemDifference(
+                            itemId = itemId,
+                            itemsBySource = sourcesWithItem.mapValues { it.value.first() }
+                        )
+                    )
+                }
+            }
+        }
+
+        return ComparisonResult(
+            equalItems = equalItems,
+            missingItems = missingItems,
+            differentItems = differentItems
+        )
+    }
+}
+
+class MessageComparator : Comparator<BackupMessage>() {
+    override fun getItemId(item: BackupMessage): String = item.id
+
+    override fun getAllItems(backupImport: BackupImport): List<BackupMessage> = backupImport.allMessages
+}
+
+class UserComparator : Comparator<BackupUser>() {
+    override fun getItemId(item: BackupUser): String = item.id.toString()
+
+    override fun getAllItems(backupImport: BackupImport): List<BackupUser> = backupImport.allUsers
+}
+
+class ConversationComparator : Comparator<BackupConversation>() {
+    override fun getItemId(item: BackupConversation): String = item.id.toString()
+
+    override fun getAllItems(backupImport: BackupImport): List<BackupConversation> = backupImport.allConversations
+}
+
+sealed interface CompleteBackupComparisonResult {
+    data class Success(
+        val messages: Comparator.ComparisonResult<BackupMessage>,
+        val users: Comparator.ComparisonResult<BackupUser>,
+        val conversations: Comparator.ComparisonResult<BackupConversation>
+    ) : CompleteBackupComparisonResult
+
+    data class Failure(
+        val errors: List<File>
+    ) : CompleteBackupComparisonResult
+}
+
+fun compareBackupMessages(
+    messagesFromSources: List<BackupImport>
+): CompleteBackupComparisonResult.Success {
+    val messageComparator = MessageComparator()
+    val userComparator = UserComparator()
+    val conversationComparator = ConversationComparator()
+
+    return CompleteBackupComparisonResult.Success(
+        messages = messageComparator.compare(messagesFromSources),
+        users = userComparator.compare(messagesFromSources),
+        conversations = conversationComparator.compare(messagesFromSources)
+    )
+}

--- a/backup-verification/src/main/kotlin/com/wire/backup/verification/MissingItem.kt
+++ b/backup-verification/src/main/kotlin/com/wire/backup/verification/MissingItem.kt
@@ -1,0 +1,89 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.backup.verification
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.wire.backup.data.BackupConversation
+import com.wire.backup.data.BackupMessage
+import com.wire.backup.data.BackupUser
+
+@Composable
+fun MissingItemsTab(result: CompleteBackupComparisonResult.Success) = LazyColumn {
+    item { Text("Conversations", fontSize = 20.sp, modifier = Modifier.padding(vertical = 8.dp)) }
+    items(result.conversations.missingItems) { conversation ->
+        MissingConversationRow(conversation)
+    }
+    item { Text("Users", fontSize = 20.sp, modifier = Modifier.padding(vertical = 8.dp)) }
+    items(result.users.missingItems) { user ->
+        MissingUserRow(user)
+    }
+    item { Text("Messages", fontSize = 20.sp, modifier = Modifier.padding(vertical = 8.dp)) }
+    items(result.messages.missingItems) { message ->
+        MissingMessageRow(message)
+    }
+}
+
+@Composable
+fun MissingConversationRow(
+    item: Comparator.ItemMissing<BackupConversation>,
+) {
+    Column {
+        Text("Missing conversation: ${item.itemId}")
+        Text("Missing from: ${item.missingFrom.joinToString { it.id }}")
+        Text("Present in other sources: ${item.presentIn.keys.joinToString { it.id }}")
+        DiffItem(compareConversationAcrossSources(item.presentIn))
+    }
+    Spacer(Modifier.size(8.dp))
+}
+
+@Composable
+fun MissingMessageRow(
+    item: Comparator.ItemMissing<BackupMessage>,
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text("Missing message: ${item.itemId}")
+        Text("Missing from: ${item.missingFrom.joinToString { it.id }}")
+        Text("Present in other sources: ${item.presentIn.keys.joinToString { it.id }}")
+        DiffItem(compareMessageAcrossSources(item.presentIn))
+    }
+    Spacer(Modifier.size(8.dp))
+}
+
+@Composable
+fun MissingUserRow(
+    item: Comparator.ItemMissing<BackupUser>,
+) {
+    Column {
+        Text("Missing user: ${item.itemId}")
+        Text("Missing from: ${item.missingFrom.joinToString { it.id }}")
+        Text("Present in other sources: ${item.presentIn.keys.joinToString { it.id }}")
+        DiffItem(compareUserAcrossSources(item.presentIn))
+    }
+    Spacer(Modifier.size(8.dp))
+}

--- a/backup-verification/src/main/kotlin/com/wire/backup/verification/Node.kt
+++ b/backup-verification/src/main/kotlin/com/wire/backup/verification/Node.kt
@@ -1,0 +1,177 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.backup.verification
+
+import com.wire.backup.data.BackupConversation
+import com.wire.backup.data.BackupMessage
+import com.wire.backup.data.BackupUser
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.encodeToJsonElement
+
+data class Node(
+    val key: String = "",
+    val presentInSources: Set<BackupId> = emptySet(),
+    val children: Map<String, Node> = emptyMap(),
+    val textValue: Map<BackupId, String?> = emptyMap(),
+    val allSourcesAgree: Boolean = false
+) {
+    val hasDisplayableTextValue = textValue.isNotEmpty()
+}
+
+fun buildTree(backupMessage: BackupMessage, sourceId: BackupId): Node {
+    val jsonElement = Json.encodeToJsonElement(backupMessage)
+    return jsonElementToNodeValue(jsonElement, sourceId = sourceId)
+}
+
+fun buildTree(backupUser: BackupUser, sourceId: BackupId): Node {
+    val jsonElement = Json.encodeToJsonElement(backupUser)
+    return jsonElementToNodeValue(jsonElement, sourceId = sourceId)
+}
+
+fun buildTree(backupConversation: BackupConversation, sourceId: BackupId): Node {
+    val jsonElement = Json.encodeToJsonElement(backupConversation)
+    return jsonElementToNodeValue(jsonElement, sourceId = sourceId)
+}
+
+private fun jsonElementToNodeValue(
+    element: JsonElement,
+    key: String = "",
+    sourceId: BackupId
+): Node {
+    val textValue = when {
+        element is JsonPrimitive -> {
+            // For primitive values, store the string representation in textValue
+            mapOf(sourceId to element.toString())
+        }
+
+        else -> mapOf(sourceId to null)
+    }
+
+    val presentInSources = setOf(sourceId)
+
+    return when (element) {
+        is JsonPrimitive -> Node(
+            key = key,
+            textValue = textValue,
+            presentInSources = presentInSources,
+            children = mapOf(),
+        )
+
+        is JsonObject -> Node(
+            key = key,
+            presentInSources = presentInSources,
+            children = element.entries.associate { (k, v) ->
+                k to jsonElementToNodeValue(v, k, sourceId)
+            },
+        )
+
+        is JsonArray -> Node(
+            key = key,
+            presentInSources = presentInSources,
+            children = element.mapIndexed { index, jsonElement ->
+                index.toString() to jsonElementToNodeValue(jsonElement, index.toString(), sourceId)
+            }.toMap(),
+        )
+    }
+}
+
+fun compareMessageAcrossSources(
+    data: Map<BackupId, BackupMessage>
+): Node {
+    val trees = data.mapValues { (sourceId, message) -> buildTree(message, sourceId) }.toMap()
+    return buildMergedTree(trees)
+}
+
+fun compareUserAcrossSources(
+    data: Map<BackupId, BackupUser>
+): Node {
+    val trees = data.mapValues { (sourceId, user) -> buildTree(user, sourceId) }.toMap()
+    return buildMergedTree(trees)
+}
+
+fun compareConversationAcrossSources(
+    data: Map<BackupId, BackupConversation>
+): Node {
+    val trees = data.mapValues { (sourceId, conversation) -> buildTree(conversation, sourceId) }.toMap()
+    return buildMergedTree(trees)
+}
+
+private fun markAllNodesAsAgreed(node: Node): Node {
+    return Node(
+        key = node.key,
+        presentInSources = node.presentInSources,
+        textValue = node.textValue,
+        children = node.children.mapValues { (_, child) -> markAllNodesAsAgreed(child) },
+        allSourcesAgree = true
+    )
+}
+
+private fun buildMergedTree(trees: Map<BackupId, Node>): Node = when (trees.size) {
+    0 -> Node()
+    1 -> markAllNodesAsAgreed(trees.values.first())
+    else -> {
+        // Initialize merged tree with the first tree
+        var mergedTree = trees.values.first()
+
+        // Merge other trees
+        trees.values.drop(1).forEach { sourceTree ->
+            mergedTree = mergeNodes(trees.keys, mergedTree, sourceTree)
+        }
+        mergedTree
+    }
+}
+
+private fun mergeNodes(allSources: Set<BackupId>, node1: Node, node2: Node): Node {
+    // Merge presence information
+    val mergedPresentInSources = node1.presentInSources + node2.presentInSources
+
+    // Merge text values
+    val mergedTextValue = node1.textValue.toMutableMap().apply {
+        putAll(node2.textValue)
+    }
+
+    // Calculate if all sources agree on the text value
+    val allSourcesPresent = mergedTextValue.keys.all { allSources.contains(it) }
+    val allValuesEqual = mergedTextValue.values.distinct().size == 1
+    val allSourcesAgree = allSourcesPresent && allValuesEqual
+
+    // Merge children recursively
+    val allChildKeys = node1.children.keys + node2.children.keys
+    val mergedChildren = allChildKeys.associateWith { key ->
+        val child1 = node1.children[key]
+        val child2 = node2.children[key]
+
+        when {
+            child1 == null -> child2!!
+            child2 == null -> child1
+            else -> mergeNodes(allSources, child1, child2)
+        }
+    }
+
+    return Node(
+        key = node1.key,
+        presentInSources = mergedPresentInSources,
+        textValue = mergedTextValue,
+        children = mergedChildren,
+        allSourcesAgree = allSourcesAgree
+    )
+}

--- a/backup/build.gradle.kts
+++ b/backup/build.gradle.kts
@@ -76,6 +76,7 @@ kotlin {
 
                 implementation(libs.coroutines.core)
                 implementation(libs.ktxDateTime)
+                implementation(libs.ktxSerialization)
 
                 implementation(libs.okio.core)
 

--- a/backup/src/commonMain/kotlin/com/wire/backup/data/BackupData.kt
+++ b/backup/src/commonMain/kotlin/com/wire/backup/data/BackupData.kt
@@ -19,6 +19,8 @@
 
 package com.wire.backup.data
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import kotlin.experimental.ExperimentalObjCName
 import kotlin.experimental.ExperimentalObjCRefinement
 import kotlin.js.JsExport
@@ -46,8 +48,11 @@ public class BackupData(
 }
 
 @JsExport
+@Serializable
 public data class BackupQualifiedId(
+    @SerialName("id")
     val id: String,
+    @SerialName("domain")
     val domain: String,
 ) {
     override fun toString(): String = "$id@$domain"
@@ -64,75 +69,126 @@ public data class BackupQualifiedId(
 }
 
 @JsExport
+@Serializable
 public data class BackupUser(
+    @SerialName("id")
     val id: BackupQualifiedId,
+    @SerialName("name")
     val name: String,
+    @SerialName("handle")
     val handle: String,
 )
 
 @JsExport
+@Serializable
 public data class BackupConversation(
+    @SerialName("id")
     val id: BackupQualifiedId,
+    @SerialName("name")
     val name: String,
 )
 
 @JsExport
+@Serializable
 public data class BackupMessage(
+    @SerialName("id")
     val id: String,
+    @SerialName("conversationId")
     val conversationId: BackupQualifiedId,
+    @SerialName("senderUserId")
     val senderUserId: BackupQualifiedId,
+    @SerialName("senderClientId")
     val senderClientId: String,
+    @SerialName("creationDate")
     val creationDate: BackupDateTime,
+    @SerialName("content")
     val content: BackupMessageContent,
+    @SerialName("webPrimaryKey")
     @Deprecated("Used only by the Webteam in order to simplify debugging", ReplaceWith(""))
     val webPrimaryKey: Int? = null,
+    @SerialName("lastEditTime")
     val lastEditTime: BackupDateTime? = null,
 )
 
+@Serializable(BackupDateTimeSerializer::class)
 public expect class BackupDateTime
 
 public expect fun BackupDateTime(timestampMillis: Long): BackupDateTime
 public expect fun BackupDateTime.toLongMilliseconds(): Long
 
 @JsExport
+@Serializable
 public sealed class BackupMessageContent {
+
+    @Serializable
     public data class Text(val text: String) : BackupMessageContent()
 
+    @Serializable
     public data class Asset(
+        @SerialName("mimeType")
         val mimeType: String,
+        @SerialName("size")
         val size: Int,
+        @SerialName("name")
         val name: String?,
+        @Serializable(with = ByteArrayStringSerializer::class)
+        @SerialName("otrKey")
         val otrKey: ByteArray,
+        @Serializable(with = ByteArrayStringSerializer::class)
+        @SerialName("sha256")
         val sha256: ByteArray,
+        @SerialName("assetId")
         val assetId: String,
+        @SerialName("assetToken")
         val assetToken: String?,
+        @SerialName("assetDomain")
         val assetDomain: String?,
+        @SerialName("encryption")
         val encryption: EncryptionAlgorithm?,
+        @SerialName("metaData")
         val metaData: AssetMetadata?,
     ) : BackupMessageContent() {
+
+        @Serializable
         public enum class EncryptionAlgorithm {
             AES_GCM, AES_CBC
         }
 
+        @Serializable
         public sealed class AssetMetadata {
+
+            @Serializable
             public data class Image(
+                @SerialName("width")
                 val width: Int,
+                @SerialName("height")
                 val height: Int,
+                @SerialName("tag")
                 val tag: String?
             ) : AssetMetadata()
 
+            @Serializable
             public data class Video(
+                @SerialName("width")
                 val width: Int?,
+                @SerialName("height")
                 val height: Int?,
+                @SerialName("duration")
                 val duration: Long?,
             ) : AssetMetadata()
 
+            @Serializable
             public data class Audio(
+                @Serializable(with = ByteArrayStringSerializer::class)
+                @SerialName("normalization")
                 val normalization: ByteArray?,
+                @SerialName("duration")
                 val duration: Long?,
             ) : AssetMetadata()
 
+            @Serializable
             public data class Generic(
+                @SerialName("name")
                 val name: String?,
             ) : AssetMetadata()
         }
@@ -166,10 +222,15 @@ public sealed class BackupMessageContent {
         }
     }
 
+    @Serializable
     public data class Location(
+        @SerialName("longitude")
         val longitude: Float,
+        @SerialName("latitude")
         val latitude: Float,
+        @SerialName("name")
         val name: String?,
+        @SerialName("zoom")
         val zoom: Int?,
     ) : BackupMessageContent()
 }

--- a/backup/src/commonMain/kotlin/com/wire/backup/data/BackupDateTimeSerializer.kt
+++ b/backup/src/commonMain/kotlin/com/wire/backup/data/BackupDateTimeSerializer.kt
@@ -1,0 +1,39 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.backup.data
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+public class BackupDateTimeSerializer : KSerializer<BackupDateTime> {
+    @OptIn(ExperimentalSerializationApi::class)
+    override val descriptor: SerialDescriptor
+        get() = SerialDescriptor("BackupDateTime", Long.serializer().descriptor)
+
+    override fun deserialize(decoder: Decoder): BackupDateTime {
+        return BackupDateTime(decoder.decodeLong())
+    }
+
+    override fun serialize(encoder: Encoder, value: BackupDateTime) {
+        encoder.encodeLong(value.toLongMilliseconds())
+    }
+}

--- a/backup/src/commonMain/kotlin/com/wire/backup/data/ByteArrayStringSerializer.kt
+++ b/backup/src/commonMain/kotlin/com/wire/backup/data/ByteArrayStringSerializer.kt
@@ -1,0 +1,40 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.backup.data
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+public class ByteArrayStringSerializer : KSerializer<ByteArray> {
+    override val descriptor: SerialDescriptor
+        get() = PrimitiveSerialDescriptor("BackupDateTime", PrimitiveKind.STRING)
+
+    @OptIn(ExperimentalStdlibApi::class)
+    override fun deserialize(decoder: Decoder): ByteArray {
+        return decoder.decodeString().hexToByteArray()
+    }
+
+    @OptIn(ExperimentalStdlibApi::class)
+    override fun serialize(encoder: Encoder, value: ByteArray) {
+        encoder.encodeString(value.toHexString())
+    }
+}

--- a/backup/src/jsMain/kotlin/com/wire/backup/data/BackupDateTime.kt
+++ b/backup/src/jsMain/kotlin/com/wire/backup/data/BackupDateTime.kt
@@ -17,9 +17,11 @@
  */
 package com.wire.backup.data
 
+import kotlinx.serialization.Serializable
 import kotlin.js.Date
 
 @JsExport
+@Serializable(BackupDateTimeSerializer::class)
 public actual data class BackupDateTime(val date: Date) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/backup/src/nonJsMain/kotlin/com/wire/backup/data/BackupDateTime.kt
+++ b/backup/src/nonJsMain/kotlin/com/wire/backup/data/BackupDateTime.kt
@@ -18,7 +18,9 @@
 package com.wire.backup.data
 
 import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
 
+@Serializable(BackupDateTimeSerializer::class)
 public actual data class BackupDateTime(val instant: Instant)
 
 public actual fun BackupDateTime(timestampMillis: Long): BackupDateTime {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,7 @@ plugins {
     alias(libs.plugins.moduleGraph)
     alias(libs.plugins.completeKotlin)
     alias(libs.plugins.compose.compiler) apply false
+    alias(libs.plugins.compose.jetbrains) apply false
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,8 +8,11 @@ cli-kt = "3.5.0"
 coroutines = "1.9.0"
 compose-ui = "1.7.6"
 compose-material = "1.6.6"
+compose-material3 = "1.0.0-alpha01"
+compose-jetbrains = "1.8.2"
 cryptobox4j = "1.4.0"
 cryptobox-android = "1.1.5"
+fileKit = "0.10.0-beta04"
 android-security = "1.1.0-alpha06"
 ktor = "2.3.10"
 okio = "3.9.0"
@@ -83,6 +86,7 @@ kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref 
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+compose-jetbrains = { id = "org.jetbrains.compose", version.ref = "compose-jetbrains" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 carthage = { id = "com.wire.carthage-gradle-plugin", version.ref = "carthage" }
@@ -110,13 +114,16 @@ ktxSerialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json"
 ktxDateTime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "ktx-datetime" }
 ktx-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "ktx-atomicfu" }
 ktxReactive = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactive", version.ref = "coroutines" }
-ktxIO = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlinx-io"}
+ktxIO = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlinx-io" }
 
 # android dependencies
 appCompat = { module = "androidx.appcompat:appcompat", version.ref = "app-compat" }
 activityCompose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
 work = { module = "androidx.work:work-runtime-ktx", version.ref = "android-work" }
 composeMaterial = { module = "androidx.compose.material:material", version.ref = "compose-material" }
+composeMaterial3-common = { module = "androidx.compose.material3:material3-common", version.ref = "compose-material3" }
+composeMaterial3-android = { module = "androidx.compose.material3:material3-common-android", version.ref = "compose-material3" }
+composeMaterial3-desktop = { module = "androidx.compose.material3:material3-common-desktop", version.ref = "compose-material3" }
 composeTooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose-ui" }
 coroutinesAndroid = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 ktor = { module = "io.ktor:ktor-client-android", version.ref = "ktor" }
@@ -149,6 +156,10 @@ coreCrypto = { module = "com.wire:core-crypto", version.ref = "core-crypto-multi
 coreCryptoJvm = { module = "com.wire:core-crypto-jvm", version.ref = "core-crypto" }
 coreCryptoAndroid = { module = "com.wire:core-crypto-android", version.ref = "core-crypto" }
 libsodiumBindingsMP = { module = "com.ionspin.kotlin:multiplatform-crypto-libsodium-bindings", version.ref = "libsodiumBindings" }
+
+# Compose Desktop / Multiplatform
+compose-fileKit-core = { module = "io.github.vinceglb:filekit-dialogs", version.ref = "fileKit"}
+compose-fileKit-compose = { module = "io.github.vinceglb:filekit-dialogs-compose", version.ref = "fileKit"}
 
 # cli
 cliKt = { module = "com.github.ajalt.clikt:clikt", version.ref = "cli-kt" }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17821" title="WPB-17821" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17821</a>  [MPBackup Library] Create a backup file comparison tool
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We have data being exported differently by each client during backup, and there is no simple way to compare.

### Solutions

Add a backup comparison tool.
Made in Compose/JVM (Desktop).

To run:

`./gradlew :backup-verification:run`

Select two or more `.wbu` files, and have fun!


It works by:
- Importing each backup and collecting the whole data set to a list based on the source (backup file)
- Comparing each data set, splitting into: 
  - Data that matches 100%, 
  - Data that is missing from one or more sources
  - Data that is present in all sources, but has differences between them
- To compare differences, it does:
  - Convert the data into JSON using KTX Serialization
  - For each item (conversation, user or message), build a tree of fields
  - Then compare the trees from each source, to see if they all match.
  - Take this result, and display in the screen 😄 


### Attachments

https://github.com/user-attachments/assets/c0830436-0f71-4149-a10b-9de554eb66b9

https://github.com/user-attachments/assets/9516d087-8e4c-459d-aaaf-15052fabf5b4

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
