### PR TITLE
feat: reset MLS conversation use case (#WPB-17704)

### DIFF
--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigModel.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigModel.kt
@@ -108,6 +108,11 @@ data class E2EIConfigModel(
     val crlProxy: String?,
 )
 
+data class AllowedGlobalOperationsModel(
+    val mlsConversationsReset: Boolean,
+    val status: Status,
+)
+
 @Serializable
 sealed interface ChannelFeatureConfiguration {
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
@@ -150,6 +150,8 @@ interface UserConfigRepository {
     suspend fun getNextTimeForCallFeedback(): Either<StorageFailure, Long>
     suspend fun setShouldFetchE2EITrustAnchors(shouldFetch: Boolean)
     suspend fun getShouldFetchE2EITrustAnchor(): Boolean
+    suspend fun setMlsConversationsResetEnabled(enabled: Boolean): Either<StorageFailure, Unit>
+    suspend fun isMlsConversationsResetEnabled(): Boolean
 }
 
 @Suppress("TooManyFunctions")
@@ -549,4 +551,10 @@ internal class UserConfigDataSource internal constructor(
     override suspend fun getNextTimeForCallFeedback() = wrapStorageRequest { userConfigDAO.getNextTimeForCallFeedback() }
 
     override suspend fun getShouldFetchE2EITrustAnchor(): Boolean = userConfigDAO.getShouldFetchE2EITrustAnchorHasRun()
+    override suspend fun setMlsConversationsResetEnabled(enabled: Boolean) =
+        wrapStorageRequest {
+            userConfigDAO.setMlsConversationsResetEnabled(enabled)
+        }
+
+    override suspend fun isMlsConversationsResetEnabled(): Boolean = userConfigDAO.getMlsConversationsResetEnabled()
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -349,6 +349,7 @@ interface ConversationRepository {
     suspend fun getConversationDetails(conversationID: ConversationId): Either<StorageFailure, Conversation>
     suspend fun getConversationIdsWithoutMetadata(): Either<CoreFailure, List<QualifiedID>>
     suspend fun fetchConversationListDetails(conversationIdList: List<QualifiedID>): Either<CoreFailure, ConversationResponseDTO>
+    suspend fun resetMlsConversation(groupId: GroupID, epoch: ULong): Either<NetworkFailure, Unit>
 }
 
 @OptIn(ConversationPersistenceApi::class)
@@ -850,6 +851,13 @@ internal class ConversationDataSource internal constructor(
         wrapApiRequest {
             conversationApi.fetchConversationsListDetails(conversationIdList.map { it.toApi() })
         }
+
+    override suspend fun resetMlsConversation(
+        groupId: GroupID,
+        epoch: ULong
+    ): Either<NetworkFailure, Unit> = wrapApiRequest {
+        conversationApi.resetMlsConversation(groupId.value, epoch)
+    }
 
     override suspend fun updateChannelAddPermissionLocally(
         conversationId: ConversationId,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt
@@ -73,7 +73,7 @@ internal class ResetMLSConversationUseCaseImpl(
             .map { updatedProtocolInfo ->
 
                 val members = conversationRepository.getConversationMembers(conversationId).getOrFail {
-                    kaliumLogger.e("Failed to get members for conversation $conversationId: $it")
+                    kaliumLogger.e("Failed to get members for conversation: $it")
                     return it.left()
                 }
 
@@ -88,7 +88,7 @@ internal class ResetMLSConversationUseCaseImpl(
         return conversationRepository.getConversationById(conversationId)
             .map {
                 it.mlsProtocolInfo() ?: return CoreFailure
-                    .Unknown(IllegalStateException("Conversation $conversationId is not an MLS conversation.")).left()
+                    .Unknown(IllegalStateException("Conversation is not an MLS conversation.")).left()
             }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt
@@ -1,0 +1,101 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.conversation
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.wrapApiRequest
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.common.functional.getOrFail
+import com.wire.kalium.common.functional.left
+import com.wire.kalium.common.functional.map
+import com.wire.kalium.common.functional.right
+import com.wire.kalium.common.logger.kaliumLogger
+import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
+
+/**
+ * Reset an MLS conversation which cannot be recovered by any other means.
+ *
+ * This use case will reset the MLS conversation by:
+ *  - Calling /mls/reset-conversation API endpoint
+ *  - Leaving the MLS group (wipeConversation)
+ *  - Fetching the conversation to update group ID
+ *  - Re-establishing the MLS group with the updated group ID and current members.
+ */
+internal interface ResetMLSConversationUseCase {
+    suspend operator fun invoke(conversationId: ConversationId): Either<CoreFailure, Unit>
+}
+
+@Suppress("ReturnCount")
+internal class ResetMLSConversationUseCaseImpl(
+    private val userConfig: UserConfigRepository,
+    private val conversationRepository: ConversationRepository,
+    private val mlsConversationRepository: MLSConversationRepository,
+    private val fetchConversationUseCase: FetchConversationUseCase,
+    private val conversationApi: ConversationApi,
+) : ResetMLSConversationUseCase {
+
+    override suspend operator fun invoke(conversationId: ConversationId): Either<CoreFailure, Unit> {
+
+        if (!userConfig.isMlsConversationsResetEnabled()) {
+            kaliumLogger.i("MLS conversation reset feature is disabled.")
+            return Unit.right()
+        }
+
+        return getMlsProtocolInfo(conversationId)
+            .flatMap { protocolInfo ->
+                wrapApiRequest {
+                    conversationApi.resetMlsConversation(protocolInfo.groupId.value, protocolInfo.epoch)
+                }.map { protocolInfo.groupId }
+            }
+            .flatMap { groupId ->
+                mlsConversationRepository.leaveGroup(groupId)
+            }
+            .flatMap { fetchConversationUseCase(conversationId) }
+            .flatMap { getMlsProtocolInfo(conversationId) }
+            .map { updatedProtocolInfo ->
+
+                val members = conversationRepository.getConversationMembers(conversationId).getOrFail {
+                    kaliumLogger.e("Failed to get members for conversation $conversationId: $it")
+                    return it.left()
+                }
+
+                mlsConversationRepository.establishMLSGroup(
+                    groupID = updatedProtocolInfo.groupId,
+                    members = members,
+                )
+            }
+    }
+
+    private suspend fun getMlsProtocolInfo(conversationId: ConversationId): Either<CoreFailure, Conversation.ProtocolInfo.MLS> {
+        return conversationRepository.getConversationById(conversationId)
+            .map {
+                it.mlsProtocolInfo() ?: return CoreFailure
+                    .Unknown(IllegalStateException("Conversation $conversationId is not an MLS conversation.")).left()
+            }
+    }
+}
+
+private fun Conversation.mlsProtocolInfo(): Conversation.ProtocolInfo.MLS? {
+    return when (this.protocol) {
+        is Conversation.ProtocolInfo.MLS -> this.protocol as? Conversation.ProtocolInfo.MLS
+        else -> null
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -32,6 +32,7 @@ import com.wire.kalium.logic.data.conversation.Conversation.TypingIndicatorMode
 import com.wire.kalium.logic.data.conversation.ConversationDetails.Group.Channel.ChannelAddPermission
 import com.wire.kalium.logic.data.conversation.FolderWithConversations
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
+import com.wire.kalium.logic.data.featureConfig.AllowedGlobalOperationsModel
 import com.wire.kalium.logic.data.featureConfig.AppLockModel
 import com.wire.kalium.logic.data.featureConfig.ClassifiedDomainsModel
 import com.wire.kalium.logic.data.featureConfig.ConferenceCallingModel
@@ -584,6 +585,18 @@ sealed class Event(open val id: String) {
                 idKey to id.obfuscateId(),
                 featureStatusKey to model.status.name,
                 "timeout" to model.inactivityTimeoutSecs
+            )
+        }
+
+        data class AllowedGlobalOperationsUpdated(
+            override val id: String,
+            val model: AllowedGlobalOperationsModel,
+        ) : FeatureConfig(id) {
+            override fun toLogMap(): Map<String, Any?> = mapOf(
+                typeKey to "FeatureConfig.AllowedGlobalOperationsUpdated",
+                idKey to id.obfuscateId(),
+                featureStatusKey to model.status.name,
+                "mlsConversationReset" to model.mlsConversationsReset
             )
         }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -551,6 +551,11 @@ class EventMapper(
             featureConfigMapper.fromDTO(featureConfigUpdatedDTO.data as FeatureConfigData.AppLock)
         )
 
+        is FeatureConfigData.AllowedGlobalOperations -> Event.FeatureConfig.AllowedGlobalOperationsUpdated(
+            id,
+            featureConfigMapper.fromDTO(featureConfigUpdatedDTO.data as FeatureConfigData.AllowedGlobalOperations)
+        )
+
         // These features are NOT received through events. As FeatureConfig Events are deprecated
         is FeatureConfigData.Channels,
         is FeatureConfigData.DigitalSignatures,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.network.api.authenticated.featureConfigs.FeatureFlagStatu
 import com.wire.kalium.network.api.authenticated.featureConfigs.MLSMigrationConfigDTO
 import com.wire.kalium.persistence.config.MLSMigrationEntity
 
+@Suppress("TooManyFunctions")
 interface FeatureConfigMapper {
     fun fromDTO(featureConfigResponse: FeatureConfigResponse): FeatureConfigModel
     fun fromDTO(status: FeatureFlagStatusDTO): Status
@@ -43,6 +44,7 @@ interface FeatureConfigMapper {
     fun fromDTO(data: FeatureConfigData.E2EI?): E2EIModel
     fun fromModel(status: Status): FeatureFlagStatusDTO
     fun fromModel(model: MLSMigrationModel): FeatureConfigData.MLSMigration
+    fun fromDTO(data: FeatureConfigData.AllowedGlobalOperations): AllowedGlobalOperationsModel
 }
 
 @Suppress("TooManyFunctions")
@@ -174,6 +176,12 @@ class FeatureConfigMapperImpl : FeatureConfigMapper {
                 null
             ),
             Status.DISABLED
+        )
+
+    override fun fromDTO(data: FeatureConfigData.AllowedGlobalOperations): AllowedGlobalOperationsModel =
+        AllowedGlobalOperationsModel(
+            mlsConversationsReset = data.config.mlsConversationsReset,
+            status = fromDTO(data.status)
         )
 
     override fun fromModel(status: Status): FeatureFlagStatusDTO =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -460,6 +460,7 @@ import com.wire.kalium.logic.sync.receiver.conversation.message.NewMessageEventH
 import com.wire.kalium.logic.sync.receiver.conversation.message.NewMessageEventHandlerImpl
 import com.wire.kalium.logic.sync.receiver.conversation.message.ProteusMessageUnpacker
 import com.wire.kalium.logic.sync.receiver.conversation.message.ProteusMessageUnpackerImpl
+import com.wire.kalium.logic.sync.receiver.handler.AllowedGlobalOperationsHandler
 import com.wire.kalium.logic.sync.receiver.handler.ButtonActionConfirmationHandler
 import com.wire.kalium.logic.sync.receiver.handler.ButtonActionConfirmationHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.ClearConversationContentHandlerImpl
@@ -1868,6 +1869,9 @@ class UserSessionScope internal constructor(
     private val appLockConfigHandler
         get() = AppLockConfigHandler(userConfigRepository)
 
+    private val allowedGlobalOperationsHandler
+        get() = AllowedGlobalOperationsHandler(userConfigRepository)
+
     private val featureConfigEventReceiver: FeatureConfigEventReceiver
         get() = FeatureConfigEventReceiverImpl(
             guestRoomConfigHandler,
@@ -1878,7 +1882,8 @@ class UserSessionScope internal constructor(
             conferenceCallingConfigHandler,
             selfDeletingMessagesConfigHandler,
             e2eiConfigHandler,
-            appLockConfigHandler
+            appLockConfigHandler,
+            allowedGlobalOperationsHandler,
         )
 
     private val preKeyRepository: PreKeyRepository

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -2039,7 +2039,9 @@ class UserSessionScope internal constructor(
             newGroupConversationSystemMessagesCreator,
             deleteConversationUseCase,
             persistConversationsUseCase,
-            cryptoTransactionProvider
+            cryptoTransactionProvider,
+            userConfigRepository,
+            fetchConversationUseCase,
         )
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.logic.feature.conversation
 import co.touchlab.stately.collections.ConcurrentMutableMap
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.cache.SelfConversationIdProvider
+import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.configuration.server.ServerConfigRepository
 import com.wire.kalium.logic.data.asset.AssetRepository
@@ -28,9 +29,12 @@ import com.wire.kalium.logic.data.client.CryptoTransactionProvider
 import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.conversation.ConversationGroupRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.FetchConversationUseCase
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.conversation.NewGroupConversationSystemMessagesCreator
 import com.wire.kalium.logic.data.conversation.PersistConversationsUseCase
+import com.wire.kalium.logic.data.conversation.ResetMLSConversationUseCase
+import com.wire.kalium.logic.data.conversation.ResetMLSConversationUseCaseImpl
 import com.wire.kalium.logic.data.conversation.TypingIndicatorIncomingRepositoryImpl
 import com.wire.kalium.logic.data.conversation.TypingIndicatorOutgoingRepositoryImpl
 import com.wire.kalium.logic.data.conversation.TypingIndicatorSenderHandler
@@ -134,6 +138,8 @@ class ConversationScope internal constructor(
     private val deleteConversationUseCase: DeleteConversationUseCase,
     private val persistConversationsUseCase: PersistConversationsUseCase,
     private val transactionProvider: CryptoTransactionProvider,
+    private val userConfigRepository: UserConfigRepository,
+    private val fetchConversationUseCase: FetchConversationUseCase,
     internal val dispatcher: KaliumDispatcher = KaliumDispatcherImpl,
 ) {
 
@@ -412,4 +418,12 @@ class ConversationScope internal constructor(
         get() = RemoveConversationFromFolderUseCaseImpl(conversationFolderRepository)
     val createConversationFolder: CreateConversationFolderUseCase
         get() = CreateConversationFolderUseCaseImpl(conversationFolderRepository)
+    val resetMlsConversation: ResetMLSConversationUseCase
+        get() = ResetMLSConversationUseCaseImpl(
+            userConfig = userConfigRepository,
+            transactionProvider = transactionProvider,
+            conversationRepository = conversationRepository,
+            mlsConversationRepository = mlsConversationRepository,
+            fetchConversationUseCase = fetchConversationUseCase,
+        )
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiver.kt
@@ -35,6 +35,7 @@ import com.wire.kalium.logic.feature.featureConfig.handler.GuestRoomConfigHandle
 import com.wire.kalium.logic.feature.featureConfig.handler.MLSConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.MLSMigrationConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.SelfDeletingMessagesConfigHandler
+import com.wire.kalium.logic.sync.receiver.handler.AllowedGlobalOperationsHandler
 import com.wire.kalium.logic.util.EventLoggingStatus
 import com.wire.kalium.logic.util.createEventProcessingLogger
 import io.mockative.Mockable
@@ -52,7 +53,8 @@ internal class FeatureConfigEventReceiverImpl internal constructor(
     private val conferenceCallingConfigHandler: ConferenceCallingConfigHandler,
     private val selfDeletingMessagesConfigHandler: SelfDeletingMessagesConfigHandler,
     private val e2EIConfigHandler: E2EIConfigHandler,
-    private val appLockConfigHandler: AppLockConfigHandler
+    private val appLockConfigHandler: AppLockConfigHandler,
+    private val allowedGlobalOperationsHandler: AllowedGlobalOperationsHandler,
 ) : FeatureConfigEventReceiver {
 
     override suspend fun onEvent(
@@ -84,7 +86,8 @@ internal class FeatureConfigEventReceiverImpl internal constructor(
                     arrayOf("info" to "Ignoring unknown feature config update")
                 )
 
-                Either.Right(Unit)
-            }
+            Either.Right(Unit)
         }
+        is Event.FeatureConfig.AllowedGlobalOperationsUpdated -> allowedGlobalOperationsHandler.handle(event.model)
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/AllowedGlobalOperationsHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/AllowedGlobalOperationsHandler.kt
@@ -25,7 +25,6 @@ import com.wire.kalium.logic.data.featureConfig.AllowedGlobalOperationsModel
 class AllowedGlobalOperationsHandler(
     private val userConfigRepository: UserConfigRepository
 ) {
-    suspend fun handle(model: AllowedGlobalOperationsModel): Either<CoreFailure, Unit> {
-        return userConfigRepository.setMlsConversationsResetEnabled(model.mlsConversationsReset)
-    }
+suspend fun handle(model: AllowedGlobalOperationsModel): Either<CoreFailure, Unit> =
+         userConfigRepository.setMlsConversationsResetEnabled(model.mlsConversationsReset)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/AllowedGlobalOperationsHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/AllowedGlobalOperationsHandler.kt
@@ -1,0 +1,31 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.receiver.handler
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.data.featureConfig.AllowedGlobalOperationsModel
+
+class AllowedGlobalOperationsHandler(
+    private val userConfigRepository: UserConfigRepository
+) {
+    suspend fun handle(model: AllowedGlobalOperationsModel): Either<CoreFailure, Unit> {
+        return userConfigRepository.setMlsConversationsResetEnabled(model.mlsConversationsReset)
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCaseTest.kt
@@ -52,7 +52,7 @@ class ResetMLSConversationUseCaseTest {
     }
 
     @Test
-    fun whenUseCaseSuccess_thenResetMLSConversationCalled() = runTest {
+    fun givenRepositorySuccess_whenUseCaseCalled_thenResetMLSConversationCalled() = runTest {
 
         val (arrangement, useCase) = Arrangement()
             .withFeatureEnabled()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCaseTest.kt
@@ -1,0 +1,161 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.conversation
+
+import com.wire.kalium.common.functional.isRight
+import com.wire.kalium.common.functional.right
+import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.data.conversation.mls.MLSAdditionResult
+import com.wire.kalium.logic.feature.backup.UserId
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
+import com.wire.kalium.network.utils.NetworkResponse
+import io.mockative.any
+import io.mockative.coEvery
+import io.mockative.coVerify
+import io.mockative.mock
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class ResetMLSConversationUseCaseTest {
+
+    @Test
+    fun whenResetMLSConversationFeatureIsDisabled_thenResetConversationNotStarted() = runTest {
+
+        val (arrangement, useCase) = Arrangement()
+            .withFeatureDisabled()
+            .arrange()
+
+        val result = useCase(TestConversation.ID)
+
+        assertTrue(result.isRight())
+
+        coVerify {
+            arrangement.conversationApi.resetMlsConversation(any(), any())
+        }.wasNotInvoked()
+    }
+
+    @Test
+    fun whenUseCaseSuccess_thenResetMLSConversationCalled() = runTest {
+
+        val (arrangement, useCase) = Arrangement()
+            .withFeatureEnabled()
+            .arrange()
+
+        useCase(TestConversation.ID)
+
+        coVerify {
+            arrangement.conversationApi.resetMlsConversation(any(), any())
+        }.wasInvoked()
+    }
+
+    @Test
+    fun whenUseCaseSuccess_thenLeaveConversationCalled() = runTest {
+
+        val (arrangement, useCase) = Arrangement()
+            .withFeatureEnabled()
+            .arrange()
+
+        useCase(TestConversation.ID)
+
+        coVerify {
+            arrangement.mlsConversationRepository.leaveGroup(any())
+        }.wasInvoked()
+    }
+
+    @Test
+    fun whenUseCaseInvoked_thenConversationFetchedAfterReset() = runTest {
+
+        val (arrangement, useCase) = Arrangement()
+            .withFeatureEnabled()
+            .arrange()
+
+        useCase(TestConversation.ID)
+
+        coVerify {
+            arrangement.fetchConversationUseCase(any())
+        }.wasInvoked()
+    }
+
+    @Test
+    fun whenUseCaseInvoked_thenConversationEstablishedAfterReset() = runTest {
+
+        val (arrangement, useCase) = Arrangement()
+            .withFeatureEnabled()
+            .arrange()
+
+        useCase(TestConversation.ID)
+
+        coVerify {
+            arrangement.mlsConversationRepository.establishMLSGroup(any(), any(), any(), any())
+        }.wasInvoked()
+    }
+
+    private class Arrangement {
+
+        val userConfig = mock(UserConfigRepository::class)
+        val conversationRepository = mock(ConversationRepository::class)
+        val mlsConversationRepository = mock(MLSConversationRepository::class)
+        val fetchConversationUseCase = mock(FetchConversationUseCase::class)
+        val conversationApi = mock(ConversationApi::class)
+
+        suspend fun withFeatureDisabled() = apply {
+            coEvery { userConfig.isMlsConversationsResetEnabled() } returns false
+        }
+
+        suspend fun withFeatureEnabled() = apply {
+            coEvery { userConfig.isMlsConversationsResetEnabled() } returns true
+        }
+
+        suspend fun arrange(): Pair<Arrangement, ResetMLSConversationUseCaseImpl> {
+
+            coEvery {
+                conversationRepository.getConversationById(any())
+            } returns TestConversation.MLS_CONVERSATION.right()
+
+            coEvery {
+                conversationApi.resetMlsConversation(any(), any())
+            } returns NetworkResponse.Success(Unit, mapOf(), 200)
+
+            coEvery {
+                mlsConversationRepository.leaveGroup(any())
+            } returns Unit.right()
+
+            coEvery {
+                mlsConversationRepository.establishMLSGroup(any(), any(), any(), any())
+            } returns MLSAdditionResult(emptySet(), emptySet()).right()
+
+            coEvery {
+                fetchConversationUseCase(any())
+            } returns Unit.right()
+
+            coEvery {
+                conversationRepository.getConversationMembers(any())
+            } returns listOf(UserId("test", "test@user")).right()
+
+            return this to ResetMLSConversationUseCaseImpl(
+                userConfig = userConfig,
+                conversationRepository = conversationRepository,
+                mlsConversationRepository = mlsConversationRepository,
+                fetchConversationUseCase = fetchConversationUseCase,
+                conversationApi = conversationApi,
+            )
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCaseTest.kt
@@ -36,7 +36,7 @@ import kotlin.test.assertTrue
 class ResetMLSConversationUseCaseTest {
 
     @Test
-    fun whenResetMLSConversationFeatureIsDisabled_thenResetConversationNotStarted() = runTest {
+    fun givenFeatureDisabled_whenUseCaseCalled_thenResetConversationNotStarted() = runTest {
 
         val (arrangement, useCase) = Arrangement()
             .withFeatureDisabled()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/FeatureConfigMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/FeatureConfigMapperTest.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.logic.data.event
 import com.wire.kalium.logic.data.featureConfig.FeatureConfigMapper
 import com.wire.kalium.logic.data.featureConfig.FeatureConfigMapperImpl
 import com.wire.kalium.logic.data.featureConfig.Status
+import com.wire.kalium.network.api.authenticated.featureConfigs.AllowedGlobalOperationsConfigDTO
 import com.wire.kalium.network.api.authenticated.featureConfigs.AppLockConfigDTO
 import com.wire.kalium.network.api.authenticated.featureConfigs.ClassifiedDomainsConfigDTO
 import com.wire.kalium.network.api.authenticated.featureConfigs.ConferenceCallingConfigDTO
@@ -172,6 +173,10 @@ class FeatureConfigMapperTest {
                 FeatureFlagStatusDTO.ENABLED
             ),
             FeatureConfigData.Channels(null, FeatureFlagStatusDTO.DISABLED),
+            FeatureConfigData.AllowedGlobalOperations(
+                AllowedGlobalOperationsConfigDTO(),
+                FeatureFlagStatusDTO.DISABLED
+            ),
         )
 
         val mapper: FeatureConfigMapper = FeatureConfigMapperImpl()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigRepositoryTest.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.test_util.TestNetworkException
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
+import com.wire.kalium.network.api.authenticated.featureConfigs.AllowedGlobalOperationsConfigDTO
 import com.wire.kalium.network.api.authenticated.featureConfigs.AppLockConfigDTO
 import com.wire.kalium.network.api.authenticated.featureConfigs.ClassifiedDomainsConfigDTO
 import com.wire.kalium.network.api.authenticated.featureConfigs.ConferenceCallingConfigDTO
@@ -172,7 +173,11 @@ class FeatureConfigRepositoryTest {
                 MLSMigrationConfigDTO(Instant.DISTANT_FUTURE, Instant.DISTANT_FUTURE),
                 FeatureFlagStatusDTO.ENABLED
             ),
-            FeatureConfigData.Channels(null, FeatureFlagStatusDTO.DISABLED)
+            FeatureConfigData.Channels(null, FeatureFlagStatusDTO.DISABLED),
+            FeatureConfigData.AllowedGlobalOperations(
+                AllowedGlobalOperationsConfigDTO(),
+                FeatureFlagStatusDTO.DISABLED
+            ),
         )
 
         val featureConfigApi: FeatureConfigApi = mock(FeatureConfigApi::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
@@ -44,6 +44,7 @@ import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.sync.receiver.handler.AllowedGlobalOperationsHandler
 import com.wire.kalium.logic.util.shouldSucceed
 import io.mockative.any
 import io.mockative.coEvery
@@ -347,7 +348,8 @@ class FeatureConfigEventReceiverTest {
                 ConferenceCallingConfigHandler(userConfigRepository),
                 SelfDeletingMessagesConfigHandler(userConfigRepository, kaliumConfigs),
                 E2EIConfigHandler(userConfigRepository),
-                AppLockConfigHandler(userConfigRepository)
+                AppLockConfigHandler(userConfigRepository),
+                AllowedGlobalOperationsHandler(userConfigRepository),
             )
         }
 

--- a/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/FeatureConfigJson.kt
+++ b/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/FeatureConfigJson.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.mocks.responses
 
+import com.wire.kalium.network.api.authenticated.featureConfigs.AllowedGlobalOperationsConfigDTO
 import com.wire.kalium.network.api.authenticated.featureConfigs.AppLockConfigDTO
 import com.wire.kalium.network.api.authenticated.featureConfigs.ClassifiedDomainsConfigDTO
 import com.wire.kalium.network.api.authenticated.featureConfigs.ConferenceCallingConfigDTO
@@ -143,6 +144,10 @@ object FeatureConfigJson {
                 FeatureFlagStatusDTO.ENABLED
             ),
             FeatureConfigData.Channels(null, FeatureFlagStatusDTO.DISABLED),
+            FeatureConfigData.AllowedGlobalOperations(
+                AllowedGlobalOperationsConfigDTO(),
+                FeatureFlagStatusDTO.DISABLED
+            ),
         ),
         featureConfigResponseSerializer
     )

--- a/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/FeatureConfigResponseJson.kt
+++ b/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/FeatureConfigResponseJson.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.kalium.mocks.responses
 
+import com.wire.kalium.network.api.authenticated.featureConfigs.AllowedGlobalOperationsConfigDTO
 import com.wire.kalium.network.api.authenticated.featureConfigs.AppLockConfigDTO
 import com.wire.kalium.network.api.authenticated.featureConfigs.ClassifiedDomainsConfigDTO
 import com.wire.kalium.network.api.authenticated.featureConfigs.ConferenceCallingConfigDTO
@@ -30,7 +31,6 @@ import com.wire.kalium.network.api.authenticated.featureConfigs.SelfDeletingMess
 import com.wire.kalium.network.api.model.SupportedProtocolDTO
 import com.wire.kalium.network.tools.KtxSerializer
 import kotlinx.datetime.Instant
-import kotlinx.serialization.encodeToString
 
 object FeatureConfigResponseJson {
     private const val VERIFICATION_EXPIRATION = 1_000_000L
@@ -78,6 +78,10 @@ object FeatureConfigResponseJson {
             FeatureFlagStatusDTO.ENABLED
         ),
         FeatureConfigData.Channels(null, FeatureFlagStatusDTO.DISABLED),
+        FeatureConfigData.AllowedGlobalOperations(
+            AllowedGlobalOperationsConfigDTO(),
+            FeatureFlagStatusDTO.DISABLED
+        ),
     )
     val valid = KtxSerializer.json.encodeToString(featureConfigResponse)
 

--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/conversation/ResetMLSConversationRequestV9.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/conversation/ResetMLSConversationRequestV9.kt
@@ -1,0 +1,29 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.authenticated.conversation
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResetMLSConversationRequestV9(
+    @SerialName("epoch")
+    val epoch: ULong,
+    @SerialName("group_id")
+    val groupId: String,
+)

--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/featureConfigs/FeatureConfigResponse.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/featureConfigs/FeatureConfigResponse.kt
@@ -58,7 +58,9 @@ data class FeatureConfigResponse(
     @SerialName("mlsMigration")
     val mlsMigration: FeatureConfigData.MLSMigration?,
     @SerialName("channels")
-    val channels: FeatureConfigData.Channels?
+    val channels: FeatureConfigData.Channels?,
+    @SerialName("allowedGlobalOperations")
+    val allowedGlobalOperations: FeatureConfigData.AllowedGlobalOperations?,
 )
 
 @Serializable
@@ -148,6 +150,12 @@ data class E2EIConfigDTO(
     val shouldUseProxy: Boolean?,
     @SerialName("verificationExpiration")
     val verificationExpirationSeconds: Long
+)
+
+@Serializable
+data class AllowedGlobalOperationsConfigDTO(
+    @SerialName("mlsConversationReset20250709")
+    val mlsConversationsReset: Boolean = false,
 )
 
 @OptIn(ExperimentalSerializationApi::class)
@@ -285,6 +293,15 @@ sealed class FeatureConfigData {
     data class Channels(
         @SerialName("config")
         val config: ChannelsConfigDTO?,
+        @SerialName("status")
+        val status: FeatureFlagStatusDTO
+    ) : FeatureConfigData()
+
+    @SerialName("allowedGlobalOperations")
+    @Serializable
+    data class AllowedGlobalOperations(
+        @SerialName("config")
+        val config: AllowedGlobalOperationsConfigDTO,
         @SerialName("status")
         val status: FeatureFlagStatusDTO
     ) : FeatureConfigData()

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationApi.kt
@@ -192,6 +192,11 @@ interface ConversationApi : BaseApi {
         conversationId: ConversationId
     ): NetworkResponse<ConversationInviteLinkResponse>
 
+    suspend fun resetMlsConversation(
+        groupId: String,
+        epoch: ULong,
+    ): NetworkResponse<Unit>
+
     companion object {
         fun getApiNotSupportError(apiName: String, apiVersion: String = "4") = NetworkResponse.Error(
             APINotSupported("${this::class.simpleName}: $apiName api is only available on API V$apiVersion")

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/ConversationApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/ConversationApiV0.kt
@@ -404,6 +404,10 @@ internal open class ConversationApiV0 internal constructor(
         APINotSupported("updateChannelPermission api is only available on API V8")
     )
 
+    override suspend fun resetMlsConversation(groupId: String, epoch: ULong): NetworkResponse<Unit> = NetworkResponse.Error(
+        APINotSupported("resetMlsConversation api is only available on API V9")
+    )
+
     protected companion object {
         const val PATH_CONVERSATIONS = "conversations"
         const val PATH_SELF = "self"

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v9/authenticated/ConversationApiV9.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v9/authenticated/ConversationApiV9.kt
@@ -19,8 +19,30 @@
 package com.wire.kalium.network.api.v9.authenticated
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.authenticated.conversation.ResetMLSConversationRequestV9
 import com.wire.kalium.network.api.v8.authenticated.ConversationApiV8
+import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.wrapKaliumResponse
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 
 internal open class ConversationApiV9 internal constructor(
     authenticatedNetworkClient: AuthenticatedNetworkClient
-) : ConversationApiV8(authenticatedNetworkClient)
+) : ConversationApiV8(authenticatedNetworkClient) {
+
+    override suspend fun resetMlsConversation(groupId: String, epoch: ULong): NetworkResponse<Unit> = wrapKaliumResponse {
+        httpClient.post("$PATH_MLS/$PATH_RESET_CONVERSATION") {
+            setBody(
+                ResetMLSConversationRequestV9(
+                    epoch = epoch,
+                    groupId = groupId
+                )
+            )
+        }
+    }
+
+    private companion object {
+        const val PATH_MLS = "mls"
+        private const val PATH_RESET_CONVERSATION = "mls-reset-conversation"
+    }
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v9/authenticated/ConversationApiV9.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v9/authenticated/ConversationApiV9.kt
@@ -43,6 +43,6 @@ internal open class ConversationApiV9 internal constructor(
 
     private companion object {
         const val PATH_MLS = "mls"
-        private const val PATH_RESET_CONVERSATION = "mls-reset-conversation"
+        private const val PATH_RESET_CONVERSATION = "reset-conversation"
     }
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/unread/UserConfigDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/unread/UserConfigDAO.kt
@@ -70,6 +70,8 @@ interface UserConfigDAO {
     suspend fun setNextTimeForCallFeedback(timestamp: Long)
     suspend fun setShouldFetchE2EITrustAnchors(shouldFetch: Boolean)
     suspend fun getShouldFetchE2EITrustAnchorHasRun(): Boolean
+    suspend fun setMlsConversationsResetEnabled(enabled: Boolean)
+    suspend fun getMlsConversationsResetEnabled(): Boolean
 }
 
 @Suppress("TooManyFunctions")
@@ -228,6 +230,13 @@ internal class UserConfigDAOImpl internal constructor(
     override suspend fun getShouldFetchE2EITrustAnchorHasRun(): Boolean =
         metadataDAO.valueByKey(SHOULD_FETCH_E2EI_GET_TRUST_ANCHORS)?.toBoolean() ?: true
 
+    override suspend fun setMlsConversationsResetEnabled(enabled: Boolean) {
+        metadataDAO.insertValue(enabled.toString(), MLS_CONVERSATIONS_RESET)
+    }
+
+    override suspend fun getMlsConversationsResetEnabled(): Boolean =
+        metadataDAO.valueByKey(MLS_CONVERSATIONS_RESET)?.toBoolean() ?: false
+
     private companion object {
         private const val DEFAULT_CIPHER_SUITE_KEY = "DEFAULT_CIPHER_SUITE"
         private const val SELF_DELETING_MESSAGES_KEY = "SELF_DELETING_MESSAGES"
@@ -240,5 +249,6 @@ internal class UserConfigDAOImpl internal constructor(
         private const val ANALYTICS_TRACKING_IDENTIFIER_PREVIOUS_KEY = "analytics_tracking_identifier_previous"
         private const val ANALYTICS_TRACKING_IDENTIFIER_KEY = "analytics_tracking_identifier"
         const val SHOULD_FETCH_E2EI_GET_TRUST_ANCHORS = "should_fetch_e2ei_trust_anchors"
+        const val MLS_CONVERSATIONS_RESET = "mls_conversations_reset"
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17704" title="WPB-17704" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17704</a>  [Android] Reset broken MLS conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

https://wearezeta.atlassian.net/browse/WPB-17704
----
# What's new in this PR?

- New feature flag `allowGlobalOperations` to control the feature status
- New V9 endpoint to reset MLS conversation `mls/mls-reset-conversation`
- Use case for resetting MLS conversation

Work in progress:
- Detecting broken MLS conversations
- Handling new `conversation.mls-reset` event

Reset MLS conversation use case specification:
https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/1997013074/Use+case+Reset+fix+a+broken+MLS+conversation