### PR TITLE
fix: backup error and performance (WPB-19481)

### DIFF
--- a/backup/src/commonMain/kotlin/com/wire/backup/dump/MPBackupExportValidation.kt
+++ b/backup/src/commonMain/kotlin/com/wire/backup/dump/MPBackupExportValidation.kt
@@ -27,18 +27,26 @@ import com.wire.backup.data.BackupUser
  *
  * @throws IllegalStateException if mandatory validation fails.
  */
-internal fun CommonMPBackupExporter.validate(user: BackupUser) {
-    if (user.id.id.isEmpty()) error("User ID cannot be empty")
-}
+internal fun CommonMPBackupExporter.validate(user: BackupUser): Boolean =
+    if (user.id.id.isEmpty()) {
+        logger?.log("User ID cannot be empty")
+        false
+    } else {
+        true
+    }
 
 /**
  * Validates the given [BackupConversation] and its content.
  *
  * @throws IllegalStateException if mandatory validation fails.
  */
-internal fun CommonMPBackupExporter.validate(conversation: BackupConversation) {
-    if (conversation.id.id.isEmpty()) error("Conversation ID cannot be empty")
-}
+internal fun CommonMPBackupExporter.validate(conversation: BackupConversation): Boolean =
+    if (conversation.id.id.isEmpty()) {
+        logger?.log("Conversation ID cannot be empty")
+        false
+    } else {
+        true
+    }
 
 /**
  * Validates the given [BackupMessage] and its content.
@@ -47,9 +55,18 @@ internal fun CommonMPBackupExporter.validate(conversation: BackupConversation) {
  * @throws IllegalStateException if mandatory validation fails.
  */
 internal fun CommonMPBackupExporter.validate(message: BackupMessage): Boolean = with(message) {
-    if (id.isEmpty()) error("Backup: Message ID cannot be empty")
-    if (conversationId.id.isEmpty()) error("Backup: Conversation ID cannot be empty")
-    if (senderUserId.id.isEmpty()) error("Backup: Sender ID cannot be empty")
+    if (id.isEmpty()) {
+        logger?.log("Backup: Message ID cannot be empty")
+        return@with false
+    }
+    if (conversationId.id.isEmpty()) {
+        logger?.log("Backup: Conversation ID cannot be empty")
+        return@with false
+    }
+    if (senderUserId.id.isEmpty()) {
+        logger?.log("Backup: Sender ID cannot be empty")
+        return@with false
+    }
 
     return@with validate(content)
 }
