### PR TITLE
chore(conversation-history): setup module [WPB-18492]

### DIFF
--- a/conversation-history/build.gradle.kts
+++ b/conversation-history/build.gradle.kts
@@ -1,0 +1,60 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+plugins {
+    id(libs.plugins.android.library.get().pluginId)
+    id(libs.plugins.kotlin.multiplatform.get().pluginId)
+    id(libs.plugins.kalium.library.get().pluginId)
+}
+
+kaliumLibrary {
+    multiplatform { enableJs.set(false) }
+}
+
+kotlin {
+    explicitApi()
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(project(":common"))
+                implementation(project(":network"))
+                implementation(project(":data"))
+                implementation(project(":util"))
+                implementation(project(":persistence"))
+                implementation(libs.coroutines.core)
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                // coroutines
+                implementation(libs.coroutines.test)
+                implementation(libs.turbine)
+            }
+        }
+
+        fun org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet.addCommonKotlinJvmSourceDir() {
+            kotlin.srcDir("src/commonJvmAndroid/kotlin")
+        }
+
+        val jvmMain by getting {
+            addCommonKotlinJvmSourceDir()
+        }
+        val androidMain by getting {
+            addCommonKotlinJvmSourceDir()
+        }
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18492" title="WPB-18492" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18492</a>  [Android] Persist all History Clients
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Add a new module for `:conversation-history`.

Following the pattern added by @sergeibakhtiarov in `:cells`, this will contain the logic for a feature. The bulk of the logic should reside in this place, and then connected to other features, and exposed to the client app if needed through the `:logic` module or whatever other module necessary.