### PR TITLE
feat: reset mls conversation event handling (#WPB-17704)

### DIFF
--- a/common/src/commonJvmAndroid/kotlin/com/wire/kalium/common/error/CoreCryptoExceptionMapper.kt
+++ b/common/src/commonJvmAndroid/kotlin/com/wire/kalium/common/error/CoreCryptoExceptionMapper.kt
@@ -64,6 +64,8 @@ private fun mapMessageRejected(message: String): MLSFailure.MessageRejected {
         "mls-stale-message" -> MLSFailure.MessageRejected.MlsStaleMessage
         "mls-client-mismatch" -> MLSFailure.MessageRejected.MlsClientMismatch
         "mls-commit-missing-references" -> MLSFailure.MessageRejected.MlsCommitMissingReferences
+        "mls-invalid-leaf-node-index" -> MLSFailure.MessageRejected.InvalidLeafNodeIndex
+        "mls-invalid-leaf-node-signature" -> MLSFailure.MessageRejected.InvalidLeafNodeIndex
         else -> MLSFailure.MessageRejected.Other(reason = reason)
     }
 }

--- a/common/src/commonMain/kotlin/com/wire/kalium/common/error/CoreFailure.kt
+++ b/common/src/commonMain/kotlin/com/wire/kalium/common/error/CoreFailure.kt
@@ -209,9 +209,10 @@ sealed interface MLSFailure : CoreFailure {
         data object MlsClientMismatch : MessageRejected()
         data object MlsCommitMissingReferences : MessageRejected()
         data object MlsStaleMessage : MessageRejected()
+        data object InvalidLeafNodeIndex : MessageRejected()
+        data object InvalidLeafNodeSignature : MessageRejected()
         data class Other(val reason: String) : MessageRejected()
     }
-
     data class Generic(val rootCause: Throwable) : MLSFailure
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -253,9 +253,13 @@ private fun CoreFailure.getStrategy(
                 }
             }
 
+            is MLSFailure.MessageRejected.InvalidLeafNodeIndex,
+            is MLSFailure.MessageRejected.InvalidLeafNodeSignature -> CommitStrategy.ABORT
+
             is MLSFailure.MessageRejected.Other -> {
                 CommitStrategy.ABORT
             }
