### PR TITLE
fix: filter emitted events [WPB-18770]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt
@@ -157,7 +157,7 @@ class EventDataSource(
             }
             if (emittedEventIndex != eventEntities.lastIndex) {
                 kaliumLogger.d("$TAG filtered out ${emittedEventIndex + 1} events already marked as processed")
-                emit(eventEntities.subList(emittedEventIndex + 1, eventEntities.lastIndex))
+                emit(eventEntities.subList(emittedEventIndex + 1, eventEntities.size))
             } else {
                 kaliumLogger.d("$TAG no unprocessed events found")
                 emit(emptyList())

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt
@@ -37,18 +37,17 @@ import com.wire.kalium.logic.util.ServerTimeHandlerImpl
 import com.wire.kalium.network.api.base.authenticated.notification.WebSocketEvent
 import io.ktor.utils.io.errors.IOException
 import io.mockative.Mockable
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.cancellable
-import kotlinx.coroutines.flow.channelFlow
-import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.transform
 import kotlinx.datetime.toInstant
 
 /**
@@ -85,25 +84,22 @@ internal class EventGathererImpl(
 
     private val logger = logger.withFeatureId(SYNC)
 
-    // TODO handle multiple events at once
-    override suspend fun gatherEvents(): Flow<EventStreamData> = channelFlow {
-        coroutineScope {
-            val waitForReceivingSetupJob = Job()
-            launch {
-                // TODO(refactor): stop emitting Unit, emit status of the underlying event fetching for clarity
-                receiveEventsFromRemoteAndInsertIntoLocalStorage().onEach { waitForReceivingSetupJob.complete() }.collect()
-            }
-            launch {
-                waitForReceivingSetupJob.join()
-                eventRepository.observeEvents().onEach { events ->
-                    kaliumLogger.d("$TAG gathering ${events.size} events")
-                }.collect { events ->
-                    if (events.isEmpty()) {
-                        send(EventStreamData.IsUpToDate)
-                    } else {
-                        send(EventStreamData.NewEvents(events))
-                    }
-                }
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override suspend fun gatherEvents(): Flow<EventStreamData> {
+        var hasEmitted = false
+
+        // TODO(refactor): stop emitting Unit, emit status of the underlying event fetching for clarity
+        return receiveEventsFromRemoteAndInsertIntoLocalStorage().transform {
+            if (hasEmitted) return@transform
+            hasEmitted = true
+            emit(Unit)
+        }.flatMapConcat { eventRepository.observeEvents() }.onEach { events ->
+            kaliumLogger.d("$TAG gathering ${events.size} events")
+        }.map { events ->
+            if (events.isEmpty()) {
+                EventStreamData.IsUpToDate
+            } else {
+                EventStreamData.NewEvents(events)
             }
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessor.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessor.kt
@@ -124,8 +124,9 @@ internal class EventProcessorImpl(
                 missedNotificationsEventReceiver.onEvent(event, deliveryInfo)
             }
         }.onSuccess {
-            eventRepository.setEventAsProcessed(event.id)
-            logger.i("Event set as processed: ${eventEnvelope.toLogString()}")
+            eventRepository.setEventAsProcessed(event.id).onSuccess {
+                logger.i("Event set as processed: ${eventEnvelope.toLogString()}")
+            }
         }
     }
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/event/EventDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/event/EventDAOImpl.kt
@@ -40,7 +40,6 @@ class EventDAOImpl(
     override suspend fun observeUnprocessedEvents(): Flow<List<EventEntity>> {
         return eventsQueries.selectUnprocessedEvents(::mapEvent)
             .asFlow()
-            .flowOn(queriesContext)
             .mapToList()
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18770" title="WPB-18770" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18770</a>  [Android] sync incorrectly switching between live and pending when processing a large number of events
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With @vitorhugods help:

- Fixed incorrect filtering of already emitted unprocessed events. Previously, the code used `subList(emittedIndex + 1, eventEntities.lastIndex)`, which mistakenly omitted the last event. Now it correctly uses `.size` to include all relevant items.
- Added dedicated regression tests in `EventRepositoryTest` to confirm that:
  - previously emitted events are not re-emitted,
  - edge cases (e.g., last processed being second-to-last) are handled gracefully.
- Refactored `EventGatherer.gatherEvents()`
  - Replaced previous `channelFlow + Job` logic with `flatMapConcat` on a single `Flow<Unit>`.
  - This ensures proper *sequential* collection:
    - The next batch is not emitted until all events from the current batch are fully processed.
    - Eliminates race conditions between database observation and event processing logic.


