### PR TITLE
feat: composite messages button action handling with non targeted messages (WPB-17920)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1546,7 +1546,7 @@ class UserSessionScope internal constructor(
     }
 
     private val buttonActionHandler: ButtonActionHandler by lazy {
-        ButtonActionHandlerImpl(userId, compositeMessageRepository, messageMetadataRepository)
+        ButtonActionHandlerImpl(userId, compositeMessageRepository)
     }
 
     private val applicationMessageHandler: ApplicationMessageHandler

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1546,7 +1546,7 @@ class UserSessionScope internal constructor(
     }
 
     private val buttonActionHandler: ButtonActionHandler by lazy {
-        ButtonActionHandlerImpl(userId, compositeMessageRepository)
+        ButtonActionHandlerImpl(userId, compositeMessageRepository, userScopedLogger)
     }
 
     private val applicationMessageHandler: ApplicationMessageHandler

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -466,6 +466,8 @@ import com.wire.kalium.logic.sync.receiver.conversation.message.ProteusMessageUn
 import com.wire.kalium.logic.sync.receiver.handler.AllowedGlobalOperationsHandler
 import com.wire.kalium.logic.sync.receiver.handler.ButtonActionConfirmationHandler
 import com.wire.kalium.logic.sync.receiver.handler.ButtonActionConfirmationHandlerImpl
+import com.wire.kalium.logic.sync.receiver.handler.ButtonActionHandler
+import com.wire.kalium.logic.sync.receiver.handler.ButtonActionHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.ClearConversationContentHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.CodeDeletedHandler
 import com.wire.kalium.logic.sync.receiver.handler.CodeDeletedHandlerImpl
@@ -1543,6 +1545,10 @@ class UserSessionScope internal constructor(
         InCallReactionsDataSource()
     }
 
