### PR TITLE
fix: syncbar mechanism with local events (WPB-18229)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -995,6 +995,7 @@ class UserSessionScope internal constructor(
         get() = EventGathererImpl(
             isClientAsyncNotificationsCapableProvider = isClientAsyncNotificationsCapableProvider,
             eventRepository = eventRepository,
+            processingScope = this@UserSessionScope,
             logger = userScopedLogger
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
@@ -114,10 +114,7 @@ internal class EventGathererImpl(
          */
         isClientAsyncNotificationsCapableProvider().flatMap { isAsyncNotifications ->
             fetchEventFlow(isAsyncNotifications)
-                .onSuccess {
-                println("KBX emit items $it")
-                    emitEvents(it)
-                }
+                .onSuccess { emitEvents(it) }
                 .onFailure { throw KaliumSyncException("Failure when gathering events", it) }
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
@@ -100,6 +100,9 @@ internal class EventGathererImpl(
         .onEach {
             it.firstOrNull()?.let { lastEvent ->
                 _currentSource.value = lastEvent.deliveryInfo.source
+                liveSourceChangeHandler.scheduleNewCatchingUpJob(
+                    onEventIntervalGapReached = { _currentSource.value = EventSource.LIVE }
+                )
             }
         }
         .flatten()
@@ -167,9 +170,6 @@ internal class EventGathererImpl(
 
     private suspend fun FlowCollector<Unit>.onWebSocketEventReceived() {
         logger.i("Websocket Binary payload received")
-        liveSourceChangeHandler.scheduleNewCatchingUpJob(
-            onEventIntervalGapReached = { _currentSource.value = EventSource.LIVE }
-        )
         emit(Unit)
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
@@ -114,7 +114,10 @@ internal class EventGathererImpl(
          */
         isClientAsyncNotificationsCapableProvider().flatMap { isAsyncNotifications ->
             fetchEventFlow(isAsyncNotifications)
-                .onSuccess { emitEvents(it) }
+                .onSuccess {
+                println("KBX emit items $it")
+                    emitEvents(it)
+                }
                 .onFailure { throw KaliumSyncException("Failure when gathering events", it) }
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/LiveSourceChangeHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/LiveSourceChangeHandler.kt
@@ -1,0 +1,113 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.incremental
+
+import com.wire.kalium.logic.sync.incremental.LiveSourceChangeHandlerImpl.Companion.CATCHING_UP_JOB_EVENT_INTERVAL
+import com.wire.kalium.logic.sync.incremental.LiveSourceChangeHandlerImpl.Companion.CATCHING_UP_JOB_INITIAL_THRESHOLD
+import io.mockative.Mockable
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Handles the change of the event source from pending to live after opening a Websocket connection.
+ * It is used to manage the catching up job that processes events when the websocket is opened to mimic the behavior of
+ * the old quick sync that was used to fetch pending events from the notification stream.
+ */
+@Mockable
+interface LiveSourceChangeHandler {
+    /**
+     * Start the processing of the catching up job.
+     *
+     * @param interval The delay after just opening the websocket connection. Default is [CATCHING_UP_JOB_INITIAL_THRESHOLD].
+     * @param onStartIntervalReached The task to be executed when the time reached. Used for marking the status of fetching events as LIVE.
+     */
+    suspend fun startNewCatchingUpJob(interval: Duration = CATCHING_UP_JOB_INITIAL_THRESHOLD, onStartIntervalReached: () -> Unit)
+
+    /**
+     * Schedule a new catching up job that will be cancelled if there was already one pending scheduled.
+     * Scheduled to run once with a delay of [CATCHING_UP_JOB_EVENT_INTERVAL].
+     *
+     * @param interval The delay between each event processing. Default is [CATCHING_UP_JOB_EVENT_INTERVAL].
+     * @param onEventIntervalGapReached The task to be executed when the time reached. Used to mark the status of fetching events as LIVE.
+     */
+    suspend fun scheduleNewCatchingUpJob(interval: Duration = CATCHING_UP_JOB_EVENT_INTERVAL, onEventIntervalGapReached: () -> Unit)
+
+    /**
+     * Cancel the catching up job and reset the last time the websocket was opened and the last time
+     * an event was received.To be called when the websocket is closed.
+     */
+    suspend fun clear()
+}
+
+internal class LiveSourceChangeHandlerImpl(private val processingScope: CoroutineScope) : LiveSourceChangeHandler {
+    private var websocketOpenedAt: Instant? = null
+    private var lastEventReceivedAt: Instant? = null
+    private var catchingUpJob: Job? = null
+    private val mutex = Mutex()
+
+    override suspend fun startNewCatchingUpJob(interval: Duration, onStartIntervalReached: () -> Unit) = mutex.withLock {
+        websocketOpenedAt = Clock.System.now()
+        catchingUpJob?.cancel()
+        catchingUpJob = processingScope.launch {
+            delay(interval)
+            onStartIntervalReached()
+        }
+    }
+
+    override suspend fun scheduleNewCatchingUpJob(interval: Duration, onEventIntervalGapReached: () -> Unit) =
+        mutex.withLock {
+            lastEventReceivedAt = Clock.System.now()
+            catchingUpJob?.cancel()
+            catchingUpJob = processingScope.launch {
+                delay(interval)
+                onEventIntervalGapReached()
+            }
+        }
+
+    override suspend fun clear() = mutex.withLock {
+        catchingUpJob?.cancel()
+        catchingUpJob = null
+        websocketOpenedAt = null
+        lastEventReceivedAt = null
+    }
+
+    override fun toString(): String {
+        return "LiveSourceChangeHandlerImpl(websocketOpenedAt=$websocketOpenedAt, " +
+                "lastEventReceivedAt=$lastEventReceivedAt, catchingUpJob.isActive=${catchingUpJob?.isActive == true})"
+    }
+
+    companion object {
+        /**
+         * Setting this up to 5 secs, as a threshold to wait for the websocket opened time and the first event received.
+         */
+        val CATCHING_UP_JOB_INITIAL_THRESHOLD = 5.seconds
+
+        /**
+         * Interval in between each event process threshold.
+         */
+        val CATCHING_UP_JOB_EVENT_INTERVAL = 0.5.seconds
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventGathererTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventGathererTest.kt
@@ -59,6 +59,7 @@ import okio.IOException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class EventGathererTest {
@@ -476,7 +477,7 @@ class EventGathererTest {
 
         assertEquals(EventSource.PENDING, eventGatherer.currentSource.value)
 
-        advanceTimeBy(1000)
+        advanceTimeBy(1.seconds)
 
         assertEquals(EventSource.LIVE, eventGatherer.currentSource.value)
     }
@@ -501,11 +502,10 @@ class EventGathererTest {
 
         assertEquals(EventSource.PENDING, eventGatherer.currentSource.value)
 
-        advanceTimeBy(1000)
+        advanceTimeBy(1.seconds)
 
         assertEquals(EventSource.LIVE, eventGatherer.currentSource.value)
     }
-
 
 
     private class Arrangement {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventGathererTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventGathererTest.kt
@@ -52,7 +52,6 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import okio.IOException
@@ -578,7 +577,6 @@ class EventGathererTest {
             isClientAsyncNotificationsCapableProvider = isClientAsyncNotificationsCapableProvider,
             eventRepository = eventRepository,
             processingScope = processingScope,
-            liveSourceChangeHandler = liveSourceChangeHandler,
             serverTimeHandler = serverTimeHandler
         )
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventGathererTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventGathererTest.kt
@@ -30,6 +30,8 @@ import com.wire.kalium.logic.data.event.EventRepository
 import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.logic.framework.TestEvent.wrapInEnvelope
 import com.wire.kalium.logic.sync.KaliumSyncException
+import com.wire.kalium.logic.sync.incremental.EventGathererTest.Arrangement.Companion.testScope
+import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import com.wire.kalium.logic.util.ServerTimeHandler
 import com.wire.kalium.network.api.base.authenticated.notification.WebSocketEvent
 import com.wire.kalium.network.api.model.ErrorResponse
@@ -39,6 +41,7 @@ import io.mockative.coEvery
 import io.mockative.coVerify
 import io.mockative.mock
 import io.mockative.once
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.channels.Channel
@@ -49,6 +52,7 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import okio.IOException
@@ -60,7 +64,7 @@ import kotlin.test.assertIs
 class EventGathererTest {
 
     @Test
-    fun givenWebSocketOpens_whenGathering_thenShouldStartFetchPendingEvents() = runTest {
+    fun givenWebSocketOpens_whenGathering_thenShouldStartFetchPendingEvents() = runTest(testScope) {
         val liveEventsChannel = Channel<WebSocketEvent<Unit>>(capacity = Channel.UNLIMITED)
 
         val (arrangement, eventGatherer) = Arrangement()
@@ -68,7 +72,7 @@ class EventGathererTest {
             .withPendingEventsReturning(emptyFlow())
             .withLiveEventsReturning(Either.Right(liveEventsChannel.consumeAsFlow()))
             .withFetchServerTimeReturning("2022-03-30T15:36:00.000Z")
-            .arrange()
+            .arrange(this.backgroundScope)
 
         eventGatherer.liveEvents().test {
             coVerify {
@@ -89,7 +93,7 @@ class EventGathererTest {
     }
 
     @Test
-    fun givenWebSocketOpens_whenGatheringFromNewAsyncNotifications_thenShouldSkipFetchPendingEvents() = runTest {
+    fun givenWebSocketOpens_whenGatheringFromNewAsyncNotifications_thenShouldSkipFetchPendingEvents() = runTest(testScope) {
         // given
         val liveEventsChannel = Channel<WebSocketEvent<Unit>>(capacity = Channel.UNLIMITED)
         val (arrangement, eventGatherer) = Arrangement()
@@ -98,7 +102,7 @@ class EventGathererTest {
             .withLiveEventsReturning(liveEventsChannel.consumeAsFlow().right())
             .withLocalEventsReturning(emptyFlow())
             .withFetchServerTimeReturning("2022-03-30T15:36:00.000Z")
-            .arrange()
+            .arrange(this.backgroundScope)
 
         eventGatherer.gatherEvents().test {
             coVerify {
@@ -122,7 +126,7 @@ class EventGathererTest {
     }
 
     @Test
-    fun givenWebSocketOpensAndDisconnectPolicy_whenGathering_thenShouldStartFetchPendingEvents() = runTest {
+    fun givenWebSocketOpensAndDisconnectPolicy_whenGathering_thenShouldStartFetchPendingEvents() = runTest(testScope) {
         val liveEventsChannel = Channel<WebSocketEvent<Unit>>(capacity = Channel.UNLIMITED)
 
         val (arrangement, eventGatherer) = Arrangement()
@@ -131,7 +135,7 @@ class EventGathererTest {
             .withLiveEventsReturning(Either.Right(liveEventsChannel.consumeAsFlow()))
             .withLocalEventsReturning(emptyFlow())
             .withFetchServerTimeReturning(null)
-            .arrange()
+            .arrange(this.backgroundScope)
 
         eventGatherer.liveEvents().test {
             coVerify {
@@ -152,7 +156,7 @@ class EventGathererTest {
     }
 
     @Test
-    fun givenPendingEventAndDisconnectPolicy_whenGathering_thenShouldEmitEvent() = runTest {
+    fun givenPendingEventAndDisconnectPolicy_whenGathering_thenShouldEmitEvent() = runTest(testScope) {
         val liveEventsChannel = Channel<WebSocketEvent<Unit>>(capacity = Channel.UNLIMITED)
 
         val pendingEvent = TestEvent.newConnection().wrapInEnvelope()
@@ -162,7 +166,7 @@ class EventGathererTest {
             .withLiveEventsReturning(Either.Right(liveEventsChannel.consumeAsFlow()))
             .withLocalEventsReturning(emptyFlow())
             .withFetchServerTimeReturning(null)
-            .arrange()
+            .arrange(this.backgroundScope)
 
         eventGatherer.liveEvents().test {
             coVerify {
@@ -179,7 +183,7 @@ class EventGathererTest {
     }
 
     @Test
-    fun givenLocalThousandsEventsAndKeepAlivePolicy_whenGathering_thenShouldEmitAllEvents() = runTest {
+    fun givenLocalThousandsEventsAndKeepAlivePolicy_whenGathering_thenShouldEmitAllEvents() = runTest(testScope) {
         val repeatValue = 10_000
         val webSocketEventFlow = channelFlow<WebSocketEvent<Unit>> {
             send(WebSocketEvent.Open())
@@ -194,7 +198,7 @@ class EventGathererTest {
             .withPendingEventsReturning(emptyFlow())
             .withLiveEventsReturning(Either.Right(webSocketEventFlow))
             .withFetchServerTimeReturning(null)
-            .arrange()
+            .arrange(this.backgroundScope)
 
         eventGatherer.liveEvents().test {
             repeat(repeatValue) { value ->
@@ -205,7 +209,7 @@ class EventGathererTest {
     }
 
     @Test
-    fun givenWebSocketOpens_whenGathering_thenSyncSourceIsUpdatedToLive() = runTest {
+    fun givenWebSocketOpens_whenGathering_thenSyncSourceIsUpdatedToLive() = runTest(testScope) {
         val liveEventsChannel = Channel<WebSocketEvent<Unit>>(capacity = Channel.UNLIMITED)
 
         val (_, eventGatherer) = Arrangement()
@@ -214,7 +218,7 @@ class EventGathererTest {
             .withLiveEventsReturning(Either.Right(liveEventsChannel.consumeAsFlow()))
             .withLocalEventsReturning(emptyFlow())
             .withFetchServerTimeReturning(null)
-            .arrange()
+            .arrange(this.backgroundScope)
 
         eventGatherer.liveEvents().test {
             // Open Websocket should trigger fetching pending events
@@ -230,7 +234,7 @@ class EventGathererTest {
     }
 
     @Test
-    fun givenEventsWithPendingSource_whenGathering_thenCurrentSourceIsPending() = runTest {
+    fun givenEventsWithPendingSource_whenGathering_thenCurrentSourceIsPending() = runTest(testScope) {
         val event = TestEvent.memberJoin()
             .wrapInEnvelope(source = EventSource.PENDING)
 
@@ -242,7 +246,7 @@ class EventGathererTest {
         val (_, eventGatherer) = Arrangement()
             .withLocalEventsReturning(webSocketEventFlow)
             .withLiveEventsReturning(Either.Right(emptyFlow()))
-            .arrange()
+            .arrange(this.backgroundScope)
 
         eventGatherer.gatherEvents().test {
             awaitItem()
@@ -253,7 +257,7 @@ class EventGathererTest {
     }
 
     @Test
-    fun givenEventsWithLiveSource_whenGathering_thenCurrentSourceIsLive() = runTest {
+    fun givenEventsWithLiveSource_whenGathering_thenCurrentSourceIsLive() = runTest(testScope) {
         val event = TestEvent.memberJoin()
             .wrapInEnvelope(source = EventSource.LIVE)
 
@@ -265,7 +269,7 @@ class EventGathererTest {
         val (_, eventGatherer) = Arrangement()
             .withLocalEventsReturning(webSocketEventFlow)
             .withLiveEventsReturning(Either.Right(emptyFlow()))
-            .arrange()
+            .arrange(this.backgroundScope)
 
         eventGatherer.gatherEvents().test {
             awaitItem()
@@ -276,7 +280,7 @@ class EventGathererTest {
     }
 
     @Test
-    fun givenWebSocketOpensAndFetchingPendingEventsFail_whenGathering_thenGatheringShouldFailWithSyncException() = runTest {
+    fun givenWebSocketOpensAndFetchingPendingEventsFail_whenGathering_thenGatheringShouldFailWithSyncException() = runTest(testScope) {
         val liveEventsChannel = Channel<WebSocketEvent<Unit>>(capacity = Channel.UNLIMITED)
 
         val failureCause = NetworkFailure.ServerMiscommunication(IOException())
@@ -285,7 +289,7 @@ class EventGathererTest {
             .withPendingEventsReturning(flowOf(Either.Left(failureCause)))
             .withLiveEventsReturning(Either.Right(liveEventsChannel.consumeAsFlow()))
             .withFetchServerTimeReturning(null)
-            .arrange()
+            .arrange(this.backgroundScope)
 
         eventGatherer.liveEvents().test {
             // Open Websocket should trigger fetching pending events
@@ -300,7 +304,7 @@ class EventGathererTest {
     }
 
     @Test
-    fun givenWebSocketReceivesEventsAndFetchingPendingEventsFail_whenGathering_thenEventsShouldNotBeEmitted() = runTest {
+    fun givenWebSocketReceivesEventsAndFetchingPendingEventsFail_whenGathering_thenEventsShouldNotBeEmitted() = runTest(testScope) {
         val liveEventsChannel = Channel<WebSocketEvent<Unit>>(capacity = Channel.UNLIMITED)
 
         val failureCause = NetworkFailure.ServerMiscommunication(IOException())
@@ -309,7 +313,7 @@ class EventGathererTest {
             .withPendingEventsReturning(flowOf(Either.Left(failureCause)))
             .withLiveEventsReturning(Either.Right(liveEventsChannel.receiveAsFlow()))
             .withFetchServerTimeReturning(null)
-            .arrange()
+            .arrange(this.backgroundScope)
 
         eventGatherer.liveEvents().test {
             // Open Websocket should trigger fetching pending events
@@ -324,14 +328,14 @@ class EventGathererTest {
     }
 
     @Test
-    fun givenNoEvents_whenGathering_thenSyncSourceDefaultsToPending() = runTest {
+    fun givenNoEvents_whenGathering_thenSyncSourceDefaultsToPending() = runTest(testScope) {
         val (_, eventGatherer) = Arrangement()
             .withLastEventIdReturning(Either.Right("lastEventId"))
             .withPendingEventsReturning(emptyFlow())
             .withLiveEventsReturning(Either.Right(emptyFlow()))
             .withLocalEventsReturning(emptyFlow())
             .withFetchServerTimeReturning(null)
-            .arrange()
+            .arrange(this.backgroundScope)
 
         eventGatherer.liveEvents().test {
             eventGatherer.currentSource.test {
@@ -343,7 +347,7 @@ class EventGathererTest {
     }
 
     @Test
-    fun givenAnEventIsInOnPendingSource_whenGathering_theEventIsEmitted() = runTest {
+    fun givenAnEventIsInOnPendingSource_whenGathering_theEventIsEmitted() = runTest(testScope) {
         val event = TestEvent.memberJoin().wrapInEnvelope()
 
         val liveEventsChannel = Channel<WebSocketEvent<Unit>>(capacity = Channel.UNLIMITED)
@@ -353,7 +357,7 @@ class EventGathererTest {
             .withPendingEventsReturning(flowOf(Either.Right(event)))
             .withLiveEventsReturning(Either.Right(liveEventsChannel.consumeAsFlow()))
             .withFetchServerTimeReturning(null)
-            .arrange()
+            .arrange(this.backgroundScope)
 
         // Open Websocket should trigger fetching pending events
         liveEventsChannel.send(WebSocketEvent.Open())
@@ -365,7 +369,7 @@ class EventGathererTest {
     }
 
     @Test
-    fun givenAnEventIsInOnLiveSource_whenGathering_theEventIsEmitted() = runTest {
+    fun givenAnEventIsInOnLiveSource_whenGathering_theEventIsEmitted() = runTest(testScope) {
         val liveEventsChannel = Channel<WebSocketEvent<Unit>>(capacity = Channel.UNLIMITED)
 
         val (_, eventGatherer) = Arrangement()
@@ -373,7 +377,7 @@ class EventGathererTest {
             .withPendingEventsReturning(emptyFlow())
             .withLiveEventsReturning(Either.Right(liveEventsChannel.consumeAsFlow()))
             .withFetchServerTimeReturning(null)
-            .arrange()
+            .arrange(this.backgroundScope)
 
         // Open Websocket should trigger fetching pending events
         liveEventsChannel.send(WebSocketEvent.Open())
@@ -387,7 +391,7 @@ class EventGathererTest {
     }
 
     @Test
-    fun givenPendingEventsFailWith404_whenGathering_thenShouldThrowExceptionWithEventNotFoundCause() = runTest {
+    fun givenPendingEventsFailWith404_whenGathering_thenShouldThrowExceptionWithEventNotFoundCause() = runTest(testScope) {
         val liveEventsChannel = Channel<WebSocketEvent<Unit>>(capacity = Channel.UNLIMITED)
 
         val failureCause = NetworkFailure.ServerMiscommunication(
@@ -404,7 +408,7 @@ class EventGathererTest {
             .withPendingEventsReturning(flowOf(Either.Left(failureCause)))
             .withLiveEventsReturning(Either.Right(liveEventsChannel.consumeAsFlow()))
             .withFetchServerTimeReturning(null)
-            .arrange()
+            .arrange(this.backgroundScope)
 
         eventGatherer.liveEvents().test {
             // Open Websocket should trigger fetching pending events
@@ -419,14 +423,14 @@ class EventGathererTest {
     }
 
     @Test
-    fun givenWebSocketOpens_whenGatheringAndAsyncNotificationsCapable_thenShouldNotFetchPendingEventsNorLastEvent() = runTest {
+    fun givenWebSocketOpens_whenGatheringAndAsyncNotificationsCapable_thenShouldNotFetchPendingEventsNorLastEvent() = runTest(testScope) {
         val liveEventsChannel = Channel<WebSocketEvent<Unit>>(capacity = Channel.UNLIMITED)
 
         val (arrangement, eventGatherer) = Arrangement()
             .withIsClientAsyncNotificationsCapableReturning(true)
             .withPendingEventsReturning(emptyFlow())
             .withLiveEventsReturning(Either.Right(liveEventsChannel.consumeAsFlow()))
-            .arrange()
+            .arrange(this.backgroundScope)
 
         eventGatherer.liveEvents().test {
             coVerify {
@@ -461,24 +465,25 @@ class EventGathererTest {
     }
 
     @Test
-    fun givenNoLastSavedEventId_whenGettingLiveEventsWithoutAsyncNotifications_thenReturnSyncEventOrClientNotFoundToRecover() = runTest {
-        val (_, eventGatherer) = Arrangement()
-            .withIsClientAsyncNotificationsCapableReturning(false)
-            .withLastEventIdReturning(Either.Left(StorageFailure.DataNotFound))
-            .arrange()
+    fun givenNoLastSavedEventId_whenGettingLiveEventsWithoutAsyncNotifications_thenReturnSyncEventOrClientNotFoundToRecover() =
+        runTest(testScope) {
+            val (_, eventGatherer) = Arrangement()
+                .withIsClientAsyncNotificationsCapableReturning(false)
+                .withLastEventIdReturning(Either.Left(StorageFailure.DataNotFound))
+                .arrange(this.backgroundScope)
 
-        eventGatherer.liveEvents().test {
-            advanceUntilIdle()
-            awaitError().let {
-                assertIs<KaliumSyncException>(it).also {
-                    assertIs<CoreFailure.SyncEventOrClientNotFound>(it.coreFailureCause)
+            eventGatherer.liveEvents().test {
+                advanceUntilIdle()
+                awaitError().let {
+                    assertIs<KaliumSyncException>(it).also {
+                        assertIs<CoreFailure.SyncEventOrClientNotFound>(it.coreFailureCause)
+                    }
                 }
             }
         }
-    }
 
     @Test
-    fun givenPendingEventThenWebSocketOpen_whenGathering_thenCurrentSourceUpdatesTwice() = runTest {
+    fun givenPendingEventThenWebSocketOpen_whenGathering_thenCurrentSourceUpdatesTwice() = runTest(testScope) {
         val liveEventsChannel = Channel<WebSocketEvent<Unit>>(capacity = Channel.UNLIMITED)
 
         val event = TestEvent.memberJoin()
@@ -489,7 +494,7 @@ class EventGathererTest {
             .withPendingEventsReturning(flowOf(Either.Right(event)))
             .withLocalEventsReturning(flowOf(listOf(event)))
             .withLiveEventsReturning(liveEventsChannel.consumeAsFlow().right())
-            .arrange()
+            .arrange(this.backgroundScope)
 
         eventGatherer.gatherEvents().test {
             awaitItem()
@@ -504,6 +509,7 @@ class EventGathererTest {
         eventGatherer.liveEvents().test {
             liveEventsChannel.send(WebSocketEvent.Open())
             advanceUntilIdle()
+            cancelAndIgnoreRemainingEvents()
 
             eventGatherer.currentSource.test {
                 assertEquals(EventSource.LIVE, awaitItem())
@@ -516,11 +522,15 @@ class EventGathererTest {
 
     private class Arrangement {
 
+        companion object {
+            val testScope = TestKaliumDispatcher.main
+        }
+
+        val liveSourceChangeHandler = mock(LiveSourceChangeHandler::class)
+
         val eventRepository = mock(EventRepository::class)
         val isClientAsyncNotificationsCapableProvider = mock(IsClientAsyncNotificationsCapableProvider::class)
         val serverTimeHandler = mock(ServerTimeHandler::class)
-
-        val eventGatherer: EventGatherer = EventGathererImpl(isClientAsyncNotificationsCapableProvider, eventRepository, serverTimeHandler)
 
         init {
             runBlocking {
@@ -564,6 +574,12 @@ class EventGathererTest {
             }.returns(either)
         }
 
-        fun arrange() = this to eventGatherer
+        fun arrange(processingScope: CoroutineScope) = this to EventGathererImpl(
+            isClientAsyncNotificationsCapableProvider = isClientAsyncNotificationsCapableProvider,
+            eventRepository = eventRepository,
+            processingScope = processingScope,
+            liveSourceChangeHandler = liveSourceChangeHandler,
+            serverTimeHandler = serverTimeHandler
+        )
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/LiveSourceChangeHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/LiveSourceChangeHandlerTest.kt
@@ -1,0 +1,170 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.incremental
+
+import app.cash.turbine.test
+import com.wire.kalium.logic.sync.incremental.LiveSourceChangeHandlerTest.Arrangement.Companion.testScope
+import com.wire.kalium.logic.test_util.TestKaliumDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+class LiveSourceChangeHandlerTest {
+    @Test
+    fun givenCreateNewCatchingUpJob_ThenSetupsOpenedDateAndStartAJob() = runTest(testScope) {
+        val (_, handler) = Arrangement().arrange(this.backgroundScope)
+
+        val taskChannel = Channel<Unit>(Channel.UNLIMITED)
+        val task: () -> Unit = { taskChannel.trySend(Unit) }
+        val taskFlow = taskChannel.receiveAsFlow()
+
+        handler.startNewCatchingUpJob(1.seconds, task)
+
+        taskFlow.test {
+            advanceTimeBy(1.seconds)
+            assertEquals(Unit, awaitItem(), "Task should have been executed")
+            assertFalse(handler.toString().contains("websocketOpenedAt=null"))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun givenScheduleNewCatchingUpJob_ThenShouldCancelPreviousJob() = runTest(testScope) {
+        val (_, handler) = Arrangement().arrange(this.backgroundScope)
+
+        val firstTaskChannel = Channel<Unit>(Channel.UNLIMITED)
+        val secondTaskChannel = Channel<Unit>(Channel.UNLIMITED)
+        val firstTask: () -> Unit = { firstTaskChannel.trySend(Unit) }
+        val secondTask: () -> Unit = { secondTaskChannel.trySend(Unit) }
+        val firstTaskFlow = firstTaskChannel.receiveAsFlow()
+        val secondTaskFlow = secondTaskChannel.receiveAsFlow()
+
+        // Create first job
+        handler.startNewCatchingUpJob(1.seconds, firstTask)
+        // advance half of the time to ensure this didn't execute yet
+        advanceTimeBy(0.5.seconds)
+
+        // Create second job
+        handler.scheduleNewCatchingUpJob(1.seconds, secondTask)
+        // advance the rest of the time to ensure second task executes
+        advanceTimeBy(1.seconds)
+
+        firstTaskFlow.test {
+            // then first task was never executed
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        secondTaskFlow.test {
+            // then second task was executed
+            assertEquals(Unit, awaitItem(), "Second task should execute")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun givenScheduleNewCatchingUpJob_ThenSetupsLastEventReceivedDateAndStartAJob() = runTest(testScope) {
+        val (_, handler) = Arrangement().arrange(this.backgroundScope)
+
+        val taskChannel = Channel<Unit>(Channel.UNLIMITED)
+        val task: () -> Unit = { taskChannel.trySend(Unit) }
+        val taskFlow = taskChannel.receiveAsFlow()
+
+        handler.scheduleNewCatchingUpJob(1.seconds, task)
+
+        taskFlow.test {
+            advanceTimeBy(1.seconds)
+            assertEquals(Unit, awaitItem(), "Task should have been executed")
+            assertFalse(handler.toString().contains("lastEventReceivedAt=null"))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun givenClearScheduledJobs_ThenRestartState() = runTest(testScope) {
+        val (_, handler) = Arrangement().arrange(this.backgroundScope)
+
+        val taskChannel = Channel<Unit>(Channel.UNLIMITED)
+        val task: () -> Unit = { taskChannel.trySend(Unit) }
+        val taskFlow = taskChannel.receiveAsFlow()
+
+        handler.scheduleNewCatchingUpJob(1.seconds, task)
+        advanceTimeBy(1.seconds)
+
+        taskFlow.test {
+            assertEquals(Unit, awaitItem(), "Task should have been executed")
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        handler.clear()
+        assertEquals("null", handler.toString().substringAfter("websocketOpenedAt=").substringBefore(","))
+        assertEquals("null", handler.toString().substringAfter("lastEventReceivedAt=").substringBefore(","))
+        assertTrue(handler.toString().contains("catchingUpJob.isActive=false"))
+
+        // Advance time again, task should not execute
+        taskFlow.test {
+            advanceTimeBy(1.seconds)
+            expectNoEvents() // Task should not execute after clear
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun givenNewJobsAreCreated_ShouldHandleGracefullyWithMutex() = runTest(testScope) {
+        val (_, handler) = Arrangement().arrange(this.backgroundScope)
+
+        val taskChannel = Channel<Unit>(Channel.UNLIMITED)
+        val task: () -> Unit = { taskChannel.trySend(Unit) }
+        val taskFlow = taskChannel.receiveAsFlow()
+
+        // Launch multiple jobs concurrently
+        val jobs = List(10) {
+            launch {
+                handler.startNewCatchingUpJob(1.seconds, task)
+            }
+        }
+        jobs.forEach { it.join() }
+        // Verify that only one job is active
+        assertTrue(handler.toString().contains("catchingUpJob.isActive=true"))
+        // Verify websocketOpenedAt is set correctly
+        assertFalse(handler.toString().contains("websocketOpenedAt=null"))
+
+        taskFlow.test {
+            advanceTimeBy(1.seconds)
+            assertEquals(Unit, awaitItem(), "Task should execute once")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private class Arrangement {
+
+        companion object {
+            val testScope = TestKaliumDispatcher.main
+        }
+
+        fun arrange(processingScope: CoroutineScope) = this to LiveSourceChangeHandlerImpl(processingScope)
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18229" title="WPB-18229" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18229</a>  [Android] User seeing decrypting messages banner until they receive a message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sync bar needs to be handled with some timing from the processing events and from the moment we open the websocket

### Solutions

Bring back the solution from 
- #3455 

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
