### PR TITLE
fix(4.11): not federating error missing when creating new conversation [WPB-16880] 🍒

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
@@ -217,7 +217,12 @@ internal class ConversationGroupRepositoryImpl(
         options: ConversationOptions,
         lastUsersAttempt: LastUsersAttempt
     ): Either<CoreFailure, Conversation> {
-        val canRetryOnce = apiResult.value.isRetryable && lastUsersAttempt is LastUsersAttempt.None
+        val canRetryOnce = apiResult.value.isRetryable
+                && lastUsersAttempt is LastUsersAttempt.None
+                && apiResult.value !is NetworkFailure.FederatedBackendFailure.ConflictingBackends
+        // For conflicting backends the app needs to show the info to the user right away so that he/she can react and adjust selection,
+        // so for this particular federation failure type it shouldn't attempt to retry automatically with extracting only valid users.
+
         return if (canRetryOnce) {
             extractValidUsersForRetryableError(apiResult.value, usersList)
                 .flatMap { (validUsers, failedUsers, failType) ->


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16880" title="WPB-16880" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16880</a>  [Android] No alert displayed when user is trying to create a group with 2 users, who don't federat with each other
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

This PR was manually cherry-picked based on the following PR:
 - #3459

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Dialog informing about federation error about conflicting backends is not displayed when creating new conversation.

### Causes (Optional)

Some time ago we introduced retrying requests of creating new conversation and adding members so that when there’s a federation error, it extracts users that cannot be added and retries request with only valid users. This made it so that when creating a group there’s no error displayed, the creation finishes successfully but there’s a system message informing that some users couldn’t be added.

### Solutions

Add additional check to the `if` so that for `ConflictingBackends` failure when creating new conversation, it doesn’t retry but directly returns this failure and the app can handle it by showing alert dialog and letting user adjust selected users.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Try to create a conversation selecting people whose backends do not federate with each other.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
