### PR TITLE
fix: duplicate tags (WPB-19375)

### DIFF
--- a/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/usecase/GetAllTagsUseCase.kt
+++ b/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/usecase/GetAllTagsUseCase.kt
@@ -20,17 +20,20 @@ package com.wire.kalium.cells.domain.usecase
 import com.wire.kalium.cells.domain.CellsRepository
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.map
 
 /**
  * Use case to retrieve all tags from the cells repository.
  */
 public interface GetAllTagsUseCase {
-    public suspend operator fun invoke(): Either<CoreFailure, List<String>>
+    public suspend operator fun invoke(): Either<CoreFailure, Set<String>>
 }
 
 internal class GetAllTagsUseCaseImpl(
     private val cellsRepository: CellsRepository,
 ) : GetAllTagsUseCase {
-    override suspend fun invoke(): Either<CoreFailure, List<String>> =
-        cellsRepository.getAllTags()
+    override suspend fun invoke(): Either<CoreFailure, Set<String>> =
+        cellsRepository.getAllTags().map {
+            it.map { tag -> tag.trim() }.toSet()
+        }
 }

--- a/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/usecase/UpdateNodeTagsUseCase.kt
+++ b/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/usecase/UpdateNodeTagsUseCase.kt
@@ -25,12 +25,12 @@ import com.wire.kalium.common.functional.Either
  * Use case to update the tags of a node in the cells repository.
  */
 public interface UpdateNodeTagsUseCase {
-    public suspend operator fun invoke(uuid: String, tags: List<String>): Either<CoreFailure, Unit>
+    public suspend operator fun invoke(uuid: String, tags: Set<String>): Either<CoreFailure, Unit>
 }
 
 internal class UpdateNodeTagsUseCaseImpl(
     private val cellsRepository: CellsRepository,
 ) : UpdateNodeTagsUseCase {
-    override suspend fun invoke(uuid: String, tags: List<String>): Either<CoreFailure, Unit> =
-        cellsRepository.updateNodeTags(uuid, tags)
+    override suspend fun invoke(uuid: String, tags: Set<String>): Either<CoreFailure, Unit> =
+        cellsRepository.updateNodeTags(uuid, tags.map { it.trim() })
 }

--- a/cells/src/commonTest/kotlin/com/wire/kalium/cells/domain/usecase/GetAllTagsUseCaseTest.kt
+++ b/cells/src/commonTest/kotlin/com/wire/kalium/cells/domain/usecase/GetAllTagsUseCaseTest.kt
@@ -34,9 +34,9 @@ class GetAllTagsUseCaseTest {
 
     @Test
     fun given_repository_returns_tagsWhen_invoke_is_calledThen_return_tags() = runTest {
-        val tags = listOf("tag1", "tag2", "tag3")
+        val tags = setOf("tag1", "tag2", "tag3")
         val (arrangement, useCase) = Arrangement()
-            .withRepositoryReturning(tags.right())
+            .withRepositoryReturning(tags.toList().right())
             .arrange()
 
         val result = useCase.invoke()

--- a/cells/src/commonTest/kotlin/com/wire/kalium/cells/domain/usecase/UpdateNodeTagsUseCaseTest.kt
+++ b/cells/src/commonTest/kotlin/com/wire/kalium/cells/domain/usecase/UpdateNodeTagsUseCaseTest.kt
@@ -36,7 +36,7 @@ class UpdateNodeTagsUseCaseTest {
     @Test
     fun given_repository_updates_tags_successfullyWhen_invoke_is_calledThen_return_Right_Unit() = runTest {
         val uuid = "node-123"
-        val tags = listOf("tag1", "tag2")
+        val tags = setOf("tag1", "tag2")
         val (arrangement, useCase) = Arrangement()
             .withRepositoryReturning(Unit.right())
             .arrange()
@@ -45,14 +45,14 @@ class UpdateNodeTagsUseCaseTest {
 
         assertEquals(Unit.right(), result)
         coVerify {
-            arrangement.cellsRepository.updateNodeTags(uuid, tags)
+            arrangement.cellsRepository.updateNodeTags(uuid, tags.toList())
         }.wasInvoked(once)
     }
 
     @Test
     fun given_repository_fails_to_update_tagsWhen_invoke_is_calledThen_return_Left_failure() = runTest {
         val uuid = "node-456"
-        val tags = listOf("tagA", "tagB")
+        val tags = setOf("tagA", "tagB")
         val failure = NetworkFailure.FeatureNotSupported
 
         val (arrangement, useCase) = Arrangement()
@@ -63,7 +63,7 @@ class UpdateNodeTagsUseCaseTest {
 
         assertEquals(failure.left(), result)
         coVerify {
-            arrangement.cellsRepository.updateNodeTags(uuid, tags)
+            arrangement.cellsRepository.updateNodeTags(uuid, tags.toList())
         }.wasInvoked(once)
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19375" title="WPB-19375" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19375</a>  [Android] Newly created tag appears duplicated in the suggested tags list
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-19375

# What's new in this PR?

### Issues
User can add duplicated tags.

### Causes
Empty spaces allow adding multiple tags with same name.

### Solutions
Use Set collections for tags, trim tag names.
