### PR TITLE
fix: handling team settings events [WPB-18202]

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ androidx-test-orchestrator = "1.5.1"
 androidx-sqlite = "2.4.0"
 benasher-uuid = "0.8.4"
 ktx-datetime = { strictly = "0.5.0" }
-ktx-serialization = "1.6.3"
+ktx-serialization = "1.8.1"
 ktx-atomicfu = "0.26.1"
 kover = "0.7.6"
 multiplatform-settings = "1.1.1"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

With recent changes to keep events in a database before handling them, now `feature-config.update` events are not being handled properly.

### Causes (Optional)

Now events are being persisted in a database to be taken in batches and handled, so to save them into db, they are serialized back to strings using the same kotlin serialization. For this specific event `feature-config.update` there is a custom serializer created `JsonCorrectingSerializer` because of the structure of that event's JSON to make it possible to use polymorphic JSON parsing feature. However, kotlin serializer has a bug resulting in passing `kotlin.collections.LinkedHashMap` instead of proper type name when serializing item that uses custom serializer: 
https://github.com/Kotlin/kotlinx.serialization/issues/2451

### Solutions

Update kotlin serialization library so that the app can use version with fix they applied.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
