### PR TITLE
fix: handle mls reset event from self (WPB-17704)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1727,6 +1727,7 @@ class UserSessionScope internal constructor(
         get() = MLSResetConversationEventHandlerImpl(
             selfUserId = userId,
             userConfig = userConfigRepository,
+            conversationRepository = conversationRepository,
             mlsConversationRepository = mlsConversationRepository,
             fetchConversation = fetchConversationUseCase,
         )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17704" title="WPB-17704" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17704</a>  [Android] Reset broken MLS conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

https://wearezeta.atlassian.net/browse/WPB-17704

# What's new in this PR?

### Issues
MlsReset event comes to all conversation participants including the user who initiated the reset. Need to avoid resetting conversation twice on the same client.

### Solutions
If event comes from same user check if group id was already updated which means that this client initiated the conversation reset.
