### PR TITLE
fix: user availability status [WPB-18697]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -76,6 +76,7 @@ import com.wire.kalium.persistence.dao.UserDAO
 import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.dao.UserTypeEntity
 import com.wire.kalium.persistence.dao.client.ClientDAO
+import com.wire.kalium.persistence.dao.member.MemberDAO
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
@@ -163,6 +164,7 @@ interface UserRepository {
 internal class UserDataSource internal constructor(
     private val userDAO: UserDAO,
     private val clientDAO: ClientDAO,
+    private val memberDAO: MemberDAO,
     private val selfApi: SelfApi,
     private val userDetailsApi: UserDetailsApi,
     private val upgradePersonalToTeamApi: UpgradePersonalToTeamApi,
@@ -508,15 +510,28 @@ internal class UserDataSource internal constructor(
                 wrapStorageRequest { userDAO.getAllUsersDetailsByTeam(selfTeamId).map { it.id.toModel() } }
             }?.getOrNull() ?: listOf()
 
+            val allUsersWithConversations = memberDAO.getAllMembers().map { it.toModel() }
+
             wrapStorageRequest {
                 memberMapper.fromMapOfClientsEntityToRecipients(clientDAO.selectAllClients())
             }.map { allRecipients ->
                 val teamRecipients = mutableListOf<Recipient>()
                 val otherRecipients = mutableListOf<Recipient>()
+
                 allRecipients.forEach {
                     if (teamMateIds.contains(it.id)) teamRecipients.add(it)
                     else otherRecipients.add(it)
                 }
+
+                val allRecipientsIds = allRecipients.mapTo(mutableSetOf()) { it.id }
+
+                // Ensure we add all users in the list even if they do not have a client id stored locally.
+                otherRecipients.addAll(
+                    allUsersWithConversations
+                        .filterNot { allRecipientsIds.contains(it) }
+                        .map { Recipient(it, emptyList()) }
+                )
+
                 teamRecipients.toList() to otherRecipients.toList()
             }
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -818,6 +818,7 @@ class UserSessionScope internal constructor(
         get() = UserDataSource(
             userDAO = userStorage.database.userDAO,
             clientDAO = userStorage.database.clientDAO,
+            memberDAO = userStorage.database.memberDAO,
             selfApi = authenticatedNetworkContainer.selfApi,
             userDetailsApi = authenticatedNetworkContainer.userDetailsApi,
             upgradePersonalToTeamApi = authenticatedNetworkContainer.upgradePersonalToTeamApi,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSender.kt
@@ -63,7 +63,6 @@ import com.wire.kalium.util.DateTimeUtil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Instant
-import kotlin.math.max
 
 /**
  * Responsible for orchestrating all the pieces necessary
@@ -532,30 +531,22 @@ internal class MessageSenderImpl internal constructor(
         teamRecipients: List<Recipient>,
         otherRecipients: List<Recipient>
     ): Pair<BroadcastMessageOption, List<Recipient>> {
-        val receivers = mutableListOf<Recipient>()
-        val filteredOut = mutableSetOf<UserId>()
-        var selfRecipient: Recipient? = null
 
-        teamRecipients.forEach {
-            when {
-                it.id == selfUserId ->
-                    selfRecipient =
-                        it.copy(clients = it.clients.filter { clientId -> clientId != selfClientId })
-
-                receivers.size < (target.limit - 1) -> receivers.add(it)
-                else -> filteredOut.add(it.id)
+        val broadcastRecipients = when (target) {
+            is BroadcastMessageTarget.AllUsers -> teamRecipients + otherRecipients
+            is BroadcastMessageTarget.OnlyTeam -> teamRecipients
+        }
+            .toSet()
+            .map { recipient ->
+                if (recipient.id == selfUserId) {
+                    recipient.copy(clients = recipient.clients.filter { it != selfClientId })
+                } else {
+                    recipient
+                }
             }
-        }
-        selfRecipient?.let { receivers.add(it) }
+            .take(target.limit)
 
-        val spaceLeftTillMax = when (target) {
-            is BroadcastMessageTarget.AllUsers -> max(target.limit - receivers.size, 0)
-            is BroadcastMessageTarget.OnlyTeam -> 0
-        }
-        receivers.addAll(otherRecipients.take(spaceLeftTillMax))
-        filteredOut.addAll(otherRecipients.takeLast(max(otherRecipients.size - spaceLeftTillMax, 0)).map { it.id })
-
-        return BroadcastMessageOption.ReportSome(filteredOut.toList()) to receivers
+        return BroadcastMessageOption.ReportSome(broadcastRecipients.map { it.id }) to broadcastRecipients
     }
 
     /**

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/user/UserRepositoryTest.kt
@@ -65,6 +65,7 @@ import com.wire.kalium.persistence.dao.UserEntityMinimized
 import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.dao.UserTypeEntity
 import com.wire.kalium.persistence.dao.client.ClientDAO
+import com.wire.kalium.persistence.dao.member.MemberDAO
 import io.ktor.http.HttpStatusCode
 import io.mockative.Mock
 import io.mockative.any
@@ -714,6 +715,9 @@ class UserRepositoryTest {
         val clientDAO = mock(ClientDAO::class)
 
         @Mock
+        val memberDAO = mock(MemberDAO::class)
+
+        @Mock
         val selfApi = mock(SelfApi::class)
 
         @Mock
@@ -741,6 +745,7 @@ class UserRepositoryTest {
             UserDataSource(
                 userDAO = userDAO,
                 clientDAO = clientDAO,
+                memberDAO = memberDAO,
                 selfApi = selfApi,
                 userDetailsApi = userDetailsApi,
                 teamsApi = teamsApi,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
@@ -633,7 +633,10 @@ class MessageSenderTest {
             isSelfMessage = false
         )
 
-        val option = BroadcastMessageOption.ReportSome(listOf())
+        val option = BroadcastMessageOption.ReportSome(listOf(
+            Arrangement.TEST_RECIPIENT_1.id,
+            Arrangement.TEST_RECIPIENT_2.id
+        ))
 
         arrangement.testScope.runTest {
             // when
@@ -691,7 +694,7 @@ class MessageSenderTest {
             isSelfMessage = false
         )
 
-        val option = BroadcastMessageOption.ReportSome(listOf(Arrangement.TEST_MEMBER_3, Arrangement.TEST_MEMBER_1))
+        val option = BroadcastMessageOption.ReportSome(listOf(Arrangement.TEST_MEMBER_2, Arrangement.TEST_MEMBER_3))
 
         arrangement.testScope.runTest {
             // when
@@ -742,7 +745,7 @@ class MessageSenderTest {
             isSelfMessage = false
         )
 
-        val option = BroadcastMessageOption.ReportSome(listOf(Arrangement.TEST_MEMBER_1, Arrangement.TEST_MEMBER_3))
+        val option = BroadcastMessageOption.ReportSome(listOf(Arrangement.TEST_RECIPIENT_2.id, senderUserId))
 
         arrangement.testScope.runTest {
             // when

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Members.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Members.sq
@@ -40,6 +40,9 @@ DELETE FROM Member WHERE conversation = :conversationId AND user IN :userIds;
 deleteMembersFromConversation:
 DELETE FROM Member WHERE conversation = ?;
 
+selectAllMembers:
+SELECT * FROM Member;
+
 selectAllMembersByConversation:
 SELECT * FROM Member WHERE conversation = :conversation;
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/member/MemberDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/member/MemberDAO.kt
@@ -67,6 +67,8 @@ interface MemberDAO {
 
     suspend fun getOneOneConversationWithFederatedMembers(domain: String): Map<ConversationIDEntity, UserIDEntity>
     suspend fun selectMembersNameAndHandle(conversationId: QualifiedIDEntity): Map<QualifiedIDEntity, NameAndHandleEntity>
+
+    suspend fun getAllMembers(): List<UserIDEntity>
 }
 
 @Suppress("TooManyFunctions")
@@ -227,5 +229,11 @@ internal class MemberDAOImpl internal constructor(
     override suspend fun selectMembersNameAndHandle(conversationId: QualifiedIDEntity) = withContext(coroutineContext) {
         memberQueries.selectMembersNamesAndHandle(conversationId).executeAsList()
             .let { members -> members.associate { it.user to NameAndHandleEntity(it.name, it.handle) } }
+    }
+
+    override suspend fun getAllMembers(): List<UserIDEntity> = withContext(coroutineContext) {
+        memberQueries.selectAllMembers()
+            .executeAsList()
+            .map { it.user }
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18697" title="WPB-18697" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18697</a>  [Android] Status not sent to other clients
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

https://wearezeta.atlassian.net/browse/WPB-18697

# What's new in this PR?

### Issues
User availability status is not sent to other users.

### Causes (Optional)
When sending status update via Proteus broadcast message app is using `report_only` strategy to discover missing clients but not preparing correct list of recipient user ids.

### Solutions
1. When preparing a list of all recipients of a broadcast message we need to include all users that have conversation with current user.
2. When setting up broadcast message app must add user ids of all recipients to the `report_only` strategy to receive 412 error message when some clients are missing.

### Documentation
https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/106660748/Use+case+setting+the+status+Proteus
https://staging-nginz-https.zinfra.io/v10/api/swagger-ui/#/default/post-proteus-broadcast