### PR TITLE
fix: make SelfDeletionTimer serializable [WPB-18248]

### DIFF
--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/SelfDeletionTimer.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/SelfDeletionTimer.kt
@@ -19,15 +19,18 @@ package com.wire.kalium.logic.data.message
 
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.util.serialization.toJsonElement
+import kotlinx.serialization.Serializable
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.ZERO
 
+@Serializable
 sealed interface SelfDeletionTimer {
     val duration: Duration?
 
     /**
      * Represents a self deletion timer that is currently disabled
      */
+    @Serializable
     data object Disabled : SelfDeletionTimer {
         override val duration: Duration? = null
     }
@@ -35,14 +38,19 @@ sealed interface SelfDeletionTimer {
     /**
      * Represents a self deletion timer that is enabled and can be changed/updated by the user
      */
+    @Serializable
     data class Enabled(override val duration: Duration?) : SelfDeletionTimer
 
     /**
      * Represents a self deletion timer that is imposed by the team or conversation settings that can't be changed by the user
-     * @param enforcedDuration the team or conversation imposed timer
      */
+    @Serializable
     sealed interface Enforced : SelfDeletionTimer {
+
+        @Serializable
         data class ByTeam(override val duration: Duration) : Enforced
+
+        @Serializable
         data class ByGroup(override val duration: Duration) : Enforced
     }
 
@@ -78,11 +86,13 @@ sealed interface SelfDeletionTimer {
     }
 }
 
+@Serializable
 data class ConversationSelfDeletionStatus(
     val conversationId: ConversationId,
     val selfDeletionTimer: SelfDeletionTimer
 )
 
+@Serializable
 data class TeamSettingsSelfDeletionStatus(
     /**
      * This value is used to inform the user that the team settings were changed. When true, an informative dialog will be shown. Once the
@@ -98,9 +108,16 @@ data class TeamSettingsSelfDeletionStatus(
     val enforcedSelfDeletionTimer: TeamSelfDeleteTimer
 )
 
+@Serializable
 sealed interface TeamSelfDeleteTimer {
+
+    @Serializable
     data object Disabled : TeamSelfDeleteTimer
+
+    @Serializable
     data object Enabled : TeamSelfDeleteTimer
+
+    @Serializable
     data class Enforced(val enforcedDuration: Duration) : TeamSelfDeleteTimer
 
     fun toLogMap(eventDescription: String): Map<String, Any?> = mapOf(

--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/SelfDeletionTimer.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/SelfDeletionTimer.kt
@@ -86,12 +86,14 @@ sealed interface SelfDeletionTimer {
     }
 }
 
+@Suppress("EnforceSerializableFields")
 @Serializable
 data class ConversationSelfDeletionStatus(
     val conversationId: ConversationId,
     val selfDeletionTimer: SelfDeletionTimer
 )
 
+@Suppress("EnforceSerializableFields")
 @Serializable
 data class TeamSettingsSelfDeletionStatus(
     /**


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18248" title="WPB-18248" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18248</a>  [Android] Bottom sheets disappearing on screen rotation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In order to be able to use `SelfDeletionTimer` sealed interface to pass it in the app and save/restore the state, it needs to be able to serialize it.

### Solutions

Make `SelfDeletionTimer` classes and interfaces serializable.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
