### PR TITLE
chore(conversation-history): store history clients [WPB-18492]

### DIFF
--- a/conversation-history/build.gradle.kts
+++ b/conversation-history/build.gradle.kts
@@ -34,8 +34,11 @@ kotlin {
                 implementation(project(":network"))
                 implementation(project(":data"))
                 implementation(project(":util"))
+                implementation(project(":cryptography"))
                 implementation(project(":persistence"))
                 implementation(libs.coroutines.core)
+                implementation(libs.sqldelight.coroutinesExtension)
+                implementation(libs.ktxDateTime)
             }
         }
         val commonTest by getting {
@@ -43,6 +46,7 @@ kotlin {
                 // coroutines
                 implementation(libs.coroutines.test)
                 implementation(libs.turbine)
+                implementation(project(":persistence-test"))
             }
         }
 

--- a/conversation-history/src/commonMain/kotlin/com/wire/kalium/conversation/history/HistoryClient.kt
+++ b/conversation-history/src/commonMain/kotlin/com/wire/kalium/conversation/history/HistoryClient.kt
@@ -1,0 +1,50 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.conversation.history
+
+import com.wire.kalium.logic.data.id.ConversationId
+import kotlinx.datetime.Instant
+import kotlin.time.ExperimentalTime
+
+public data class HistoryClient @OptIn(ExperimentalTime::class) constructor(
+    val conversationId: ConversationId,
+    val id: String,
+    val creationTime: Instant,
+    val secret: Secret,
+) {
+
+    public data class Secret(
+        val value: ByteArray,
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null || this::class != other::class) return false
+
+            other as Secret
+
+            if (!value.contentEquals(other.value)) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            return value.contentHashCode()
+        }
+
+    }
+}

--- a/conversation-history/src/commonMain/kotlin/com/wire/kalium/conversation/history/data/HistoryClientDAO.kt
+++ b/conversation-history/src/commonMain/kotlin/com/wire/kalium/conversation/history/data/HistoryClientDAO.kt
@@ -1,0 +1,73 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.conversation.history.data
+
+import com.wire.kalium.conversation.history.HistoryClient
+import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.datetime.Instant
+import kotlin.time.ExperimentalTime
+
+/**
+ * Data Access Object for history clients.
+ */
+@OptIn(ExperimentalTime::class)
+public interface HistoryClientDAO {
+    /**
+     * Selects all history clients for a given conversation ID.
+     *
+     * @param conversationId the conversation ID
+     * @return a list of history clients
+     */
+    public suspend fun getAllForConversation(conversationId: QualifiedIDEntity): List<HistoryClient>
+
+    /**
+     * Selects all history clients for a given conversation ID from a specific date onwards.
+     *
+     * @param conversationId the conversation ID
+     * @param fromDate the date from which to select history clients
+     * @return a list of history clients
+     */
+    public suspend fun getAllForConversationFromDateOnwards(
+        conversationId: QualifiedIDEntity,
+        fromDate: Instant
+    ): List<HistoryClient>
+
+    /**
+     * Observes all history clients for a given conversation ID.
+     *
+     * @param conversationId the conversation ID
+     * @return a flow of history clients
+     */
+    public fun observeAllForConversation(conversationId: QualifiedIDEntity): Flow<List<HistoryClient>>
+
+    /**
+     * Inserts a new history client.
+     *
+     * @param conversationId the conversation ID
+     * @param id the client ID
+     * @param secret the client secret
+     * @param creationDate the creation date
+     */
+    public suspend fun insertClient(
+        conversationId: QualifiedIDEntity,
+        id: String,
+        secret: ByteArray,
+        creationDate: Instant
+    )
+}

