### PR TITLE
feat: mls conversation reset feature config (WPB-17704)

### DIFF
--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigModel.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigModel.kt
@@ -42,7 +42,8 @@ data class FeatureConfigModel(
     val e2EIModel: E2EIModel,
     val mlsMigrationModel: MLSMigrationModel?,
     val channelsModel: ChannelFeatureConfiguration,
-    val consumableNotificationsModel: ConfigsStatusModel?
+    val consumableNotificationsModel: ConfigsStatusModel?,
+    val allowedGlobalOperationsModel: AllowedGlobalOperationsModel?,
 )
 
 enum class Status {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
@@ -71,7 +71,8 @@ class FeatureConfigMapperImpl : FeatureConfigMapper {
                 e2EIModel = fromDTO(mlsE2EI),
                 mlsMigrationModel = mlsMigration?.let { fromDTO(it) },
                 channelsModel = fromDTO(channels),
-                consumableNotificationsModel = consumableNotifications?.let { ConfigsStatusModel(fromDTO(it.status)) }
+                consumableNotificationsModel = consumableNotifications?.let { ConfigsStatusModel(fromDTO(it.status)) },
+                allowedGlobalOperationsModel = allowedGlobalOperations?.let { fromDTO(it) },
             )
         }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -2341,7 +2341,8 @@ class UserSessionScope internal constructor(
             e2eiConfigHandler,
             appLockConfigHandler,
             channels.channelsFeatureConfigHandler,
-            consumableNotificationsConfigHandler
+            consumableNotificationsConfigHandler,
+            allowedGlobalOperationsHandler,
         )
 
     val team: TeamScope

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCase.kt
@@ -37,6 +37,7 @@ import com.wire.kalium.logic.feature.featureConfig.handler.MLSConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.MLSMigrationConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.SecondFactorPasswordChallengeConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.SelfDeletingMessagesConfigHandler
+import com.wire.kalium.logic.sync.receiver.handler.AllowedGlobalOperationsHandler
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.exceptions.isNoTeam
 import io.mockative.Mockable
