### PR TITLE
refactor: separate logic for deleting conversation [WPB-14735]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -54,6 +54,7 @@ import com.wire.kalium.logic.feature.conversation.createconversation.CreateRegul
 import com.wire.kalium.logic.feature.conversation.createconversation.CreateRegularGroupUseCaseImpl
 import com.wire.kalium.logic.feature.conversation.createconversation.GroupConversationCreator
 import com.wire.kalium.logic.feature.conversation.createconversation.GroupConversationCreatorImpl
+import com.wire.kalium.logic.feature.conversation.delete.DeleteConversationUseCase
 import com.wire.kalium.logic.feature.conversation.folder.AddConversationToFavoritesUseCase
 import com.wire.kalium.logic.feature.conversation.folder.AddConversationToFavoritesUseCaseImpl
 import com.wire.kalium.logic.feature.conversation.folder.CreateConversationFolderUseCase
@@ -128,6 +129,7 @@ class ConversationScope internal constructor(
     internal val messageRepository: MessageRepository,
     internal val assetRepository: AssetRepository,
     private val newGroupConversationSystemMessagesCreator: NewGroupConversationSystemMessagesCreator,
+    private val deleteConversationUseCase: DeleteConversationUseCase,
     internal val dispatcher: KaliumDispatcher = KaliumDispatcherImpl,
 ) {
 
@@ -182,7 +184,7 @@ class ConversationScope internal constructor(
         )
 
     val deleteTeamConversation: DeleteTeamConversationUseCase
-        get() = DeleteTeamConversationUseCaseImpl(selfTeamIdProvider, teamRepository, conversationRepository)
+        get() = DeleteTeamConversationUseCaseImpl(selfTeamIdProvider, teamRepository, deleteConversationUseCase)
 
     internal val createGroupConversation: GroupConversationCreator
         get() = GroupConversationCreatorImpl(
@@ -293,7 +295,7 @@ class ConversationScope internal constructor(
     val deleteConversationLocallyUseCase: DeleteConversationLocallyUseCase
         get() = DeleteConversationLocallyUseCaseImpl(
             clearConversationContent,
-            conversationRepository
+            deleteConversationUseCase
         )
 
     val joinConversationViaCode: JoinConversationViaCodeUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/DeleteConversationLocallyUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/DeleteConversationLocallyUseCase.kt
@@ -18,10 +18,10 @@
 package com.wire.kalium.logic.feature.conversation
 
 import com.wire.kalium.common.error.CoreFailure
-import com.wire.kalium.logic.data.conversation.ConversationRepository
-import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.left
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.feature.conversation.delete.DeleteConversationUseCase
 
 interface DeleteConversationLocallyUseCase {
     /**
@@ -38,7 +38,7 @@ interface DeleteConversationLocallyUseCase {
 
 internal class DeleteConversationLocallyUseCaseImpl(
     private val clearConversationContent: ClearConversationContentUseCase,
-    private val conversationRepository: ConversationRepository,
+    private val deleteConversation: DeleteConversationUseCase,
 ) : DeleteConversationLocallyUseCase {
 
     override suspend fun invoke(conversationId: ConversationId): Either<CoreFailure, Unit> {
@@ -46,7 +46,7 @@ internal class DeleteConversationLocallyUseCaseImpl(
         return if (clearResult is ClearConversationContentUseCase.Result.Failure) {
             clearResult.failure.left()
         } else {
-            conversationRepository.deleteConversation(conversationId)
+            deleteConversation(conversationId)
         }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/delete/DeleteConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/delete/DeleteConversationUseCase.kt
@@ -1,0 +1,60 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.conversation.delete
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.id.ConversationId
+import io.mockative.Mockable
+
+/**
+ * Use case responsible for deleting a conversation, handling both Proteus and MLS protocols.
+ *
+ * - For **Proteus** conversations, this simply deletes the local database entry.
+ * - For **MLS** conversations, this deletes the local conversation and also wipes it from the MLS client.
+ */
+
+@Mockable
+interface DeleteConversationUseCase {
+    suspend operator fun invoke(conversationId: ConversationId): Either<CoreFailure, Unit>
+}
+
+internal class DeleteConversationUseCaseImpl(
+    private val conversationRepository: ConversationRepository,
+    private val mlsConversationRepository: MLSConversationRepository
+) : DeleteConversationUseCase {
+    override suspend fun invoke(conversationId: ConversationId): Either<CoreFailure, Unit> {
+        return conversationRepository.getConversationProtocolInfo(conversationId).flatMap { protocolInfo ->
+            when (protocolInfo) {
+                is Conversation.ProtocolInfo.MLSCapable -> {
+                    conversationRepository.deleteConversationLocally(conversationId).flatMap {
+                        mlsConversationRepository.leaveGroup(protocolInfo.groupId)
+                    }
+                }
+
+                is Conversation.ProtocolInfo.Proteus -> {
+                    conversationRepository.deleteConversationLocally(conversationId)
+                }
+            }
+        }
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/DeleteTeamConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/DeleteTeamConversationUseCase.kt
@@ -19,13 +19,13 @@
 package com.wire.kalium.logic.feature.team
 
 import com.wire.kalium.common.error.CoreFailure
-import com.wire.kalium.logic.data.conversation.ConversationRepository
-import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.team.TeamRepository
-import com.wire.kalium.logic.data.id.SelfTeamIdProvider
 import com.wire.kalium.common.functional.flatMap
 import com.wire.kalium.common.functional.fold
 import com.wire.kalium.common.functional.map
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.SelfTeamIdProvider
+import com.wire.kalium.logic.data.team.TeamRepository
+import com.wire.kalium.logic.feature.conversation.delete.DeleteConversationUseCase
 
 fun interface DeleteTeamConversationUseCase {
 
@@ -42,7 +42,7 @@ fun interface DeleteTeamConversationUseCase {
 internal class DeleteTeamConversationUseCaseImpl(
     private val selfTeamIdProvider: SelfTeamIdProvider,
     private val teamRepository: TeamRepository,
-    private val conversationRepository: ConversationRepository,
+    private val deleteConversation: DeleteConversationUseCase
 ) : DeleteTeamConversationUseCase {
 
     override suspend fun invoke(conversationId: ConversationId): Result {
@@ -55,7 +55,7 @@ internal class DeleteTeamConversationUseCaseImpl(
             }.fold({
                 Result.Failure.GenericFailure(it)
             }, {
-                conversationRepository.deleteConversation(conversationId)
+                deleteConversation(conversationId)
                 Result.Success
             })
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/TeamScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/TeamScope.kt
@@ -18,7 +18,6 @@
 
 package com.wire.kalium.logic.feature.team
 
-import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.SelfTeamIdProvider
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.team.TeamRepository
@@ -27,7 +26,6 @@ import com.wire.kalium.logic.feature.user.IsSelfATeamMemberUseCaseImpl
 
 class TeamScope internal constructor(
     private val teamRepository: TeamRepository,
-    private val conversationRepository: ConversationRepository,
     private val slowSyncRepository: SlowSyncRepository,
     private val selfTeamIdProvider: SelfTeamIdProvider
 ) {
@@ -37,15 +35,9 @@ class TeamScope internal constructor(
             teamRepository = teamRepository,
         )
 
-    val deleteTeamConversationUseCase: DeleteTeamConversationUseCase
-        get() = DeleteTeamConversationUseCaseImpl(
+    val isSelfATeamMember: IsSelfATeamMemberUseCase
+        get() = IsSelfATeamMemberUseCaseImpl(
             selfTeamIdProvider = selfTeamIdProvider,
-            teamRepository = teamRepository,
-            conversationRepository = conversationRepository,
+            slowSyncRepository = slowSyncRepository
         )
-
-    val isSelfATeamMember: IsSelfATeamMemberUseCase get() = IsSelfATeamMemberUseCaseImpl(
-        selfTeamIdProvider = selfTeamIdProvider,
-        slowSyncRepository = slowSyncRepository
-    )
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/DeletedConversationEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/DeletedConversationEventHandler.kt
@@ -18,15 +18,16 @@
 
 package com.wire.kalium.logic.sync.receiver.conversation
 
+import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.common.functional.onFailure
+import com.wire.kalium.common.functional.onSuccess
+import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.notification.EphemeralConversationNotification
 import com.wire.kalium.logic.data.notification.NotificationEventsManager
 import com.wire.kalium.logic.data.user.UserRepository
-import com.wire.kalium.common.functional.flatMap
-import com.wire.kalium.common.functional.onFailure
-import com.wire.kalium.common.functional.onSuccess
-import com.wire.kalium.common.logger.kaliumLogger
+import com.wire.kalium.logic.feature.conversation.delete.DeleteConversationUseCase
 import com.wire.kalium.logic.util.EventLoggingStatus
 import com.wire.kalium.logic.util.createEventProcessingLogger
 import io.mockative.Mockable
@@ -40,7 +41,8 @@ interface DeletedConversationEventHandler {
 internal class DeletedConversationEventHandlerImpl(
     private val userRepository: UserRepository,
     private val conversationRepository: ConversationRepository,
-    private val notificationEventsManager: NotificationEventsManager
+    private val notificationEventsManager: NotificationEventsManager,
+    private val deleteConversation: DeleteConversationUseCase
 ) : DeletedConversationEventHandler {
 
     override suspend fun handle(event: Event.Conversation.DeletedConversation) {
@@ -55,7 +57,7 @@ internal class DeletedConversationEventHandlerImpl(
                 )
             }
             .flatMap { conversation ->
-                conversationRepository.deleteConversation(event.conversationId)
+                deleteConversation(event.conversationId)
                     .onFailure {
                         logger.logFailure(it)
                     }.onSuccess {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberLeaveEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberLeaveEventHandler.kt
@@ -19,17 +19,14 @@
 package com.wire.kalium.logic.sync.receiver.conversation
 
 import com.wire.kalium.common.error.CoreFailure
-import com.wire.kalium.common.error.wrapMLSRequest
 import com.wire.kalium.common.error.wrapStorageRequest
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
 import com.wire.kalium.common.functional.getOrElse
 import com.wire.kalium.common.functional.getOrNull
-import com.wire.kalium.common.functional.map
 import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.common.functional.onSuccess
 import com.wire.kalium.common.logger.kaliumLogger
-import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.event.MemberLeaveReason
@@ -42,10 +39,9 @@ import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.call.usecase.UpdateConversationClientsForCurrentCallUseCase
+import com.wire.kalium.logic.feature.conversation.delete.DeleteConversationUseCase
 import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldHandler
 import com.wire.kalium.logic.util.createEventProcessingLogger
-import com.wire.kalium.persistence.dao.conversation.ConversationDAO
-import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 import com.wire.kalium.persistence.dao.member.MemberDAO
 import io.mockative.Mockable
 
@@ -60,11 +56,10 @@ internal class MemberLeaveEventHandlerImpl(
     private val userRepository: UserRepository,
     private val conversationRepository: ConversationRepository,
     private val persistMessage: PersistMessageUseCase,
-    private val mlsClientProvider: MLSClientProvider,
-    private val conversationDAO: ConversationDAO, // TODO: refactor to not have DAO here
     private val updateConversationClientsForCurrentCall: Lazy<UpdateConversationClientsForCurrentCallUseCase>,
     private val legalHoldHandler: LegalHoldHandler,
     private val selfTeamIdProvider: SelfTeamIdProvider,
+    private val deleteConversation: DeleteConversationUseCase,
     private val selfUserId: UserId,
 ) : MemberLeaveEventHandler {
 
@@ -144,7 +139,7 @@ internal class MemberLeaveEventHandlerImpl(
 
         // User wanted to delete conversation fully, but MessageContent.Cleared event came before and we couldn't delete it then.
         // Now, when user left the conversation, we can delete it.
-        conversationRepository.deleteConversation(event.conversationId)
+        deleteConversation(event.conversationId)
         conversationRepository.removeConversationFromDeleteQueue(event.conversationId)
     }
 
@@ -157,25 +152,5 @@ internal class MemberLeaveEventHandlerImpl(
                 userIDList.map { it.toDao() },
                 conversationID.toDao()
             )
-        }.onSuccess {
-            wrapStorageRequest { conversationDAO.getConversationProtocolInfo(conversationID.toDao()) }
-                .onSuccess { protocol ->
-                    when (protocol) {
-                        is ConversationEntity.ProtocolInfo.MLSCapable -> {
-                            if (userIDList.contains(selfUserId)) {
-                                mlsClientProvider.getMLSClient().map { mlsClient ->
-                                    wrapMLSRequest {
-                                        mlsClient.wipeConversation(protocol.groupId)
-                                    }
-                                }
-                            }
-                        }
-
-                        ConversationEntity.ProtocolInfo.Proteus -> {}
-                    }
-                }
-                .onFailure {
-                    kaliumLogger.e("Failed to get protocol info for conversation ${conversationID.toLogString()}, error: $it")
-                }
         }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/ClearConversationContentHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/ClearConversationContentHandler.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.logic.sync.receiver.handler
 
+import com.wire.kalium.common.functional.fold
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.IsMessageSentInSelfConversationUseCase
@@ -25,7 +26,7 @@ import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.conversation.ClearConversationAssetsLocallyUseCase
-import com.wire.kalium.common.functional.fold
+import com.wire.kalium.logic.feature.conversation.delete.DeleteConversationUseCase
 import io.mockative.Mockable
 
 @Mockable
@@ -40,7 +41,8 @@ internal class ClearConversationContentHandlerImpl(
     private val conversationRepository: ConversationRepository,
     private val selfUserId: UserId,
     private val isMessageSentInSelfConversation: IsMessageSentInSelfConversationUseCase,
-    private val clearLocalConversationAssets: ClearConversationAssetsLocallyUseCase
+    private val clearLocalConversationAssets: ClearConversationAssetsLocallyUseCase,
+    private val deleteConversation: DeleteConversationUseCase,
 ) : ClearConversationContentHandler {
 
     override suspend fun handle(
@@ -67,7 +69,7 @@ internal class ClearConversationContentHandlerImpl(
                     // In that case we couldn't delete it and should wait for user leave and delete after that.
                     conversationRepository.addConversationToDeleteQueue(conversationId)
                 } else {
-                    conversationRepository.deleteConversation(conversationId)
+                    deleteConversation(conversationId)
                 }
             }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -713,29 +713,9 @@ class ConversationRepositoryTest {
             .arrange()
         val conversationId = ConversationId("conv_id", "conv_domain")
 
-        conversationRepository.deleteConversation(conversationId).shouldSucceed()
+        conversationRepository.deleteConversationLocally(conversationId).shouldSucceed()
 
         with(arrangement) {
-            coVerify {
-                conversationDAO.deleteConversationByQualifiedID(eq(conversationId.toDao()))
-            }.wasInvoked(once)
-        }
-    }
-
-    @Test
-    fun givenMlsConversation_WhenDeletingTheConversation_ThenShouldBeDeletedLocally() = runTest {
-        val (arrangement, conversationRepository) = Arrangement()
-            .withGetConversationProtocolInfoReturns(MLS_PROTOCOL_INFO)
-            .withSuccessfulConversationDeletion()
-            .arrange()
-        val conversationId = ConversationId("conv_id", "conv_domain")
-
-        conversationRepository.deleteConversation(conversationId).shouldSucceed()
-
-        with(arrangement) {
-            coVerify {
-                mlsClient.wipeConversation(eq(GROUP_ID.toCrypto()))
-            }.wasInvoked(once)
             coVerify {
                 conversationDAO.deleteConversationByQualifiedID(eq(conversationId.toDao()))
             }.wasInvoked(once)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/delete/DeleteConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/delete/DeleteConversationUseCaseTest.kt
@@ -1,0 +1,122 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.conversation.delete
+
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.GroupID
+import com.wire.kalium.logic.data.mls.CipherSuite
+import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangementImpl
+import com.wire.kalium.logic.util.arrangement.repository.MLSConversationRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.repository.MLSConversationRepositoryArrangementImpl
+import com.wire.kalium.logic.util.shouldFail
+import com.wire.kalium.logic.util.shouldSucceed
+import com.wire.kalium.util.DateTimeUtil
+import io.mockative.coVerify
+import io.mockative.eq
+import io.mockative.once
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class DeleteConversationUseCaseTest {
+
+    @Test
+    fun givenMlsConversation_WhenDeletingTheConversation_ThenShouldBeDeletedLocallyAndWiped() = runTest {
+        // given
+        val (arrangement, useCase) = Arrangement()
+            .arrange {
+                withGetConversationProtocolInfo(Either.Right(MLS_PROTOCOL_INFO))
+                withSuccessfulLeaveGroup(GROUP_ID)
+                withDeletingConversationLocallySucceeding()
+            }
+
+        // when
+        val result = useCase(CONVERSATION_ID)
+
+        // then
+        result.shouldSucceed()
+        coVerify { arrangement.mlsConversationRepository.leaveGroup(eq(GROUP_ID)) }.wasInvoked(once)
+        coVerify { arrangement.conversationRepository.deleteConversationLocally(eq(CONVERSATION_ID)) }.wasInvoked(once)
+    }
+
+    @Test
+    fun givenMlsConversation_WhenDeletingConversationLocallyFails_ThenShouldNotWipeAndReturnError() = runTest {
+        // given
+        val (arrangement, useCase) = Arrangement()
+            .arrange {
+                withGetConversationProtocolInfo(Either.Right(MLS_PROTOCOL_INFO))
+                withDeletingConversationLocallyFailing()
+            }
+
+        // when
+        val result = useCase(CONVERSATION_ID)
+
+        // then
+        result.shouldFail()
+        coVerify { arrangement.conversationRepository.deleteConversationLocally(eq(CONVERSATION_ID)) }.wasInvoked(once)
+        coVerify { arrangement.mlsConversationRepository.leaveGroup(eq(GROUP_ID)) }.wasNotInvoked()
+    }
+
+    @Test
+    fun givenMlsConversation_WhenWipingFails_ThenShouldReturnError() = runTest {
+        // given
+        val (arrangement, useCase) = Arrangement()
+            .arrange {
+                withGetConversationProtocolInfo(Either.Right(MLS_PROTOCOL_INFO))
+                withDeletingConversationLocallySucceeding()
+                withFailedLeaveGroup(GROUP_ID)
+            }
+
+        // when
+        val result = useCase(CONVERSATION_ID)
+
+        // then
+        result.shouldFail()
+        coVerify { arrangement.conversationRepository.deleteConversationLocally(eq(CONVERSATION_ID)) }.wasInvoked(once)
+        coVerify { arrangement.mlsConversationRepository.leaveGroup(eq(GROUP_ID)) }.wasInvoked(once)
+    }
+
+    private class Arrangement :
+        ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
+        MLSConversationRepositoryArrangement by MLSConversationRepositoryArrangementImpl() {
+
+        suspend fun arrange(block: suspend Arrangement.() -> Unit): Pair<Arrangement, DeleteConversationUseCase> = run {
+            val useCase = DeleteConversationUseCaseImpl(
+                conversationRepository = conversationRepository,
+                mlsConversationRepository = mlsConversationRepository
+            )
+            block()
+            return this to useCase
+        }
+    }
+
+    companion object {
+        val GROUP_ID = GroupID("mls_group_id")
+        val CONVERSATION_ID = ConversationId("conv_id", "conv_domain")
+
+        val MLS_PROTOCOL_INFO = Conversation.ProtocolInfo.MLS(
+            GROUP_ID,
+            Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED,
+            epoch = 1UL,
+            keyingMaterialLastUpdate = DateTimeUtil.currentInstant(),
+            cipherSuite = CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+        )
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/team/DeleteTeamConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/team/DeleteTeamConversationUseCaseTest.kt
@@ -19,14 +19,15 @@
 package com.wire.kalium.logic.feature.team
 
 import com.wire.kalium.common.error.CoreFailure
-import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.id.SelfTeamIdProvider
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.team.Team
 import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestTeam
-import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.util.arrangement.usecase.DeleteConversationArrangement
+import com.wire.kalium.logic.util.arrangement.usecase.DeleteConversationArrangementImpl
 import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.coVerify
@@ -44,8 +45,10 @@ class DeleteTeamConversationUseCaseTest {
         val (arrangement, deleteTeamConversation) = Arrangement()
             .withGetSelfTeam()
             .withSuccessApiDeletingConversation()
-            .withSuccessDeletingConversationLocally()
-            .arrange()
+//             .withSuccessDeletingConversationLocally()
+            .arrange {
+                withDeletingConversationSucceeding()
+            }
 
         val result = deleteTeamConversation(TestConversation.ID)
 
@@ -57,7 +60,7 @@ class DeleteTeamConversationUseCaseTest {
             arrangement.teamRepository.deleteConversation(eq(TestConversation.ID), eq(TeamId(TestTeam.TEAM.id)))
         }.wasInvoked(once)
         coVerify {
-            arrangement.conversationRepository.deleteConversation(eq(TestConversation.ID))
+            arrangement.deleteConversation(eq(TestConversation.ID))
         }.wasInvoked(once)
     }
 
@@ -66,7 +69,9 @@ class DeleteTeamConversationUseCaseTest {
         val (arrangement, deleteTeamConversation) = Arrangement()
             .withGetSelfTeam()
             .withApiErrorDeletingConversation()
-            .arrange()
+            .arrange {
+                withDeletingConversationSucceeding()
+            }
 
         val result = deleteTeamConversation(TestConversation.ID)
 
@@ -78,7 +83,7 @@ class DeleteTeamConversationUseCaseTest {
             arrangement.teamRepository.deleteConversation(eq(TestConversation.ID), eq(TeamId(TestTeam.TEAM.id)))
         }.wasInvoked(once)
         coVerify {
-            arrangement.conversationRepository.deleteConversation(eq(TestConversation.ID))
+            arrangement.deleteConversation(eq(TestConversation.ID))
         }.wasNotInvoked()
     }
 
@@ -87,7 +92,9 @@ class DeleteTeamConversationUseCaseTest {
         val (arrangement, deleteTeamConversation) = Arrangement()
             .withGetSelfTeam(null)
             .withApiErrorDeletingConversation()
-            .arrange()
+            .arrange {
+                withDeletingConversationSucceeding()
+            }
 
         val result = deleteTeamConversation(TestConversation.ID)
 
@@ -99,21 +106,14 @@ class DeleteTeamConversationUseCaseTest {
             arrangement.teamRepository.deleteConversation(eq(TestConversation.ID), eq(TestTeam.TEAM_ID))
         }.wasNotInvoked()
         coVerify {
-            arrangement.conversationRepository.deleteConversation(eq(TestConversation.ID))
+            arrangement.deleteConversation(eq(TestConversation.ID))
         }.wasNotInvoked()
     }
 
-    private class Arrangement {
-
-        var deleteTeamConversation: DeleteTeamConversationUseCase
+    private class Arrangement : DeleteConversationArrangement by DeleteConversationArrangementImpl() {
 
         val selfTeamIdProvider: SelfTeamIdProvider = mock(SelfTeamIdProvider::class)
         val teamRepository: TeamRepository = mock(TeamRepository::class)
-        val conversationRepository: ConversationRepository = mock(ConversationRepository::class)
-
-        init {
-            deleteTeamConversation = DeleteTeamConversationUseCaseImpl(selfTeamIdProvider, teamRepository, conversationRepository)
-        }
 
         suspend fun withGetSelfTeam(team: Team? = TestTeam.TEAM) = apply {
             val result = team?.id?.let {
@@ -136,13 +136,11 @@ class DeleteTeamConversationUseCaseTest {
             }.returns(Either.Right(Unit))
         }
 
-        suspend fun withSuccessDeletingConversationLocally() = apply {
-            coEvery {
-                conversationRepository.deleteConversation(any())
-            }.returns(Either.Right(Unit))
+        suspend fun arrange(block: suspend Arrangement.() -> Unit): Pair<Arrangement, DeleteTeamConversationUseCase> = run {
+            val useCase = DeleteTeamConversationUseCaseImpl(selfTeamIdProvider, teamRepository, deleteConversation)
+            block()
+            this to useCase
         }
-
-        fun arrange() = this to deleteTeamConversation
     }
 
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ClearConversationContentHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ClearConversationContentHandlerTest.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.kalium.logic.sync.receiver.conversation
 
+import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.IsMessageSentInSelfConversationUseCase
@@ -25,11 +26,12 @@ import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.conversation.ClearConversationAssetsLocallyUseCase
 import com.wire.kalium.logic.framework.TestUser
-import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.sync.receiver.handler.ClearConversationContentHandler
 import com.wire.kalium.logic.sync.receiver.handler.ClearConversationContentHandlerImpl
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangementImpl
+import com.wire.kalium.logic.util.arrangement.usecase.DeleteConversationArrangement
+import com.wire.kalium.logic.util.arrangement.usecase.DeleteConversationArrangementImpl
 import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.coVerify
@@ -61,7 +63,7 @@ class ClearConversationContentHandlerTest {
             )
 
             // then
-            coVerify { arrangement.conversationRepository.deleteConversation(any()) }.wasNotInvoked()
+            coVerify { arrangement.deleteConversation(any()) }.wasNotInvoked()
             coVerify { arrangement.conversationRepository.clearContent(any()) }.wasInvoked(exactly = once)
         }
 
@@ -85,7 +87,7 @@ class ClearConversationContentHandlerTest {
             )
 
             // then
-            coVerify { arrangement.conversationRepository.deleteConversation(any()) }.wasNotInvoked()
+            coVerify { arrangement.deleteConversation(any()) }.wasNotInvoked()
             coVerify { arrangement.conversationRepository.clearContent(any()) }.wasNotInvoked()
         }
 
@@ -109,7 +111,7 @@ class ClearConversationContentHandlerTest {
             )
 
             // then
-            coVerify { arrangement.conversationRepository.deleteConversation(any()) }.wasNotInvoked()
+            coVerify { arrangement.deleteConversation(any()) }.wasNotInvoked()
             coVerify { arrangement.conversationRepository.clearContent(any()) }.wasInvoked(exactly = once)
         }
 
@@ -132,7 +134,7 @@ class ClearConversationContentHandlerTest {
         )
 
         // then
-        coVerify { arrangement.conversationRepository.deleteConversation(any()) }.wasNotInvoked()
+        coVerify { arrangement.deleteConversation(any()) }.wasNotInvoked()
         coVerify { arrangement.conversationRepository.clearContent(any()) }.wasNotInvoked()
     }
 
@@ -156,7 +158,7 @@ class ClearConversationContentHandlerTest {
         )
 
         // then
-        coVerify { arrangement.conversationRepository.deleteConversation(any()) }.wasNotInvoked()
+        coVerify { arrangement.deleteConversation(any()) }.wasNotInvoked()
         coVerify { arrangement.conversationRepository.clearContent(any()) }.wasInvoked(exactly = once)
         coVerify { arrangement.conversationRepository.addConversationToDeleteQueue(any()) }.wasInvoked(exactly = once)
     }
@@ -181,7 +183,7 @@ class ClearConversationContentHandlerTest {
         )
 
         // then
-        coVerify { arrangement.conversationRepository.deleteConversation(any()) }.wasInvoked(exactly = once)
+        coVerify { arrangement.deleteConversation(any()) }.wasInvoked(exactly = once)
         coVerify { arrangement.conversationRepository.clearContent(any()) }.wasInvoked(exactly = once)
         coVerify { arrangement.conversationRepository.addConversationToDeleteQueue(any()) }.wasNotInvoked()
     }
@@ -205,13 +207,15 @@ class ClearConversationContentHandlerTest {
         )
 
         // then
-        coVerify { arrangement.conversationRepository.deleteConversation(any()) }.wasNotInvoked()
+        coVerify { arrangement.deleteConversation(any()) }.wasNotInvoked()
         coVerify { arrangement.conversationRepository.clearContent(any()) }.wasInvoked(exactly = once)
     }
 
 
-    private class Arrangement : ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl() {
-        
+    private class Arrangement :
+        ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
+        DeleteConversationArrangement by DeleteConversationArrangementImpl() {
+
         val isMessageSentInSelfConversationUseCase = mock(IsMessageSentInSelfConversationUseCase::class)
         val clearConversationAssetsLocally = mock(ClearConversationAssetsLocallyUseCase::class)
 
@@ -224,7 +228,8 @@ class ClearConversationContentHandlerTest {
                 conversationRepository = conversationRepository,
                 selfUserId = TestUser.USER_ID,
                 isMessageSentInSelfConversation = isMessageSentInSelfConversationUseCase,
-                clearLocalConversationAssets = clearConversationAssetsLocally
+                clearLocalConversationAssets = clearConversationAssetsLocally,
+                deleteConversation = deleteConversation
             )
             withDeletingConversationSucceeding()
             withClearContentSucceeding()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/DeletedConversationEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/DeletedConversationEventHandlerTest.kt
@@ -26,8 +26,10 @@ import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryA
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangementImpl
-import com.wire.kalium.logic.util.arrangement.usecase.NotificationEventsManagerArrangement
+import com.wire.kalium.logic.util.arrangement.usecase.DeleteConversationArrangement
+import com.wire.kalium.logic.util.arrangement.usecase.DeleteConversationArrangementImpl
 import com.wire.kalium.logic.util.arrangement.usecase.EphemeralEventsNotificationManagerArrangementImpl
+import com.wire.kalium.logic.util.arrangement.usecase.NotificationEventsManagerArrangement
 import io.mockative.any
 import io.mockative.coVerify
 import io.mockative.eq
@@ -53,7 +55,7 @@ class DeletedConversationEventHandlerTest {
 
         with(arrangement) {
             coVerify {
-                conversationRepository.deleteConversation(eq(TestConversation.ID))
+                deleteConversation(eq(TestConversation.ID))
             }.wasNotInvoked()
         }
     }
@@ -73,7 +75,7 @@ class DeletedConversationEventHandlerTest {
 
         with(arrangement) {
             coVerify {
-                conversationRepository.deleteConversation(eq(TestConversation.ID))
+                deleteConversation(eq(TestConversation.ID))
             }.wasInvoked(exactly = once)
 
             coVerify {
@@ -116,6 +118,7 @@ class DeletedConversationEventHandlerTest {
         private val block: suspend Arrangement.() -> Unit
     ) : ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
         UserRepositoryArrangement by UserRepositoryArrangementImpl(),
+        DeleteConversationArrangement by DeleteConversationArrangementImpl(),
         NotificationEventsManagerArrangement by EphemeralEventsNotificationManagerArrangementImpl() {
 
         fun arrange() = run {
@@ -123,7 +126,8 @@ class DeletedConversationEventHandlerTest {
             this@Arrangement to DeletedConversationEventHandlerImpl(
                 conversationRepository = conversationRepository,
                 userRepository = userRepository,
-                notificationEventsManager = notificationEventsManager
+                notificationEventsManager = notificationEventsManager,
+                deleteConversation = deleteConversation
             )
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/ConversationRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/ConversationRepositoryArrangement.kt
@@ -19,6 +19,7 @@ package com.wire.kalium.logic.util.arrangement.repository
 
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.ConversationRepository
@@ -28,7 +29,6 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.framework.TestConversation
-import com.wire.kalium.common.functional.Either
 import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.eq
@@ -52,8 +52,8 @@ internal interface ConversationRepositoryArrangement {
         domain: Matcher<String> = AnyMatcher(valueOf())
     )
 
-    suspend fun withDeletingConversationSucceeding(conversationId: Matcher<ConversationId> = AnyMatcher(valueOf()))
-    suspend fun withDeletingConversationFailing(conversationId: Matcher<ConversationId> = AnyMatcher(valueOf()))
+    suspend fun withDeletingConversationLocallySucceeding(conversationId: Matcher<ConversationId> = AnyMatcher(valueOf()))
+    suspend fun withDeletingConversationLocallyFailing(conversationId: Matcher<ConversationId> = AnyMatcher(valueOf()))
     suspend fun withGetConversationByIdReturning(conversation: Conversation? = TestConversation.CONVERSATION)
     suspend fun withSetInformedAboutDegradedMLSVerificationFlagResult(result: Either<StorageFailure, Unit> = Either.Right(Unit))
     suspend fun withInformedAboutDegradedMLSVerification(isInformed: Either<StorageFailure, Boolean>): ConversationRepositoryArrangement
@@ -145,15 +145,15 @@ internal open class ConversationRepositoryArrangementImpl : ConversationReposito
         }.returns(result)
     }
 
-    override suspend fun withDeletingConversationSucceeding(conversationId: Matcher<ConversationId>) {
+    override suspend fun withDeletingConversationLocallySucceeding(conversationId: Matcher<ConversationId>) {
         coEvery {
-            conversationRepository.deleteConversation(matches { conversationId.matches(it) })
+            conversationRepository.deleteConversationLocally(matches { conversationId.matches(it) })
         }.returns(Either.Right(Unit))
     }
 
-    override suspend fun withDeletingConversationFailing(conversationId: Matcher<ConversationId>) {
+    override suspend fun withDeletingConversationLocallyFailing(conversationId: Matcher<ConversationId>) {
         coEvery {
-            conversationRepository.deleteConversation(matches { conversationId.matches(it) })
+            conversationRepository.deleteConversationLocally(matches { conversationId.matches(it) })
         }.returns(Either.Left(CoreFailure.Unknown(RuntimeException("some error"))))
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/usecase/DeleteConversationArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/usecase/DeleteConversationArrangement.kt
@@ -1,0 +1,53 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.util.arrangement.usecase
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.feature.conversation.delete.DeleteConversationUseCase
+import io.mockative.coEvery
+import io.mockative.fake.valueOf
+import io.mockative.matchers.AnyMatcher
+import io.mockative.matchers.Matcher
+import io.mockative.mock
+
+internal interface DeleteConversationArrangement {
+    val deleteConversation: DeleteConversationUseCase
+
+    suspend fun withDeletingConversationSucceeding(conversationId: Matcher<ConversationId> = AnyMatcher(valueOf()))
+    suspend fun withDeletingConversationFailing(conversationId: Matcher<ConversationId> = AnyMatcher(valueOf()))
+}
+
+internal open class DeleteConversationArrangementImpl : DeleteConversationArrangement {
+
+    override val deleteConversation: DeleteConversationUseCase = mock(DeleteConversationUseCase::class)
+
+    override suspend fun withDeletingConversationSucceeding(conversationId: Matcher<ConversationId>) {
+        coEvery {
+            deleteConversation(io.mockative.matches { conversationId.matches(it) })
+        }.returns(Either.Right(Unit))
+    }
+
+    override suspend fun withDeletingConversationFailing(conversationId: Matcher<ConversationId>) {
+        coEvery {
+            deleteConversation(io.mockative.matches { conversationId.matches(it) })
+        }.returns(Either.Left(CoreFailure.Unknown(RuntimeException("some error"))))
+    }
+
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14735" title="WPB-14735" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-14735</a>  [Android] Batch decrypt using CC transaction
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Refactored the logic responsible for wiping MLS conversations after a user leaves a group.

### Issues

- Previously, `mlsClient.wipeConversation(...)` was executed as a side-effect of `deleteMembers(...)`, which caused logic duplication and made behavior hard to test and reason about.
- There was no unified way to handle the full deletion flow of an MLS conversation (local + remote wipe).

### Causes (Optional)

- `deleteMembers(...)` handled both DAO-level member deletion and MLS-layer wiping, which violated separation of concerns and created inconsistencies when the deletion logic was moved elsewhere.
- The logic relied on indirect triggering (side-effect) rather than explicit flow.

### Solutions

- Introduced a dedicated `DeleteConversationUseCase` to encapsulate the logic for deleting conversations based on their protocol.
- Moved the responsibility of wiping MLS conversations into this use case.
- Ensured that `MemberLeaveEventHandlerImpl` now explicitly checks whether the current user left the conversation and triggers `DeleteConversationUseCase` when appropriate.
- Updated existing unit tests and arrangements to reflect this flow change, avoiding duplicate wipe logic.
- 🔧 This is part of a broader refactor aimed at removing the dependency on `MLSClientProvider` from `ConversationRepository`.