--- a/conversation-history/src/commonMain/kotlin/com/wire/kalium/conversation/history/data/SQLiteHistoryClientDAO.kt
+++ b/conversation-history/src/commonMain/kotlin/com/wire/kalium/conversation/history/data/SQLiteHistoryClientDAO.kt
@@ -1,0 +1,123 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.conversation.history.data
+
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
+import com.wire.kalium.conversation.history.HistoryClient
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.persistence.HistoryClientQueries
+import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
+import kotlin.time.ExperimentalTime
+import kotlinx.datetime.Instant
+
+/**
+ * Implementation of [HistoryClientDAO] that uses SQLDelight to access the database.
+ */
+@OptIn(ExperimentalTime::class)
+internal class SQLiteHistoryClientDAO internal constructor(
+    private val historyClientQueries: HistoryClientQueries,
+    private val queriesContext: CoroutineContext = Dispatchers.IO
+) : HistoryClientDAO {
+
+    /**
+     * Maps a database entity to a domain model.
+     */
+    private fun mapToHistoryClient(
+        conversationId: QualifiedIDEntity,
+        id: String,
+        secret: ByteArray,
+        creationDate: Instant
+    ): HistoryClient = HistoryClient(
+        conversationId = ConversationId(conversationId.value, conversationId.domain),
+        id = id,
+        creationTime = creationDate,
+        secret = HistoryClient.Secret(secret)
+    )
+
+    /**
+     * Selects all history clients for a given conversation ID.
+     *
+     * @param conversationId the conversation ID
+     * @return a list of history clients
+     */
+    override suspend fun getAllForConversation(conversationId: QualifiedIDEntity): List<HistoryClient> =
+        withContext(queriesContext) {
+            historyClientQueries.selectAllForConversation(
+                conversation_id = conversationId,
+                mapper = ::mapToHistoryClient
+            ).executeAsList()
+        }
+
+    /**
+     * Selects all history clients for a given conversation ID from a specific date onwards.
+     *
+     * @param conversationId the conversation ID
+     * @param fromDate the date from which to select history clients
+     * @return a list of history clients
+     */
+    override suspend fun getAllForConversationFromDateOnwards(
+        conversationId: QualifiedIDEntity,
+        fromDate: Instant
+    ): List<HistoryClient> = withContext(queriesContext) {
+        historyClientQueries.selectAllForConversationFromDateOnwards(
+            conversation_id = conversationId,
+            creation_date = fromDate,
+            mapper = ::mapToHistoryClient
+        ).executeAsList()
+    }
+
+    /**
+     * Observes all history clients for a given conversation ID.
+     *
+     * @param conversationId the conversation ID
+     * @return a flow of history clients
+     */
+    override fun observeAllForConversation(conversationId: QualifiedIDEntity): Flow<List<HistoryClient>> =
+        historyClientQueries.selectAllForConversation(
+            conversation_id = conversationId,
+            mapper = ::mapToHistoryClient
+        ).asFlow().mapToList(queriesContext)
+
+    /**
+     * Inserts a new history client.
+     *
+     * @param conversationId the conversation ID
+     * @param id the client ID
+     * @param secret the client secret
+     * @param creationDate the creation date
+     */
+    override suspend fun insertClient(
+        conversationId: QualifiedIDEntity,
+        id: String,
+        secret: ByteArray,
+        creationDate: Instant
+    ) = withContext(queriesContext) {
+        historyClientQueries.insertClient(
+            conversation_id = conversationId,
+            id = id,
+            secret = secret,
+            creation_date = creationDate
+        )
+    }
+}

