### PR TITLE
fix: pending events handling [WPB-18144]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessor.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessor.kt
@@ -129,6 +129,4 @@ internal class EventProcessorImpl(
             logger.i("Updated lastProcessedEventId: ${eventEnvelope.toLogString()}")
         }
     }
-
-    private fun EventDeliveryInfo.shouldUpdateLastProcessedEventId(): Boolean = !isTransient
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessor.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessor.kt
@@ -62,7 +62,7 @@ internal interface EventProcessor {
      * @return [Either] [CoreFailure] if the event processing failed, or [Unit] if the event was processed successfully.
      * @see EventRepository.lastProcessedEventId
      * @see EventDeliveryInfo.isTransient
-     * @see EventRepository.updateLastProcessedEventId
+     * @see EventRepository.setEventAsProcessed
      * @see EventDeliveryInfo
      * @see Event
      */
@@ -125,12 +125,8 @@ internal class EventProcessorImpl(
                 missedNotificationsEventReceiver.onEvent(event, deliveryInfo)
             }
         }.onSuccess {
-            if (deliveryInfo.shouldUpdateLastProcessedEventId()) {
-                eventRepository.updateLastProcessedEventId(event.id)
-                logger.i("Updated lastProcessedEventId: ${eventEnvelope.toLogString()}")
-            } else {
-                logger.i("Skipping update of lastProcessedEventId: ${eventEnvelope.toLogString()}")
-            }
+            eventRepository.setEventAsProcessed(event.id)
+            logger.i("Updated lastProcessedEventId: ${eventEnvelope.toLogString()}")
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
@@ -66,7 +66,7 @@ internal interface SlowSyncManager {
          * Useful when a new step is added to Slow Sync, or when we fix some bug in Slow Sync,
          * and we'd like to get all users to take advantage of the fix.
          */
-        const val CURRENT_VERSION = 8
+        const val CURRENT_VERSION = 10
         // because we already had version 9, the next version should be 10
 
         val MIN_RETRY_DELAY = 1.seconds

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorker.kt
@@ -123,7 +123,7 @@ internal class SlowSyncWorkerImpl(
     private suspend fun saveLastProcessedEventIdIfNeeded(lastProcessedEventIdToSaveOnSuccess: String?) =
         if (lastProcessedEventIdToSaveOnSuccess != null) {
             logger.i("Saving last processed event ID to complete SlowSync: $lastProcessedEventIdToSaveOnSuccess")
-            eventRepository.updateLastProcessedEventId(lastProcessedEventIdToSaveOnSuccess)
+            eventRepository.setEventAsProcessed(lastProcessedEventIdToSaveOnSuccess)
         } else {
             logger.i("Skipping saving last processed event ID to complete SlowSync")
             Either.Right(Unit)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
@@ -26,10 +26,6 @@ import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestConversation
-import com.wire.kalium.logic.framework.TestConversation.ADD_MEMBER_TO_CONVERSATION_SUCCESSFUL_RESPONSE
-import com.wire.kalium.logic.framework.TestEvent
-import com.wire.kalium.logic.framework.TestEvent.wrapAsyncInEnvelope
-import com.wire.kalium.logic.framework.TestEvent.wrapInEnvelope
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
@@ -40,10 +36,8 @@ import com.wire.kalium.network.api.authenticated.notification.EventContentDTO
 import com.wire.kalium.network.api.authenticated.notification.EventDataDTO
 import com.wire.kalium.network.api.authenticated.notification.EventResponse
 import com.wire.kalium.network.api.authenticated.notification.NotificationResponse
-import com.wire.kalium.network.api.authenticated.notification.conversation.MessageEventData
 import com.wire.kalium.network.api.base.authenticated.notification.NotificationApi
 import com.wire.kalium.network.api.base.authenticated.notification.WebSocketEvent
-import com.wire.kalium.network.api.model.UserId
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.tools.KtxSerializer
 import com.wire.kalium.network.utils.NetworkResponse
@@ -61,7 +55,6 @@ import io.mockative.matches
 import io.mockative.mock
 import io.mockative.once
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
@@ -268,7 +261,7 @@ class EventRepositoryTest {
 
 
     private companion object {
-        const val LAST_PROCESSED_EVENT_ID_KEY = "last_processed_event_id"
+        const val LAST_SAVED_EVENT_ID_KEY = "last_processed_event_id"
         val MEMBER_JOIN_EVENT = EventContentDTO.Conversation.MemberJoinDTO(
             TestConversation.NETWORK_ID,
             TestConversation.NETWORK_USER_ID1,
@@ -310,7 +303,7 @@ class EventRepositoryTest {
 
         suspend fun withLastStoredEventId(value: String?) = apply {
             coEvery {
-                metaDAO.valueByKey(LAST_PROCESSED_EVENT_ID_KEY)
+                metaDAO.valueByKey(LAST_SAVED_EVENT_ID_KEY)
             }.returns(value)
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessorTest.kt
@@ -21,7 +21,6 @@ package com.wire.kalium.logic.sync.incremental
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.functional.Either
-import com.wire.kalium.common.functional.right
 import com.wire.kalium.logic.data.event.EventRepository
 import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.logic.framework.TestEvent.wrapInEnvelope
@@ -46,7 +45,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.coroutines.cancellation.CancellationException
@@ -72,7 +70,7 @@ class EventProcessorTest {
 
         // Then
         coVerify {
-            arrangement.eventRepository.updateLastProcessedEventId(eq(event.id))
+            arrangement.eventRepository.setEventAsProcessed(eq(event.id))
         }.wasInvoked(exactly = once)
     }
 
@@ -111,7 +109,7 @@ class EventProcessorTest {
 
         // Then
         coVerify {
-            arrangement.eventRepository.updateLastProcessedEventId(any())
+            arrangement.eventRepository.setEventAsProcessed(any())
         }.wasNotInvoked()
     }
 
@@ -150,7 +148,7 @@ class EventProcessorTest {
 
         // Then
         coVerify {
-            arrangement.eventRepository.updateLastProcessedEventId(any())
+            arrangement.eventRepository.setEventAsProcessed(any())
         }.wasNotInvoked()
     }
 
@@ -168,24 +166,8 @@ class EventProcessorTest {
 
         // Then
         coVerify {
-            arrangement.eventRepository.updateLastProcessedEventId(eq(envelope.event.id))
+            arrangement.eventRepository.setEventAsProcessed(eq(envelope.event.id))
         }.wasInvoked(exactly = once)
-    }
-
-    @Test
-    fun givenTransientEvent_whenProcessingEvent_thenLastProcessedEventIdIsNotUpdated() = runTest {
-        // Given
-        val event = TestEvent.newConnection().wrapInEnvelope(isTransient = true)
-
-        val (arrangement, eventProcessor) = Arrangement(this).arrange()
-
-        // When
-        eventProcessor.processEvent(event)
-
-        // Then
-        coVerify {
-            arrangement.eventRepository.updateLastProcessedEventId(any())
-        }.wasNotInvoked()
     }
 
     @Test
@@ -221,7 +203,7 @@ class EventProcessorTest {
 
         // Then
         coVerify {
-            arrangement.eventRepository.updateLastProcessedEventId(any())
+            arrangement.eventRepository.setEventAsProcessed(any())
         }.wasNotInvoked()
     }
 
@@ -249,7 +231,7 @@ class EventProcessorTest {
             arrangement.userPropertiesEventReceiver.onEvent(any(), any())
         }.wasInvoked(exactly = once)
         coVerify {
-            arrangement.eventRepository.updateLastProcessedEventId(any())
+            arrangement.eventRepository.setEventAsProcessed(any())
         }.wasInvoked(exactly = once)
     }
 
@@ -276,7 +258,7 @@ class EventProcessorTest {
             arrangement.userPropertiesEventReceiver.onEvent(any(), any())
         }.wasInvoked(exactly = once)
         coVerify {
-            arrangement.eventRepository.updateLastProcessedEventId(any())
+            arrangement.eventRepository.setEventAsProcessed(any())
         }.wasInvoked(exactly = once)
     }
 
@@ -300,7 +282,7 @@ class EventProcessorTest {
             arrangement.userPropertiesEventReceiver.onEvent(any(), any())
         }.wasNotInvoked()
         coVerify {
-            arrangement.eventRepository.updateLastProcessedEventId(any())
+            arrangement.eventRepository.setEventAsProcessed(any())
         }.wasNotInvoked()
     }
 
@@ -319,7 +301,7 @@ class EventProcessorTest {
 
         suspend fun withUpdateLastProcessedEventId(eventId: String, result: Either<StorageFailure, Unit>) = apply {
             coEvery {
-                eventRepository.updateLastProcessedEventId(eq(eventId))
+                eventRepository.setEventAsProcessed(eq(eventId))
             }.returns(result)
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorkerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorkerTest.kt
@@ -387,7 +387,7 @@ class SlowSyncWorkerTest {
         }.wasNotInvoked()
 
         coVerify {
-            arrangement.eventRepository.updateLastProcessedEventId(any())
+            arrangement.eventRepository.setEventAsProcessed(any())
         }.wasNotInvoked()
     }
 
@@ -404,7 +404,7 @@ class SlowSyncWorkerTest {
         }
 
         coVerify {
-            arrangement.eventRepository.updateLastProcessedEventId(any())
+            arrangement.eventRepository.setEventAsProcessed(any())
         }.wasNotInvoked()
     }
 
@@ -431,7 +431,7 @@ class SlowSyncWorkerTest {
         slowSyncWorker.slowSyncStepsFlow(successfullyMigration).collect()
 
         coVerify {
-            arrangement.eventRepository.updateLastProcessedEventId(eq(fetchedEventId))
+            arrangement.eventRepository.setEventAsProcessed(eq(fetchedEventId))
         }.wasInvoked(exactly = once)
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/EventRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/EventRepositoryArrangement.kt
@@ -69,7 +69,7 @@ internal class EventRepositoryArrangementImpl : EventRepositoryArrangement {
 
     override suspend fun withUpdateLastProcessedEventIdReturning(result: Either<StorageFailure, Unit>) {
         coEvery {
-            eventRepository.updateLastProcessedEventId(any())
+            eventRepository.setEventAsProcessed(any())
         }.returns(result)
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18144" title="WPB-18144" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18144</a>  [Android] App not receiving messages (at all!) when in background
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- Variable for process pending events was not properly passed which caused problems with receiving events and decrypting them.
- updating last processed event should not update last fetched event

### Solutions

- pass variable properly
- split updating processed event and last saved event to separate functions
- trigger slow sync to get users recovered for lost events