+
         }
     } else {
         CommitStrategy.ABORT

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt
@@ -73,7 +73,7 @@ internal class ResetMLSConversationUseCaseImpl(
                     mlsConversationRepository.leaveGroup(mlsContext, groupId)
                 }
                 .flatMap { fetchConversation(transaction, conversationId) }
-                .flatMap { fetchConversationUseCase(conversationId) }
+                .flatMap { fetchConversation(conversationId) }
             .flatMap { getMlsProtocolInfo(conversationId) }
                 .map { updatedProtocolInfo ->
 
@@ -95,6 +95,11 @@ internal class ResetMLSConversationUseCaseImpl(
         transaction: CryptoTransactionContext,
         conversationId: ConversationId
     ): Either<CoreFailure, Unit> = fetchConversationUseCase(transaction, conversationId)
+
+    private suspend fun fetchConversation(conversationId: ConversationId): Either<CoreFailure, Unit> =
+        transactionProvider.transaction("FetchConversation") { context ->
+            fetchConversationUseCase(context, conversationId)
+        }
 
     private suspend fun getMlsProtocolInfo(conversationId: ConversationId): Either<CoreFailure, Conversation.ProtocolInfo.MLS> {
         return conversationRepository.getConversationById(conversationId)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.cryptography.CryptoTransactionContext
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.client.CryptoTransactionProvider
 import com.wire.kalium.logic.data.id.ConversationId
+import io.mockative.Mockable
 
 /**
  * Reset an MLS conversation which cannot be recovered by any other means.
@@ -39,6 +40,7 @@ import com.wire.kalium.logic.data.id.ConversationId
  *  - Fetching the conversation to update group ID
  *  - Re-establishing the MLS group with the updated group ID and current members.
  */
+@Mockable
 interface ResetMLSConversationUseCase {
     suspend operator fun invoke(conversationId: ConversationId): Either<CoreFailure, Unit>
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt
@@ -73,7 +73,8 @@ internal class ResetMLSConversationUseCaseImpl(
                     mlsConversationRepository.leaveGroup(mlsContext, groupId)
                 }
                 .flatMap { fetchConversation(transaction, conversationId) }
-                .flatMap { getMlsProtocolInfo(conversationId) }
+                .flatMap { fetchConversationUseCase(conversationId) }
+            .flatMap { getMlsProtocolInfo(conversationId) }
                 .map { updatedProtocolInfo ->
 
                     val members = conversationRepository.getConversationMembers(conversationId).getOrFail {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt
@@ -18,7 +18,6 @@
 package com.wire.kalium.logic.data.conversation
 
 import com.wire.kalium.common.error.CoreFailure
-import com.wire.kalium.common.error.wrapApiRequest
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
 import com.wire.kalium.common.functional.getOrFail
@@ -30,7 +29,6 @@ import com.wire.kalium.cryptography.CryptoTransactionContext
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.client.CryptoTransactionProvider
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
 
 /**
  * Reset an MLS conversation which cannot be recovered by any other means.
@@ -52,7 +50,6 @@ internal class ResetMLSConversationUseCaseImpl(
     private val conversationRepository: ConversationRepository,
     private val mlsConversationRepository: MLSConversationRepository,
     private val fetchConversationUseCase: FetchConversationUseCase,
-    private val conversationApi: ConversationApi,
 ) : ResetMLSConversationUseCase {
 
     override suspend operator fun invoke(conversationId: ConversationId): Either<CoreFailure, Unit> {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt
@@ -18,6 +18,7 @@
 package com.wire.kalium.logic.data.conversation
 
 import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.wrapApiRequest
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
 import com.wire.kalium.common.functional.getOrFail
@@ -29,6 +30,7 @@ import com.wire.kalium.cryptography.CryptoTransactionContext
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.client.CryptoTransactionProvider
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
 
 /**
  * Reset an MLS conversation which cannot be recovered by any other means.
@@ -50,6 +52,7 @@ internal class ResetMLSConversationUseCaseImpl(
     private val conversationRepository: ConversationRepository,
     private val mlsConversationRepository: MLSConversationRepository,
     private val fetchConversationUseCase: FetchConversationUseCase,
+    private val conversationApi: ConversationApi,
 ) : ResetMLSConversationUseCase {
 
     override suspend operator fun invoke(conversationId: ConversationId): Either<CoreFailure, Unit> {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt
@@ -73,8 +73,7 @@ internal class ResetMLSConversationUseCaseImpl(
                     mlsConversationRepository.leaveGroup(mlsContext, groupId)
                 }
                 .flatMap { fetchConversation(transaction, conversationId) }
-                .flatMap { fetchConversation(conversationId) }
-            .flatMap { getMlsProtocolInfo(conversationId) }
+                .flatMap { getMlsProtocolInfo(conversationId) }
                 .map { updatedProtocolInfo ->
 
                     val members = conversationRepository.getConversationMembers(conversationId).getOrFail {
@@ -90,11 +89,6 @@ internal class ResetMLSConversationUseCaseImpl(
                 }.map {}
         }
     }
-
-    private suspend fun fetchConversation(
-        transaction: CryptoTransactionContext,
-        conversationId: ConversationId
-    ): Either<CoreFailure, Unit> = fetchConversationUseCase(transaction, conversationId)
 
     private suspend fun fetchConversation(
         transaction: CryptoTransactionContext,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt
@@ -96,10 +96,10 @@ internal class ResetMLSConversationUseCaseImpl(
         conversationId: ConversationId
     ): Either<CoreFailure, Unit> = fetchConversationUseCase(transaction, conversationId)
 
-    private suspend fun fetchConversation(conversationId: ConversationId): Either<CoreFailure, Unit> =
-        transactionProvider.transaction("FetchConversation") { context ->
-            fetchConversationUseCase(context, conversationId)
-        }
+    private suspend fun fetchConversation(
+        transaction: CryptoTransactionContext,
+        conversationId: ConversationId
+    ): Either<CoreFailure, Unit> = fetchConversationUseCase(transaction, conversationId)
 
     private suspend fun getMlsProtocolInfo(conversationId: ConversationId): Either<CoreFailure, Conversation.ProtocolInfo.MLS> {
         return conversationRepository.getConversationById(conversationId)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -42,6 +42,7 @@ import com.wire.kalium.logic.data.featureConfig.MLSMigrationModel
 import com.wire.kalium.logic.data.featureConfig.MLSModel
 import com.wire.kalium.logic.data.featureConfig.SelfDeletingMessagesModel
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.SubconversationId
 import com.wire.kalium.logic.data.legalhold.LastPreKey
 import com.wire.kalium.logic.data.user.Connection
@@ -455,6 +456,20 @@ sealed class Event(open val id: String) {
                 conversationIdKey to conversationId.toLogString(),
                 "channelAddPermission" to channelAddPermission.name,
                 senderUserIdKey to senderUserId.toLogString(),
+            )
+        }
+
+        data class MLSReset(
+            override val id: String,
+            override val conversationId: ConversationId,
+            val from: UserId,
+            val groupID: GroupID,
+            val newGroupID: GroupID? = null,
+        ) : Conversation(id, conversationId) {
+            override fun toLogMap() = mapOf(
+                typeKey to "Conversation.MlsReset",
+                idKey to id.obfuscateId(),
+                conversationIdKey to conversationId.toLogString(),
             )
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -33,6 +33,7 @@ import com.wire.kalium.logic.data.conversation.toModel
 import com.wire.kalium.logic.data.event.Event.UserProperty.ReadReceiptModeSet
 import com.wire.kalium.logic.data.event.Event.UserProperty.TypingIndicatorModeSet
 import com.wire.kalium.logic.data.featureConfig.FeatureConfigMapper
+import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.id.SubconversationId
 import com.wire.kalium.logic.data.id.toModel
@@ -138,6 +139,7 @@ class EventMapper(
             is EventContentDTO.Conversation.ConversationTypingDTO -> conversationTyping(id, eventContentDTO)
             is EventContentDTO.Conversation.ProtocolUpdate -> conversationProtocolUpdate(id, eventContentDTO)
             is EventContentDTO.Conversation.ChannelAddPermissionUpdate -> conversationChannelPermissionUpdate(id, eventContentDTO)
+            is EventContentDTO.Conversation.MlsResetConversationDTO -> mlsConversationReset(id, eventContentDTO)
             EventContentDTO.AsyncMissedNotification -> Event.AsyncMissed(id)
         }
 
@@ -445,6 +447,17 @@ class EventMapper(
         removedList = eventContentDTO.removedUsers.qualifiedUserIds.map { it.toModel() },
         dateTime = eventContentDTO.time,
         reason = eventContentDTO.removedUsers.reason.toModel()
+    )
+
+    fun mlsConversationReset(
+        id: String,
+        eventContentDTO: EventContentDTO.Conversation.MlsResetConversationDTO
+    ) = Event.Conversation.MLSReset(
+        id = id,
+        conversationId = eventContentDTO.qualifiedConversation.toModel(),
+        from = eventContentDTO.qualifiedFrom.toModel(),
+        groupID = GroupID(eventContentDTO.data.groupId),
+        newGroupID = eventContentDTO.data.newGroupId?.let { GroupID(it) },
     )
 
     private fun memberUpdate(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1721,7 +1721,6 @@ class UserSessionScope internal constructor(
     private val mlsResetConversationEventHandler: MLSResetConversationEventHandler
         get() = MLSResetConversationEventHandlerImpl(
             selfUserId = userId,
-            transactionProvider = cryptoTransactionProvider,
             userConfig = userConfigRepository,
             mlsConversationRepository = mlsConversationRepository,
             fetchConversation = fetchConversationUseCase,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -437,6 +437,8 @@ import com.wire.kalium.logic.sync.receiver.conversation.ConversationMessageTimer
 import com.wire.kalium.logic.sync.receiver.conversation.ConversationMessageTimerEventHandlerImpl
 import com.wire.kalium.logic.sync.receiver.conversation.DeletedConversationEventHandler
 import com.wire.kalium.logic.sync.receiver.conversation.DeletedConversationEventHandlerImpl
+import com.wire.kalium.logic.sync.receiver.conversation.MLSResetConversationEventHandler
+import com.wire.kalium.logic.sync.receiver.conversation.MLSResetConversationEventHandlerImpl
 import com.wire.kalium.logic.sync.receiver.conversation.MLSWelcomeEventHandler
 import com.wire.kalium.logic.sync.receiver.conversation.MLSWelcomeEventHandlerImpl
 import com.wire.kalium.logic.sync.receiver.conversation.MemberChangeEventHandler
@@ -1701,6 +1703,14 @@ class UserSessionScope internal constructor(
             selfUserId = userId
         )
 
+    private val mlsResetConversationEventHandler: MLSResetConversationEventHandler
+        get() = MLSResetConversationEventHandlerImpl(
+            selfUserId = userId,
+            userConfig = userConfigRepository,
+            mlsConversationRepository = mlsConversationRepository,
+            fetchConversation = fetchConversationUseCase,
+        )
+
     private val conversationEventReceiver: ConversationEventReceiver by lazy {
         ConversationEventReceiverImpl(
             newMessageHandler,
@@ -1719,6 +1729,7 @@ class UserSessionScope internal constructor(
             protocolUpdateEventHandler,
             channelAddPermissionUpdateEventHandler,
             conversationAccessUpdateEventHandler,
+            mlsResetConversationEventHandler,
         )
     }
     override val coroutineContext: CoroutineContext = SupervisorJob()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -21,7 +21,6 @@ package com.wire.kalium.logic.feature.conversation
 import co.touchlab.stately.collections.ConcurrentMutableMap
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.cache.SelfConversationIdProvider
-import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.configuration.server.ServerConfigRepository
 import com.wire.kalium.logic.data.asset.AssetRepository
@@ -29,12 +28,10 @@ import com.wire.kalium.logic.data.client.CryptoTransactionProvider
 import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.conversation.ConversationGroupRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
-import com.wire.kalium.logic.data.conversation.FetchConversationUseCase
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.conversation.NewGroupConversationSystemMessagesCreator
 import com.wire.kalium.logic.data.conversation.PersistConversationsUseCase
 import com.wire.kalium.logic.data.conversation.ResetMLSConversationUseCase
-import com.wire.kalium.logic.data.conversation.ResetMLSConversationUseCaseImpl
 import com.wire.kalium.logic.data.conversation.TypingIndicatorIncomingRepositoryImpl
 import com.wire.kalium.logic.data.conversation.TypingIndicatorOutgoingRepositoryImpl
 import com.wire.kalium.logic.data.conversation.TypingIndicatorSenderHandler
@@ -138,8 +135,7 @@ class ConversationScope internal constructor(
     private val deleteConversationUseCase: DeleteConversationUseCase,
     private val persistConversationsUseCase: PersistConversationsUseCase,
     private val transactionProvider: CryptoTransactionProvider,
-    private val userConfigRepository: UserConfigRepository,
-    private val fetchConversationUseCase: FetchConversationUseCase,
+    private val resetMLSConversationUseCase: ResetMLSConversationUseCase,
     internal val dispatcher: KaliumDispatcher = KaliumDispatcherImpl,
 ) {
 
@@ -214,7 +210,12 @@ class ConversationScope internal constructor(
         get() = CreateChannelUseCase(createGroupConversation)
 
     val addMemberToConversationUseCase: AddMemberToConversationUseCase
-        get() = AddMemberToConversationUseCaseImpl(conversationGroupRepository, userRepository, refreshUsersWithoutMetadata)
+        get() = AddMemberToConversationUseCaseImpl(
+            conversationGroupRepository,
+            userRepository,
+            refreshUsersWithoutMetadata,
+            resetMLSConversationUseCase
+        )
 
     val addServiceToConversationUseCase: AddServiceToConversationUseCase
         get() = AddServiceToConversationUseCase(groupRepository = conversationGroupRepository)
@@ -418,12 +419,4 @@ class ConversationScope internal constructor(
         get() = RemoveConversationFromFolderUseCaseImpl(conversationFolderRepository)
     val createConversationFolder: CreateConversationFolderUseCase
         get() = CreateConversationFolderUseCaseImpl(conversationFolderRepository)
-    val resetMlsConversation: ResetMLSConversationUseCase
-        get() = ResetMLSConversationUseCaseImpl(
-            userConfig = userConfigRepository,
-            transactionProvider = transactionProvider,
-            conversationRepository = conversationRepository,
-            mlsConversationRepository = mlsConversationRepository,
-            fetchConversationUseCase = fetchConversationUseCase,
-        )
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.sync.receiver.conversation.AccessUpdateEventHandler
 import com.wire.kalium.logic.sync.receiver.conversation.ChannelAddPermissionUpdateEventHandler
 import com.wire.kalium.logic.sync.receiver.conversation.ConversationMessageTimerEventHandler
 import com.wire.kalium.logic.sync.receiver.conversation.DeletedConversationEventHandler
+import com.wire.kalium.logic.sync.receiver.conversation.MLSResetConversationEventHandler
 import com.wire.kalium.logic.sync.receiver.conversation.MLSWelcomeEventHandler
 import com.wire.kalium.logic.sync.receiver.conversation.MemberChangeEventHandler
 import com.wire.kalium.logic.sync.receiver.conversation.MemberJoinEventHandler
@@ -63,7 +64,8 @@ internal class ConversationEventReceiverImpl(
     private val typingIndicatorHandler: TypingIndicatorHandler,
     private val protocolUpdateEventHandler: ProtocolUpdateEventHandler,
     private val channelAddPermissionUpdateEventHandler: ChannelAddPermissionUpdateEventHandler,
-    private val accessUpdateEventHandler: AccessUpdateEventHandler
+    private val accessUpdateEventHandler: AccessUpdateEventHandler,
+    private val mlsResetConversationEventHandler: MLSResetConversationEventHandler,
 ) : ConversationEventReceiver {
     override suspend fun onEvent(
         transactionContext: CryptoTransactionContext,
@@ -116,6 +118,11 @@ internal class ConversationEventReceiverImpl(
 
             is Event.Conversation.ConversationReceiptMode -> {
                 receiptModeUpdateEventHandler.handle(event)
+                Either.Right(Unit)
+            }
+
+            is Event.Conversation.MLSReset -> {
+                mlsResetConversationEventHandler.handle(event)
                 Either.Right(Unit)
             }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
@@ -122,7 +122,7 @@ internal class ConversationEventReceiverImpl(
             }
 
             is Event.Conversation.MLSReset -> {
-                mlsResetConversationEventHandler.handle(event)
+                mlsResetConversationEventHandler.handle(transactionContext, event)
                 Either.Right(Unit)
             }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSResetConversationEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSResetConversationEventHandler.kt
@@ -24,7 +24,9 @@ import com.wire.kalium.logic.data.conversation.FetchConversationUseCase
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.user.UserId
+import io.mockative.Mockable
 
+@Mockable
 interface MLSResetConversationEventHandler {
     suspend fun handle(event: Event.Conversation.MLSReset)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSResetConversationEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSResetConversationEventHandler.kt
@@ -1,0 +1,52 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.receiver.conversation
+
+import com.wire.kalium.common.logger.kaliumLogger
+import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.data.conversation.FetchConversationUseCase
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.user.UserId
+
+interface MLSResetConversationEventHandler {
+    suspend fun handle(event: Event.Conversation.MLSReset)
+}
+
+internal class MLSResetConversationEventHandlerImpl(
+    private val selfUserId: UserId,
+    private val userConfig: UserConfigRepository,
+    private val mlsConversationRepository: MLSConversationRepository,
+    private val fetchConversation: FetchConversationUseCase,
+) : MLSResetConversationEventHandler {
+    override suspend fun handle(event: Event.Conversation.MLSReset) {
+
+        if (!userConfig.isMlsConversationsResetEnabled()) {
+            kaliumLogger.i("MLS conversation reset feature is disabled.")
+            return
+        }
+
+        if (event.from != selfUserId) {
+            mlsConversationRepository.leaveGroup(event.groupID)
+
+            // Will be replaced by updating Group ID when it is added in a new
+            // version of mls-reset event.
+            fetchConversation(event.conversationId)
+        }
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageFailureHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageFailureHandler.kt
@@ -28,6 +28,7 @@ sealed class MLSMessageFailureResolution {
     data object Ignore : MLSMessageFailureResolution()
     data object InformUser : MLSMessageFailureResolution()
     data object OutOfSync : MLSMessageFailureResolution()
+    data object ResetConversation : MLSMessageFailureResolution()
 }
 
 internal object MLSMessageFailureHandler {
@@ -35,6 +36,9 @@ internal object MLSMessageFailureHandler {
         return when (failure) {
             // Received messages targeting a future epoch (outside epoch bounds), we might have lost messages.
             is MLSFailure.WrongEpoch -> MLSMessageFailureResolution.OutOfSync
+
+            is MLSFailure.MessageRejected.InvalidLeafNodeIndex,
+            is MLSFailure.MessageRejected.InvalidLeafNodeSignature -> MLSMessageFailureResolution.ResetConversation
 
             // Received already sent or received message, can safely be ignored.
             is MLSFailure.DuplicateMessage,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/AllowedGlobalOperationsHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/AllowedGlobalOperationsHandler.kt
@@ -25,6 +25,6 @@ import com.wire.kalium.logic.data.featureConfig.AllowedGlobalOperationsModel
 class AllowedGlobalOperationsHandler(
     private val userConfigRepository: UserConfigRepository
 ) {
-suspend fun handle(model: AllowedGlobalOperationsModel): Either<CoreFailure, Unit> =
-         userConfigRepository.setMlsConversationsResetEnabled(model.mlsConversationsReset)
+    suspend fun handle(model: AllowedGlobalOperationsModel): Either<CoreFailure, Unit> =
+        userConfigRepository.setMlsConversationsResetEnabled(model.mlsConversationsReset)
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCaseTest.kt
@@ -180,6 +180,7 @@ class ResetMLSConversationUseCaseTest {
                 conversationRepository = conversationRepository,
                 mlsConversationRepository = mlsConversationRepository,
                 fetchConversationUseCase = fetchConversationUseCase,
+                conversationApi = conversationApi,
             )
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCaseTest.kt
@@ -180,7 +180,6 @@ class ResetMLSConversationUseCaseTest {
                 conversationRepository = conversationRepository,
                 mlsConversationRepository = mlsConversationRepository,
                 fetchConversationUseCase = fetchConversationUseCase,
-                conversationApi = conversationApi,
             )
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCaseTest.kt
@@ -114,6 +114,7 @@ class ResetMLSConversationUseCaseTest {
         val conversationRepository = mock(ConversationRepository::class)
         val mlsConversationRepository = mock(MLSConversationRepository::class)
         val fetchConversationUseCase = mock(FetchConversationUseCase::class)
+        val conversationApi = mock(ConversationApi::class)
 
         suspend fun withFeatureDisabled() = apply {
             coEvery { userConfig.isMlsConversationsResetEnabled() } returns false
@@ -158,6 +159,7 @@ class ResetMLSConversationUseCaseTest {
                 conversationRepository = conversationRepository,
                 mlsConversationRepository = mlsConversationRepository,
                 fetchConversationUseCase = fetchConversationUseCase,
+                conversationApi = conversationApi,
             )
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCaseTest.kt
@@ -20,10 +20,7 @@ package com.wire.kalium.logic.data.conversation
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.isRight
 import com.wire.kalium.common.functional.right
-import com.wire.kalium.cryptography.CryptoTransactionContext
-import com.wire.kalium.cryptography.MlsCoreCryptoContext
 import com.wire.kalium.logic.configuration.UserConfigRepository
-import com.wire.kalium.logic.data.client.CryptoTransactionProvider
 import com.wire.kalium.logic.data.conversation.mls.MLSAdditionResult
 import com.wire.kalium.logic.feature.backup.UserId
 import com.wire.kalium.logic.framework.TestConversation
@@ -117,9 +114,6 @@ class ResetMLSConversationUseCaseTest {
         val conversationRepository = mock(ConversationRepository::class)
         val mlsConversationRepository = mock(MLSConversationRepository::class)
         val fetchConversationUseCase = mock(FetchConversationUseCase::class)
-        val transactionProvider = mock(CryptoTransactionProvider::class)
-        val transactionContext: CryptoTransactionContext = mock(CryptoTransactionContext::class)
-        val mlsContext: MlsCoreCryptoContext = mock(MlsCoreCryptoContext::class)
 
         suspend fun withFeatureDisabled() = apply {
             coEvery { userConfig.isMlsConversationsResetEnabled() } returns false
@@ -157,22 +151,6 @@ class ResetMLSConversationUseCaseTest {
             coEvery {
                 conversationRepository.getConversationMembers(any())
             } returns listOf(UserId("test", "test@user")).right()
-
-            coEvery {
-                transactionProvider.mlsTransaction<Any>(any(), any())
-            }.invokes { args ->
-                @Suppress("UNCHECKED_CAST")
-                val block = args[1] as suspend (MlsCoreCryptoContext) -> Either<CoreFailure, Any>
-                block(mlsContext)
-            }
-
-            coEvery {
-                transactionProvider.transaction<Any>(any(), any())
-            }.invokes { args ->
-                @Suppress("UNCHECKED_CAST")
-                val block = args[1] as suspend (CryptoTransactionContext) -> Either<CoreFailure, Any>
-                block(transactionContext)
-            }
 
             return this to ResetMLSConversationUseCaseImpl(
                 userConfig = userConfig,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCaseTest.kt
@@ -24,6 +24,8 @@ import com.wire.kalium.logic.data.conversation.ConversationGroupRepository
 import com.wire.kalium.logic.feature.publicuser.RefreshUsersWithoutMetadataUseCase
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.right
+import com.wire.kalium.logic.data.conversation.ResetMLSConversationUseCase
 import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangementImpl
 import io.mockative.any
@@ -89,11 +91,13 @@ class AddMemberToConversationUseCaseTest {
 
         val conversationGroupRepository = mock(ConversationGroupRepository::class)
         val refreshUsersWithoutMetadata = mock(RefreshUsersWithoutMetadataUseCase::class)
+        val resetMLSConversationUseCase = mock(ResetMLSConversationUseCase::class)
 
         private val addMemberUseCase = AddMemberToConversationUseCaseImpl(
             conversationGroupRepository,
             userRepository,
-            refreshUsersWithoutMetadata
+            refreshUsersWithoutMetadata,
+            resetMLSConversationUseCase,
         )
 
         suspend fun withAddMembers(either: Either<CoreFailure, Unit>) = apply {
@@ -108,6 +112,13 @@ class AddMemberToConversationUseCaseTest {
             }.returns(Either.Right(Unit))
         }
 
-        fun arrange(block: Arrangement.() -> Unit = { }) = apply(block).let { this to addMemberUseCase }
+        suspend fun arrange(block: Arrangement.() -> Unit = { }): Pair<Arrangement, AddMemberToConversationUseCase> {
+
+            coEvery {
+                resetMLSConversationUseCase(any())
+            } returns Unit.right()
+
+            return apply(block).let { this to addMemberUseCase }
+        }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCaseTest.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.logic.feature.conversation
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.right
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
@@ -28,6 +29,7 @@ import com.wire.kalium.logic.data.conversation.FetchConversationUseCase
 import com.wire.kalium.logic.data.conversation.FetchMLSOneToOneConversationUseCase
 import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCaseImpl
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.conversation.ResetMLSConversationUseCase
 import com.wire.kalium.logic.data.conversation.mls.MLSAdditionResult
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.GroupID
@@ -249,6 +251,7 @@ class JoinExistingMLSConversationUseCaseTest {
         val mlsConversationRepository = mock(MLSConversationRepository::class)
         val fetchMLSOneToOneConversation = mock(FetchMLSOneToOneConversationUseCase::class)
         val fetchConversation = mock(FetchConversationUseCase::class)
+        val resetMlsConversation = mock(ResetMLSConversationUseCase::class)
 
         val selfUserId = TestUser.USER_ID
 
@@ -260,10 +263,15 @@ class JoinExistingMLSConversationUseCaseTest {
             mlsConversationRepository,
             fetchMLSOneToOneConversation,
             fetchConversation,
+            resetMlsConversation,
             selfUserId,
             dispatcher
         ).also {
             withTransactionReturning(Either.Right(Unit))
+
+            coEvery {
+                resetMlsConversation.invoke(any())
+            } returns Unit.right()
         }
 
         @Suppress("MaxLineLength")

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.sync.receiver.conversation.AccessUpdateEventHandler
 import com.wire.kalium.logic.sync.receiver.conversation.ChannelAddPermissionUpdateEventHandler
 import com.wire.kalium.logic.sync.receiver.conversation.ConversationMessageTimerEventHandler
 import com.wire.kalium.logic.sync.receiver.conversation.DeletedConversationEventHandler
+import com.wire.kalium.logic.sync.receiver.conversation.MLSResetConversationEventHandler
 import com.wire.kalium.logic.sync.receiver.conversation.MLSWelcomeEventHandler
 import com.wire.kalium.logic.sync.receiver.conversation.MemberChangeEventHandler
 import com.wire.kalium.logic.sync.receiver.conversation.MemberJoinEventHandler
@@ -462,6 +463,7 @@ class ConversationEventReceiverTest {
         val protocolUpdateEventHandler = mock(ProtocolUpdateEventHandler::class)
         val channelAddPermissionUpdateEventHandler = mock(ChannelAddPermissionUpdateEventHandler::class)
         val accessUpdateEventHandler = mock(AccessUpdateEventHandler::class)
+        val mlsResetConversationEventHandler = mock(MLSResetConversationEventHandler::class)
 
         private val conversationEventReceiver: ConversationEventReceiver = ConversationEventReceiverImpl(
             newMessageHandler = newMessageEventHandler,
@@ -479,7 +481,8 @@ class ConversationEventReceiverTest {
             typingIndicatorHandler = typingIndicatorHandler,
             protocolUpdateEventHandler = protocolUpdateEventHandler,
             channelAddPermissionUpdateEventHandler = channelAddPermissionUpdateEventHandler,
-            accessUpdateEventHandler = accessUpdateEventHandler
+            accessUpdateEventHandler = accessUpdateEventHandler,
+            mlsResetConversationEventHandler = mlsResetConversationEventHandler,
         )
 
         fun arrange(block: suspend Arrangement.() -> Unit = {}) = run {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.logic.sync.receiver
 
 import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.configuration.FileSharingStatus
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.event.Event
@@ -41,10 +42,9 @@ import com.wire.kalium.logic.feature.featureConfig.handler.SelfDeletingMessagesC
 import com.wire.kalium.logic.feature.user.UpdateSupportedProtocolsAndResolveOneOnOnesUseCase
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.framework.TestEvent
-import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.sync.receiver.handler.AllowedGlobalOperationsHandler
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
-import com.wire.kalium.logic.sync.receiver.handler.AllowedGlobalOperationsHandler
 import com.wire.kalium.logic.util.shouldSucceed
 import io.mockative.any
 import io.mockative.coEvery

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
@@ -36,6 +36,7 @@ import com.wire.kalium.logic.feature.message.ephemeral.EphemeralMessageDeletionH
 import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.conversation.ResetMLSConversationUseCase
 import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldHandler
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
@@ -435,6 +436,7 @@ class NewMessageEventHandlerTest {
         val ephemeralMessageDeletionHandler = mock(EphemeralMessageDeletionHandler::class)
         val confirmationDeliveryHandler = mock(ConfirmationDeliveryHandler::class)
         val legalHoldHandler = mock(LegalHoldHandler::class)
+        val resetMlsConversation = mock(ResetMLSConversationUseCase::class)
 
         private val newMessageEventHandler: NewMessageEventHandler = NewMessageEventHandlerImpl(
             proteusMessageUnpacker,
@@ -451,7 +453,8 @@ class NewMessageEventHandlerTest {
                 confirmationDeliveryHandler.enqueueConfirmationDelivery(conversationId, messageId)
             },
             SELF_USER_ID,
-            staleEpochVerifier
+            staleEpochVerifier,
+            resetMlsConversation,
         )
 
         suspend fun withProteusUnpackerReturning(result: Either<CoreFailure, MessageUnpackResult.ApplicationMessage>) = apply {

--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/notification/EventContentDTO.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/notification/EventContentDTO.kt
@@ -37,6 +37,7 @@ import com.wire.kalium.network.api.authenticated.featureConfigs.FeatureConfigDat
 import com.wire.kalium.network.api.authenticated.featureConfigs.FeatureFlagStatusDTO
 import com.wire.kalium.network.api.authenticated.keypackage.LastPreKeyDTO
 import com.wire.kalium.network.api.authenticated.notification.conversation.MessageEventData
+import com.wire.kalium.network.api.authenticated.notification.conversation.MlsConversationResetData
 import com.wire.kalium.network.api.authenticated.notification.team.TeamMemberIdData
 import com.wire.kalium.network.api.authenticated.notification.user.RemoveClientEventData
 import com.wire.kalium.network.api.authenticated.notification.user.UserUpdateEventData
@@ -342,6 +343,14 @@ sealed class EventContentDTO {
             @SerialName("from") val from: String,
             @SerialName("qualified_from") val qualifiedFrom: UserId,
             @SerialName("time") val time: Instant
+        ) : Conversation()
+
+        @Serializable
+        @SerialName("conversation.mls-reset")
+        data class MlsResetConversationDTO(
+            @SerialName("qualified_conversation") val qualifiedConversation: ConversationId,
+            @SerialName("qualified_from") val qualifiedFrom: UserId,
+            @SerialName("data") val data: MlsConversationResetData,
         ) : Conversation()
     }
 

--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/notification/conversation/MlsConversationResetData.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/notification/conversation/MlsConversationResetData.kt
@@ -1,0 +1,29 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.authenticated.notification.conversation
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MlsConversationResetData(
+    @SerialName("group_id")
+    val groupId: String,
+    @SerialName("new_group_id")
+    val newGroupId: String? = null, // Will be added in new event version
+)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17704" title="WPB-17704" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17704</a>  [Android] Reset broken MLS conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

https://wearezeta.atlassian.net/browse/WPB-17704

# What's new in this PR?

- Conversation.MlsReset event
- Handler for new event
