### PR TITLE
fix(sync): prevent sync from stopping due to flaky db cursor row count [WPB-18757]

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Events.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Events.sq
@@ -45,7 +45,8 @@ WHERE is_processed = 0;
 selectUnprocessedEvents:
 SELECT * FROM Events
 WHERE is_processed = 0
-ORDER BY id ASC;
+ORDER BY id ASC
+LIMIT 500;
 
 deleteUnprocessedLiveEventsByIds:
 DELETE FROM Events

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/event/EventDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/event/EventDAOImpl.kt
@@ -54,14 +54,16 @@ class EventDAOImpl(
 
     override suspend fun insertEvents(events: List<NewEventEntity>) {
         withContext(queriesContext) {
-            events.forEach { event ->
-                eventsQueries.insertOrIgnoreEvent(
-                    event_id = event.eventId,
-                    is_processed = 0,
-                    payload = event.payload,
-                    is_live = if (event.isLive) 1L else 0L,
-                    transient = event.transient
-                )
+            eventsQueries.transaction {
+                events.forEach { event ->
+                    eventsQueries.insertOrIgnoreEvent(
+                        event_id = event.eventId,
+                        is_processed = 0,
+                        payload = event.payload,
+                        is_live = if (event.isLive) 1L else 0L,
+                        transient = event.transient
+                    )
+                }
             }
         }
     }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/event/EventDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/event/EventDAOTest.kt
@@ -182,4 +182,27 @@ class EventDAOTest : BaseDatabaseTest() {
         assertTrue(updated.isProcessed)
     }
 
+    @Test
+    fun givenThousandsOfUnprocessedEvents_whenObserving_thenShouldGetUpTo500AtOnce() {
+        runTest {
+            val eventSize = 5_000
+            val expectedSize = 500
+            val eventList = buildList {
+                repeat(eventSize) { i ->
+                    add(
+                        NewEventEntity(
+                            eventId = "e$i",
+                            payload = """{"wawawweewa":"it's a very nice"}""",
+                            isLive = false,
+                            transient = false
+                        )
+                    )
+                }
+            }
+            dao.insertEvents(eventList)
+
+            assertEquals(expectedSize, dao.observeUnprocessedEvents().first().size)
+        }
+    }
+
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18757" title="WPB-18757" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18757</a>  [Android] add a limit to how many events are read from DB when processing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

See: https://github.com/sqldelight/sqldelight/issues/4194

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some users are struggling with Sync. Sync is stopping midway through and then resuming.

### Causes

It seems that under the hood, SQLite / the Android driver, is having a hard time to keep track of the number of rows in the CursorWindow (see: https://github.com/sqldelight/sqldelight/issues/4194).

It doesn't seem straightforward to reproduce, but we've seen users with dozens of logs in this format:

`Failed to read row 2578, column 0 from a window with 2569 rows, 6 columns`

### Solutions

For now, just limit the query size. But it would be ideal to dive a bit deeper into this.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