--- a/conversation-history/src/commonTest/kotlin/com/wire/kalium/conversation/history/data/SQLiteHistoryClientDAOTest.kt
+++ b/conversation-history/src/commonTest/kotlin/com/wire/kalium/conversation/history/data/SQLiteHistoryClientDAOTest.kt
@@ -1,0 +1,246 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.conversation.history.data
+
+import app.cash.turbine.test
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.persistence.TestUserDatabase
+import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.persistence.dao.UserIDEntity
+import com.wire.kalium.persistence.dao.conversation.ConversationEntity
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.days
+import kotlin.time.ExperimentalTime
+
+@OptIn(ExperimentalTime::class)
+class SQLiteHistoryClientDAOTest {
+
+    private lateinit var testDatabase: TestUserDatabase
+    private lateinit var testDispatcher: TestDispatcher
+    private lateinit var historyClientDAO: SQLiteHistoryClientDAO
+
+    @BeforeTest
+    fun setup() = runTest(StandardTestDispatcher()) {
+        testDispatcher = StandardTestDispatcher()
+        testDatabase = TestUserDatabase(TEST_USER_ID, testDispatcher)
+        historyClientDAO = SQLiteHistoryClientDAO(
+            historyClientQueries = testDatabase.builder.historyClientQueries,
+            queriesContext = testDispatcher
+        )
+        
+        // Insert fake conversations to satisfy foreign key constraint
+        insertFakeConversations()
+    }
+    
+    private suspend fun insertFakeConversations() {
+        // Insert the test conversation used in most tests
+        insertFakeConversation(TEST_CONVERSATION_ID)
+        
+        // Insert the second test conversation used in some tests
+        val secondConversationId = QualifiedIDEntity("conversation2", "domain")
+        insertFakeConversation(secondConversationId)
+    }
+    
+    private suspend fun insertFakeConversation(conversationId: QualifiedIDEntity) {
+        val now = Instant.DISTANT_PAST
+        
+        val conversationEntity = ConversationEntity(
+            id = conversationId,
+            name = "Test Conversation",
+            type = ConversationEntity.Type.GROUP,
+            teamId = null,
+            protocolInfo = ConversationEntity.ProtocolInfo.Proteus,
+            creatorId = TEST_USER_ID.value,
+            lastNotificationDate = now,
+            lastModifiedDate = now,
+            lastReadDate = now,
+            access = listOf(ConversationEntity.Access.PRIVATE),
+            accessRole = listOf(ConversationEntity.AccessRole.TEAM_MEMBER),
+            receiptMode = ConversationEntity.ReceiptMode.ENABLED,
+            messageTimer = null,
+            userMessageTimer = null,
+            archivedInstant = null,
+            mlsVerificationStatus = ConversationEntity.VerificationStatus.NOT_VERIFIED,
+            proteusVerificationStatus = ConversationEntity.VerificationStatus.NOT_VERIFIED,
+            legalHoldStatus = ConversationEntity.LegalHoldStatus.DISABLED,
+            isChannel = false,
+            channelAccess = null,
+            channelAddPermission = null,
+            wireCell = null
+        )
+        
+        testDatabase.builder.conversationDAO.insertConversation(conversationEntity)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        testDatabase.delete()
+    }
+
+    @Test
+    fun givenHistoryClientInserted_whenGettingAllForConversation_thenShouldReturnInsertedClient() = runTest(testDispatcher) {
+        // Given
+        val conversationId = TEST_CONVERSATION_ID
+        val clientId = "client1"
+        val secret = byteArrayOf(1, 2, 3, 4)
+        val creationDate = Instant.fromEpochMilliseconds(42L)
+
+        historyClientDAO.insertClient(
+            conversationId = conversationId,
+            id = clientId,
+            secret = secret,
+            creationDate = creationDate
+        )
+
+        // When
+        val result = historyClientDAO.getAllForConversation(conversationId)
+
+        // Then
+        assertEquals(1, result.size)
+        with(result.first()) {
+            assertEquals(ConversationId(conversationId.value, conversationId.domain), this.conversationId)
+            assertEquals(clientId, this.id)
+            assertEquals(creationDate, this.creationTime)
+            assertTrue(this.secret.value.contentEquals(secret))
+        }
+    }
+
+    @Test
+    fun givenMultipleHistoryClientsInserted_whenGettingAllForConversation_thenShouldReturnAllClientsForThatConversation() = runTest(testDispatcher) {
+        // Given
+        val conversationId1 = TEST_CONVERSATION_ID
+        val conversationId2 = QualifiedIDEntity("conversation2", "domain")
+        val clientId1 = "client1"
+        val clientId2 = "client2"
+        val secret1 = byteArrayOf(1, 2, 3, 4)
+        val secret2 = byteArrayOf(5, 6, 7, 8)
+        val baseInstant = Instant.DISTANT_PAST
+        val creationDate1 = baseInstant
+        val creationDate2 = baseInstant + 1.days // One day later
+
+        // Insert clients for first conversation
+        historyClientDAO.insertClient(
+            conversationId = conversationId1,
+            id = clientId1,
+            secret = secret1,
+            creationDate = creationDate1
+        )
+
+        // Insert client for second conversation
+        historyClientDAO.insertClient(
+            conversationId = conversationId2,
+            id = clientId2,
+            secret = secret2,
+            creationDate = creationDate2
+        )
+
+        // When
+        val result1 = historyClientDAO.getAllForConversation(conversationId1)
+        val result2 = historyClientDAO.getAllForConversation(conversationId2)
+
+        // Then
+        assertEquals(1, result1.size)
+        assertEquals(1, result2.size)
+        
+        with(result1.first()) {
+            assertEquals(ConversationId(conversationId1.value, conversationId1.domain), this.conversationId)
+            assertEquals(clientId1, this.id)
+        }
+        
+        with(result2.first()) {
+            assertEquals(ConversationId(conversationId2.value, conversationId2.domain), this.conversationId)
+            assertEquals(clientId2, this.id)
+        }
+    }
+
+    @Test
+    fun givenHistoryClientsWithDifferentDates_whenGettingAllFromDateOnwards_thenShouldReturnOnlyClientsFromThatDateOnwards() = runTest(testDispatcher) {
+        // Given
+        val conversationId = TEST_CONVERSATION_ID
+        val clientId1 = "client1"
+        val clientId2 = "client2"
+        val clientId3 = "client3"
+        val secret = byteArrayOf(1, 2, 3, 4)
+        
+        val baseInstant = Instant.DISTANT_PAST
+        val date1 = baseInstant
+        val date2 = baseInstant + 1.days // One day later
+        val date3 = baseInstant + 2.days // Two days later
+
+        // Insert clients with different dates
+        historyClientDAO.insertClient(conversationId, clientId1, secret, date1)
+        historyClientDAO.insertClient(conversationId, clientId2, secret, date2)
+        historyClientDAO.insertClient(conversationId, clientId3, secret, date3)
+
+        // When - get clients from date2 onwards
+        val result = historyClientDAO.getAllForConversationFromDateOnwards(conversationId, date2)
+
+        // Then
+        assertEquals(2, result.size)
+        val clientIds = result.map { it.id }.toSet()
+        assertTrue(clientIds.contains(clientId2))
+        assertTrue(clientIds.contains(clientId3))
+        assertTrue(!clientIds.contains(clientId1))
+    }
+
+    @Test
+    fun givenHistoryClientsInserted_whenObservingAllForConversation_thenShouldEmitClientsForThatConversation() = runTest(testDispatcher) {
+        // Given
+        val conversationId = TEST_CONVERSATION_ID
+        val clientId1 = "client1"
+        val clientId2 = "client2"
+        val secret = byteArrayOf(1, 2, 3, 4)
+        val date = Instant.DISTANT_PAST
+        
+        // Insert clients
+        historyClientDAO.insertClient(conversationId, clientId1, secret, date)
+        
+        // When - observe clients
+        historyClientDAO.observeAllForConversation(conversationId).test {
+            // Then - initial emission should contain the first client
+            val initialClients = awaitItem()
+            assertEquals(1, initialClients.size)
+            assertEquals(clientId1, initialClients.first().id)
+            
+            // When - insert another client
+            historyClientDAO.insertClient(conversationId, clientId2, secret, date)
+            
+            // Then - should emit updated list with both clients
+            val updatedClients = awaitItem()
+            assertEquals(2, updatedClients.size)
+            val clientIds = updatedClients.map { it.id }.toSet()
+            assertTrue(clientIds.contains(clientId1))
+            assertTrue(clientIds.contains(clientId2))
+            
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    companion object {
+        private val TEST_USER_ID = UserIDEntity("testUser", "domain")
+        private val TEST_CONVERSATION_ID = QualifiedIDEntity("conversation1", "domain")
+    }
+}

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/HistoryClient.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/HistoryClient.sq
@@ -1,0 +1,24 @@
+import com.wire.kalium.persistence.dao.QualifiedIDEntity;
+import kotlinx.datetime.Instant;
+
+CREATE TABLE HistoryClient (
+      conversation_id TEXT AS QualifiedIDEntity NOT NULL,
+      id TEXT NOT NULL,
+      secret BLOB NOT NULL,
+      creation_date INTEGER AS Instant NOT NULL,
+
+      FOREIGN KEY (conversation_id) REFERENCES Conversation(qualified_id) ON DELETE CASCADE ON UPDATE SET NULL,
+      PRIMARY KEY (conversation_id, id)
+);
+
+CREATE INDEX history_client_id ON HistoryClient(id);
+CREATE INDEX history_client_conversation_date ON HistoryClient(conversation_id, creation_date);
+
+selectAllForConversation:
+SELECT * FROM HistoryClient WHERE conversation_id = ?;
+
+selectAllForConversationFromDateOnwards:
+SELECT * FROM HistoryClient WHERE conversation_id = ? AND creation_date >= ?;
+
+insertClient:
+INSERT OR IGNORE INTO HistoryClient(conversation_id, id, secret, creation_date) VALUES (?, ?, ?, ?);

--- a/persistence/src/commonMain/db_user/migrations/110.sqm
+++ b/persistence/src/commonMain/db_user/migrations/110.sqm
@@ -1,0 +1,13 @@
+
+CREATE TABLE HistoryClient (
+      conversation_id TEXT AS QualifiedIDEntity NOT NULL,
+      id TEXT NOT NULL,
+      secret BLOB NOT NULL,
+      creation_date INTEGER AS Instant NOT NULL,
+
+      FOREIGN KEY (conversation_id) REFERENCES Conversation(qualified_id) ON DELETE CASCADE ON UPDATE SET NULL,
+      PRIMARY KEY (conversation_id, id)
+);
+
+CREATE INDEX history_client_id ON HistoryClient(id);
+CREATE INDEX history_client_conversation_date ON HistoryClient(conversation_id, creation_date);

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/TableMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/TableMapper.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.persistence.Connection
 import com.wire.kalium.persistence.Conversation
 import com.wire.kalium.persistence.ConversationFolder
 import com.wire.kalium.persistence.ConversationLegalHoldStatusChangeNotified
+import com.wire.kalium.persistence.HistoryClient
 import com.wire.kalium.persistence.LastMessage
 import com.wire.kalium.persistence.LabeledConversation
 import com.wire.kalium.persistence.Member
@@ -296,5 +297,10 @@ internal object TableMapper {
         conversation_idAdapter = QualifiedIDAdapter,
         asset_widthAdapter = IntColumnAdapter,
         asset_heightAdapter = IntColumnAdapter,
+    )
+
+    val historyClientAdapter = HistoryClient.Adapter(
+        conversation_idAdapter = QualifiedIDAdapter,
+        creation_dateAdapter = InstantTypeAdapter,
     )
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.persistence.db
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlSchema
+import com.wire.kalium.persistence.HistoryClientQueries
 import com.wire.kalium.persistence.UserDatabase
 import com.wire.kalium.persistence.backup.DatabaseExporter
 import com.wire.kalium.persistence.backup.DatabaseExporterImpl
@@ -172,6 +173,7 @@ class UserDatabaseBuilder internal constructor(
         ConversationFolderAdapter = TableMapper.conversationFolderAdapter,
         MessageAttachmentDraftAdapter = TableMapper.messageAttachmentDraftAdapter,
         MessageAttachmentsAdapter = TableMapper.messageAttachmentsAdapter,
+        HistoryClientAdapter = TableMapper.historyClientAdapter,
     )
 
     init {
@@ -326,6 +328,9 @@ class UserDatabaseBuilder internal constructor(
 
     val messageAttachmentDraftDao: MessageAttachmentDraftDao
         get() = MessageAttachmentDraftDaoImpl(database.messageAttachmentDraftQueries)
+
+    val historyClientQueries: HistoryClientQueries
+        get() = database.historyClientQueries
 
     val messageAttachments: MessageAttachmentsDao
         get() = MessageAttachmentsDaoImpl(database.messageAttachmentsQueries)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18492" title="WPB-18492" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18492</a>  [Android] Persist all History Clients
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Add storage for `HistoryClient`.

## Dependencies

This PR requires the following PR to be merged before:

- #3536 

# Implementation

The idea here is to add sql-related stuff to the `persistence` module, in order to generate the `*Queries` classes using SQLDelight. However, the `DAO` implementation, mapping to domain models, etc. happen within the new `:conversation-history` module.