@@ -64,7 +65,8 @@ internal class SyncFeatureConfigsUseCaseImpl(
     private val e2EIConfigHandler: E2EIConfigHandler,
     private val appLockConfigHandler: AppLockConfigHandler,
     private val channelsConfigHandler: ChannelsFeatureConfigurationHandler,
-    private val consumableNotificationsConfigHandler: ConsumableNotificationsConfigHandler
+    private val consumableNotificationsConfigHandler: ConsumableNotificationsConfigHandler,
+    private val allowedGlobalOperationsHandler: AllowedGlobalOperationsHandler,
 ) : SyncFeatureConfigsUseCase {
     override suspend operator fun invoke(): Either<CoreFailure, Unit> =
         featureConfigRepository.getFeatureConfigs().flatMap { it ->
@@ -85,6 +87,7 @@ internal class SyncFeatureConfigsUseCaseImpl(
                     consumableNotificationsModel
                 )
             }
+            it.allowedGlobalOperationsModel?.let { model -> allowedGlobalOperationsHandler.handle(model) }
             Either.Right(Unit)
         }.onFailure { networkFailure ->
             if (

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/AllowedGlobalOperationsHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/AllowedGlobalOperationsHandler.kt
@@ -21,10 +21,15 @@ import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.featureConfig.AllowedGlobalOperationsModel
+import com.wire.kalium.logic.data.featureConfig.Status
 
 class AllowedGlobalOperationsHandler(
     private val userConfigRepository: UserConfigRepository
 ) {
     suspend fun handle(model: AllowedGlobalOperationsModel): Either<CoreFailure, Unit> =
-        userConfigRepository.setMlsConversationsResetEnabled(model.mlsConversationsReset)
+        if (model.status == Status.ENABLED) {
+            userConfigRepository.setMlsConversationsResetEnabled(model.mlsConversationsReset)
+        } else {
+            userConfigRepository.setMlsConversationsResetEnabled(false)
+        }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigRepositoryTest.kt
@@ -90,7 +90,11 @@ class FeatureConfigRepositoryTest {
                 Status.ENABLED
             ),
             channelsModel = ChannelFeatureConfiguration.Disabled,
-            consumableNotificationsModel = ConfigsStatusModel(Status.DISABLED)
+            consumableNotificationsModel = ConfigsStatusModel(Status.DISABLED),
+            allowedGlobalOperationsModel = AllowedGlobalOperationsModel(
+                status = Status.DISABLED,
+                mlsConversationsReset = false,
+            )
         )
 
         val expectedSuccess = Either.Right(featureConfigModel)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigTest.kt
@@ -56,7 +56,11 @@ object FeatureConfigTest {
             Status.ENABLED
         ),
         channelFeatureConfiguration: ChannelFeatureConfiguration = ChannelFeatureConfiguration.Disabled,
-        asyncNotificationsModel: ConfigsStatusModel? = ConfigsStatusModel(Status.ENABLED)
+        asyncNotificationsModel: ConfigsStatusModel? = ConfigsStatusModel(Status.ENABLED),
+        allowedGlobalOperationsModel: AllowedGlobalOperationsModel? = AllowedGlobalOperationsModel(
+            status = Status.ENABLED,
+            mlsConversationsReset = false,
+        ),
     ): FeatureConfigModel = FeatureConfigModel(
         appLockModel,
         classifiedDomainsModel,
@@ -75,6 +79,7 @@ object FeatureConfigTest {
         e2EIModel,
         mlsMigrationModel,
         channelFeatureConfiguration,
-        asyncNotificationsModel
+        asyncNotificationsModel,
+        allowedGlobalOperationsModel,
     )
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCaseTest.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.logic.configuration.FileSharingStatus
 import com.wire.kalium.logic.configuration.GuestRoomLinkStatus
 import com.wire.kalium.logic.configuration.UserConfigDataSource
 import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.data.featureConfig.AllowedGlobalOperationsModel
 import com.wire.kalium.logic.data.featureConfig.ChannelFeatureConfiguration
 import com.wire.kalium.logic.data.featureConfig.ConferenceCallingModel
 import com.wire.kalium.logic.data.featureConfig.ConfigsStatusModel
@@ -54,6 +55,7 @@ import com.wire.kalium.logic.feature.user.UpdateSupportedProtocolsAndResolveOneO
 import com.wire.kalium.logic.featureFlags.BuildFileRestrictionState
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.sync.receiver.handler.AllowedGlobalOperationsHandler
 import com.wire.kalium.logic.test_util.TestNetworkException
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
@@ -741,6 +743,64 @@ class SyncFeatureConfigsUseCaseTest {
         }.wasNotInvoked()
     }
 
+    @Test
+    fun givenMlsConversationResetIsEnabled_whenSyncing_thenItShouldBeStoredCorrectlyAsEnabled() = runTest {
+        val (arrangement, syncFeatureConfigsUseCase) = arrangement()
+            .withRemoteFeatureConfigsSucceeding(
+                FeatureConfigTest.newModel(
+                    allowedGlobalOperationsModel = AllowedGlobalOperationsModel(
+                        mlsConversationsReset = true,
+                        status = Status.ENABLED,
+                    )
+                )
+            )
+            .withGetSupportedProtocolsReturning(null)
+            .arrange()
+
+        syncFeatureConfigsUseCase()
+
+        coVerify {
+            arrangement.userConfigDAO.setMlsConversationsResetEnabled(eq(true))
+        }
+    }
+
+    @Test
+    fun givenMlsConversationResetIsDisabled_whenSyncing_thenItShouldBeStoredCorrectlyAsDisabled() = runTest {
+        val (arrangement, syncFeatureConfigsUseCase) = arrangement()
+            .withRemoteFeatureConfigsSucceeding(
+                FeatureConfigTest.newModel(
+                    allowedGlobalOperationsModel = AllowedGlobalOperationsModel(
+                        mlsConversationsReset = true,
+                        status = Status.DISABLED,
+                    )
+                )
+            )
+            .withGetSupportedProtocolsReturning(null)
+            .arrange()
+
+        syncFeatureConfigsUseCase()
+
+        coVerify {
+            arrangement.userConfigDAO.setMlsConversationsResetEnabled(eq(false))
+        }
+    }
+
+    @Test
+    fun givenMlsConversationResetNotPresent_whenSyncing_thenItShouldNotBeCalled() = runTest {
+        val (arrangement, syncFeatureConfigsUseCase) = arrangement()
+            .withRemoteFeatureConfigsSucceeding(
+                FeatureConfigTest.newModel(allowedGlobalOperationsModel = null)
+            )
+            .withGetSupportedProtocolsReturning(null)
+            .arrange()
+
+        syncFeatureConfigsUseCase()
+
+        coVerify {
+            arrangement.userConfigDAO.setMlsConversationsResetEnabled(any())
+        }.wasNotInvoked()
+    }
+
     @OptIn(ExperimentalStdlibApi::class)
     private fun TestScope.arrangement() = Arrangement(coroutineContext[CoroutineDispatcher]!! as TestDispatcher)
 
@@ -849,7 +909,8 @@ class SyncFeatureConfigsUseCaseTest {
                 E2EIConfigHandler(userConfigRepository),
                 AppLockConfigHandler(userConfigRepository),
                 ChannelsFeatureConfigurationHandler(channelsConfigurationStorage),
-                ConsumableNotificationsConfigHandler(userConfigRepository)
+                ConsumableNotificationsConfigHandler(userConfigRepository),
+                AllowedGlobalOperationsHandler(userConfigRepository),
             )
             return this to syncFeatureConfigsUseCase
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17704" title="WPB-17704" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17704</a>  [Android] Reset broken MLS conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-17704
# What's new in this PR?

Previously the handler for the new allowedGlobalOperations feature config was only used for FeatureConfig event.

- Added handling of the allowedGlobalOperations config for feature-configs API response
- Added feature status handling
- Updated unit tests