@@ -63,7 +80,10 @@ internal fun CommonMPBackupExporter.validate(message: BackupMessage): Boolean = 
 private fun CommonMPBackupExporter.validate(content: BackupMessageContent): Boolean = with(content) {
     when (this) {
         is BackupMessageContent.Text -> {
-            if (text.isEmpty()) error("Backup: Text content cannot be empty")
+            if (text.isEmpty()) {
+                logger?.log("Backup: Text content cannot be empty")
+                return@with false
+            }
         }
 
         is BackupMessageContent.Asset -> {
@@ -83,7 +103,8 @@ private fun CommonMPBackupExporter.validate(content: BackupMessageContent): Bool
 
         is BackupMessageContent.Location -> {
             if (latitude == 0f || longitude == 0f) {
-                error("Backup: Location content must have valid latitude and longitude")
+                logger?.log("Backup: Location content must have valid latitude and longitude")
+                return@with false
             }
         }
     }

--- a/backup/src/commonMain/kotlin/com/wire/backup/dump/MPBackupExporter.kt
+++ b/backup/src/commonMain/kotlin/com/wire/backup/dump/MPBackupExporter.kt
@@ -77,10 +77,11 @@ public abstract class CommonMPBackupExporter(
 
     @JsName("addUser")
     public fun add(user: BackupUser) {
-        validate(user)
-        usersChunk.add(mapper.mapUserToProtobuf(user))
-        if (usersChunk.size > ITEMS_CHUNK_SIZE) {
-            flushUsers()
+        if (validate(user)) {
+            usersChunk.add(mapper.mapUserToProtobuf(user))
+            if (usersChunk.size > ITEMS_CHUNK_SIZE) {
+                flushUsers()
+            }
         }
     }
 
@@ -99,10 +100,11 @@ public abstract class CommonMPBackupExporter(
 
     @JsName("addConversation")
     public fun add(conversation: BackupConversation) {
-        validate(conversation)
-        conversationsChunk.add(mapper.mapConversationToProtobuf(conversation))
-        if (conversationsChunk.size > ITEMS_CHUNK_SIZE) {
-            flushConversations()
+        if (validate(conversation)) {
+            conversationsChunk.add(mapper.mapConversationToProtobuf(conversation))
+            if (conversationsChunk.size > ITEMS_CHUNK_SIZE) {
+                flushConversations()
+            }
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/CreateMPBackupUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/CreateMPBackupUseCase.kt
@@ -97,7 +97,7 @@ internal class CreateMPBackupUseCaseImpl(
                     },
                     coroutineScope {
                         async {
-                            getMessages { totalPages, page ->
+                            getMessages().collect { (page, totalPages) ->
                                 page.mapNotNull(Message::toBackupMessage)
                                     .forEach { mpBackupExporter.add(it) }
                                 onProgress(pageIndex++.toFloat() / totalPages)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/CreateMPBackupUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/CreateMPBackupUseCaseTest.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.right
 import com.wire.kalium.logic.data.asset.FakeKaliumFileSystem
 import com.wire.kalium.logic.data.backup.BackupRepository
+import com.wire.kalium.logic.data.backup.PagedMessages
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
@@ -48,6 +49,8 @@ import io.mockative.every
 import io.mockative.mock
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -115,9 +118,12 @@ class CreateMPBackupUseCaseTest {
 
             override suspend fun getConversations(): List<Conversation> = listOf(TestConversation.CONVERSATION)
 
-            override fun getMessages(onPage: (Int, List<Message.Standalone>) -> Unit) {
-                onPage(1, backupMessages)
-            }
+            override fun getMessages(): Flow<PagedMessages> = flowOf(
+                PagedMessages(
+                    messages = backupMessages,
+                    totalPages = 1,
+                )
+            )
 
             override suspend fun insertUsers(users: List<OtherUser>): Either<CoreFailure, Unit> = Unit.right()
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -64,7 +64,7 @@ interface MessageDAO {
      *
      * @see insertOrIgnoreMessage
      */
-    suspend fun insertOrIgnoreMessages(messages: List<MessageEntity>, withUnreadEvents: Boolean = true)
+    suspend fun insertOrIgnoreMessages(messages: List<MessageEntity>, withUnreadEvents: Boolean = true, checkAssetUpdate: Boolean = true)
     suspend fun persistSystemMessageToAllConversations(message: MessageEntity.System)
     suspend fun needsToBeNotified(id: String, conversationId: QualifiedIDEntity): Boolean
     suspend fun updateMessageStatus(status: MessageEntity.Status, id: String, conversationId: QualifiedIDEntity)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19481" title="WPB-19481" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19481</a>  [Android] Backup creation failing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

https://wearezeta.atlassian.net/browse/WPB-19481

# What's new in this PR?

### Issues
1. Backup creating fails for some users
2. Creating/restoring backup takes a lot of time on accounts with large history

### Solutions
#### Backup failures
Issue was caused by validation code aborting the backup after finding a text message with no text.
Updated validation code so that it ignores all invalid messages instead of aborting the backup.

#### Performance issues
Creating backup involves two I/O operations: reading from database and saving to file. Adding a buffered channel for reading from database allowed the backup code to continue reading next page(s) when saving current page to file. This improved backup performance by 30%.

Restoring backup has a bottleneck: slow writing to database. I managed to find only minor optimizations for backup restore:
- applying the same buffered read approach to reading data from backup file
- excluding some extra unnecessary queries when inserting backup messages in database.
