### PR TITLE
fix: ignore event about new client added is the current client (WPB-18910)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
@@ -156,7 +156,7 @@ internal class UserEventReceiverImpl internal constructor(
         val logger = kaliumLogger.createEventProcessingLogger(event)
 
         if (shouldSkipCurrentClientId(event)) {
-            logger.logSuccess("info" to "SKIPPED_CURRENT_CLIENT_ID")
+            logger.logSuccess()
             return Unit.right()
         }
 
@@ -174,7 +174,8 @@ internal class UserEventReceiverImpl internal constructor(
             fnL = { false },
             fnR = { currentClientId ->
                 currentClientId == event.client.id
-            })
+            }
+        )
     }
 
     private suspend fun handleUserDelete(event: Event.User.UserDelete): Either<CoreFailure, Unit> {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
@@ -23,10 +23,12 @@ import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
 import com.wire.kalium.common.functional.flatMapLeft
+import com.wire.kalium.common.functional.fold
 import com.wire.kalium.common.functional.getOrNull
 import com.wire.kalium.common.functional.map
 import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.common.functional.onSuccess
+import com.wire.kalium.common.functional.right
 import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.cryptography.CryptoTransactionContext
 import com.wire.kalium.logic.data.client.ClientRepository
@@ -64,7 +66,7 @@ internal class UserEventReceiverImpl internal constructor(
     private val currentClientIdProvider: CurrentClientIdProvider,
     private val newGroupConversationSystemMessagesCreator: Lazy<NewGroupConversationSystemMessagesCreator>,
     private val legalHoldRequestHandler: LegalHoldRequestHandler,
-    private val legalHoldHandler: LegalHoldHandler
+    private val legalHoldHandler: LegalHoldHandler,
 ) : UserEventReceiver {
 
     override suspend fun onEvent(
@@ -152,9 +154,27 @@ internal class UserEventReceiverImpl internal constructor(
 
     private suspend fun handleNewClient(event: Event.User.NewClient): Either<CoreFailure, Unit> {
         val logger = kaliumLogger.createEventProcessingLogger(event)
+
+        if (shouldSkipCurrentClientId(event)) {
+            logger.logSuccess("info" to "SKIPPED_CURRENT_CLIENT_ID")
+            return Unit.right()
+        }
+
         return clientRepository.saveNewClientEvent(event)
             .onSuccess { logger.logSuccess() }
             .onFailure { logger.logFailure(it) }
+    }
+
+    /**
+     * For some reasons we receive the current client id as a NewClient event.
+     * Then skip it, because is not needed to be processed.
+     */
+    private suspend fun shouldSkipCurrentClientId(event: Event.User.NewClient): Boolean {
+        return currentClientIdProvider().fold(
+            fnL = { false },
+            fnR = { currentClientId ->
+                currentClientId == event.client.id
+            })
     }
 
     private suspend fun handleUserDelete(event: Event.User.UserDelete): Either<CoreFailure, Unit> {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
@@ -105,7 +105,7 @@ object TestEvent {
     )
 
     fun newClient(eventId: String = "eventId", clientId: ClientId = ClientId("client")) = Event.User.NewClient(
-        eventId, TestClient.CLIENT
+        eventId, TestClient.CLIENT.copy(id = clientId)
     )
 
     fun newConnection(eventId: String = "eventId", status: ConnectionState = ConnectionState.PENDING) = Event.User.NewConnection(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

ACK sends duplicated events

### Causes (Optional)

¯\_(ツ)_/¯

### Solutions

Ignore, skip this event.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
