### PR TITLE
fix: improve backup performance (#WPB-18216)

### DIFF
--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/util/BackupUtils.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/util/BackupUtils.kt
@@ -148,15 +148,10 @@ private fun readCompressedEntry(
     entry: ZipEntry
 ): Long {
     var totalExtractedFilesSize = 0L
-    var byteCount: Int
     val entryPathName = "$outputRootPath/${entry.name}"
     val outputSink = fileSystem.sink(entryPathName.toPath().normalized())
-    outputSink.buffer().use { output ->
-        while (zipInputStream.read().also { byteCount = it } != -1) {
-            output.writeByte(byteCount)
-            totalExtractedFilesSize += byteCount
-        }
-        output.write(zipInputStream.readBytes())
+    outputSink.buffer().outputStream().use { output ->
+        totalExtractedFilesSize = zipInputStream.copyTo(output, BUFFER_SIZE.toInt())
     }
     return totalExtractedFilesSize
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/CreateMPBackupUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/CreateMPBackupUseCaseTest.kt
@@ -124,6 +124,9 @@ class CreateMPBackupUseCaseTest {
             override suspend fun insertMessages(messages: List<Message.Standalone>): Either<CoreFailure, Unit> = Unit.right()
         }
 
+        val exporter = mock(BackupExporter::class)
+        val exporterProvider = mock(MPBackupExporterProvider::class)
+
         fun withMessages(messages: List<Message.Standalone>) = apply {
             backupMessages = messages
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/CreateMPBackupUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/CreateMPBackupUseCaseTest.kt
@@ -79,7 +79,7 @@ class CreateMPBackupUseCaseTest {
             .withMessages(listOf(TEXT_MESSAGE))
             .arrange()
 
-        val result = useCase("test_password")
+        val result = useCase("test_password") {}
 
         assertTrue(result is CreateBackupResult.Success)
         coVerify { arrangement.exporter.add(testUser.toBackupUser()) }.wasInvoked(1)
@@ -95,7 +95,7 @@ class CreateMPBackupUseCaseTest {
             .withMessages(listOf(TEXT_MESSAGE))
             .arrange()
 
-        val result = useCase("test_password")
+        val result = useCase("test_password") {}
 
         assertTrue(result is CreateBackupResult.Failure)
     }
@@ -113,8 +113,8 @@ class CreateMPBackupUseCaseTest {
 
             override suspend fun getConversations(): List<Conversation> = listOf(TestConversation.CONVERSATION)
 
-            override fun getMessages(onPage: (List<Message.Standalone>) -> Unit) {
-                onPage(backupMessages)
+            override fun getMessages(onPage: (Int, List<Message.Standalone>) -> Unit) {
+                onPage(1, backupMessages)
             }
 
             override suspend fun insertUsers(users: List<OtherUser>): Either<CoreFailure, Unit> = Unit.right()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/CreateMPBackupUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/CreateMPBackupUseCaseTest.kt
@@ -124,9 +124,6 @@ class CreateMPBackupUseCaseTest {
             override suspend fun insertMessages(messages: List<Message.Standalone>): Either<CoreFailure, Unit> = Unit.right()
         }
 
-        val exporter = mock(BackupExporter::class)
-        val exporterProvider = mock(MPBackupExporterProvider::class)
-
         fun withMessages(messages: List<Message.Standalone>) = apply {
             backupMessages = messages
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/RestoreMPBackupUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/RestoreMPBackupUseCaseTest.kt
@@ -79,7 +79,7 @@ class RestoreMPBackupUseCaseTest {
             .withSuccessImport()
             .arrange()
 
-        useCase(arrangement.storedPath, null)
+        useCase(arrangement.storedPath, null) {}
 
         coVerify { arrangement.backupRepository.insertUsers(any()) }.wasInvoked(exactly = 1)
         coVerify { arrangement.backupRepository.insertConversations(any()) }.wasInvoked(exactly = 1)
@@ -93,7 +93,7 @@ class RestoreMPBackupUseCaseTest {
             .withSuccessImport()
             .arrange()
 
-        useCase(arrangement.storedPath, "test_password")
+        useCase(arrangement.storedPath, "test_password") {}
 
         coVerify { arrangement.backupRepository.insertUsers(any()) }.wasInvoked(exactly = 1)
         coVerify { arrangement.backupRepository.insertConversations(any()) }.wasInvoked(exactly = 1)
@@ -107,7 +107,7 @@ class RestoreMPBackupUseCaseTest {
             .withInvalidPassword()
             .arrange()
 
-        val result = useCase(arrangement.storedPath, "invalid_password")
+        val result = useCase(arrangement.storedPath, "invalid_password") {}
 
         assertTrue(result is RestoreBackupResult.Failure)
         assertEquals(RestoreBackupResult.BackupRestoreFailure.InvalidPassword, result.failure)
@@ -120,7 +120,7 @@ class RestoreMPBackupUseCaseTest {
             .withParsingFailure()
             .arrange()
 
-        val result = useCase(arrangement.storedPath, "invalid_password")
+        val result = useCase(arrangement.storedPath, "invalid_password") {}
 
         assertTrue(result is RestoreBackupResult.Failure)
         assertEquals(RestoreBackupResult.BackupRestoreFailure.BackupIOFailure("Parsing failure"), result.failure)
@@ -133,7 +133,7 @@ class RestoreMPBackupUseCaseTest {
             .withUnzipFailure()
             .arrange()
 
-        val result = useCase(arrangement.storedPath, "invalid_password")
+        val result = useCase(arrangement.storedPath, "invalid_password") {}
 
         assertTrue(result is RestoreBackupResult.Failure)
         assertEquals(RestoreBackupResult.BackupRestoreFailure.BackupIOFailure("Unzipping error"), result.failure)
@@ -146,7 +146,7 @@ class RestoreMPBackupUseCaseTest {
             .withOtherFailure()
             .arrange()
 
-        val result = useCase(arrangement.storedPath, "invalid_password")
+        val result = useCase(arrangement.storedPath, "invalid_password") {}
 
         assertTrue(result is RestoreBackupResult.Failure)
         assertEquals(RestoreBackupResult.BackupRestoreFailure.BackupIOFailure("Unknown error"), result.failure)
@@ -216,6 +216,7 @@ class RestoreMPBackupUseCaseTest {
             every { resultPager.usersPager }.returns(usersPager)
             every { resultPager.conversationsPager }.returns(conversationsPager)
             every { resultPager.messagesPager }.returns(messagesPager)
+            every { resultPager.totalPagesCount }.returns(1)
 
             return this to RestoreMPBackupUseCaseImpl(
                 selfUserId = selfUserId,

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -497,6 +497,9 @@ SELECT count(*) FROM Message WHERE conversation_id = ? AND visibility IN ? ORDER
 selectByConversationIdAndVisibility:
 SELECT * FROM MessageDetailsView WHERE conversationId = :conversationId AND visibility IN :visibility ORDER BY date DESC LIMIT :limit OFFSET :offset;
 
+countBackupMessages:
+SELECT count(*) FROM MessageDetailsView WHERE visibility = "VISIBLE" AND selfDeletionEndDate IS NULL AND contentType IN :contentType;
+
 selectForBackup:
 SELECT * FROM MessageDetailsView WHERE visibility = "VISIBLE" AND selfDeletionEndDate IS NULL AND contentType IN :contentType ORDER BY date ASC LIMIT :limit OFFSET :offset;
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -171,4 +171,5 @@ interface MessageDAO {
         pageSize: Int,
         onPage: (List<MessageEntity>) -> Unit,
     )
+    fun countMessagesForBackup(contentTypes: Collection<MessageEntity.ContentType>): Long
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -534,6 +534,9 @@ internal class MessageDAOImpl internal constructor(
             queries.selectNextAudioMessage(conversationId, prevMessageId).executeAsOneOrNull()
         }
 
+    override fun countMessagesForBackup(contentTypes: Collection<MessageEntity.ContentType>): Long =
+        queries.countBackupMessages(contentTypes).executeAsOne()
+
     override fun getMessagesPaged(
         contentTypes: Collection<MessageEntity.ContentType>,
         pageSize: Int,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18216" title="WPB-18216" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18216</a>  [Android] Improve backup performance
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

https://wearezeta.atlassian.net/browse/WPB-18216
----
# What's new in this PR?

### Issues
Creating and restoring backups for large number of messages takes a long time.

### Solutions

Backup creation:
- Increase the page size for reading messages from database.

Backup restore:
- Fix issue with unbuffered zip file extraction (extracting was taking 1 minute)

Backup/Restore Progress:
- Calculate progress to give user an indication of backup/restore progress. 
