### PR TITLE
fix: add location name to backup restore mapper (#WPB-18232)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/mapper/RestoreDataMappers.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/mapper/RestoreDataMappers.kt
@@ -118,6 +118,7 @@ private fun BackupMessageContent.toMessageContent() =
         is BackupMessageContent.Location -> MessageContent.Location(
             latitude = latitude,
             longitude = longitude,
+            name = name,
         )
 
         is BackupMessageContent.Asset -> MessageContent.Asset(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18232" title="WPB-18232" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18232</a>  [Android] Shared location is missing details after restoring from backup
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-18232
----
# What's new in this PR?

### Issues
Adding location name to the backup data mapper to restore location address.