### PR TITLE
fix: invalid asset handling for backup (#WPB-18821)

### DIFF
--- a/backup/src/commonMain/kotlin/com/wire/backup/dump/MPBackupExportValidation.kt
+++ b/backup/src/commonMain/kotlin/com/wire/backup/dump/MPBackupExportValidation.kt
@@ -47,9 +47,9 @@ internal fun CommonMPBackupExporter.validate(conversation: BackupConversation) {
  * @throws IllegalStateException if mandatory validation fails.
  */
 internal fun CommonMPBackupExporter.validate(message: BackupMessage): Boolean = with(message) {
-    if (id.isEmpty()) error("Message ID cannot be empty")
-    if (conversationId.id.isEmpty()) error("Conversation ID cannot be empty")
-    if (senderUserId.id.isEmpty()) error("Sender ID cannot be empty")
+    if (id.isEmpty()) error("Backup: Message ID cannot be empty")
+    if (conversationId.id.isEmpty()) error("Backup: Conversation ID cannot be empty")
+    if (senderUserId.id.isEmpty()) error("Backup: Sender ID cannot be empty")
 
     return@with validate(content)
 }
@@ -63,24 +63,27 @@ internal fun CommonMPBackupExporter.validate(message: BackupMessage): Boolean = 
 private fun CommonMPBackupExporter.validate(content: BackupMessageContent): Boolean = with(content) {
     when (this) {
         is BackupMessageContent.Text -> {
-            if (text.isEmpty()) error("Text content cannot be empty")
+            if (text.isEmpty()) error("Backup: Text content cannot be empty")
         }
 
         is BackupMessageContent.Asset -> {
-            if (assetId.isEmpty()) error("Asset ID cannot be empty")
+            if (assetId.isEmpty()) {
+                logger?.log("Backup: Asset ID cannot be empty")
+                return@with false
+            }
             if (otrKey.isEmpty()) {
-                logger?.log("Asset OTR key cannot be empty")
+                logger?.log("Backup: Asset OTR key cannot be empty")
                 return@with false
             }
             if (sha256.isEmpty()) {
-                logger?.log("Asset SHA256 cannot be empty")
+                logger?.log("Backup: Asset SHA256 cannot be empty")
                 return@with false
             }
         }
 
         is BackupMessageContent.Location -> {
             if (latitude == 0f || longitude == 0f) {
-                error("Location content must have valid latitude and longitude")
+                error("Backup: Location content must have valid latitude and longitude")
             }
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18821" title="WPB-18821" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18821</a>  [Android] Creating backup not possible if the client has assets without an ID
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-18821

# What's new in this PR?

### Issues
Backup creation failing for some users.

### Causes (Optional)
Caused by validation stopping backup when exporting asset with empty id.

### Solutions
Ignore assets with empty ID instead of stopping the backup.
