### PR TITLE
fix: endless initial sync because of no last saved event id [WPB-18144]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt
@@ -86,21 +86,31 @@ interface EventRepository {
     fun parseExternalEvents(data: String): List<EventEnvelope>
 
     /**
-     * Retrieves the last processed event ID from the storage.
+     * Retrieves the last saved event ID from the storage.
      *
      * @return an [Either] object representing either a [StorageFailure] or a [String].
-     *         - If the retrieval is successful, returns [Either.Right] with the last processed event ID as a [String].
+     *         - If the retrieval is successful, returns [Either.Right] with the last saved event ID as a [String].
      *         - If there is a failure during retrieval, returns [Either.Left] with a [StorageFailure] object.
      */
-    suspend fun lastProcessedEventId(): Either<StorageFailure, String>
+    suspend fun lastSavedEventId(): Either<StorageFailure, String>
 
     /**
-     * Clears the last processed event ID.
+     * Clears the last saved event ID.
      *
      * @return An [Either] object representing the result of the operation.
      * The [Either] object contains either a [StorageFailure] if the operation fails, or [Unit] if the operation succeeds.
      */
-    suspend fun clearLastProcessedEventId(): Either<StorageFailure, Unit>
+    suspend fun clearLastSavedEventId(): Either<StorageFailure, Unit>
+
+    /**
+     * Updates the last saved event ID.
+     *
+     * @param eventId The ID of the event to be set as the last saved event ID.
+     *
+     * @return An [Either] object representing the result of the operation.
+     * The [Either] object contains either a [StorageFailure] if the operation fails, or [Unit] if the operation succeeds.
+     */
+    suspend fun updateLastSavedEventId(eventId: String): Either<StorageFailure, Unit>
 
     suspend fun fetchMostRecentEventId(): Either<CoreFailure, String>
 
@@ -351,11 +361,11 @@ class EventDataSource(
         }
     }
 
