### PR TITLE
refactor: store events payload in the db instead of the full event response [WPB-18756]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventExtention.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventExtention.kt
@@ -1,0 +1,28 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.event
+
+import com.wire.kalium.network.api.authenticated.notification.EventResponse
+import com.wire.kalium.network.api.authenticated.notification.EventResponseToStore
+import com.wire.kalium.network.tools.KtxSerializer
+
+fun EventResponse.toEventResponseToStore(): EventResponseToStore = EventResponseToStore(
+    id = id,
+    payload = KtxSerializer.json.encodeToString(payload),
+    transient = transient,
+)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -57,7 +57,6 @@ import io.ktor.utils.io.core.toByteArray
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.Transient
 import kotlinx.serialization.serializer
 
 @Suppress("TooManyFunctions", "LongParameterList", "LargeClass")

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -57,6 +57,7 @@ import io.ktor.utils.io.core.toByteArray
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.Transient
 import kotlinx.serialization.serializer
 
 @Suppress("TooManyFunctions", "LongParameterList", "LargeClass")
@@ -75,6 +76,19 @@ class EventMapper(
         // TODO(edge-case): Multiple payloads in the same event have the same ID, is this an issue when marking lastProcessedEventId?
         val id = eventResponse.id
         return eventResponse.payload?.map { eventContentDTO ->
+            val eventSource = if (isLive) EventSource.LIVE else EventSource.PENDING
+            EventEnvelope(
+                fromEventContentDTO(id, eventContentDTO),
+                EventDeliveryInfo(eventSource)
+            )
+        } ?: listOf()
+    }
+
+    fun fromStoredDTO(eventId: String, payload: List<EventContentDTO>?, isLive: Boolean): List<EventEnvelope> {
+        // TODO(edge-case): Multiple payloads in the same event have the same ID, is this an issue when marking lastProcessedEventId?
+        val id = eventId
+
+        return payload?.map { eventContentDTO ->
             val eventSource = if (isLive) EventSource.LIVE else EventSource.PENDING
             EventEnvelope(
                 fromEventContentDTO(id, eventContentDTO),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt
@@ -45,7 +45,6 @@ import com.wire.kalium.network.api.authenticated.notification.ConsumableNotifica
 import com.wire.kalium.network.api.authenticated.notification.EventAcknowledgeRequest
 import com.wire.kalium.network.api.authenticated.notification.EventContentDTO
 import com.wire.kalium.network.api.authenticated.notification.EventDataDTO
-import com.wire.kalium.network.api.authenticated.notification.EventResponse
 import com.wire.kalium.network.api.authenticated.notification.EventResponseToStore
 import com.wire.kalium.network.api.authenticated.notification.NotificationResponse
 import com.wire.kalium.network.api.base.authenticated.notification.NotificationApi
@@ -171,7 +170,10 @@ class EventDataSource(
             }
             .map { eventEntities ->
                 eventEntities.map { entity ->
-                    val payload:  List<EventContentDTO>? = entity.payload?.let { KtxSerializer.json.decodeFromString<List<EventContentDTO>>(it) }
+                    val payload: List<EventContentDTO>? =
+                        entity.payload?.let {
+                            KtxSerializer.json.decodeFromString<List<EventContentDTO>>(it)
+                        }
                     eventMapper.fromStoredDTO(eventId = entity.eventId, payload = payload, isLive = entity.isLive)
                 }
                     .flatten()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
@@ -38,6 +38,7 @@ import com.wire.kalium.network.api.authenticated.notification.ConsumableNotifica
 import com.wire.kalium.network.api.authenticated.notification.EventContentDTO
 import com.wire.kalium.network.api.authenticated.notification.EventDataDTO
 import com.wire.kalium.network.api.authenticated.notification.EventResponse
+import com.wire.kalium.network.api.authenticated.notification.EventResponseToStore
 import com.wire.kalium.network.api.authenticated.notification.NotificationResponse
 import com.wire.kalium.network.api.base.authenticated.notification.NotificationApi
 import com.wire.kalium.network.api.base.authenticated.notification.WebSocketEvent
@@ -64,6 +65,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
+import kotlinx.serialization.Transient
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -172,9 +174,9 @@ class EventRepositoryTest {
     @Test
     fun givenLiveEvent_whenReceived_thenShouldAcknowledgeWithACK() = runTest {
         val eventId = "event-id"
-        val testEventResponse = EventResponse(
+        val testEventResponse = EventResponseToStore(
             id = eventId,
-            payload = listOf(MEMBER_JOIN_EVENT)
+            payload = KtxSerializer.json.encodeToString(listOf(MEMBER_JOIN_EVENT))
         )
         val deliveryTag = 987654UL
 
@@ -244,14 +246,15 @@ class EventRepositoryTest {
             id = "test-event-id",
             payload = listOf(EventContentDTO.AsyncMissedNotification)
         )
-        val testPayload = KtxSerializer.json.encodeToString(testEvent)
+        val testPayload = KtxSerializer.json.encodeToString(testEvent.payload)
 
         val testEventEntity = EventEntity(
             id = 1L,
             eventId = testEvent.id,
             isProcessed = false,
             payload = testPayload,
-            isLive = true
+            isLive = true,
+            transient = testEvent.transient
         )
 
         val (_, repository) = Arrangement()
@@ -280,8 +283,9 @@ class EventRepositoryTest {
                 id = index.toLong(),
                 eventId = e.id,
                 isProcessed = false,
-                payload = KtxSerializer.json.encodeToString(e),
-                isLive = true
+                payload = KtxSerializer.json.encodeToString(e.payload),
+                isLive = true,
+                transient = e.transient
             )
         }
 
@@ -313,8 +317,9 @@ class EventRepositoryTest {
                 id = index.toLong(),
                 eventId = e.id,
                 isProcessed = false,
-                payload = KtxSerializer.json.encodeToString(e),
-                isLive = true
+                payload = KtxSerializer.json.encodeToString(e.payload),
+                isLive = true,
+                transient = e.transient
             )
         }
 
@@ -484,7 +489,7 @@ class EventRepositoryTest {
             }.returns(result)
         }
 
-        suspend fun withListenLiveEventsReturning(result: NetworkResponse<Flow<WebSocketEvent<EventResponse>>>) = apply {
+        suspend fun withListenLiveEventsReturning(result: NetworkResponse<Flow<WebSocketEvent<EventResponseToStore>>>) = apply {
             coEvery {
                 notificationApi.listenToLiveEvents(any())
             }.returns(result)
@@ -514,14 +519,15 @@ class EventRepositoryTest {
             }.returns(Unit)
         }
 
-        suspend fun withClearProcessedEvents(eventId: String, id: Long = 1L) = apply {
+        suspend fun withClearProcessedEvents(eventId: String, id: Long = 1L, transient: Boolean = false) = apply {
             coEvery { eventDAO.getEventById(eq(eventId)) }.returns(
                 EventEntity(
                     id = id,
                     eventId = eventId,
                     isProcessed = false,
                     payload = "",
-                    isLive = true
+                    isLive = true,
+                    transient = transient
                 )
             )
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventRepositoryTest.kt
@@ -146,7 +146,7 @@ class EventRepositoryTest {
     fun givenAPISucceeds_whenFetchingOldestEventId_thenShouldPropagateEventId() = runTest {
         val eventId = "testEventId"
         val result = NetworkResponse.Success(
-            value = EventResponse(eventId, emptyList()),
+            value = EventResponseToStore(eventId, "[]"),
             headers = mapOf(),
             httpCode = HttpStatusCode.OK.value
         )
@@ -465,7 +465,7 @@ class EventRepositoryTest {
             }.returns(result)
         }
 
-        suspend fun withOldestNotificationReturning(result: NetworkResponse<EventResponse>) = apply {
+        suspend fun withOldestNotificationReturning(result: NetworkResponse<EventResponseToStore>) = apply {
             coEvery {
                 notificationApi.oldestNotification(any())
             }.returns(result)

--- a/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/ConsumableNotificationEventsResponseJson.kt
+++ b/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/ConsumableNotificationEventsResponseJson.kt
@@ -22,10 +22,18 @@ import com.wire.kalium.mocks.extensions.toJsonString
 import com.wire.kalium.network.api.authenticated.notification.ConsumableNotificationResponse
 import com.wire.kalium.network.api.authenticated.notification.EventDataDTO
 import com.wire.kalium.network.api.authenticated.notification.EventResponse
+import com.wire.kalium.network.api.authenticated.notification.EventResponseToStore
+import com.wire.kalium.network.tools.KtxSerializer
 
 object ConsumableNotificationEventsResponseJson {
     val validEventDataJson = ConsumableNotificationResponse.EventNotification(
-        data = EventDataDTO((ULong.MAX_VALUE), EventResponse("some_id", listOf(EventContentDTOJson.validMemberJoin.serializableData)))
+        data = EventDataDTO(
+            (ULong.MAX_VALUE),
+            EventResponseToStore(
+                "some_id",
+                KtxSerializer.json.encodeToString(listOf(EventContentDTOJson.validMemberJoin.serializableData))
+            )
+        )
     ).toJsonString()
 
     val validMissedNotificationsJson = ConsumableNotificationResponse.MissedNotification.toJsonString()

--- a/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/ConsumableNotificationEventsResponseJson.kt
+++ b/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/ConsumableNotificationEventsResponseJson.kt
@@ -21,7 +21,6 @@ package com.wire.kalium.mocks.responses
 import com.wire.kalium.mocks.extensions.toJsonString
 import com.wire.kalium.network.api.authenticated.notification.ConsumableNotificationResponse
 import com.wire.kalium.network.api.authenticated.notification.EventDataDTO
-import com.wire.kalium.network.api.authenticated.notification.EventResponse
 import com.wire.kalium.network.api.authenticated.notification.EventResponseToStore
 import com.wire.kalium.network.tools.KtxSerializer
 

--- a/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/NotificationEventsResponseJson.kt
+++ b/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/NotificationEventsResponseJson.kt
@@ -34,10 +34,12 @@ import com.wire.kalium.network.api.authenticated.featureConfigs.MLSConfigDTO
 import com.wire.kalium.network.api.authenticated.featureConfigs.SelfDeletingMessagesConfigDTO
 import com.wire.kalium.network.api.authenticated.notification.EventContentDTO
 import com.wire.kalium.network.api.authenticated.notification.EventResponse
+import com.wire.kalium.network.api.authenticated.notification.EventResponseToStore
 import com.wire.kalium.network.api.authenticated.notification.NotificationResponse
 import com.wire.kalium.network.api.model.ConversationId
 import com.wire.kalium.network.api.model.QualifiedID
 import com.wire.kalium.network.api.model.SupportedProtocolDTO
+import com.wire.kalium.network.tools.KtxSerializer
 import kotlinx.datetime.Instant
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.encodeToString
@@ -361,9 +363,9 @@ object NotificationEventsResponseJson {
             time = "someTime",
             hasMore = false,
             notifications = listOf(
-                EventResponse(
+                EventResponseToStore(
                     id = "eventId",
-                    payload = listOf(EventContentDTOJson.validUpdateReceiptMode.serializableData),
+                    payload = KtxSerializer.json.encodeToString(listOf(EventContentDTOJson.validUpdateReceiptMode.serializableData)),
                     transient = false
                 )
             )
@@ -395,9 +397,9 @@ object NotificationEventsResponseJson {
         time = "2022-02-15T12:54:30Z",
         hasMore = false,
         notifications = listOf(
-            EventResponse(
+            EventResponseToStore(
                 id = "eventId",
-                payload = listOf(),
+                payload = KtxSerializer.json.encodeToString(listOf<EventContentDTO>()),
                 transient = false
             )
         )

--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/notification/ConsumableNotificationResponse.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/notification/ConsumableNotificationResponse.kt
@@ -42,7 +42,7 @@ data class EventDataDTO(
     @SerialName("delivery_tag")
     val deliveryTag: ULong?,
     @SerialName("event")
-    val event: EventResponse
+    val event: EventResponseToStore
 )
 
 @Serializable

--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/notification/EventContentDTO.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/notification/EventContentDTO.kt
@@ -44,6 +44,7 @@ import com.wire.kalium.network.api.authenticated.properties.LabelListResponseDTO
 import com.wire.kalium.network.api.model.ConversationId
 import com.wire.kalium.network.api.model.TeamId
 import com.wire.kalium.network.api.model.UserId
+import com.wire.kalium.network.tools.KtxSerializer
 import com.wire.kalium.network.utils.kaliumUtilLogger
 import com.wire.kalium.util.serialization.toJsonElement
 import kotlinx.datetime.Instant
@@ -53,7 +54,10 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.Serializer
 import kotlinx.serialization.descriptors.PolymorphicKind
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.buildClassSerialDescriptor
 import kotlinx.serialization.descriptors.buildSerialDescriptor
@@ -63,8 +67,10 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.encoding.decodeStructure
 import kotlinx.serialization.encoding.encodeStructure
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonEncoder
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.JsonTransformingSerializer
@@ -74,12 +80,51 @@ import kotlin.jvm.JvmInline
 
 @Serializable
 data class EventResponse(
-    @Serializable
     @SerialName("id") val id: String,
     @SerialName("payload") val payload: List<EventContentDTO>?,
     @SerialName("transient") val transient: Boolean = false
 )
 
+@Serializer(forClass = String::class)
+object RawJsonStringSerializer : KSerializer<String> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("RawJsonString", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): String {
+        // Expect a JsonDecoder so we can grab the raw element
+        require(decoder is JsonDecoder)
+        val element: JsonElement = decoder.decodeJsonElement()
+        // Return the raw JSON text of that element
+        return element.toString()
+    }
+
+    override fun serialize(encoder: Encoder, value: String) {
+        // On serialization, we assume the value *is* raw JSON text.
+        require(encoder is JsonEncoder)
+        // Parse it back to a JsonElement so it's emitted as JSON, not as a quoted string
+        val jsonElement = Json.parseToJsonElement(value)
+        encoder.encodeJsonElement(jsonElement)
+    }
+}
+
+@Serializable
+data class EventResponseToStore(
+    @SerialName("id") val id: String,
+    @Serializable(with = RawJsonStringSerializer::class)
+    @SerialName("payload") val payload: String?,
+    @SerialName("transient") val transient: Boolean = false
+) {
+
+    fun toEventResponse(): EventResponse {
+        return EventResponse(
+            id = this.id,
+            payload = this.payload?.let { payload ->
+                KtxSerializer.json.decodeFromString(payload)
+            },
+            transient = this.transient
+        )
+    }
+}
 /**
  * Handwritten serializer of the FeatureConfigUpdatedDTO because we want to extend it with the
  * `JsonCorrectingSerializer`, which is not possible using the plugin generated serializer.

--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/notification/EventContentDTO.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/notification/EventContentDTO.kt
@@ -125,6 +125,7 @@ data class EventResponseToStore(
         )
     }
 }
+
 /**
  * Handwritten serializer of the FeatureConfigUpdatedDTO because we want to extend it with the
  * `JsonCorrectingSerializer`, which is not possible using the plugin generated serializer.

--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/notification/NotificationResponse.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/notification/NotificationResponse.kt
@@ -25,5 +25,5 @@ import kotlinx.serialization.Serializable
 data class NotificationResponse(
     @SerialName("time") val time: String,
     @SerialName("has_more") val hasMore: Boolean,
-    @SerialName("notifications") val notifications: List<EventResponse>,
+    @SerialName("notifications") val notifications: List<EventResponseToStore>,
 )

--- a/network-model/src/commonTest/kotlin/com/wire/kalium/network/api/authenticated/notification/RawJsonStringSerializerTest.kt
+++ b/network-model/src/commonTest/kotlin/com/wire/kalium/network/api/authenticated/notification/RawJsonStringSerializerTest.kt
@@ -1,0 +1,168 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.authenticated.notification
+
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.JsonElement
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class RawJsonStringSerializerTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun givenJsonObject_whenUsingSerializer_thenReturnsRawJsonString() {
+        val inputJson = """{"key":"value","number":42}"""
+        
+        val result = json.decodeFromString(RawJsonStringSerializer, inputJson)
+        
+        assertEquals(inputJson, result)
+    }
+
+    @Test
+    fun givenJsonArray_whenUsingSerializer_thenReturnsRawJsonString() {
+        val inputJson = """[{"id":1},{"id":2}]"""
+        
+        val result = json.decodeFromString(RawJsonStringSerializer, inputJson)
+        
+        assertEquals(inputJson, result)
+    }
+
+    @Test
+    fun givenJsonString_whenUsingSerializer_thenReturnsRawJsonString() {
+        val inputJson = """"test string""""
+        
+        val result = json.decodeFromString(RawJsonStringSerializer, inputJson)
+        
+        assertEquals(inputJson, result)
+    }
+
+    @Test
+    fun givenJsonNumber_whenUsingSerializer_thenReturnsRawJsonString() {
+        val inputJson = """123"""
+        
+        val result = json.decodeFromString(RawJsonStringSerializer, inputJson)
+        
+        assertEquals(inputJson, result)
+    }
+
+    @Test
+    fun givenJsonBoolean_whenUsingSerializer_thenReturnsRawJsonString() {
+        val inputJson = """true"""
+        
+        val result = json.decodeFromString(RawJsonStringSerializer, inputJson)
+        
+        assertEquals(inputJson, result)
+    }
+
+    @Test
+    fun givenJsonNull_whenUsingSerializer_thenReturnsRawJsonString() {
+        val inputJson = """null"""
+        
+        val result = json.decodeFromString(RawJsonStringSerializer, inputJson)
+        
+        assertEquals(inputJson, result)
+    }
+
+    @Test
+    fun givenComplexNestedJson_whenUsingSerializer_thenReturnsRawJsonString() {
+        val inputJson = """{"users":[{"name":"John","age":30},{"name":"Jane","age":25}],"count":2}"""
+        
+        val result = json.decodeFromString(RawJsonStringSerializer, inputJson)
+        
+        assertEquals(inputJson, result)
+    }
+
+    @Test
+    fun givenRawJsonObjectString_whenSerializing_thenEncodesAsJsonElement() {
+        val rawJsonString = """{"key":"value","number":42}"""
+        
+        val result = json.encodeToString(RawJsonStringSerializer, rawJsonString)
+        
+        assertEquals(rawJsonString, result)
+    }
+
+    @Test
+    fun givenRawJsonArrayString_whenSerializing_thenEncodesAsJsonElement() {
+        val rawJsonString = """[{"id":1},{"id":2}]"""
+        
+        val result = json.encodeToString(RawJsonStringSerializer, rawJsonString)
+        
+        assertEquals(rawJsonString, result)
+    }
+
+    @Test
+    fun givenRawJsonPrimitiveString_whenSerializing_thenEncodesAsJsonElement() {
+        val rawJsonString = """"test string""""
+        
+        val result = json.encodeToString(RawJsonStringSerializer, rawJsonString)
+        
+        assertEquals(rawJsonString, result)
+    }
+
+    @Test
+    fun givenRawJsonNumberString_whenSerializing_thenEncodesAsJsonElement() {
+        val rawJsonString = """123"""
+        
+        val result = json.encodeToString(RawJsonStringSerializer, rawJsonString)
+        
+        assertEquals(rawJsonString, result)
+    }
+
+    @Test
+    fun givenInvalidJsonString_whenSerializing_thenThrowsSerializationException() {
+        val invalidJsonString = "not valid json"
+
+        assertFailsWith<SerializationException> {
+            json.encodeToString(RawJsonStringSerializer, invalidJsonString)
+        }
+    }
+
+    @Test
+    fun givenIncompleteJsonString_whenSerializing_thenThrowsSerializationException() {
+        val incompleteJsonString = """{"key": "value"""
+
+        assertFailsWith<SerializationException> {
+            json.encodeToString(RawJsonStringSerializer, incompleteJsonString)
+        }
+    }
+
+    @Test
+    fun givenRoundTripSerialization_whenSerializingAndDeserializing_thenReturnsOriginalJson() {
+        val originalJson = """{"name":"John","age":30,"active":true,"score":95.5}"""
+        
+        // Serialize
+        val serialized = json.encodeToString(RawJsonStringSerializer, originalJson)
+        
+        // Deserialize
+        val result = json.decodeFromString(RawJsonStringSerializer, serialized)
+        
+        assertEquals(originalJson, result)
+    }
+
+    @Test
+    fun givenDescriptor_thenHasCorrectSerialName() {
+        assertEquals("RawJsonString", RawJsonStringSerializer.descriptor.serialName)
+    }
+}

--- a/network-model/src/commonTest/kotlin/com/wire/kalium/network/api/authenticated/notification/RawJsonStringSerializerTest.kt
+++ b/network-model/src/commonTest/kotlin/com/wire/kalium/network/api/authenticated/notification/RawJsonStringSerializerTest.kt
@@ -20,9 +20,6 @@ package com.wire.kalium.network.api.authenticated.notification
 
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonDecoder
-import kotlinx.serialization.json.JsonEncoder
-import kotlinx.serialization.json.JsonElement
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/notification/NotificationApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/notification/NotificationApi.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.network.api.base.authenticated.notification
 import com.wire.kalium.network.api.authenticated.notification.ConsumableNotificationResponse
 import com.wire.kalium.network.api.authenticated.notification.EventAcknowledgeRequest
 import com.wire.kalium.network.api.authenticated.notification.EventResponse
+import com.wire.kalium.network.api.authenticated.notification.EventResponseToStore
 import com.wire.kalium.network.api.authenticated.notification.NotificationResponse
 import com.wire.kalium.network.api.base.authenticated.BaseApi
 import com.wire.kalium.network.utils.NetworkResponse
@@ -63,7 +64,7 @@ interface NotificationApi : BaseApi {
 
     suspend fun notificationsByBatch(querySize: Int, queryClient: String, querySince: String): NetworkResponse<NotificationResponse>
 
-    suspend fun oldestNotification(queryClient: String): NetworkResponse<EventResponse>
+    suspend fun oldestNotification(queryClient: String): NetworkResponse<EventResponseToStore>
 
     /**
      * request Notifications from the beginning of time
@@ -73,7 +74,7 @@ interface NotificationApi : BaseApi {
     suspend fun getServerTime(querySize: Int): NetworkResponse<String>
 
     @Deprecated("Starting API v8 prefer consumeLiveEvents instead", ReplaceWith("consumeLiveEvents(clientId)"))
-    suspend fun listenToLiveEvents(clientId: String): NetworkResponse<Flow<WebSocketEvent<EventResponse>>>
+    suspend fun listenToLiveEvents(clientId: String): NetworkResponse<Flow<WebSocketEvent<EventResponseToStore>>>
     suspend fun consumeLiveEvents(clientId: String): NetworkResponse<Flow<WebSocketEvent<ConsumableNotificationResponse>>>
     suspend fun acknowledgeEvents(clientId: String, eventAcknowledgeRequest: EventAcknowledgeRequest)
 

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/NotificationApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/NotificationApiV0.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.network.AuthenticatedWebSocketClient
 import com.wire.kalium.network.api.authenticated.notification.ConsumableNotificationResponse
 import com.wire.kalium.network.api.authenticated.notification.EventAcknowledgeRequest
 import com.wire.kalium.network.api.authenticated.notification.EventResponse
+import com.wire.kalium.network.api.authenticated.notification.EventResponseToStore
 import com.wire.kalium.network.api.authenticated.notification.NotificationResponse
 import com.wire.kalium.network.api.base.authenticated.notification.NotificationApi
 import com.wire.kalium.network.api.base.authenticated.notification.WebSocketEvent
@@ -75,7 +76,7 @@ internal open class NotificationApiV0 internal constructor(
         }
     }
 
-    override suspend fun oldestNotification(queryClient: String): NetworkResponse<EventResponse> =
+    override suspend fun oldestNotification(queryClient: String): NetworkResponse<EventResponseToStore> =
         getAllNotifications(
             querySize = MINIMUM_QUERY_SIZE,
             queryClient = queryClient
@@ -116,7 +117,7 @@ internal open class NotificationApiV0 internal constructor(
     }
 
     @Deprecated("Starting API v8 prefer consumeLiveEvents instead", ReplaceWith("consumeLiveEvents(clientId)"))
-    override suspend fun listenToLiveEvents(clientId: String): NetworkResponse<Flow<WebSocketEvent<EventResponse>>> =
+    override suspend fun listenToLiveEvents(clientId: String): NetworkResponse<Flow<WebSocketEvent<EventResponseToStore>>> =
         mostRecentNotification(clientId).mapSuccess {
             flow {
                 // TODO: Delete this once we can intercept and handle token refresh when connecting WebSocket
@@ -139,7 +140,7 @@ internal open class NotificationApiV0 internal constructor(
         getApiNotSupportedError(::acknowledgeEvents.name, MIN_API_VERSION_CONSUMABLE_EVENTS)
     }
 
-    private suspend fun FlowCollector<WebSocketEvent<EventResponse>>.emitWebSocketEvents(
+    private suspend fun FlowCollector<WebSocketEvent<EventResponseToStore>>.emitWebSocketEvents(
         defaultClientWebSocketSession: WebSocketSession
     ) {
         val logger = kaliumLogger.withFeatureId(EVENT_RECEIVER)
@@ -161,7 +162,7 @@ internal open class NotificationApiV0 internal constructor(
                         val jsonString = io.ktor.utils.io.core.String(frame.data)
 
                         logger.v("Binary frame content: '${deleteSensitiveItemsFromJson(jsonString)}'")
-                        val event = KtxSerializer.json.decodeFromString<EventResponse>(jsonString)
+                        val event = KtxSerializer.json.decodeFromString<EventResponseToStore>(jsonString)
                         emit(WebSocketEvent.BinaryPayloadReceived(event))
                     }
 

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v0/notification/NotificationApiV0Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v0/notification/NotificationApiV0Test.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.network.api.authenticated.notification.NotificationRespon
 import com.wire.kalium.network.api.base.authenticated.notification.WebSocketEvent
 import com.wire.kalium.network.api.v0.authenticated.NotificationApiV0
 import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.network.tools.KtxSerializer
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.HttpStatusCode
@@ -102,8 +103,8 @@ internal class NotificationApiV0Test : ApiTest() {
         assertTrue(result.isSuccessful())
         val notifications = result.value.notifications.first()
 
-        val firstEvent = notifications.payload!!.first()
-        assertIs<EventContentDTO.Unknown>(firstEvent)
+        val firstEvent = notifications.payload
+        assertIs<EventContentDTO.Unknown>(KtxSerializer.json.decodeFromString<List<EventContentDTO>>(firstEvent!!).first())
     }
 
     @Test
@@ -119,8 +120,8 @@ internal class NotificationApiV0Test : ApiTest() {
         assertTrue(result.isSuccessful())
         val notifications = result.value.notifications.first()
 
-        val firstEvent = notifications.payload!!.first()
-        assertIs<EventContentDTO.Unknown>(firstEvent)
+        val firstEvent = notifications.payload
+        assertIs<EventContentDTO.Unknown>(KtxSerializer.json.decodeFromString<List<EventContentDTO>>(firstEvent!!).first())
     }
 
     @Test
@@ -203,7 +204,11 @@ internal class NotificationApiV0Test : ApiTest() {
         val result = notificationsApi.oldestNotification("")
 
         assertTrue(result.isSuccessful())
-        assertEquals(jsonProvider.serializableData.notifications.first(), result.value)
+        
+        val expectedNotificationResponse = KtxSerializer.json.decodeFromString<NotificationResponse>(jsonProvider.rawJson)
+        val expectedOldestNotification = expectedNotificationResponse.notifications.first()
+        
+        assertEquals(expectedOldestNotification, result.value)
     }
 
     private companion object {

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Events.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Events.sq
@@ -1,14 +1,17 @@
+import kotlin.Boolean;
+
 CREATE TABLE Events (
     id INTEGER NOT NULL PRIMARY KEY,
     event_id TEXT NOT NULL UNIQUE,
     is_processed INTEGER NOT NULL,
-    payload TEXT NOT NULL,
+    payload TEXT,
+    transient INTEGER AS Boolean NOT NULL,
     is_live INTEGER NOT NULL DEFAULT 0
 );
 
 insertOrIgnoreEvent:
-INSERT OR IGNORE INTO Events(event_id, is_processed, payload, is_live)
-VALUES (?, ?, ?, ?);
+INSERT OR IGNORE INTO Events(event_id, is_processed, payload, is_live, transient)
+VALUES (:event_id, :is_processed, :payload, :is_live, :transient);
 
 selectAll:
 SELECT * FROM Events;

--- a/persistence/src/commonMain/db_user/migrations/108.sqm
+++ b/persistence/src/commonMain/db_user/migrations/108.sqm
@@ -1,0 +1,37 @@
+import kotlin.Boolean;
+
+--
+-- Add transient column to Events table and make payload nullable
+--
+-- Changes:
+-- * Add transient column as Boolean NOT NULL
+-- * Remove NOT NULL constraint from payload column
+-- * Update insertOrIgnoreEvent query to include transient parameter
+--
+
+-- Turn off foreign key constraints during migration
+PRAGMA foreign_keys = 0;
+
+-- Create new Events table with the updated schema
+CREATE TABLE Events_temp (
+    id INTEGER NOT NULL PRIMARY KEY,
+    event_id TEXT NOT NULL UNIQUE,
+    is_processed INTEGER NOT NULL,
+    payload TEXT,
+    transient INTEGER AS Boolean NOT NULL,
+    is_live INTEGER NOT NULL DEFAULT 0
+);
+
+-- Copy data from old table to new table
+INSERT INTO Events_temp (id, event_id, is_processed, payload, transient, is_live)
+SELECT id, event_id, is_processed, payload, 0, is_live
+FROM Events;
+
+-- Drop old table
+DROP TABLE Events;
+
+-- Rename new table to original name
+ALTER TABLE Events_temp RENAME TO Events;
+
+-- Re-enable foreign key constraints
+PRAGMA foreign_keys = 1;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/event/EventDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/event/EventDAOImpl.kt
@@ -99,6 +99,7 @@ class EventDAOImpl(
         }
     }
 
+    @Suppress("LongParameterList")
     private fun mapEvent(
         id: Long,
         eventId: String,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/event/EventDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/event/EventDAOImpl.kt
@@ -56,10 +56,11 @@ class EventDAOImpl(
         withContext(queriesContext) {
             events.forEach { event ->
                 eventsQueries.insertOrIgnoreEvent(
-                    event.eventId,
-                    0,
-                    event.payload,
-                    if (event.isLive) 1L else 0L
+                    event_id = event.eventId,
+                    is_processed = 0,
+                    payload = event.payload,
+                    is_live = if (event.isLive) 1L else 0L,
+                    transient = event.transient
                 )
             }
         }
@@ -102,7 +103,8 @@ class EventDAOImpl(
         id: Long,
         eventId: String,
         isProcessed: Long,
-        payload: String,
+        payload: String?,
+        transient: Boolean,
         isLive: Long
     ): EventEntity {
         return EventEntity(
@@ -110,7 +112,8 @@ class EventDAOImpl(
             eventId = eventId,
             isProcessed = isProcessed != 0L,
             payload = payload,
-            isLive = isLive != 0L
+            isLive = isLive != 0L,
+            transient = transient
         )
     }
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/event/EventEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/event/EventEntity.kt
@@ -21,12 +21,14 @@ data class EventEntity(
     val id: Long,
     val eventId: String,
     val isProcessed: Boolean,
-    val payload: String,
+    val payload: String?,
+    val transient: Boolean,
     val isLive: Boolean
 )
 
 data class NewEventEntity(
     val eventId: String,
-    val payload: String,
+    val payload: String?,
+    val transient: Boolean,
     val isLive: Boolean
 )

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/event/EventDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/event/EventDAOTest.kt
@@ -48,7 +48,7 @@ class EventDAOTest : BaseDatabaseTest() {
 
     @Test
     fun givenUnprocessedEventInserted_whenObservingUnprocessed_shouldReturnEvent() = runTest {
-        val event = NewEventEntity(eventId = "e1", payload = "{\"test\":true}", isLive = false)
+        val event = NewEventEntity(eventId = "e1", payload = "{\"test\":true}", isLive = false, transient = true)
         dao.insertEvents(listOf(event))
 
         val result = dao.observeUnprocessedEvents().first()
@@ -63,7 +63,7 @@ class EventDAOTest : BaseDatabaseTest() {
 
     @Test
     fun givenEventInserted_whenMarkingAsProcessed_thenShouldBeExcludedFromUnprocessedFlow() = runTest {
-        val event = NewEventEntity(eventId = "e2", payload = "{}", isLive = false)
+        val event = NewEventEntity(eventId = "e2", payload = "{}", isLive = false, transient = false)
         dao.insertEvents(listOf(event))
 
         dao.markEventAsProcessed("e2")
@@ -75,9 +75,9 @@ class EventDAOTest : BaseDatabaseTest() {
     @Test
     fun givenMultipleEventsMarkedProcessed_whenDeletingAllProcessed_thenOnlyUnprocessedRemain() = runTest {
         val events = listOf(
-            NewEventEntity(eventId = "e1", payload = "{}", isLive = false),
-            NewEventEntity(eventId = "e2", payload = "{}", isLive = false),
-            NewEventEntity(eventId = "e3", payload = "{}", isLive = false)
+            NewEventEntity(eventId = "e1", payload = "{}", isLive = false, transient = false),
+            NewEventEntity(eventId = "e2", payload = "{}", isLive = false, transient = false),
+            NewEventEntity(eventId = "e3", payload = "{}", isLive = false, transient = true)
         )
         dao.insertEvents(events)
         dao.markEventAsProcessed("e1")
@@ -92,8 +92,8 @@ class EventDAOTest : BaseDatabaseTest() {
 
     @Test
     fun givenEventsWithDifferentIds_whenGettingById_shouldReturnCorrectEvent() = runTest {
-        val e1 = NewEventEntity(eventId = "eventA", payload = "{\"a\":1}", isLive = false)
-        val e2 = NewEventEntity(eventId = "eventB", payload = "{\"b\":2}", isLive = false)
+        val e1 = NewEventEntity(eventId = "eventA", payload = "{\"a\":1}", isLive = false, transient = false)
+        val e2 = NewEventEntity(eventId = "eventB", payload = "{\"b\":2}", isLive = false, transient = true)
         dao.insertEvents(listOf(e1, e2))
 
         val result = dao.getEventById("eventB")
@@ -107,9 +107,9 @@ class EventDAOTest : BaseDatabaseTest() {
     fun givenProcessedEventsBeforeId_whenDeletingBefore_shouldRemoveOnlyThose() = runTest {
         dao.insertEvents(
             listOf(
-                NewEventEntity(eventId = "e1", payload = "{}", isLive = false),
-                NewEventEntity(eventId = "e2", payload = "{}", isLive = false),
-                NewEventEntity(eventId = "e3", payload = "{}", isLive = false)
+                NewEventEntity(eventId = "e1", payload = "{}", isLive = false, transient = false),
+                NewEventEntity(eventId = "e2", payload = "{}", isLive = false, transient = false),
+                NewEventEntity(eventId = "e3", payload = "{}", isLive = false, transient = true)
             )
         )
         dao.markEventAsProcessed("e1")
@@ -126,9 +126,9 @@ class EventDAOTest : BaseDatabaseTest() {
     @Test
     fun givenMultipleEventsInserted_whenObservingEvents_shouldReturnAll() = runTest {
         val events = listOf(
-            NewEventEntity(eventId = "e1", payload = "{}", isLive = false),
-            NewEventEntity(eventId = "e2", payload = "{}", isLive = false),
-            NewEventEntity(eventId = "e3", payload = "{}", isLive = false)
+            NewEventEntity(eventId = "e1", payload = "{}", isLive = false, transient = false),
+            NewEventEntity(eventId = "e2", payload = "{}", isLive = false, transient = true),
+            NewEventEntity(eventId = "e3", payload = "{}", isLive = false, transient = false)
         )
         dao.insertEvents(events)
 
@@ -141,7 +141,7 @@ class EventDAOTest : BaseDatabaseTest() {
 
     @Test
     fun givenDuplicateEventIds_whenInserting_thenShouldIgnoreDuplicates() = runTest {
-        val event = NewEventEntity(eventId = "duplicate", payload = "{\"x\":1}", isLive = false)
+        val event = NewEventEntity(eventId = "duplicate", payload = "{\"x\":1}", isLive = false, transient = false)
         dao.insertEvents(listOf(event))
         dao.insertEvents(listOf(event))
 
@@ -159,8 +159,8 @@ class EventDAOTest : BaseDatabaseTest() {
     @Test
     fun givenOnlyUnprocessedEvents_whenDeletingProcessed_thenNoneShouldBeDeleted() = runTest {
         val events = listOf(
-            NewEventEntity(eventId = "a", payload = "{}", isLive = false),
-            NewEventEntity(eventId = "b", payload = "{}", isLive = false)
+            NewEventEntity(eventId = "a", payload = "{}", isLive = false, transient = true),
+            NewEventEntity(eventId = "b", payload = "{}", isLive = false, transient = false)
         )
         dao.insertEvents(events)
 
@@ -172,7 +172,7 @@ class EventDAOTest : BaseDatabaseTest() {
 
     @Test
     fun givenUnprocessedEvent_whenMarkingAsProcessed_thenShouldBeMarked() = runTest {
-        val event = NewEventEntity(eventId = "z", payload = "{}", isLive = false)
+        val event = NewEventEntity(eventId = "z", payload = "{}", isLive = false, transient = false)
         dao.insertEvents(listOf(event))
 
         dao.markEventAsProcessed("z")

--- a/tango-tests/src/integrationTest/kotlin/PocIntegrationTest.kt
+++ b/tango-tests/src/integrationTest/kotlin/PocIntegrationTest.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.logic.feature.auth.AuthenticationScope
 import com.wire.kalium.logic.feature.auth.autoVersioningAuth.AutoVersionAuthScopeUseCase
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.common.functional.getOrFail
+import com.wire.kalium.logic.data.event.toEventResponseToStore
 import com.wire.kalium.logic.util.TimeLogger
 import com.wire.kalium.mocks.mocks.conversation.ConversationMocks
 import com.wire.kalium.mocks.requests.ACMERequests
@@ -173,7 +174,7 @@ class PocIntegrationTest {
             val response = NotificationResponse(
                 time = Clock.System.now().toString(),
                 hasMore = false,
-                notifications = events.toList()
+                notifications = events.toList().map { it.toEventResponseToStore() }
             )
 
             val encodedData = json.encodeToString(response)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18756" title="WPB-18756" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18756</a>  [ANdroid] Refactor events buffer to not double json convert events
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

the current implementation will parse the json from the backend to EventResponse -> then we take the id form the response and convert the whole struct to json again just to be stored in the DB

### Solutions

change what how we parse Event structs 
```kotlin
@Serializable
data class EventResponseToStore(
    @SerialName("id") val id: String,
    @Serializable(with = RawJsonStringSerializer::class)
    @SerialName("payload") val payload: String?,
    @SerialName("transient") val transient: Boolean = false
)
```

and in the DB we store the ID + transient + the payload as string 

then when handling we decode it from string 

this avoid parsing from and to string 

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
