### PR TITLE
feat(cells): retrieve tags from remote (WPB-18466)

### DIFF
--- a/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/model/CellNodeDTO.kt
+++ b/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/model/CellNodeDTO.kt
@@ -38,6 +38,7 @@ internal data class CellNodeDTO(
     val ownerUserId: String?,
     val conversationId: String?,
     val publicLinkId: String?,
+    val tags: List<String> = emptyList(),
 )
 
 internal fun CellNodeDTO.toModel() = CellNode(
@@ -57,6 +58,7 @@ internal fun CellNodeDTO.toModel() = CellNode(
     ownerUserId = ownerUserId,
     conversationId = conversationId,
     publicLinkId = publicLinkId,
+    tags = tags
 )
 
 internal fun CellNode.toDto() = CellNodeDTO(
@@ -75,6 +77,7 @@ internal fun CellNode.toDto() = CellNodeDTO(
     ownerUserId = ownerUserId,
     conversationId = conversationId,
     publicLinkId = publicLinkId,
+    tags = tags
 )
 
 internal fun RestNode.toDto() = CellNodeDTO(
@@ -101,6 +104,12 @@ internal fun RestNode.toDto() = CellNodeDTO(
     ownerUserId = userMetadata
         ?.firstOrNull { it.namespace == "usermeta-owner-uuid" }
         ?.jsonValue?.removeSurrounding("\""),
+    tags = userMetadata?.firstOrNull { it.namespace == "usermeta-tags" }
+        ?.jsonValue
+        ?.removeSurrounding("\"")
+        ?.split(",")
+        ?.map { it.trim() }
+        ?: emptyList(),
     conversationId = contextWorkspace?.uuid,
     publicLinkId = shares?.firstOrNull()?.uuid,
 )

--- a/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/model/CellNode.kt
+++ b/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/model/CellNode.kt
@@ -35,6 +35,7 @@ public data class CellNode(
     val ownerUserId: String? = null,
     val conversationId: String? = null,
     val publicLinkId: String? = null,
+    val tags: List<String> = emptyList(),
 )
 
 public enum class CellNodeType(public val value: String) {

--- a/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/model/Node.kt
+++ b/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/model/Node.kt
@@ -30,6 +30,7 @@ public sealed class Node {
     public abstract val modifiedTime: Long?
     public abstract val remotePath: String?
     public abstract val size: Long?
+    public abstract val tags: List<String>
 
     public data class Folder(
         override val name: String?,
@@ -38,7 +39,8 @@ public sealed class Node {
         override val conversationName: String? = null,
         override val modifiedTime: Long?,
         override val remotePath: String?,
-        override val size: Long?
+        override val size: Long?,
+        override val tags: List<String> = emptyList(),
     ) : Node()
 
     /**
@@ -61,6 +63,7 @@ public sealed class Node {
         val previewUrl: String? = null,
         val metadata: AssetMetadata? = null,
         val publicLinkId: String? = null,
+        override val tags: List<String> = emptyList(),
     ) : Node()
 }
 
@@ -77,6 +80,7 @@ internal fun CellNode.toFileModel() = Node.File(
     size = size,
     publicLinkId = publicLinkId,
     modifiedTime = modified?.let { it * 1000 },
+    tags = tags,
 )
 
 @Suppress("MagicNumber")
@@ -86,4 +90,5 @@ internal fun CellNode.toFolderModel() = Node.Folder(
     modifiedTime = modified?.let { it * 1000 },
     remotePath = path,
     size = size,
+    tags = tags,
 )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18466" title="WPB-18466" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18466</a>  [Android] Show tags in files list
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Parse the list of tags retrieved from remote

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
