### PR TITLE
fix(sync): consider Live after connecting websocket [WPB-18531]

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorkerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorkerTest.kt
@@ -51,7 +51,6 @@ class IncrementalSyncWorkerTest {
         val envelope = TestEvent.memberJoin().wrapInEnvelope()
         val (arrangement, worker) = Arrangement()
             .withEventGathererReturning(flowOf(EventStreamData.NewEvents(listOf(envelope))))
-            .withLiveEventsReturning(flowOf(Unit))
             .arrange()
 
         // When
@@ -69,7 +68,6 @@ class IncrementalSyncWorkerTest {
             // Given
             val event = TestEvent.memberJoin().wrapInEnvelope()
             val (_, worker) = Arrangement()
-                .withLiveEventsReturning(flowOf(Unit))
                 .withEventGathererReturning(flowOf(EventStreamData.NewEvents(listOf(event))))
                 .arrange()
 
@@ -87,7 +85,6 @@ class IncrementalSyncWorkerTest {
             // Given
             val event = TestEvent.memberJoin().wrapInEnvelope()
             val (_, worker) = Arrangement()
-                .withLiveEventsReturning(flowOf(Unit))
                 .withEventGathererReturning(
                     flowOf(
                         EventStreamData.NewEvents(listOf(event)),
@@ -151,12 +148,6 @@ class IncrementalSyncWorkerTest {
         suspend fun withEventGathererReturning(eventFlow: Flow<EventStreamData>) = apply {
             coEvery {
                 eventGatherer.gatherEvents()
-            }.returns(eventFlow)
-        }
-
-        suspend fun withLiveEventsReturning(eventFlow: Flow<Unit>) = apply {
-            coEvery {
-                eventGatherer.receiveEvents()
             }.returns(eventFlow)
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18531" title="WPB-18531" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18531</a>  [Android] Notification not showing if app process was not running
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After #3506, we are still emitting `Live` before processing any events, if there are 0 events in the local storage.

### Causes

Missing edge case, where there are no events in the storage, but we haven't connected through the websocket yet

### Solutions

Quick and dirty solution:
- Rename `receiveEvents()` to `receiveEventsFromRemoteAndInsertIntoLocalStorage()` for clarity
- Make it so the `EventGatherer` waits for a signal from the `receiveEventsFromRemoteAndInsertIntoLocalStorage` flow before emitting.

`receiveEventsFromRemoteAndInsertIntoLocalStorage` will emit:
- After fetching pending events (yayy!)
- On each new event

This guarantees that we do not emit `IsUpToDate` before we actually check with remote.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

The new test covers this case:
`givenNoMoreEvents_whenGathering_thenShouldReceiveUpToDateOnlyAfterWebsocketIsConnected`

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