+    private val buttonActionHandler: ButtonActionHandler by lazy {
+        ButtonActionHandlerImpl(compositeMessageRepository, messageMetadataRepository)
+    }
+
     private val applicationMessageHandler: ApplicationMessageHandler
         get() = ApplicationMessageHandlerImpl(
             userRepository,
@@ -1572,6 +1578,7 @@ class UserSessionScope internal constructor(
             buttonActionConfirmationHandler,
             dataTransferEventHandler,
             inCallReactionsRepository,
+            buttonActionHandler,
             userId,
         )
 
@@ -2141,6 +2148,7 @@ class UserSessionScope internal constructor(
             cells.deleteAttachmentsUseCase,
             fetchConversationUseCase,
             cryptoTransactionProvider,
+            compositeMessageRepository,
             this,
             userScopedLogger,
         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1546,7 +1546,7 @@ class UserSessionScope internal constructor(
     }
 
     private val buttonActionHandler: ButtonActionHandler by lazy {
-        ButtonActionHandlerImpl(compositeMessageRepository, messageMetadataRepository)
+        ButtonActionHandlerImpl(userId, compositeMessageRepository, messageMetadataRepository)
     }
 
     private val applicationMessageHandler: ApplicationMessageHandler

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -139,7 +139,7 @@ class MessageScope internal constructor(
     private val scope: CoroutineScope,
     kaliumLogger: KaliumLogger,
     internal val dispatcher: KaliumDispatcher = KaliumDispatcherImpl,
-    private val legalHoldStatusMapper: LegalHoldStatusMapper = LegalHoldStatusMapperImpl,
+    private val legalHoldStatusMapper: LegalHoldStatusMapper = LegalHoldStatusMapperImpl
 ) {
 
     private val messageSendFailureHandler: MessageSendFailureHandler

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -36,6 +36,7 @@ import com.wire.kalium.logic.data.conversation.LegalHoldStatusMapperImpl
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.message.CompositeMessageRepository
 import com.wire.kalium.logic.data.message.MessageMetadataRepository
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
@@ -134,10 +135,11 @@ class MessageScope internal constructor(
     private val deleteMessageAttachmentsUseCase: DeleteMessageAttachmentsUseCase,
     private val fetchConversationUseCase: FetchConversationUseCase,
     private val transactionProvider: CryptoTransactionProvider,
+    private val compositeMessageRepository: CompositeMessageRepository,
     private val scope: CoroutineScope,
     kaliumLogger: KaliumLogger,
     internal val dispatcher: KaliumDispatcher = KaliumDispatcherImpl,
-    private val legalHoldStatusMapper: LegalHoldStatusMapper = LegalHoldStatusMapperImpl
+    private val legalHoldStatusMapper: LegalHoldStatusMapper = LegalHoldStatusMapperImpl,
 ) {
 
     private val messageSendFailureHandler: MessageSendFailureHandler
@@ -441,7 +443,8 @@ class MessageScope internal constructor(
             messageSender = messageSender,
             selfUserId = selfUserId,
             currentClientIdProvider = currentClientIdProvider,
-            messageMetadataRepository = messageMetadataRepository
+            messageMetadataRepository = messageMetadataRepository,
+            compositeMessageRepository = compositeMessageRepository
         )
 
     val sendButtonMessage: SendButtonMessageUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/composite/SendButtonActionMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/composite/SendButtonActionMessageUseCase.kt
@@ -19,34 +19,36 @@ package com.wire.kalium.logic.feature.message.composite
 
 import com.benasher44.uuid.uuid4
 import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.common.functional.fold
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.CurrentClientIdProvider
+import com.wire.kalium.logic.data.message.CompositeMessageRepository
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageMetadataRepository
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.message.MessageSender
-import com.wire.kalium.logic.data.message.MessageTarget
-import com.wire.kalium.common.functional.flatMap
-import com.wire.kalium.common.functional.fold
 import com.wire.kalium.logic.sync.SyncManager
 import kotlinx.datetime.Clock
 
-/**
- * Use case for sending a button action message.
- * @param conversationId The conversation id.
- * @param messageId The id of the message that contains the button.
- * @param buttonId The id of the button.
- *
- * the action message is sent only to the message original sender.
- */
 class SendButtonActionMessageUseCase internal constructor(
     private val messageSender: MessageSender,
+    private val compositeMessageRepository: CompositeMessageRepository,
     private val messageMetadataRepository: MessageMetadataRepository,
     private val syncManager: SyncManager,
     private val currentClientIdProvider: CurrentClientIdProvider,
     private val selfUserId: UserId
 ) {
+    /**
+     * Use case for sending a button action message, this means pressing a button in a [MessageContent.Composite].
+     * Sends a button action message.
+     *
+     * @param conversationId The conversation id.
+     * @param messageId The id of the message that contains the button.
+     * @param buttonId The id of the button.
+     * @return [Result.Success] if the message was sent successfully, [Result.Failure] otherwise.
+     */
     suspend operator fun invoke(
         conversationId: ConversationId,
         messageId: String,
@@ -55,7 +57,7 @@ class SendButtonActionMessageUseCase internal constructor(
         messageMetadataRepository.originalSenderId(
             conversationId,
             messageId
-        ).flatMap { originalSenderId ->
+        ).flatMap { _ ->
             currentClientIdProvider().flatMap { currentClientId ->
                 val regularMessage = Message.Signaling(
                     id = uuid4().toString(),
@@ -71,10 +73,18 @@ class SendButtonActionMessageUseCase internal constructor(
                     isSelfMessage = true,
                     expirationData = null
                 )
-                messageSender.sendMessage(regularMessage, messageTarget = MessageTarget.Users(originalSenderId))
+                messageSender.sendMessage(regularMessage)
             }
         }
-    }.fold(Result::Failure, { Result.Success })
+    }.flatMap {
+        compositeMessageRepository.markSelected(
+            messageId = messageId,
+            conversationId = conversationId,
+            buttonId = buttonId
+        )
+    }.fold(Result::Failure) {
+        Result.Success
+    }
 
     sealed interface Result {
         data object Success : Result

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/ButtonActionHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/ButtonActionHandler.kt
@@ -19,12 +19,10 @@ package com.wire.kalium.logic.sync.receiver.handler
 
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.functional.Either
-import com.wire.kalium.common.functional.flatMap
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.MessageButtonId
 import com.wire.kalium.logic.data.id.MessageId
 import com.wire.kalium.logic.data.message.CompositeMessageRepository
-import com.wire.kalium.logic.data.message.MessageMetadataRepository
 import com.wire.kalium.logic.data.user.UserId
 import io.mockative.Mockable
 
@@ -40,8 +38,7 @@ internal interface ButtonActionHandler {
 
 internal class ButtonActionHandlerImpl internal constructor(
     private val selfUserId: UserId,
-    private val compositeMessageRepository: CompositeMessageRepository,
-    private val messageMetadataRepository: MessageMetadataRepository
+    private val compositeMessageRepository: CompositeMessageRepository
 ) : ButtonActionHandler {
 
     override suspend fun handle(
@@ -53,14 +50,11 @@ internal class ButtonActionHandlerImpl internal constructor(
         if (senderId != selfUserId) {
             return Either.Left(CoreFailure.InvalidEventSenderID)
         }
-
-        return messageMetadataRepository.originalSenderId(conversationId, messageId)
-            .flatMap {
-                compositeMessageRepository.markSelected(
-                    messageId = messageId,
-                    conversationId = conversationId,
-                    buttonId = buttonId
-                )
-            }
+        return compositeMessageRepository.markSelected(
+            messageId = messageId,
+            conversationId = conversationId,
+            buttonId = buttonId
+        )
     }
+
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/ButtonActionHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/ButtonActionHandler.kt
@@ -17,8 +17,8 @@
  */
 package com.wire.kalium.logic.sync.receiver.handler
 
-import com.wire.kalium.common.error.CoreFailure
-import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.logger.kaliumLogger
+import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.MessageButtonId
 import com.wire.kalium.logic.data.id.MessageId
@@ -33,24 +33,28 @@ internal interface ButtonActionHandler {
         senderId: UserId,
         messageId: MessageId,
         buttonId: MessageButtonId,
-    ): Either<CoreFailure, Unit>
+    )
 }
 
 internal class ButtonActionHandlerImpl internal constructor(
     private val selfUserId: UserId,
-    private val compositeMessageRepository: CompositeMessageRepository
+    private val compositeMessageRepository: CompositeMessageRepository,
+    logger: KaliumLogger = kaliumLogger,
 ) : ButtonActionHandler {
+
+    private val logger = logger.withTextTag("ButtonActionHandler")
 
     override suspend fun handle(
         conversationId: ConversationId,
         senderId: UserId,
         messageId: MessageId,
         buttonId: MessageButtonId
-    ): Either<CoreFailure, Unit> {
+    ) {
         if (senderId != selfUserId) {
-            return Either.Left(CoreFailure.InvalidEventSenderID)
+            logger.d("Ignoring button action from ${senderId.toLogString()}, as it is not from self user.")
+            return
         }
-        return compositeMessageRepository.markSelected(
+        compositeMessageRepository.markSelected(
             messageId = messageId,
             conversationId = conversationId,
             buttonId = buttonId

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/ButtonActionHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/ButtonActionHandler.kt
@@ -1,0 +1,61 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.receiver.handler
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.MessageButtonId
+import com.wire.kalium.logic.data.id.MessageId
+import com.wire.kalium.logic.data.message.CompositeMessageRepository
+import com.wire.kalium.logic.data.message.MessageMetadataRepository
+import com.wire.kalium.logic.data.user.UserId
+import io.mockative.Mockable
+
+@Mockable
+internal interface ButtonActionHandler {
+    suspend fun handle(
+        conversationId: ConversationId,
+        senderId: UserId,
+        messageId: MessageId,
+        buttonId: MessageButtonId,
+    ): Either<CoreFailure, Unit>
+}
+
+internal class ButtonActionHandlerImpl internal constructor(
+    private val compositeMessageRepository: CompositeMessageRepository,
+    private val messageMetadataRepository: MessageMetadataRepository
+) : ButtonActionHandler {
+
+    override suspend fun handle(
+        conversationId: ConversationId,
+        senderId: UserId,
+        messageId: MessageId,
+        buttonId: MessageButtonId
+    ): Either<CoreFailure, Unit> {
+        return messageMetadataRepository.originalSenderId(conversationId, messageId)
+            .flatMap {
+                compositeMessageRepository.markSelected(
+                    messageId = messageId,
+                    conversationId = conversationId,
+                    buttonId = buttonId
+                )
+            }
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/ButtonActionHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/ButtonActionHandler.kt
@@ -39,6 +39,7 @@ internal interface ButtonActionHandler {
 }
 
 internal class ButtonActionHandlerImpl internal constructor(
+    private val selfUserId: UserId,
     private val compositeMessageRepository: CompositeMessageRepository,
     private val messageMetadataRepository: MessageMetadataRepository
 ) : ButtonActionHandler {
@@ -49,6 +50,10 @@ internal class ButtonActionHandlerImpl internal constructor(
         messageId: MessageId,
         buttonId: MessageButtonId
     ): Either<CoreFailure, Unit> {
+        if (senderId != selfUserId) {
+            return Either.Left(CoreFailure.InvalidEventSenderID)
+        }
+
         return messageMetadataRepository.originalSenderId(conversationId, messageId)
             .flatMap {
                 compositeMessageRepository.markSelected(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendButtonActionMessageTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendButtonActionMessageTest.kt
@@ -18,22 +18,23 @@
 package com.wire.kalium.logic.feature.message
 
 import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.right
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.message.MessageTarget
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.message.composite.SendButtonActionMessageUseCase
-import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.util.arrangement.MessageSenderArrangement
 import com.wire.kalium.logic.util.arrangement.MessageSenderArrangementImpl
 import com.wire.kalium.logic.util.arrangement.SyncManagerArrangement
 import com.wire.kalium.logic.util.arrangement.SyncManagerArrangementImpl
 import com.wire.kalium.logic.util.arrangement.provider.CurrentClientIdProviderArrangement
 import com.wire.kalium.logic.util.arrangement.provider.CurrentClientIdProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.repository.CompositeMessageRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.repository.CompositeMessageRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.repository.MessageMetadataRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.MessageMetadataRepositoryArrangementImpl
 import io.mockative.any
-import io.mockative.matches
 import io.mockative.coVerify
 import io.mockative.once
 import kotlinx.coroutines.runBlocking
@@ -85,6 +86,7 @@ class SendButtonActionMessageTest {
                 withWaitUntilLiveOrFailure(Either.Right(Unit))
                 withCurrentClientIdSuccess(ClientId("client-id"))
                 withMessageOriginalSender(Either.Right(originalSender))
+                withMarkSelected(Unit.right())
                 withSendMessageSucceed()
             }
 
@@ -122,6 +124,7 @@ class SendButtonActionMessageTest {
                 withWaitUntilLiveOrFailure(Either.Right(Unit))
                 withCurrentClientIdSuccess(ClientId("client-id"))
                 withMessageOriginalSender(Either.Right(originalSender))
+                withMarkSelected(Unit.right())
                 withSendMessageSucceed()
             }
 
@@ -138,9 +141,7 @@ class SendButtonActionMessageTest {
         }.wasInvoked(exactly = once)
 
         coVerify {
-            arrangement.messageSender.sendMessage(any(), matches {
-                it is MessageTarget.Users && it.userId == listOf(originalSender)
-            })
+            arrangement.messageSender.sendMessage(any(), any())
         }.wasInvoked(exactly = once)
 
         coVerify {
@@ -160,6 +161,7 @@ class SendButtonActionMessageTest {
         MessageMetadataRepositoryArrangement by MessageMetadataRepositoryArrangementImpl(),
         MessageSenderArrangement by MessageSenderArrangementImpl(),
         SyncManagerArrangement by SyncManagerArrangementImpl(),
+        CompositeMessageRepositoryArrangement by CompositeMessageRepositoryArrangementImpl(),
         CurrentClientIdProviderArrangement by CurrentClientIdProviderArrangementImpl() {
 
         private lateinit var useCase: SendButtonActionMessageUseCase
@@ -172,6 +174,7 @@ class SendButtonActionMessageTest {
                 syncManager = syncManager,
                 currentClientIdProvider = currentClientIdProvider,
                 selfUserId = SELF_USER_ID,
+                compositeMessageRepository = compositeMessageRepository
             )
 
             return this to useCase

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/ButtonActionHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/ButtonActionHandlerTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.receiver.handler
+
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.right
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.CompositeMessageRepository
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.framework.TestUser
+import io.mockative.any
+import io.mockative.coEvery
+import io.mockative.coVerify
+import io.mockative.eq
+import io.mockative.mock
+import io.mockative.once
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class ButtonActionHandlerTest {
+
+    @Test
+    fun givenContentWithButtonId_whenHandlingEvent_thenThatButtonIdAsSelected() = runTest {
+        val convId = CONVERSATION_ID
+        val senderId = TestUser.SELF.id
+        val content = MessageContent.ButtonAction(
+            referencedMessageId = "messageId",
+            buttonId = "buttonId"
+        )
+        val (arrangement, handler) = Arrangement().withMarkSelected().arrange()
+
+        handler.handle(convId, senderId, content.referencedMessageId, content.buttonId)
+
+        coVerify {
+            arrangement.compositeMessageRepository.markSelected(eq("messageId"), eq(convId), eq("buttonId"))
+        }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenSenderIdIsNotTheSameAsSelfUserSender_whenHandlingEvent_thenIgnore() = runTest {
+        val convId = CONVERSATION_ID
+        val senderId = TestUser.OTHER_USER_ID
+
+        val content = MessageContent.ButtonAction(
+            referencedMessageId = "messageId",
+            buttonId = "buttonId"
+        )
+
+        val (arrangement, handler) = Arrangement().withMarkSelected().arrange()
+
+        handler.handle(convId, senderId, content.referencedMessageId, content.buttonId)
+
+        coVerify {
+            arrangement.compositeMessageRepository.markSelected(any(), any(), any())
+        }.wasNotInvoked()
+    }
+
+    private companion object {
+        val CONVERSATION_ID = ConversationId("conversationId", "domain")
+    }
+
+    private class Arrangement {
+
+        val compositeMessageRepository = mock(CompositeMessageRepository::class)
+
+        suspend fun withMarkSelected(result: Either<StorageFailure, Unit> = Unit.right()) = apply {
+            coEvery { compositeMessageRepository.markSelected(any(), any(), any()) }.returns(result)
+        }
+
+        fun arrange() = this to ButtonActionHandlerImpl(
+            compositeMessageRepository = compositeMessageRepository,
+            selfUserId = TestUser.SELF.id
+        )
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17920" title="WPB-17920" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-17920</a>  [Android] Receiving and answering messages with buttons (without targeted messages)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Preparing the work for APP's SDK (rework of old bots SDK) with support for MLS, we need a way to handle action buttons, or better known as composite messages.

### Causes (Optional)

 In MLS, there is no support for targeted messages.

### Solutions

Implement the new Use Case of handling this in MLS. https://wearezeta.atlassian.net/wiki/x/L4DqcQ
In summary, this is:

- Send `ButtonAction` as a non targeted message
- Marks on success the button as selected (before we were waiting for the bot to send `ButtonActionConfirmation`)
- Create a handler of `ButtonAction` and handle this to perform marking a button as selected only if the `senderId` is the same as the Self User.
- Keeps the `ButtonActionConfirmation` handling for retrocompatibility reasons and future reinstatement on MLS.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
