### PR TITLE
fix: notifications not showing (#WPB-18531)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncRequest.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncRequest.kt
@@ -32,13 +32,19 @@ interface SyncRequest {
      * @return An [Either] containing [CoreFailure] if [SyncState.Failed] is encountered,
      * or [Unit] if the specified [syncState] is reached.
      */
-    suspend fun waitUntilOrFailure(syncState: SyncState): Either<CoreFailure, Unit>
+    suspend fun waitUntilOrFailure(syncState: SyncState, dropFirst: Int = 0): Either<CoreFailure, Unit>
 
     /**
      * Shortcut for [waitUntilOrFailure] with Live state.
      * @see waitUntilOrFailure
      */
     suspend fun waitUntilLiveOrFailure(): Either<CoreFailure, Unit>
+
+    /**
+     * Shortcut for [waitUntilOrFailure] with Live state dropping first event.
+     * @see waitUntilOrFailure
+     */
+    suspend fun waitUntilSecondLiveOrFailure(): Either<CoreFailure, Unit>
 
     /**
      * When called, the sync process continues without being released.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18531" title="WPB-18531" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18531</a>  [Android] Notification not showing if app process was not running
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-18531
# What's new in this PR?

### Issues
No notifications are shown if push message comes when application process is not running.

### Causes
Here is the flow of notification handling events.
1. Push notification handler starts NotificationFetchWorker
2. NotificationFetchWorker starts observing notification events, request sync and wait for Live SyncStatus.
3. Once Live status is received app waits for 1 extra second
4. Notification event observers are cancelled, worker is complete

The problem is that Live sync status comes instantly after starting sync status observation because there are no pending events available for processing. After that application starts opening the socket to receive actual messages but in 1 second it is cancelled since worker stops observer, cancels it's coroutine scope and stops.

### Solutions

Option 1: Increase delay after getting the Live sync status to 10 seconds. This will keep the worker running and will let the app connect to the socket, fetch events and show notification.

Option 2: Ignore the first Live event when waiting for Live sync status in WireNotificationsManager. This will let the worker wait until the app opens the socket, fetches messages and switch to Live state again.

Proposed solution in this PR is option 2.
