### PR TITLE
fix: read receipt race condition (#WPB-8756)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -264,6 +264,12 @@ internal interface MessageRepository {
         messageIds: List<String>,
         conversationId: ConversationId
     ): Either<CoreFailure, List<Pair<String, MessageEntity.Status>>>
+
+    suspend fun compareAndSetMessagesStatus(
+        messageStatus: MessageEntity.Status,
+        conversationId: ConversationId,
+        messageUuids: List<String>
+    ): Either<StorageFailure, Unit>
 }
 
 // TODO: suppress TooManyFunctions for now, something we need to fix in the future
@@ -402,6 +408,19 @@ internal class MessageDataSource internal constructor(
     ) =
         wrapStorageRequest {
             messageDAO.updateMessagesStatus(
+                status = messageStatus,
+                id = messageUuids,
+                conversationId = conversationId.toDao()
+            )
+        }
+
+    override suspend fun compareAndSetMessagesStatus(
+        messageStatus: MessageEntity.Status,
+        conversationId: ConversationId,
+        messageUuids: List<String>
+    ) =
+        wrapStorageRequest {
+            messageDAO.compareAndSetMessagesStatus(
                 status = messageStatus,
                 id = messageUuids,
                 conversationId = conversationId.toDao()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/ReceiptMessageHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/ReceiptMessageHandler.kt
@@ -66,10 +66,10 @@ internal class ReceiptMessageHandlerImpl(
         messageContent: MessageContent.Receipt,
         message: Message.Signaling
     ) {
-        messageRepository.compareAndSetMessagesStatus(
-            messageUuids = messageContent.messageIds,
-            conversationId = message.conversationId,
+        messageRepository.updateMessagesStatusIfNotRead(
             messageStatus = receiptsMapper.fromTypeToMessageStatus(messageContent.type),
+            messageIds = messageContent.messageIds,
+            conversationId = message.conversationId,
         )
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ReceiptMessageHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ReceiptMessageHandlerTest.kt
@@ -77,7 +77,7 @@ class ReceiptMessageHandlerTest {
         val type = ReceiptType.READ
 
         coEvery {
-            messageRepository.updateMessagesStatus(any(), any(), any())
+            messageRepository.updateMessagesStatusIfNotRead(any(), any(), any())
         }.returns(Either.Right(Unit))
         // when
         handleNewReceipt(type, date, senderUserId)
@@ -99,7 +99,7 @@ class ReceiptMessageHandlerTest {
         val type = ReceiptType.READ
 
         coEvery {
-            messageRepository.updateMessagesStatus(any(), any(), any())
+            messageRepository.updateMessagesStatusIfNotRead(any(), any(), any())
         }.returns(Either.Right(Unit))
         // when
         handleNewReceipt(type, date, senderUserId)
@@ -126,7 +126,7 @@ class ReceiptMessageHandlerTest {
         val type = ReceiptType.READ
 
         coEvery {
-            messageRepository.updateMessagesStatus(any(), any(), any())
+            messageRepository.updateMessagesStatusIfNotRead(any(), any(), any())
         }.returns(Either.Right(Unit))
         // when
         handleNewReceipt(type, date, senderUserId)
@@ -149,7 +149,7 @@ class ReceiptMessageHandlerTest {
         val type = ReceiptType.DELIVERED
 
         coEvery {
-            messageRepository.updateMessagesStatus(any(), any(), any())
+            messageRepository.updateMessagesStatusIfNotRead(any(), any(), any())
         }.returns(Either.Right(Unit))
         // when
         handleNewReceipt(type, date, senderUserId)
@@ -169,7 +169,7 @@ class ReceiptMessageHandlerTest {
         val messageUuids = listOf("1", "2", "3")
 
         coEvery {
-            messageRepository.updateMessagesStatus(any(), any(), any())
+            messageRepository.updateMessagesStatusIfNotRead(any(), any(), any())
         }.returns(Either.Right(Unit))
 
         // when
@@ -177,7 +177,7 @@ class ReceiptMessageHandlerTest {
 
         // then
         coVerify {
-            messageRepository.updateMessagesStatus(eq(MessageEntity.Status.DELIVERED), any(), eq(messageUuids))
+            messageRepository.updateMessagesStatusIfNotRead(eq(MessageEntity.Status.DELIVERED), any(), eq(messageUuids))
         }.wasInvoked(exactly = once)
     }
 

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -452,8 +452,12 @@ UPDATE Message
 SET status = ?
 WHERE id = ? AND conversation_id = ?;
 
-getMessagesStatus:
-SELECT id, status FROM Message WHERE id IN ? AND conversation_id = ?;
+updateMessagesStatusIfNotRead:
+UPDATE Message
+SET status = ?
+WHERE id IN ?
+AND conversation_id = ?
+AND status != 'READ';
 
 updateQuotedMessageId:
 UPDATE MessageTextContent

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -452,6 +452,9 @@ UPDATE Message
 SET status = ?
 WHERE id = ? AND conversation_id = ?;
 
+getMessagesStatus:
+SELECT id, status FROM Message WHERE id IN ? AND conversation_id = ?;
+
 updateQuotedMessageId:
 UPDATE MessageTextContent
 SET quoted_message_id = ?

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -18,7 +18,6 @@
 
 package com.wire.kalium.persistence.dao.message
 
-import com.wire.kalium.persistence.GetMessagesStatus
 import com.wire.kalium.persistence.dao.ConversationIDEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserIDEntity
@@ -173,6 +172,6 @@ interface MessageDAO {
         onPage: (List<MessageEntity>) -> Unit,
     )
     fun countMessagesForBackup(contentTypes: Collection<MessageEntity.ContentType>): Long
-    suspend fun getMessagesStatus(ids: List<String>, conversationId: QualifiedIDEntity): List<GetMessagesStatus>
-    suspend fun compareAndSetMessagesStatus(status: MessageEntity.Status, id: List<String>, conversationId: QualifiedIDEntity)
+
+    suspend fun updateMessagesStatusIfNotRead(status: MessageEntity.Status, conversationId: QualifiedIDEntity, messageIds: List<String>)
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.persistence.dao.message
 
+import com.wire.kalium.persistence.GetMessagesStatus
 import com.wire.kalium.persistence.dao.ConversationIDEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserIDEntity
@@ -172,4 +173,5 @@ interface MessageDAO {
         onPage: (List<MessageEntity>) -> Unit,
     )
     fun countMessagesForBackup(contentTypes: Collection<MessageEntity.ContentType>): Long
+    suspend fun getMessagesStatus(ids: List<String>, conversationId: QualifiedIDEntity): List<GetMessagesStatus>
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -174,4 +174,5 @@ interface MessageDAO {
     )
     fun countMessagesForBackup(contentTypes: Collection<MessageEntity.ContentType>): Long
     suspend fun getMessagesStatus(ids: List<String>, conversationId: QualifiedIDEntity): List<GetMessagesStatus>
+    suspend fun compareAndSetMessagesStatus(status: MessageEntity.Status, id: List<String>, conversationId: QualifiedIDEntity)
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -253,6 +253,13 @@ internal class MessageDAOImpl internal constructor(
         }
     }
 
+    override suspend fun getMessagesStatus(
+        ids: List<String>,
+        conversationId: QualifiedIDEntity,
+    ) = withContext(coroutineContext) {
+        queries.getMessagesStatus(ids, conversationId).executeAsList()
+    }
+
     override suspend fun getMessageById(id: String, conversationId: QualifiedIDEntity): MessageEntity? = withContext(coroutineContext) {
         queries.selectById(id, conversationId, mapper::toEntityMessageFromView).executeAsOneOrNull()
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8756" title="WPB-8756" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-8756</a>  [Android] Read receipts not generated when responding from notification popup
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

https://wearezeta.atlassian.net/browse/WPB-8756

# What's new in this PR?

### Issues
Message status is inconsistent. Changing from read to delivered.

### Causes (Optional)
Delivered status receipt from one client overwrites current Read status received from another client. 

### Solutions
Check message status before updating and do not allow changing from Read to Delivered.
