### PR TITLE
fix: race condition when updating call metadata [WPB-18303]

### DIFF
--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallMetadataProfile.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallMetadataProfile.kt
@@ -30,7 +30,9 @@ import kotlinx.datetime.Instant
 class CallMetadataProfile(
     data: Map<ConversationId, CallMetadata> = emptyMap()
 ) {
-    private val flowData: Map<ConversationId, MutableStateFlow<CallMetadata>> = data.mapValues { MutableStateFlow(it.value) }
+    private val flowData: Map<ConversationId, MutableStateFlow<CallMetadata>> = data.mapValues {
+        MutableStateFlow(it.value)
+    }
 
     operator fun get(conversationId: ConversationId): MutableStateFlow<CallMetadata>? = flowData[conversationId]
 

--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallMetadataProfile.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallMetadataProfile.kt
@@ -24,12 +24,20 @@ import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.OtherUserMinimized
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.datetime.Instant
 
-data class CallMetadataProfile(
-    val data: Map<ConversationId, CallMetadata>
+class CallMetadataProfile(
+    data: Map<ConversationId, CallMetadata> = emptyMap()
 ) {
-    operator fun get(conversationId: ConversationId): CallMetadata? = data[conversationId]
+    private val flowData: Map<ConversationId, MutableStateFlow<CallMetadata>> = data.mapValues { MutableStateFlow(it.value) }
+
+    operator fun get(conversationId: ConversationId): MutableStateFlow<CallMetadata>? = flowData[conversationId]
+
+    fun containsKey(conversationId: ConversationId): Boolean = flowData.containsKey(conversationId)
+
+    fun plus(conversationId: ConversationId, metadata: CallMetadata): CallMetadataProfile =
+        CallMetadataProfile(data = flowData.mapValues { it.value.value } + (conversationId to metadata))
 }
 
 data class CallMetadata(

--- a/detekt/detekt.yml
+++ b/detekt/detekt.yml
@@ -224,6 +224,9 @@ formatting:
     ArgumentListWrapping:
         active: true
         maxLineLength: 140
+    PropertyWrapping:
+      active: true
+      maxLineLength: 140
     ChainWrapping:
         active: false
         autoCorrect: true

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -323,7 +323,7 @@ class CallManagerImpl internal constructor(
         withCalling {
             val avsCallType = callMapper.toCallTypeCalling(callType)
 
-            if (callRepository.getCallMetadataProfile()[conversationId]?.protocol is Conversation.ProtocolInfo.MLS) {
+            if (callRepository.getCallMetadata(conversationId)?.protocol is Conversation.ProtocolInfo.MLS) {
                 callRepository.joinMlsConference(
                     conversationId = conversationId,
                     onJoined = {
@@ -368,7 +368,7 @@ class CallManagerImpl internal constructor(
             )
             val callType = if (isVideoCall) CallTypeCalling.VIDEO else CallTypeCalling.AUDIO
 
-            if (callRepository.getCallMetadataProfile()[conversationId]?.protocol is Conversation.ProtocolInfo.MLS) {
+            if (callRepository.getCallMetadata(conversationId)?.protocol is Conversation.ProtocolInfo.MLS) {
                 callRepository.joinMlsConference(
                     conversationId = conversationId,
                     onJoined = {
@@ -551,7 +551,7 @@ class CallManagerImpl internal constructor(
         conversationId: ConversationId,
         clients: String
     ) {
-        if (callRepository.getCallMetadataProfile()[conversationId]?.protocol is Conversation.ProtocolInfo.Proteus) {
+        if (callRepository.getCallMetadata(conversationId)?.protocol is Conversation.ProtocolInfo.Proteus) {
             withCalling {
                 wcall_set_clients_for_conv(
                     it,

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnCloseCall.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnCloseCall.kt
@@ -64,7 +64,7 @@ class OnCloseCall(
         val conversationIdWithDomain = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
 
         scope.launch {
-            val callMetadata = callRepository.getCallMetadataProfile()[conversationIdWithDomain]
+            val callMetadata = callRepository.getCallMetadata(conversationIdWithDomain)
 
             val isConnectedToInternet =
                 networkStateObserver.observeNetworkState().value == NetworkState.ConnectedWithInternet
@@ -98,7 +98,7 @@ class OnCloseCall(
     ): Boolean {
         if (callStatus == CallStatus.MISSED)
             return true
-        return callRepository.getCallMetadataProfile().data[conversationId]?.let {
+        return callRepository.getCallMetadata(conversationId)?.let {
             val isGroupCall = it.conversationType is Conversation.Type.Group
             (callStatus == CallStatus.CLOSED &&
                     isGroupCall &&

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnParticipantListChanged.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnParticipantListChanged.kt
@@ -52,6 +52,10 @@ class OnParticipantListChanged internal constructor(
     override fun onParticipantChanged(remoteConversationId: String, data: String, arg: Pointer?) {
 
         val participantsChange = jsonDecoder.decodeFromString<CallParticipants>(data)
+        callingLogger.i(
+            "[OnParticipantListChanged] -> ConversationId: ${remoteConversationId.obfuscateId()}" +
+                    " | Participants: ${participantsChange.members.size}"
+        )
 
         callingScope.launch {
             val participants = mutableListOf<ParticipantMinimized>()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/CreateAndPersistRecentlyEndedCallMetadataUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/CreateAndPersistRecentlyEndedCallMetadataUseCase.kt
@@ -46,7 +46,7 @@ class CreateAndPersistRecentlyEndedCallMetadataUseCaseImpl internal constructor(
     private val selfTeamIdProvider: SelfTeamIdProvider,
 ) : CreateAndPersistRecentlyEndedCallMetadataUseCase {
     override suspend fun invoke(conversationId: ConversationId, callEndedReason: Int) {
-        callRepository.getCallMetadataProfile()[conversationId]?.createMetadata(
+        callRepository.getCallMetadata(conversationId)?.createMetadata(
             conversationId = conversationId,
             callEndedReason = callEndedReason
         )?.let { metadata ->

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/CreateAndPersistRecentlyEndedCallMetadataUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/CreateAndPersistRecentlyEndedCallMetadataUseCaseTest.kt
@@ -17,8 +17,8 @@
  */
 package com.wire.kalium.logic.feature.call.usecase
 
+import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.call.CallMetadata
-import com.wire.kalium.logic.data.call.CallMetadataProfile
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.CallStatus
 import com.wire.kalium.logic.data.call.ParticipantMinimized
@@ -32,7 +32,6 @@ import com.wire.kalium.logic.feature.conversation.ObserveConversationMembersUseC
 import com.wire.kalium.logic.framework.TestCall.CALLER_ID
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.framework.TestUser.OTHER_MINIMIZED
-import com.wire.kalium.common.functional.Either
 import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.coVerify
@@ -149,36 +148,19 @@ class CreateAndPersistRecentlyEndedCallMetadataUseCaseTest {
     }
 
     private class Arrangement {
-        
+
         val observeConversationMembers = mock(ObserveConversationMembersUseCase::class)
         val selfTeamIdProvider = mock(SelfTeamIdProvider::class)
         val callRepository = mock(CallRepository::class)
 
         fun withOutgoingCall() = apply {
-            every { callRepository.getCallMetadataProfile() }
-                .returns(
-                    CallMetadataProfile(
-                        mapOf(
-                            CONVERSATION_ID to callMetadata().copy(
-                                callStatus = CallStatus.STARTED
-                            )
-                        )
-                    )
-                )
+            every { callRepository.getCallMetadata(CONVERSATION_ID) }
+                .returns(callMetadata().copy(callStatus = CallStatus.STARTED))
         }
 
         fun withIncomingCall() = apply {
-            every { callRepository.getCallMetadataProfile() }
-                .returns(
-                    CallMetadataProfile(
-                        mapOf(
-                            CONVERSATION_ID to callMetadata().copy(
-                                callerId = CALLER_ID.copy(value = "external"),
-                                callStatus = CallStatus.INCOMING
-                            )
-                        )
-                    )
-                )
+            every { callRepository.getCallMetadata(CONVERSATION_ID) }
+                .returns(callMetadata().copy(callerId = CALLER_ID.copy(value = "external"), callStatus = CallStatus.INCOMING))
         }
 
         suspend fun withConversationMembers() = apply {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18303" title="WPB-18303" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18303</a>  [Android] Answered call shows “Connecting” indefinitely, despite call being active.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There's a race condition when updating call metadata at the same time (e.g. call status and participants list are usually updated at the same time) resulting in some updates being lost. 
There's one particular case when it's visible to the user by call being shown as connecting even though it's already established and working properly. It happens when call status update starts first but ends after participants update, then participants list is lost until the next update.

### Solutions

Update metadata atomically, provide `StateFlow`s for each call's metadata so that they can be updated simultaneously and observed independently if needed, update of one of them won't cause update of the whole map.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

- user A calls B 1:1
- user B answers
- the call becomes established so user A should not see it "connecting"

This issue is not reproducible each time, but it happens from time to time.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
