### PR TITLE
fix: wrong sender client id parsing [WPB-19122]

### DIFF
--- a/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/utils/CryptoMappers.kt
+++ b/cryptography/src/commonJvmAndroid/kotlin/com.wire.kalium.cryptography/utils/CryptoMappers.kt
@@ -148,7 +148,7 @@ fun com.wire.crypto.E2eiConversationState.toCryptography(): E2EIConversationStat
 fun DecryptedMessage.toBundle() = DecryptedMessageBundle(
     message,
     commitDelay,
-    senderClientId?.let { CryptoQualifiedClientId.fromEncodedString(it.value.encodeBase64()) },
+    senderClientId?.let { CryptoQualifiedClientId.fromEncodedString(it.value.decodeToString()) },
     hasEpochChanged,
     identity.toCryptography(),
     crlNewDistributionPoints?.value?.map { it.toString() }
@@ -157,7 +157,7 @@ fun DecryptedMessage.toBundle() = DecryptedMessageBundle(
 fun BufferedDecryptedMessage.toBundle() = DecryptedMessageBundle(
     message,
     commitDelay,
-    senderClientId?.let { CryptoQualifiedClientId.fromEncodedString(it.value.encodeBase64()) },
+    senderClientId?.let { CryptoQualifiedClientId.fromEncodedString(it.value.decodeToString()) },
     hasEpochChanged,
     identity.toCryptography(),
     crlNewDistributionPoints?.value?.map { it.toString() }

--- a/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/MLSClientTest.kt
+++ b/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/MLSClientTest.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -165,9 +166,11 @@ class MLSClientTest : BaseMLSClientTest() {
         val welcomeBundle = aliceClient.transaction { it.processWelcomeMessage(welcome) }
 
         val applicationMessage = aliceClient.transaction { it.encryptMessage(welcomeBundle.groupId, PLAIN_TEXT.encodeToByteArray()) }
-        val plainMessage = bobClient.transaction { it.decryptMessage(welcomeBundle.groupId, applicationMessage).first().message }
+        val bundle = bobClient.transaction { it.decryptMessage(welcomeBundle.groupId, applicationMessage).first() }
 
-        assertEquals(PLAIN_TEXT, plainMessage?.decodeToString())
+        assertNotNull(bundle.senderClientId)
+        assertEquals(PLAIN_TEXT, bundle.message?.decodeToString())
+
     }
 
     @Test


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19122" title="WPB-19122" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19122</a>  [Android] Decryption errors in 1:1 conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
- fixed wrong sender clientId decoding causing null pointer exception and decryption errors