-    override suspend fun lastProcessedEventId(): Either<StorageFailure, String> = wrapStorageRequest {
+    override suspend fun lastSavedEventId(): Either<StorageFailure, String> = wrapStorageRequest {
         metadataDAO.valueByKey(LAST_SAVED_EVENT_ID_KEY)
     }
 
-    override suspend fun clearLastProcessedEventId(): Either<StorageFailure, Unit> = wrapStorageRequest {
+    override suspend fun clearLastSavedEventId(): Either<StorageFailure, Unit> = wrapStorageRequest {
         metadataDAO.deleteValue(LAST_SAVED_EVENT_ID_KEY)
     }
 
@@ -366,8 +376,8 @@ class EventDataSource(
                     .map { it.id }
             }
 
-    private suspend fun updateLastSavedEventId(eventId: String): Either<StorageFailure, Unit> {
-        return wrapStorageRequest { metadataDAO.insertValue(eventId, LAST_SAVED_EVENT_ID_KEY) }
+    override suspend fun updateLastSavedEventId(eventId: String): Either<StorageFailure, Unit> = wrapStorageRequest {
+        metadataDAO.insertValue(eventId, LAST_SAVED_EVENT_ID_KEY)
     }
 
     override suspend fun setEventAsProcessed(eventId: String): Either<StorageFailure, Unit> {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
@@ -116,7 +116,7 @@ internal class EventGathererImpl(
     private suspend fun fetchEventFlow(isAsyncNotifications: Boolean) = if (isAsyncNotifications) {
         eventRepository.liveEvents()
     } else {
-        // in the old system we fetch pending events from the notification stream based on last processed event id
+        // in the old system we fetch pending events from the notification stream based on last saved event id
         eventRepository.lastSavedEventId()
             .flatMap {
                 eventRepository.liveEvents()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessor.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessor.kt
@@ -60,7 +60,6 @@ internal interface EventProcessor {
      * is not transient (see [EventDeliveryInfo.isTransient]).
      * If the processing fails, the last processed event ID will not be updated.
      * @return [Either] [CoreFailure] if the event processing failed, or [Unit] if the event was processed successfully.
-     * @see EventRepository.lastProcessedEventId
      * @see EventDeliveryInfo.isTransient
      * @see EventRepository.setEventAsProcessed
      * @see EventDeliveryInfo
@@ -126,7 +125,7 @@ internal class EventProcessorImpl(
             }
         }.onSuccess {
             eventRepository.setEventAsProcessed(event.id)
-            logger.i("Updated lastProcessedEventId: ${eventEnvelope.toLogString()}")
+            logger.i("Event set as processed: ${eventEnvelope.toLogString()}")
         }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncRecoveryHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncRecoveryHandler.kt
@@ -62,7 +62,7 @@ internal class IncrementalSyncRecoveryHandlerImpl(
         logger.i("$TAG Checking if we can recover from the failure: $failure")
         if (shouldDiscardEventsAndRestartSlowSync(failure)) {
             logger.i("$TAG Discarding all events and restarting the slow sync process")
-            eventRepository.clearLastProcessedEventId().onSuccess {
+            eventRepository.clearLastSavedEventId().onSuccess {
                 restartSlowSyncProcessForRecoveryUseCase()
             }
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorker.kt
@@ -89,10 +89,10 @@ internal class SlowSyncWorkerImpl(
 
         logger.d("Starting SlowSync")
 
-        val lastProcessedEventIdToSaveOnSuccess =
+        val lastSavedEventIdToSaveOnSuccess =
             isClientAsyncNotificationsCapableProvider().nullableFold({ null }, { isAsyncNotificationsCapable ->
                 when {
-                    !isAsyncNotificationsCapable -> getLastProcessedEventIdToSaveOnSuccess()
+                    !isAsyncNotificationsCapable -> getLastSavedEventIdToSaveOnSuccess()
                     else -> null
                 }
             })
@@ -113,34 +113,34 @@ internal class SlowSyncWorkerImpl(
             .continueWithStep(SlowSyncStep.JOINING_MLS_CONVERSATIONS, joinMLSConversations::invoke)
             .continueWithStep(SlowSyncStep.RESOLVE_ONE_ON_ONE_PROTOCOLS, oneOnOneResolver::resolveAllOneOnOneConversations)
             .flatMap {
-                saveLastProcessedEventIdIfNeeded(lastProcessedEventIdToSaveOnSuccess)
+                saveLastSavedEventIdIfNeeded(lastSavedEventIdToSaveOnSuccess)
             }
             .onFailure {
                 throw KaliumSyncException("Failure during SlowSync", it)
             }
     }
 
-    private suspend fun saveLastProcessedEventIdIfNeeded(lastProcessedEventIdToSaveOnSuccess: String?) =
-        if (lastProcessedEventIdToSaveOnSuccess != null) {
-            logger.i("Saving last processed event ID to complete SlowSync: $lastProcessedEventIdToSaveOnSuccess")
-            eventRepository.setEventAsProcessed(lastProcessedEventIdToSaveOnSuccess)
+    private suspend fun saveLastSavedEventIdIfNeeded(lastSavedEventIdToSaveOnSuccess: String?) =
+        if (lastSavedEventIdToSaveOnSuccess != null) {
+            logger.i("Saving last saved event ID to complete SlowSync: $lastSavedEventIdToSaveOnSuccess")
+            eventRepository.updateLastSavedEventId(lastSavedEventIdToSaveOnSuccess)
         } else {
-            logger.i("Skipping saving last processed event ID to complete SlowSync")
+            logger.i("Skipping saving last saved event ID to complete SlowSync")
             Either.Right(Unit)
         }
 
-    private suspend fun getLastProcessedEventIdToSaveOnSuccess(): String? {
-        val hasLastEventId = eventRepository.lastProcessedEventId().isRight()
-        val lastProcessedEventIdToSaveOnSuccess = if (hasLastEventId) {
-            logger.i("Last processed event ID already exists, skipping fetch")
+    private suspend fun getLastSavedEventIdToSaveOnSuccess(): String? {
+        val hasLastEventId = eventRepository.lastSavedEventId().isRight()
+        val lastSavedEventIdToSaveOnSuccess = if (hasLastEventId) {
+            logger.i("Last saved event ID already exists, skipping fetch")
             null
         } else {
-            logger.i("Last processed event ID does not exist, fetching most recent event ID from remote")
+            logger.i("Last saved event ID does not exist, fetching most recent event ID from remote")
             eventRepository.fetchMostRecentEventId().onFailure {
                 throw KaliumSyncException("Failure during SlowSync. Unable to fetch most recent event ID", it)
             }.nullableFold({ null }, { it })
         }
-        return lastProcessedEventIdToSaveOnSuccess
+        return lastSavedEventIdToSaveOnSuccess
     }
 
     private suspend fun FlowCollector<SlowSyncStep>.performStep(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
@@ -95,14 +95,14 @@ class EventRepositoryTest {
     }
 
     @Test
-    fun givenASavedLastProcessedId_whenGettingLastEventId_thenShouldReturnIt() = runTest {
+    fun givenASavedLastSavedId_whenGettingLastEventId_thenShouldReturnIt() = runTest {
         val eventId = "dh817h2e"
 
         val (arrangement, eventRepository) = Arrangement()
             .withLastStoredEventId(eventId)
             .arrange()
 
-        val result = eventRepository.lastProcessedEventId()
+        val result = eventRepository.lastSavedEventId()
         result.shouldSucceed { assertEquals(eventId, it) }
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncRecoveryHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncRecoveryHandlerTest.kt
@@ -40,7 +40,7 @@ class IncrementalSyncRecoveryHandlerTest {
         val (arrangement, recoveryHandler) = arrange {
             withOldestEventIdReturning(Either.Right(oldestEventId))
             withClearLastEventIdReturning(Either.Right(Unit))
-            withUpdateLastProcessedEventIdReturning(Either.Right(Unit))
+            withUpdateLastSavedEventIdReturning(Either.Right(Unit))
         }
 
         var wasInvoked = false
@@ -52,7 +52,7 @@ class IncrementalSyncRecoveryHandlerTest {
         // then
         with(arrangement) {
             coVerify {
-                eventRepository.clearLastProcessedEventId()
+                eventRepository.clearLastSavedEventId()
             }.wasInvoked(exactly = once)
 
             coVerify {
@@ -67,7 +67,7 @@ class IncrementalSyncRecoveryHandlerTest {
         // given
         val (arrangement, recoveryHandler) = arrange {
             withOldestEventIdReturning(Either.Right("oldestEventId"))
-            withUpdateLastProcessedEventIdReturning(Either.Right(Unit))
+            withUpdateLastSavedEventIdReturning(Either.Right(Unit))
         }
 
         var wasInvoked = false
@@ -87,12 +87,12 @@ class IncrementalSyncRecoveryHandlerTest {
     }
 
     @Test
-    fun givenUnknownFailure_whenRecovering_thenShouldNotClearLastProcessedEventId() = runTest {
+    fun givenUnknownFailure_whenRecovering_thenShouldNotClearLastSavedEventId() = runTest {
         // given
         val (arrangement, recoveryHandler) = arrange {
             withOldestEventIdReturning(Either.Right("oldestEventId"))
             withClearLastEventIdReturning(Either.Right(Unit))
-            withUpdateLastProcessedEventIdReturning(Either.Right(Unit))
+            withUpdateLastSavedEventIdReturning(Either.Right(Unit))
         }
 
         // when
@@ -101,7 +101,7 @@ class IncrementalSyncRecoveryHandlerTest {
         // then
         with(arrangement) {
             coVerify {
-                eventRepository.clearLastProcessedEventId()
+                eventRepository.clearLastSavedEventId()
             }.wasNotInvoked()
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorkerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorkerTest.kt
@@ -340,7 +340,7 @@ class SlowSyncWorkerTest {
     @Test
     fun givenNoExistingLastProcessedId_whenWorking_thenShouldFetchMostRecentEvent() = runTest {
         val (arrangement, slowSyncWorker) = Arrangement().apply {
-            withLastProcessedEventIdReturning(Either.Left(StorageFailure.DataNotFound))
+            withLastSavedEventIdReturning(Either.Left(StorageFailure.DataNotFound))
             withFetchMostRecentEventReturning(Either.Right("mostRecentEventId"))
         }.withSyncSelfUserFailure()
             .arrange()
@@ -358,7 +358,7 @@ class SlowSyncWorkerTest {
     fun givenNoExistingLastProcessedId_whenWorkingAndAsyncNotifications_thenShouldNotFetchMostRecentEvent() = runTest {
         val (arrangement, slowSyncWorker) = Arrangement().apply {
             withIsClientAsyncNotificationsCapableReturning(true)
-            withLastProcessedEventIdReturning(Either.Left(StorageFailure.DataNotFound))
+            withLastSavedEventIdReturning(Either.Left(StorageFailure.DataNotFound))
         }.withSyncSelfUserFailure()
             .arrange()
 
@@ -374,7 +374,7 @@ class SlowSyncWorkerTest {
     @Test
     fun givenAlreadyExistingLastProcessedId_whenWorking_thenShouldNotFetchMostRecentEvent() = runTest {
         val (arrangement, slowSyncWorker) = Arrangement().apply {
-            withLastProcessedEventIdReturning(Either.Right("lastProcessedEventId"))
+            withLastSavedEventIdReturning(Either.Right("LastSavedEventId"))
         }.withSyncSelfUserFailure()
             .arrange()
 
@@ -387,14 +387,14 @@ class SlowSyncWorkerTest {
         }.wasNotInvoked()
 
         coVerify {
-            arrangement.eventRepository.setEventAsProcessed(any())
+            arrangement.eventRepository.updateLastSavedEventId(any())
         }.wasNotInvoked()
     }
 
     @Test
-    fun givenFetchedEventIdAndSomethingFails_whenWorking_thenShouldNotUpdateLastProcessedEventId() = runTest {
+    fun givenFetchedEventIdAndSomethingFails_whenWorking_thenShouldNotUpdateLastSavedEventId() = runTest {
         val (arrangement, slowSyncWorker) = Arrangement().apply {
-            withLastProcessedEventIdReturning(Either.Left(StorageFailure.DataNotFound))
+            withLastSavedEventIdReturning(Either.Left(StorageFailure.DataNotFound))
             withFetchMostRecentEventReturning(Either.Right("mostRecentEventId"))
         }.withSyncSelfUserFailure()
             .arrange()
@@ -404,17 +404,17 @@ class SlowSyncWorkerTest {
         }
 
         coVerify {
-            arrangement.eventRepository.setEventAsProcessed(any())
+            arrangement.eventRepository.updateLastSavedEventId(any())
         }.wasNotInvoked()
     }
 
     @Test
-    fun givenFetchedEventIdAndEverythingSucceeds_whenWorking_thenShouldUpdateLastProcessedEventId() = runTest {
+    fun givenFetchedEventIdAndEverythingSucceeds_whenWorking_thenShouldUpdateLastSavedEventId() = runTest {
         val fetchedEventId = "aTestEventId"
         val (arrangement, slowSyncWorker) = Arrangement().apply {
-            withLastProcessedEventIdReturning(Either.Left(StorageFailure.DataNotFound))
+            withLastSavedEventIdReturning(Either.Left(StorageFailure.DataNotFound))
             withFetchMostRecentEventReturning(Either.Right(fetchedEventId))
-            withUpdateLastProcessedEventIdReturning(Either.Right(Unit))
+            withUpdateLastSavedEventIdReturning(Either.Right(Unit))
         }.withSyncSelfUserSuccess()
             .withUpdateSupportedProtocolsSuccess()
             .withSyncFeatureConfigsSuccess()
@@ -431,7 +431,7 @@ class SlowSyncWorkerTest {
         slowSyncWorker.slowSyncStepsFlow(successfullyMigration).collect()
 
         coVerify {
-            arrangement.eventRepository.setEventAsProcessed(eq(fetchedEventId))
+            arrangement.eventRepository.updateLastSavedEventId(eq(fetchedEventId))
         }.wasInvoked(exactly = once)
     }
 
@@ -512,7 +512,7 @@ class SlowSyncWorkerTest {
 
         init {
             runBlocking {
-                withLastProcessedEventIdReturning(Either.Right("lastProcessedEventId"))
+                withLastSavedEventIdReturning(Either.Right("LastSavedEventId"))
                 withIsClientAsyncNotificationsCapableReturning(false)
             }
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/EventRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/EventRepositoryArrangement.kt
@@ -34,7 +34,9 @@ internal interface EventRepositoryArrangement {
 
     suspend fun withFetchMostRecentEventReturning(result: Either<CoreFailure, String>)
 
-    suspend fun withLastProcessedEventIdReturning(result: Either<StorageFailure, String>)
+    suspend fun withLastSavedEventIdReturning(result: Either<StorageFailure, String>)
+
+    suspend fun withUpdateLastSavedEventIdReturning(result: Either<StorageFailure, Unit>)
 
     suspend fun withUpdateLastProcessedEventIdReturning(result: Either<StorageFailure, Unit>)
 }
@@ -51,7 +53,7 @@ internal class EventRepositoryArrangementImpl : EventRepositoryArrangement {
 
     override suspend fun withClearLastEventIdReturning(result: Either<StorageFailure, Unit>) {
         coEvery {
-            eventRepository.clearLastProcessedEventId()
+            eventRepository.clearLastSavedEventId()
         }.returns(result)
     }
 
@@ -61,9 +63,15 @@ internal class EventRepositoryArrangementImpl : EventRepositoryArrangement {
         }.returns(result)
     }
 
-    override suspend fun withLastProcessedEventIdReturning(result: Either<StorageFailure, String>) {
+    override suspend fun withLastSavedEventIdReturning(result: Either<StorageFailure, String>) {
         coEvery {
-            eventRepository.lastProcessedEventId()
+            eventRepository.lastSavedEventId()
+        }.returns(result)
+    }
+
+    override suspend fun withUpdateLastSavedEventIdReturning(result: Either<StorageFailure, Unit>) {
+        coEvery {
+            eventRepository.updateLastSavedEventId(any())
         }.returns(result)
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18144" title="WPB-18144" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18144</a>  [Android] App not receiving messages (at all!) when in background
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This is a follow-up to this one: https://github.com/wireapp/kalium/pull/3473

### Issues

After a fresh install, the app is stuck on initial sync screen.

### Causes (Optional)

No "last saved event id" resulting in `DataNotFound` and retrying the initial sync all over again.
After successful slow sync, "last saved event id" should be updated, but because of a mistake, this event is being marked as processed instead, so there is no "last saved event id" stored.

### Solutions

Changed the method to the proper one, applied option to recovery from this loop by restarting slow sync when the app detects this specific scenario, fixed names of methods to make clear distinction between "last saved event" and "last processed event" and added some tests.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Fresh install and login - the app should not be stuck on initial sync screen.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
