### PR TITLE
feat: support receiving composite message edition (WPB-19100)

### DIFF
--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
@@ -31,7 +31,6 @@ import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlin.time.Duration
 
@@ -257,6 +256,10 @@ sealed interface Message {
                     typeKey to "inCallEmoji",
                     "content" to content.emojis
                 )
+
+                is MessageContent.CompositeEdited -> mutableMapOf(
+                    typeKey to "compositeEdited"
+                )
             }
 
             val standardProperties = mapOf(
@@ -385,15 +388,18 @@ sealed interface Message {
                 MessageContent.LegalHold.ForConversation.Disabled -> mutableMapOf(
                     typeKey to "legalHoldDisabledForConversation"
                 )
+
                 MessageContent.LegalHold.ForConversation.Enabled -> mutableMapOf(
                     typeKey to "legalHoldEnabledForConversation"
                 )
+
                 is MessageContent.LegalHold.ForMembers.Disabled -> mutableMapOf(
                     typeKey to "legalHoldDisabledForMembers",
                     "members" to content.members.fold("") { acc, member ->
                         "$acc, ${member.value.obfuscateId()}@${member.domain.obfuscateDomain()}"
                     }
                 )
+
                 is MessageContent.LegalHold.ForMembers.Enabled -> mutableMapOf(
                     typeKey to "legalHoldEnabledForMembers",
                     "members" to content.members.fold("") { acc, member ->

--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.MessageButtonId
 import com.wire.kalium.logic.data.id.MessageId
+import com.wire.kalium.logic.data.message.composite.Button
 import com.wire.kalium.logic.data.message.linkpreview.MessageLinkPreview
 import com.wire.kalium.logic.data.message.mention.MessageMention
 import com.wire.kalium.logic.data.message.receipt.ReceiptType
@@ -201,18 +202,18 @@ sealed interface MessageContent {
         val newMentions: List<MessageMention> = listOf()
     ) : Signaling
 
+    data class CompositeEdited(
+        val editMessageId: String,
+        val newTextContent: Text? = null,
+        val newButtonList: List<Button> = listOf()
+    ) : Signaling
+
     data class Knock(val hotKnock: Boolean) : Regular()
 
     data class Composite(
         val textContent: Text?,
         val buttonList: List<Button>
-    ) : Regular() {
-        data class Button(
-            val text: String,
-            val id: String,
-            val isSelected: Boolean
-        )
-    }
+    ) : Regular()
 
     /**
      * Notifies the author of a [Composite] message that a user has
@@ -476,6 +477,7 @@ fun MessageContent?.getType() = when (this) {
     is MessageContent.DataTransfer -> "DataTransfer"
     is MessageContent.InCallEmoji -> "InCallEmoji"
     is MessageContent.Multipart -> "Multipart"
+    is MessageContent.CompositeEdited -> "CompositeEdited"
     null -> "null"
 }
 

--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContentLogging.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContentLogging.kt
@@ -43,4 +43,5 @@ inline fun MessageContent.FromProto.typeDescription(): String = when (this) {
     is MessageContent.DataTransfer -> "DataTransfer"
     is MessageContent.InCallEmoji -> "InCallEmoji"
     is MessageContent.Multipart -> "Multipart"
+    is MessageContent.CompositeEdited -> "CompositeEdited"
 }

--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/composite/Button.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/composite/Button.kt
@@ -25,3 +25,5 @@ data class Button(
     val id: String,
     val isSelected: Boolean
 )
+
+typealias CompositeButton = Button

--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/composite/Button.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/composite/Button.kt
@@ -1,0 +1,27 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.message.composite
+
+/**
+ * Represents a button in a composite message.
+ */
+data class Button(
+    val text: String,
+    val id: String,
+    val isSelected: Boolean
+)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.logic.data.message.AssetContent.AssetMetadata.Image
 import com.wire.kalium.logic.data.message.AssetContent.AssetMetadata.Video
 import com.wire.kalium.logic.data.message.attachment.MessageAttachmentMapper
 import com.wire.kalium.logic.data.message.attachment.toModel
+import com.wire.kalium.logic.data.message.composite.Button
 import com.wire.kalium.logic.data.message.linkpreview.LinkPreviewMapper
 import com.wire.kalium.logic.data.message.mention.MessageMentionMapper
 import com.wire.kalium.logic.data.message.mention.toModel
@@ -646,7 +647,7 @@ fun MessageEntityContent.Regular.toMessageContent(hidden: Boolean, selfUserId: U
     is MessageEntityContent.Composite -> MessageContent.Composite(
         this.text?.toMessageContent(hidden, selfUserId) as? MessageContent.Text,
         this.buttonList.map {
-            MessageContent.Composite.Button(
+            Button(
                 text = it.text,
                 id = it.id,
                 isSelected = it.isSelected

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/PersistMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/PersistMessageUseCase.kt
@@ -87,6 +87,7 @@ internal class PersistMessageUseCaseImpl(
             is MessageContent.Knock -> true
             is MessageContent.DeleteMessage -> false
             is MessageContent.TextEdited -> false
+            is MessageContent.CompositeEdited -> false
             is MessageContent.RestrictedAsset -> true
             is MessageContent.DeleteForMe -> false
             is MessageContent.Unknown -> false
@@ -148,6 +149,7 @@ internal class PersistMessageUseCaseImpl(
             is MessageContent.Calling,
             is MessageContent.DeleteMessage,
             is MessageContent.TextEdited,
+            is MessageContent.CompositeEdited,
             is MessageContent.DeleteForMe,
             is MessageContent.Unknown,
             is MessageContent.Availability,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.data.asset.toProto
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.IdMapper
+import com.wire.kalium.logic.data.message.composite.CompositeButton
 import com.wire.kalium.logic.data.message.linkpreview.LinkPreviewMapper
 import com.wire.kalium.logic.data.message.mention.MessageMentionMapper
 import com.wire.kalium.logic.data.message.receipt.ReceiptType
@@ -727,7 +728,7 @@ class ProtoContentMapperImpl(
         )
     }
 
-    private fun packButtonList(buttonList: List<com.wire.kalium.logic.data.message.composite.Button>): List<Composite.Item> =
+    private fun packButtonList(buttonList: List<CompositeButton>): List<Composite.Item> =
         buttonList.map {
             Composite.Item(
                 Composite.Item.Content.Button(
@@ -751,10 +752,10 @@ class ProtoContentMapperImpl(
         quotedMessageDetails = null
     )
 
-    private fun unpackButtonList(compositeItemList: List<Composite.Item>): List<com.wire.kalium.logic.data.message.composite.Button> =
+    private fun unpackButtonList(compositeItemList: List<Composite.Item>): List<CompositeButton> =
         compositeItemList.mapNotNull {
             it.button?.let { button ->
-                com.wire.kalium.logic.data.message.composite.Button(
+                CompositeButton(
                     text = button.text,
                     id = button.id,
                     isSelected = false

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1587,7 +1587,7 @@ class UserSessionScope internal constructor(
             dataTransferEventHandler,
             inCallReactionsRepository,
             buttonActionHandler,
-            MessageCompositeEditHandlerImpl(messageRepository, compositeMessageRepository, NotificationEventsManagerImpl),
+            MessageCompositeEditHandlerImpl(messageRepository),
             userId
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -279,9 +279,9 @@ import com.wire.kalium.logic.feature.e2ei.usecase.ObserveE2EIConversationsVerifi
 import com.wire.kalium.logic.feature.featureConfig.SyncFeatureConfigsUseCase
 import com.wire.kalium.logic.feature.featureConfig.SyncFeatureConfigsUseCaseImpl
 import com.wire.kalium.logic.feature.featureConfig.handler.AppLockConfigHandler
-import com.wire.kalium.logic.feature.featureConfig.handler.ConsumableNotificationsConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.ClassifiedDomainsConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.ConferenceCallingConfigHandler
+import com.wire.kalium.logic.feature.featureConfig.handler.ConsumableNotificationsConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.E2EIConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.FileSharingConfigHandler
 import com.wire.kalium.logic.feature.featureConfig.handler.GuestRoomConfigHandler
@@ -483,6 +483,7 @@ import com.wire.kalium.logic.sync.receiver.handler.DataTransferEventHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.DeleteForMeHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.DeleteMessageHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.LastReadContentHandlerImpl
+import com.wire.kalium.logic.sync.receiver.handler.MessageCompositeEditHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.MessageTextEditHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.ReceiptMessageHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.TypingIndicatorHandler
@@ -1586,7 +1587,8 @@ class UserSessionScope internal constructor(
             dataTransferEventHandler,
             inCallReactionsRepository,
             buttonActionHandler,
-            userId,
+            MessageCompositeEditHandlerImpl(messageRepository, compositeMessageRepository, NotificationEventsManagerImpl),
+            userId
         )
 
     private val staleEpochVerifier: StaleEpochVerifier

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/composite/SendButtonMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/composite/SendButtonMessageUseCase.kt
@@ -19,21 +19,22 @@ package com.wire.kalium.logic.feature.message.composite
 
 import com.benasher44.uuid.uuid4
 import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
+import com.wire.kalium.logic.data.message.composite.Button
 import com.wire.kalium.logic.data.message.mention.MessageMention
 import com.wire.kalium.logic.data.properties.UserPropertyRepository
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.feature.message.MessageSendFailureHandler
 import com.wire.kalium.logic.feature.message.MessageSender
-import com.wire.kalium.common.functional.Either
-import com.wire.kalium.common.functional.flatMap
-import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.CoroutineScope
@@ -85,7 +86,7 @@ class SendButtonMessageUseCase internal constructor(
                 }
             )
 
-            val transform: (String) -> MessageContent.Composite.Button = { MessageContent.Composite.Button(it, it, false) }
+            val transform: (String) -> Button = { Button(it, it, false) }
             val buttonContent = buttons.map(transform)
             val content = MessageContent.Composite(textContent, buttonContent)
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
@@ -172,7 +172,7 @@ internal class ApplicationMessageHandlerImpl(
         }
     }
 
-    @Suppress("CyclomaticComplexMethod")
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
     private suspend fun processSignaling(transactionContext: CryptoTransactionContext, signaling: Message.Signaling) {
         when (val content = signaling.content) {
             MessageContent.Ignored -> {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
@@ -47,6 +47,7 @@ import com.wire.kalium.logic.sync.receiver.handler.DataTransferEventHandler
 import com.wire.kalium.logic.sync.receiver.handler.DeleteForMeHandler
 import com.wire.kalium.logic.sync.receiver.handler.DeleteMessageHandler
 import com.wire.kalium.logic.sync.receiver.handler.LastReadContentHandler
+import com.wire.kalium.logic.sync.receiver.handler.MessageCompositeEditHandler
 import com.wire.kalium.logic.sync.receiver.handler.MessageTextEditHandler
 import com.wire.kalium.logic.sync.receiver.handler.ReceiptMessageHandler
 import com.wire.kalium.logic.util.MessageContentEncoder
@@ -99,6 +100,7 @@ internal class ApplicationMessageHandlerImpl(
     private val dataTransferEventHandler: DataTransferEventHandler,
     private val inCallReactionsRepository: InCallReactionsRepository,
     private val buttonActionHandler: ButtonActionHandler,
+    private val messageCompositeEditHandler: MessageCompositeEditHandler,
     private val selfUserId: UserId,
 ) : ApplicationMessageHandler {
 
@@ -237,7 +239,7 @@ internal class ApplicationMessageHandlerImpl(
                 emojis = content.emojis.keys,
             )
 
-            is MessageContent.CompositeEdited -> TODO("ym handle this")
+            is MessageContent.CompositeEdited -> messageCompositeEditHandler.handle(signaling, content)
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
@@ -236,6 +236,8 @@ internal class ApplicationMessageHandlerImpl(
                 senderUserId = signaling.senderUserId,
                 emojis = content.emojis.keys,
             )
+
+            is MessageContent.CompositeEdited -> TODO("ym handle this")
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/MessageCompositeEditHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/MessageCompositeEditHandler.kt
@@ -23,11 +23,9 @@ import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
 import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.logger.obfuscateId
-import com.wire.kalium.logic.data.message.CompositeMessageRepository
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageRepository
-import com.wire.kalium.logic.data.notification.NotificationEventsManager
 
 internal interface MessageCompositeEditHandler {
     suspend fun handle(
@@ -37,9 +35,7 @@ internal interface MessageCompositeEditHandler {
 }
 
 internal class MessageCompositeEditHandlerImpl internal constructor(
-    private val messageRepository: MessageRepository,
-    private val compositeMessageRepository: CompositeMessageRepository,
-    private val notificationEventsManager: NotificationEventsManager,
+    private val messageRepository: MessageRepository
 ) : MessageCompositeEditHandler {
 
     override suspend fun handle(
@@ -57,19 +53,11 @@ internal class MessageCompositeEditHandlerImpl internal constructor(
                 return@flatMap Either.Left(StorageFailure.DataNotFound)
             }
 
-
-
-            // update text and buttons in composite messages
-            
-//         messageRepository.updateTextMessage(
-//             conversationId = message.conversationId,
-//             messageContent = messageContent.newTextContent, // this is edited type, change or support another function.
-//             newMessageId = message.id,
-//             editInstant = message.date
-//         )
-//         messageContent.newButtonList.firstNotNullOfOrNull { it. }
-
-            // update composite message content, ie. empty list of selected buttons remove text, ?remove message?
-            TODO("ym. implement me")
+            messageRepository.updateCompositeMessage(
+                conversationId = message.conversationId,
+                messageContent = messageContent,
+                newMessageId = message.id,
+                editInstant = message.date
+            )
         }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/MessageCompositeEditHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/MessageCompositeEditHandler.kt
@@ -1,0 +1,75 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.receiver.handler
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.common.logger.kaliumLogger
+import com.wire.kalium.logger.obfuscateId
+import com.wire.kalium.logic.data.message.CompositeMessageRepository
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.data.notification.NotificationEventsManager
+
+internal interface MessageCompositeEditHandler {
+    suspend fun handle(
+        message: Message.Signaling,
+        messageContent: MessageContent.CompositeEdited
+    ): Either<CoreFailure, Unit>
+}
+
+internal class MessageCompositeEditHandlerImpl internal constructor(
+    private val messageRepository: MessageRepository,
+    private val compositeMessageRepository: CompositeMessageRepository,
+    private val notificationEventsManager: NotificationEventsManager,
+) : MessageCompositeEditHandler {
+
+    override suspend fun handle(
+        message: Message.Signaling,
+        messageContent: MessageContent.CompositeEdited
+    ): Either<CoreFailure, Unit> =
+        messageRepository.getMessageById(message.conversationId, messageContent.editMessageId).flatMap { currentMessage ->
+
+            if (currentMessage.senderUserId != message.senderUserId) {
+                val obfuscatedId = message.senderUserId.toString().obfuscateId()
+                kaliumLogger.w(
+                    message = "User '$obfuscatedId' attempted to edit a message from another user. Ignoring the edit completely"
+                )
+                // Same as message not found. _i.e._ not found for the original sender at least
+                return@flatMap Either.Left(StorageFailure.DataNotFound)
+            }
+
+
+
+            // update text and buttons in composite messages
+            
+//         messageRepository.updateTextMessage(
+//             conversationId = message.conversationId,
+//             messageContent = messageContent.newTextContent, // this is edited type, change or support another function.
+//             newMessageId = message.id,
+//             editInstant = message.date
+//         )
+//         messageContent.newButtonList.firstNotNullOfOrNull { it. }
+
+            // update composite message content, ie. empty list of selected buttons remove text, ?remove message?
+            TODO("ym. implement me")
+        }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/MessageCompositeEditHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/MessageCompositeEditHandler.kt
@@ -26,7 +26,9 @@ import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageRepository
+import io.mockative.Mockable
 
+@Mockable
 internal interface MessageCompositeEditHandler {
     suspend fun handle(
         message: Message.Signaling,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
@@ -216,11 +216,11 @@ class ProtoContentMapperTest {
     @Test
     fun givenEditedCompositeGenericMessage_whenMappingFromProtoData_thenTheReturnValueShouldHaveTheCorrectEditedMessageId() {
         val replacedMessageId = "replacedMessageId"
-        val textContent = MessageEdit.Content.Composite(Composite())
+        val compositeContent = MessageEdit.Content.Composite(Composite())
         val genericMessage = GenericMessage(
             messageId = TEST_MESSAGE_UUID,
             content = GenericMessage.Content.Edited(
-                MessageEdit(replacedMessageId, textContent)
+                MessageEdit(replacedMessageId, compositeContent)
             )
         )
         val protobufBlob = PlainMessageBlob(genericMessage.encodeToByteArray())
@@ -229,7 +229,7 @@ class ProtoContentMapperTest {
 
         assertIs<ProtoContent.Readable>(result)
         val content = result.messageContent
-        assertIs<MessageContent.TextEdited>(content)
+        assertIs<MessageContent.CompositeEdited>(content)
         assertEquals(replacedMessageId, content.editMessageId)
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
@@ -22,11 +22,13 @@ import com.wire.kalium.cryptography.utils.generateRandomAES256Key
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.IdMapperImpl
+import com.wire.kalium.logic.data.message.composite.Button
 import com.wire.kalium.logic.data.message.receipt.ReceiptType
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.protobuf.encodeToByteArray
 import com.wire.kalium.protobuf.messages.Asset
+import com.wire.kalium.protobuf.messages.Composite
 import com.wire.kalium.protobuf.messages.Confirmation
 import com.wire.kalium.protobuf.messages.GenericMessage
 import com.wire.kalium.protobuf.messages.GenericMessage.UnknownStrategy
@@ -212,6 +214,26 @@ class ProtoContentMapperTest {
     }
 
     @Test
+    fun givenEditedCompositeGenericMessage_whenMappingFromProtoData_thenTheReturnValueShouldHaveTheCorrectEditedMessageId() {
+        val replacedMessageId = "replacedMessageId"
+        val textContent = MessageEdit.Content.Composite(Composite())
+        val genericMessage = GenericMessage(
+            messageId = TEST_MESSAGE_UUID,
+            content = GenericMessage.Content.Edited(
+                MessageEdit(replacedMessageId, textContent)
+            )
+        )
+        val protobufBlob = PlainMessageBlob(genericMessage.encodeToByteArray())
+
+        val result = protoContentMapper.decodeFromProtobuf(protobufBlob)
+
+        assertIs<ProtoContent.Readable>(result)
+        val content = result.messageContent
+        assertIs<MessageContent.TextEdited>(content)
+        assertEquals(replacedMessageId, content.editMessageId)
+    }
+
+    @Test
     fun givenEditedTextGenericMessage_whenMappingFromProtoData_thenTheReturnValueShouldHaveTheCorrectUpdatedContent() {
         val replacedMessageId = "replacedMessageId"
         val textContent = MessageEdit.Content.Text(Text("textContent"))
@@ -292,8 +314,8 @@ class ProtoContentMapperTest {
         val messageUid = "uid"
         val textContent = MessageContent.Text("Hello")
         val buttons = listOf(
-            MessageContent.Composite.Button("button1", "button1", false),
-            MessageContent.Composite.Button("button2", "button2", false)
+            Button("button1", "button1", false),
+            Button("button2", "button2", false)
         )
         val content = MessageContent.Composite(textContent, buttons)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapperTest.kt
@@ -216,7 +216,21 @@ class ProtoContentMapperTest {
     @Test
     fun givenEditedCompositeGenericMessage_whenMappingFromProtoData_thenTheReturnValueShouldHaveTheCorrectEditedMessageId() {
         val replacedMessageId = "replacedMessageId"
-        val compositeContent = MessageEdit.Content.Composite(Composite())
+        val compositeContent = MessageEdit.Content.Composite(
+            Composite(
+                listOf(
+                    Composite.Item(Composite.Item.Content.Text(Text("textContent"))),
+                    Composite.Item(
+                        Composite.Item.Content.Button(
+                            com.wire.kalium.protobuf.messages.Button(
+                                text = "button1",
+                                id = "button1",
+                            )
+                        )
+                    )
+                )
+            )
+        )
         val genericMessage = GenericMessage(
             messageId = TEST_MESSAGE_UUID,
             content = GenericMessage.Content.Edited(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/MessageCompositeEditHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/MessageCompositeEditHandlerTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.sync.receiver.handler
+
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.right
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.message.composite.Button
+import com.wire.kalium.logic.framework.TestMessage
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.util.arrangement.repository.MessageRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.repository.MessageRepositoryArrangementImpl
+import io.mockative.any
+import io.mockative.coEvery
+import io.mockative.coVerify
+import io.mockative.eq
+import io.mockative.once
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class MessageCompositeEditHandlerTest {
+
+    @Test
+    fun givenEditMatchesOriginalSender_whenHandling_thenShouldUpdateContentWithCorrectParameters() =
+        runTest {
+            val (arrangement, messageCompositeEditHandler) = arrange {
+                withGetMessageById(Either.Right(ORIGINAL_MESSAGE))
+                withEditCompositeMessage(Unit.right())
+            }
+
+            messageCompositeEditHandler.handle(
+                EDIT_MESSAGE.copy(senderUserId = ORIGINAL_SENDER_USER_ID),
+                EDIT_COMPOSITE_CONTENT
+            )
+
+            with(arrangement) {
+                coVerify {
+                    messageRepository.updateCompositeMessage(
+                        eq(EDIT_MESSAGE.conversationId),
+                        eq(EDIT_COMPOSITE_CONTENT),
+                        eq(EDIT_MESSAGE.id),
+                        eq(EDIT_MESSAGE.date)
+                    )
+                }.wasInvoked(exactly = once)
+            }
+        }
+
+    @Test
+    fun givenEditDoesNOTMatchesOriginalSender_whenHandling_thenShouldNOTUpdateContent() = runTest {
+        val (arrangement, messageCompositeEditHandler) = arrange {
+            withGetMessageById(Either.Right(ORIGINAL_MESSAGE))
+            withEditCompositeMessage(Unit.right())
+        }
+
+        messageCompositeEditHandler.handle(
+            EDIT_MESSAGE.copy(senderUserId = TestUser.OTHER_USER_ID),
+            EDIT_COMPOSITE_CONTENT
+        )
+
+        with(arrangement) {
+            coVerify {
+                messageRepository.updateCompositeMessage(any(), any(), any(), any())
+            }.wasNotInvoked()
+        }
+    }
+
+    private suspend fun arrange(block: suspend Arrangement.() -> Unit) =
+        Arrangement(block).arrange()
+
+    private class Arrangement(
+        private val block: suspend Arrangement.() -> Unit
+    ) : MessageRepositoryArrangement by MessageRepositoryArrangementImpl() {
+
+        suspend fun arrange() = block().run {
+            coEvery {
+                messageRepository.updateTextMessage(any(), any(), any(), any())
+            }.returns(Either.Right(Unit))
+            coEvery {
+                messageRepository.updateMessageStatus(any(), any(), any())
+            }.returns(Either.Right(Unit))
+            this@Arrangement to MessageCompositeEditHandlerImpl(
+                messageRepository = messageRepository,
+            )
+        }
+    }
+
+    private companion object {
+        val ORIGINAL_MESSAGE = TestMessage.TEXT_MESSAGE
+        val ORIGINAL_MESSAGE_ID = ORIGINAL_MESSAGE.id
+        val ORIGINAL_SENDER_USER_ID = ORIGINAL_MESSAGE.senderUserId
+
+        val EDIT_COMPOSITE_CONTENT = MessageContent.CompositeEdited(
+            editMessageId = ORIGINAL_MESSAGE_ID,
+            newTextContent = (ORIGINAL_MESSAGE.content as MessageContent.Text).copy(value = "edited content"),
+            newButtonList = listOf(Button("new added button", "new id", false))
+        )
+
+        val EDIT_MESSAGE = TestMessage.signalingMessage(
+            content = EDIT_COMPOSITE_CONTENT
+        )
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/MessageRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/MessageRepositoryArrangement.kt
@@ -19,12 +19,13 @@ package com.wire.kalium.logic.util.arrangement.repository
 
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.message.SystemMessageInserter
 import com.wire.kalium.logic.data.notification.LocalNotification
-import com.wire.kalium.common.functional.Either
 import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.fake.valueOf
@@ -63,6 +64,23 @@ internal interface MessageRepositoryArrangement {
         originalConversation: Matcher<ConversationId> = AnyMatcher(valueOf()),
         targetConversation: Matcher<ConversationId> = AnyMatcher(valueOf())
     )
+
+    suspend fun withEditCompositeMessage(
+        result: Either<StorageFailure, Unit>,
+        conversationId: Matcher<ConversationId> = AnyMatcher(valueOf()),
+        content: Matcher<MessageContent.CompositeEdited> = AnyMatcher(valueOf()),
+        messageId: Matcher<String> = AnyMatcher(valueOf()),
+        date: Matcher<Long> = AnyMatcher(valueOf())
+    ) {
+        coEvery {
+            messageRepository.updateCompositeMessage(
+                matches { conversationId.matches(it) },
+                matches { content.matches(it) },
+                matches { messageId.matches(it) },
+                matches { date.matches(it) }
+            )
+        }.returns(result)
+    }
 }
 
 internal open class MessageRepositoryArrangementImpl : MessageRepositoryArrangement {
@@ -124,6 +142,23 @@ internal open class MessageRepositoryArrangementImpl : MessageRepositoryArrangem
             messageRepository.moveMessagesToAnotherConversation(
                 matches { originalConversation.matches(it) },
                 matches { targetConversation.matches(it) }
+            )
+        }.returns(result)
+    }
+
+    override suspend fun withEditCompositeMessage(
+        result: Either<StorageFailure, Unit>,
+        conversationId: Matcher<ConversationId>,
+        content: Matcher<MessageContent.CompositeEdited>,
+        messageId: Matcher<String>,
+        date: Matcher<Long>
+    ) {
+        coEvery {
+            messageRepository.updateCompositeMessage(
+                matches { conversationId.matches(it) },
+                matches { content.matches(it) },
+                matches { messageId.matches(it) },
+                matches { date.matches(it) }
             )
         }.returns(result)
     }

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/content/ButtonContent.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/content/ButtonContent.sq
@@ -30,5 +30,8 @@ markSelected {
       id = :id;
 }
 
-remmoveAllSelection:
+removeAllSelection:
 UPDATE ButtonContent SET is_selected = 0 WHERE conversation_id = :conversation_id AND message_id = :message_id;
+
+deleteAllButtons:
+DELETE FROM ButtonContent WHERE conversation_id = :conversation_id AND message_id = :message_id;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/CompositeMessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/CompositeMessageDAO.kt
@@ -44,6 +44,6 @@ internal class CompositeMessageDAOImpl internal constructor(
     }
 
     override suspend fun resetSelection(messageId: String, conversationId: QualifiedIDEntity) = withContext(context) {
-        buttonContentQueries.remmoveAllSelection(conversation_id = conversationId, message_id = messageId)
+        buttonContentQueries.removeAllSelection(conversation_id = conversationId, message_id = messageId)
     }
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -175,4 +175,12 @@ interface MessageDAO {
     fun countMessagesForBackup(contentTypes: Collection<MessageEntity.ContentType>): Long
 
     suspend fun updateMessagesStatusIfNotRead(status: MessageEntity.Status, conversationId: QualifiedIDEntity, messageIds: List<String>)
+
+    suspend fun updateCompositeMessageContent(
+        conversationId: QualifiedIDEntity,
+        currentMessageId: String,
+        editInstant: Instant,
+        newCompositeContent: MessageEntityContent.Composite,
+        newMessageId: String
+    )
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -610,6 +610,9 @@ internal class MessageDAOImpl internal constructor(
         with(newCompositeContent) {
             // start a transaction for operations in message and button content tables.
             queries.transaction {
+                // delete all buttons for the current message
+                buttonContentQueries.deleteAllButtons(conversationId, currentMessageId)
+
                 // update the message content associated with the composite message
                 text?.let { textContent ->
                     updateTextMessageContentInDB(
@@ -620,9 +623,6 @@ internal class MessageDAOImpl internal constructor(
                         newMessageId = newMessageId
                     )
                 }
-
-                // delete all buttons for the current message
-                buttonContentQueries.deleteAllButtons(conversationId, currentMessageId)
 
                 // insert new buttons if any
                 buttonList.forEach { button ->

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -65,7 +65,7 @@ internal class MessageDAOImpl internal constructor(
     private val userQueries: UsersQueries,
     private val coroutineContext: CoroutineContext,
     private val assetStatusQueries: MessageAssetTransferStatusQueries,
-    buttonContentQueries: ButtonContentQueries
+    private val buttonContentQueries: ButtonContentQueries
 ) : MessageDAO,
     MessageInsertExtension by MessageInsertExtensionImpl(
         queries,
@@ -350,42 +350,62 @@ internal class MessageDAOImpl internal constructor(
         newMessageId: String
     ): Unit = withContext(coroutineContext) {
         queries.transaction {
-            queries.markMessageAsEdited(editInstant, currentMessageId, conversationId)
-            reactionsQueries.deleteAllReactionsForMessage(currentMessageId, conversationId)
-            queries.deleteMessageMentions(currentMessageId, conversationId)
-            queries.deleteMessageLinkPreviews(currentMessageId, conversationId)
-            queries.updateMessageTextContent(newTextContent.messageBody, currentMessageId, conversationId)
-            newTextContent.linkPreview.forEach {
-                queries.insertMessageLinkPreview(
-                    message_id = currentMessageId,
-                    conversation_id = conversationId,
-                    url = it.url,
-                    url_offset = it.urlOffset,
-                    permanent_url = it.permanentUrl,
-                    title = it.title,
-                    summary = it.summary
-                )
-            }
-            newTextContent.mentions.forEach {
-                queries.insertMessageMention(
-                    message_id = currentMessageId,
-                    conversation_id = conversationId,
-                    start = it.start,
-                    length = it.length,
-                    user_id = it.userId
-                )
-            }
-
-            val selfMention = newTextContent.mentions.firstOrNull { it.userId == selfUserId }
-            if (selfMention != null) {
-                unreadEventsQueries.updateEvent(UnreadEventTypeEntity.MENTION, currentMessageId, conversationId)
-            } else {
-                unreadEventsQueries.updateEvent(UnreadEventTypeEntity.MESSAGE, currentMessageId, conversationId)
-            }
-
-            queries.updateMessageId(newMessageId, currentMessageId, conversationId)
-            queries.updateQuotedMessageId(newMessageId, currentMessageId, conversationId)
+            updateTextMessageContentInDB(
+                editInstant = editInstant,
+                conversationId = conversationId,
+                currentMessageId = currentMessageId,
+                newTextContent = newTextContent,
+                newMessageId = newMessageId
+            )
         }
+    }
+
+    /**
+     * Be careful and run this operation in ONE wrapping transaction.
+     */
+    private fun updateTextMessageContentInDB(
+        editInstant: Instant,
+        conversationId: QualifiedIDEntity,
+        currentMessageId: String,
+        newTextContent: MessageEntityContent.Text,
+        newMessageId: String
+    ) {
+        // do not add withContext
+        queries.markMessageAsEdited(editInstant, currentMessageId, conversationId)
+        reactionsQueries.deleteAllReactionsForMessage(currentMessageId, conversationId)
+        queries.deleteMessageMentions(currentMessageId, conversationId)
+        queries.deleteMessageLinkPreviews(currentMessageId, conversationId)
+        queries.updateMessageTextContent(newTextContent.messageBody, currentMessageId, conversationId)
+        newTextContent.linkPreview.forEach {
+            queries.insertMessageLinkPreview(
+                message_id = currentMessageId,
+                conversation_id = conversationId,
+                url = it.url,
+                url_offset = it.urlOffset,
+                permanent_url = it.permanentUrl,
+                title = it.title,
+                summary = it.summary
+            )
+        }
+        newTextContent.mentions.forEach {
+            queries.insertMessageMention(
+                message_id = currentMessageId,
+                conversation_id = conversationId,
+                start = it.start,
+                length = it.length,
+                user_id = it.userId
+            )
+        }
+
+        val selfMention = newTextContent.mentions.firstOrNull { it.userId == selfUserId }
+        if (selfMention != null) {
+            unreadEventsQueries.updateEvent(UnreadEventTypeEntity.MENTION, currentMessageId, conversationId)
+        } else {
+            unreadEventsQueries.updateEvent(UnreadEventTypeEntity.MESSAGE, currentMessageId, conversationId)
+        }
+
+        queries.updateMessageId(newMessageId, currentMessageId, conversationId)
+        queries.updateQuotedMessageId(newMessageId, currentMessageId, conversationId)
     }
 
     override suspend fun updateLegalHoldMessageMembers(
@@ -579,6 +599,43 @@ internal class MessageDAOImpl internal constructor(
         offset = offset,
         mapper::toEntityMessageFromView
     ).executeAsList()
+
+    override suspend fun updateCompositeMessageContent(
+        conversationId: QualifiedIDEntity,
+        currentMessageId: String,
+        editInstant: Instant,
+        newCompositeContent: MessageEntityContent.Composite,
+        newMessageId: String
+    ) = withContext(coroutineContext) {
+        with(newCompositeContent) {
+            // start a transaction for operations in message and button content tables.
+            queries.transaction {
+                // update the message content associated with the composite message
+                text?.let { textContent ->
+                    updateTextMessageContentInDB(
+                        editInstant = editInstant,
+                        conversationId = conversationId,
+                        currentMessageId = currentMessageId,
+                        newTextContent = textContent,
+                        newMessageId = newMessageId
+                    )
+                }
+
+                // delete all buttons for the current message
+                buttonContentQueries.deleteAllButtons(conversationId, currentMessageId)
+
+                // insert new buttons if any
+                buttonList.forEach { button ->
+                    buttonContentQueries.insertButton(
+                        message_id = newMessageId,
+                        conversation_id = conversationId,
+                        id = button.id,
+                        text = button.text
+                    )
+                }
+            }
+        }
+    }
 
     override val platformExtensions: MessageExtensions = MessageExtensionsImpl(queries, assetViewQueries, mapper, coroutineContext)
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
@@ -164,7 +164,7 @@ class UserDatabaseBuilder internal constructor(
         MessageConversationLocationContentAdapter = TableMapper.messageConversationLocationContentAdapter,
         MessageLegalHoldContentAdapter = TableMapper.messageLegalHoldContentAdapter,
         MessageConversationProtocolChangedDuringACallContentAdapter =
-        TableMapper.messageConversationProtocolChangedDuringACAllContentAdapter,
+            TableMapper.messageConversationProtocolChangedDuringACAllContentAdapter,
         ConversationLegalHoldStatusChangeNotifiedAdapter = TableMapper.conversationLegalHoldStatusChangeNotifiedAdapter,
         MessageAssetTransferStatusAdapter = TableMapper.messageAssetTransferStatusAdapter,
         MessageDraftAdapter = TableMapper.messageDraftsAdapter,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19100" title="WPB-19100" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-19100</a>  [Android] Support editing a Composite message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

To support the work of new apps, there is a new case where apps/bots, can edit composite messages.

### Issues

Never supported in the app, just a `TODO()`

### Solutions

- Implement the logic to handle the `protobuf` mapping, and add all the persistence handling.
- Clients cannot modify, so it will continue to be unsupported, since clients cannot send composite messages.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

### Attachments (Optional)
[Screen_recording_20250807_105501.webm](https://github.com/user-attachments/assets/4b2b7f1d-f236-40de-a82e-4a14092f7b41)

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
