### PR TITLE
chore: remove extra slash from http logs (#WPB-18325)

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/utils/ObfuscateUtil.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/utils/ObfuscateUtil.kt
@@ -86,23 +86,22 @@ fun obfuscatedJsonElement(element: JsonElement): JsonElement =
     }
 
 fun obfuscatePath(url: Url): String {
+
     var requestToLog = url.host
-    if (url.pathSegments.isNotEmpty()) {
-        url.pathSegments.map {
-            requestToLog += "/${it.obfuscateUrlPath()}"
-        }
+
+    requestToLog += url.pathSegments.joinToString("/") {
+        it.obfuscateUrlPath()
     }
 
     if (url.parameters.entries().isNotEmpty()) {
         requestToLog += "?"
-        url.parameters.entries().map {
-            if (it.value.isNotEmpty()) {
-                requestToLog += "${it.key}=${it.value[0].obfuscateUrlPath()}&"
+        requestToLog += url.parameters.entries()
+            .filter { it.value.isNotEmpty() }.joinToString("&") { (key, value) ->
+                "$key=${value[0].obfuscateUrlPath()}"
             }
-        }
     }
 
-    return requestToLog.trimEnd('&')
+    return requestToLog
 }
 
 fun deleteSensitiveItemsFromJson(text: String): String {


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-18325

# What's new in this PR?

### Issues
Http request / response logs contain double slash. This is causing misunderstanding with the tech support claiming the Android application is using malformed URLs.

### Causes (Optional)
The 'pathSegments' method from ktor library returns empty segment as the first element.

### Solutions
Use joinToString method with the "/" separator. This solution logs the actual URL, so we will still print double slash if the actual URL has it.
