### PR TITLE
chore: allow calling fetch conversation from debug screen UI (WPB-19107)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/FetchConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/FetchConversationUseCase.kt
@@ -55,16 +55,6 @@ internal class FetchConversationUseCaseImpl(
             }
     }
 
-    override suspend fun fetchWithTransaction(conversationId: ConversationId): Either<CoreFailure, Unit> {
-        return transactionProvider.transaction { transaction ->
-            conversationRepository.fetchConversation(conversationId)
-                .flatMap {
-                    persistConversations(
-                        transaction,
-                        listOf(it),
-                        invalidateMembers = true
-                    )
-                }
-        }
-    }
+    override suspend fun fetchWithTransaction(conversationId: ConversationId): Either<CoreFailure, Unit> =
+        transactionProvider.transaction { invoke(it, conversationId) }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/FetchConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/FetchConversationUseCase.kt
@@ -21,6 +21,7 @@ import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
 import com.wire.kalium.cryptography.CryptoTransactionContext
+import com.wire.kalium.logic.data.client.CryptoTransactionProvider
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.util.ConversationPersistenceApi
 import io.mockative.Mockable
@@ -32,12 +33,15 @@ import io.mockative.Mockable
 @Mockable
 interface FetchConversationUseCase {
     suspend operator fun invoke(transactionContext: CryptoTransactionContext, conversationId: ConversationId): Either<CoreFailure, Unit>
+    suspend fun fetchWithTransaction(conversationId: ConversationId): Either<CoreFailure, Unit>
+
 }
 
 @OptIn(ConversationPersistenceApi::class)
 internal class FetchConversationUseCaseImpl(
     private val conversationRepository: ConversationRepository,
-    private val persistConversations: PersistConversationsUseCase
+    private val persistConversations: PersistConversationsUseCase,
+    private val transactionProvider: CryptoTransactionProvider,
 ) : FetchConversationUseCase {
 
     override suspend fun invoke(transactionContext: CryptoTransactionContext, conversationId: ConversationId): Either<CoreFailure, Unit> {
@@ -49,5 +53,18 @@ internal class FetchConversationUseCaseImpl(
                     invalidateMembers = true
                 )
             }
+    }
+
+    override suspend fun fetchWithTransaction(conversationId: ConversationId): Either<CoreFailure, Unit> {
+        return transactionProvider.transaction { transaction ->
+            conversationRepository.fetchConversation(conversationId)
+                .flatMap {
+                    persistConversations(
+                        transaction,
+                        listOf(it),
+                        invalidateMembers = true
+                    )
+                }
+        }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -941,10 +941,11 @@ class UserSessionScope internal constructor(
             persistConversations = persistConversationsUseCase
         )
 
-    private val fetchConversationUseCase: FetchConversationUseCase
+    val fetchConversationUseCase: FetchConversationUseCase
         get() = FetchConversationUseCaseImpl(
             conversationRepository = conversationRepository,
-            persistConversations = persistConversationsUseCase
+            persistConversations = persistConversationsUseCase,
+            transactionProvider = cryptoTransactionProvider,
         )
 
     private val fetchConversationIfUnknownUseCase: FetchConversationIfUnknownUseCase


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19107" title="WPB-19107" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-19107</a>  [Android] Adopt apiVersion 10 breaking changes  - Conversations endpoint
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

https://wearezeta.atlassian.net/browse/WPB-19138

# What's new in this PR?

Allow calling FetchConversationUseCase from conversation debug screen view model.