### PR TITLE
chore: add the new ConversationHistoryApi structure [WPB-18407]

### DIFF
--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/history/ConversationHistoryApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/history/ConversationHistoryApi.kt
@@ -1,0 +1,24 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.base.authenticated.conversation.history
+
+import com.wire.kalium.network.api.base.authenticated.BaseApi
+import io.mockative.Mockable
+
+@Mockable
+interface ConversationHistoryApi : BaseApi

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/ConversationHistoryApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/ConversationHistoryApiV0.kt
@@ -1,0 +1,23 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v0.authenticated
+
+import com.wire.kalium.network.api.base.authenticated.conversation.history.ConversationHistoryApi
+
+internal open class ConversationHistoryApiV0 internal constructor() : ConversationHistoryApi

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/networkContainer/AuthenticatedNetworkContainerV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/networkContainer/AuthenticatedNetworkContainerV0.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.network.api.base.authenticated.asset.AssetApi
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
 import com.wire.kalium.network.api.base.authenticated.connection.ConnectionApi
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
+import com.wire.kalium.network.api.base.authenticated.conversation.history.ConversationHistoryApi
 import com.wire.kalium.network.api.base.authenticated.e2ei.E2EIApi
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigApi
 import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageApi
@@ -61,6 +62,7 @@ import com.wire.kalium.network.api.v0.authenticated.PreKeyApiV0
 import com.wire.kalium.network.api.v0.authenticated.PropertiesApiV0
 import com.wire.kalium.network.api.v0.authenticated.SelfApiV0
 import com.wire.kalium.network.api.v0.authenticated.ServerTimeApiV0
+import com.wire.kalium.network.api.v0.authenticated.ConversationHistoryApiV0
 import com.wire.kalium.network.api.v0.authenticated.TeamsApiV0
 import com.wire.kalium.network.api.v0.authenticated.UpgradePersonalToTeamApiV0
 import com.wire.kalium.network.api.v0.authenticated.UserDetailsApiV0
@@ -140,6 +142,8 @@ internal class AuthenticatedNetworkContainerV0 internal constructor(
     override val propertiesApi: PropertiesApi get() = PropertiesApiV0(networkClient)
 
     override val wildCardApi: WildCardApi get() = WildCardApiImpl(networkClient)
+
+    override val conversationHistoryApi: ConversationHistoryApi get() = ConversationHistoryApiV0()
 
     override val upgradePersonalToTeamApi: UpgradePersonalToTeamApi
         get() = UpgradePersonalToTeamApiV0(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v10/authenticated/ConversationHistoryApiV10.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v10/authenticated/ConversationHistoryApiV10.kt
@@ -1,0 +1,23 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v10.authenticated
+
+import com.wire.kalium.network.api.v0.authenticated.ConversationHistoryApiV0
+
+internal open class ConversationHistoryApiV10 internal constructor() : ConversationHistoryApiV0()

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v10/authenticated/networkContainer/AuthenticatedNetworkContainerV10.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v10/authenticated/networkContainer/AuthenticatedNetworkContainerV10.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.network.api.base.authenticated.asset.AssetApi
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
 import com.wire.kalium.network.api.base.authenticated.connection.ConnectionApi
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
+import com.wire.kalium.network.api.base.authenticated.conversation.history.ConversationHistoryApi
 import com.wire.kalium.network.api.base.authenticated.e2ei.E2EIApi
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigApi
 import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageApi
@@ -62,6 +63,7 @@ import com.wire.kalium.network.api.v10.authenticated.PreKeyApiV10
 import com.wire.kalium.network.api.v10.authenticated.PropertiesApiV10
 import com.wire.kalium.network.api.v10.authenticated.SelfApiV10
 import com.wire.kalium.network.api.v10.authenticated.ServerTimeApiV10
+import com.wire.kalium.network.api.v10.authenticated.ConversationHistoryApiV10
 import com.wire.kalium.network.api.v10.authenticated.TeamsApiV10
 import com.wire.kalium.network.api.v10.authenticated.UpgradePersonalToTeamApiV10
 import com.wire.kalium.network.api.v10.authenticated.UserDetailsApiV10
@@ -155,6 +157,8 @@ internal class AuthenticatedNetworkContainerV10 internal constructor(
     override val propertiesApi: PropertiesApi get() = PropertiesApiV10(networkClient)
 
     override val wildCardApi: WildCardApi get() = WildCardApiImpl(networkClient)
+
+    override val conversationHistoryApi: ConversationHistoryApi get() = ConversationHistoryApiV10()
 
     override val upgradePersonalToTeamApi: UpgradePersonalToTeamApi
         get() = UpgradePersonalToTeamApiV10(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v11/authenticated/ConversationHistoryApiV11.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v11/authenticated/ConversationHistoryApiV11.kt
@@ -1,0 +1,23 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v11.authenticated
+
+import com.wire.kalium.network.api.v0.authenticated.ConversationHistoryApiV0
+
+internal open class ConversationHistoryApiV11 internal constructor() : ConversationHistoryApiV0()

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v11/authenticated/networkContainer/AuthenticatedNetworkContainerV11.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v11/authenticated/networkContainer/AuthenticatedNetworkContainerV11.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.network.api.base.authenticated.asset.AssetApi
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
 import com.wire.kalium.network.api.base.authenticated.connection.ConnectionApi
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
+import com.wire.kalium.network.api.base.authenticated.conversation.history.ConversationHistoryApi
 import com.wire.kalium.network.api.base.authenticated.e2ei.E2EIApi
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigApi
 import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageApi
@@ -62,6 +63,7 @@ import com.wire.kalium.network.api.v11.authenticated.PreKeyApiV11
 import com.wire.kalium.network.api.v11.authenticated.PropertiesApiV11
 import com.wire.kalium.network.api.v11.authenticated.SelfApiV11
 import com.wire.kalium.network.api.v11.authenticated.ServerTimeApiV11
+import com.wire.kalium.network.api.v11.authenticated.ConversationHistoryApiV11
 import com.wire.kalium.network.api.v11.authenticated.TeamsApiV11
 import com.wire.kalium.network.api.v11.authenticated.UpgradePersonalToTeamApiV11
 import com.wire.kalium.network.api.v11.authenticated.UserDetailsApiV11
@@ -155,6 +157,8 @@ internal class AuthenticatedNetworkContainerV11 internal constructor(
     override val propertiesApi: PropertiesApi get() = PropertiesApiV11(networkClient)
 
     override val wildCardApi: WildCardApi get() = WildCardApiImpl(networkClient)
+
+    override val conversationHistoryApi: ConversationHistoryApi get() = ConversationHistoryApiV11()
 
     override val upgradePersonalToTeamApi: UpgradePersonalToTeamApi
         get() = UpgradePersonalToTeamApiV11(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/authenticated/ConversationHistoryApiV2.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/authenticated/ConversationHistoryApiV2.kt
@@ -1,0 +1,23 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v2.authenticated
+
+import com.wire.kalium.network.api.v0.authenticated.ConversationHistoryApiV0
+
+internal open class ConversationHistoryApiV2 internal constructor() : ConversationHistoryApiV0()

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/authenticated/networkContainer/AuthenticatedNetworkContainerV2.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v2/authenticated/networkContainer/AuthenticatedNetworkContainerV2.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.network.api.base.authenticated.asset.AssetApi
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
 import com.wire.kalium.network.api.base.authenticated.connection.ConnectionApi
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
+import com.wire.kalium.network.api.base.authenticated.conversation.history.ConversationHistoryApi
 import com.wire.kalium.network.api.base.authenticated.e2ei.E2EIApi
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigApi
 import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageApi
@@ -62,6 +63,7 @@ import com.wire.kalium.network.api.v2.authenticated.PreKeyApiV2
 import com.wire.kalium.network.api.v2.authenticated.PropertiesApiV2
 import com.wire.kalium.network.api.v2.authenticated.SelfApiV2
 import com.wire.kalium.network.api.v2.authenticated.ServerTimeApiV2
+import com.wire.kalium.network.api.v2.authenticated.ConversationHistoryApiV2
 import com.wire.kalium.network.api.v2.authenticated.TeamsApiV2
 import com.wire.kalium.network.api.v2.authenticated.UpgradePersonalToTeamApiV2
 import com.wire.kalium.network.api.v2.authenticated.UserDetailsApiV2
@@ -143,6 +145,8 @@ internal class AuthenticatedNetworkContainerV2 internal constructor(
     override val propertiesApi: PropertiesApi get() = PropertiesApiV2(networkClient)
 
     override val wildCardApi: WildCardApi get() = WildCardApiImpl(networkClient)
+
+    override val conversationHistoryApi: ConversationHistoryApi get() = ConversationHistoryApiV2()
 
     override val upgradePersonalToTeamApi: UpgradePersonalToTeamApi
         get() = UpgradePersonalToTeamApiV2(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/authenticated/ConversationHistoryApiV3.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/authenticated/ConversationHistoryApiV3.kt
@@ -1,0 +1,23 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v3.authenticated
+
+import com.wire.kalium.network.api.v0.authenticated.ConversationHistoryApiV0
+
+internal open class ConversationHistoryApiV3 internal constructor() : ConversationHistoryApiV0()

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/authenticated/networkContainer/AuthenticatedNetworkContainerV3.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/authenticated/networkContainer/AuthenticatedNetworkContainerV3.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.network.api.base.authenticated.asset.AssetApi
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
 import com.wire.kalium.network.api.base.authenticated.connection.ConnectionApi
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
+import com.wire.kalium.network.api.base.authenticated.conversation.history.ConversationHistoryApi
 import com.wire.kalium.network.api.base.authenticated.e2ei.E2EIApi
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigApi
 import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageApi
@@ -63,6 +64,7 @@ import com.wire.kalium.network.api.v3.authenticated.PreKeyApiV3
 import com.wire.kalium.network.api.v3.authenticated.PropertiesApiV3
 import com.wire.kalium.network.api.v3.authenticated.SelfApiV3
 import com.wire.kalium.network.api.v3.authenticated.ServerTimeApiV3
+import com.wire.kalium.network.api.v3.authenticated.ConversationHistoryApiV3
 import com.wire.kalium.network.api.v3.authenticated.TeamsApiV3
 import com.wire.kalium.network.api.v3.authenticated.UpgradePersonalToTeamApiV3
 import com.wire.kalium.network.api.v3.authenticated.UserDetailsApiV3
@@ -144,6 +146,8 @@ internal class AuthenticatedNetworkContainerV3 internal constructor(
     override val propertiesApi: PropertiesApi get() = PropertiesApiV3(networkClient)
 
     override val wildCardApi: WildCardApi get() = WildCardApiImpl(networkClient)
+
+    override val conversationHistoryApi: ConversationHistoryApi get() = ConversationHistoryApiV3()
 
     override val upgradePersonalToTeamApi: UpgradePersonalToTeamApi
         get() = UpgradePersonalToTeamApiV3(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/ConversationHistoryApiV4.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/ConversationHistoryApiV4.kt
@@ -1,0 +1,23 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v4.authenticated
+
+import com.wire.kalium.network.api.v0.authenticated.ConversationHistoryApiV0
+
+internal open class ConversationHistoryApiV4 internal constructor() : ConversationHistoryApiV0()

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/networkContainer/AuthenticatedNetworkContainerV4.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v4/authenticated/networkContainer/AuthenticatedNetworkContainerV4.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.network.api.base.authenticated.asset.AssetApi
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
 import com.wire.kalium.network.api.base.authenticated.connection.ConnectionApi
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
+import com.wire.kalium.network.api.base.authenticated.conversation.history.ConversationHistoryApi
 import com.wire.kalium.network.api.base.authenticated.e2ei.E2EIApi
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigApi
 import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageApi
@@ -62,6 +63,7 @@ import com.wire.kalium.network.api.v4.authenticated.PreKeyApiV4
 import com.wire.kalium.network.api.v4.authenticated.PropertiesApiV4
 import com.wire.kalium.network.api.v4.authenticated.SelfApiV4
 import com.wire.kalium.network.api.v4.authenticated.ServerTimeApiV4
+import com.wire.kalium.network.api.v4.authenticated.ConversationHistoryApiV4
 import com.wire.kalium.network.api.v4.authenticated.TeamsApiV4
 import com.wire.kalium.network.api.v4.authenticated.UpgradePersonalToTeamApiV4
 import com.wire.kalium.network.api.v4.authenticated.UserDetailsApiV4
@@ -143,6 +145,8 @@ internal class AuthenticatedNetworkContainerV4 internal constructor(
     override val propertiesApi: PropertiesApi get() = PropertiesApiV4(networkClient)
 
     override val wildCardApi: WildCardApi get() = WildCardApiImpl(networkClient)
+
+    override val conversationHistoryApi: ConversationHistoryApi get() = ConversationHistoryApiV4()
 
     override val upgradePersonalToTeamApi: UpgradePersonalToTeamApi
         get() = UpgradePersonalToTeamApiV4(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/ConversationHistoryApiV5.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/ConversationHistoryApiV5.kt
@@ -1,0 +1,23 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v5.authenticated
+
+import com.wire.kalium.network.api.v0.authenticated.ConversationHistoryApiV0
+
+internal open class ConversationHistoryApiV5 internal constructor() : ConversationHistoryApiV0()

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/networkContainer/AuthenticatedNetworkContainerV5.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v5/authenticated/networkContainer/AuthenticatedNetworkContainerV5.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.network.api.base.authenticated.asset.AssetApi
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
 import com.wire.kalium.network.api.base.authenticated.connection.ConnectionApi
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
+import com.wire.kalium.network.api.base.authenticated.conversation.history.ConversationHistoryApi
 import com.wire.kalium.network.api.base.authenticated.e2ei.E2EIApi
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigApi
 import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageApi
@@ -62,6 +63,7 @@ import com.wire.kalium.network.api.v5.authenticated.PreKeyApiV5
 import com.wire.kalium.network.api.v5.authenticated.PropertiesApiV5
 import com.wire.kalium.network.api.v5.authenticated.SelfApiV5
 import com.wire.kalium.network.api.v5.authenticated.ServerTimeApiV5
+import com.wire.kalium.network.api.v5.authenticated.ConversationHistoryApiV5
 import com.wire.kalium.network.api.v5.authenticated.TeamsApiV5
 import com.wire.kalium.network.api.v5.authenticated.UpgradePersonalToTeamApiV5
 import com.wire.kalium.network.api.v5.authenticated.UserDetailsApiV5
@@ -143,6 +145,8 @@ internal class AuthenticatedNetworkContainerV5 internal constructor(
     override val propertiesApi: PropertiesApi get() = PropertiesApiV5(networkClient)
 
     override val wildCardApi: WildCardApi get() = WildCardApiImpl(networkClient)
+
+    override val conversationHistoryApi: ConversationHistoryApi get() = ConversationHistoryApiV5()
 
     override val upgradePersonalToTeamApi: UpgradePersonalToTeamApi
         get() = UpgradePersonalToTeamApiV5(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v6/authenticated/ConversationHistoryApiV6.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v6/authenticated/ConversationHistoryApiV6.kt
@@ -1,0 +1,23 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v6.authenticated
+
+import com.wire.kalium.network.api.v0.authenticated.ConversationHistoryApiV0
+
+internal open class ConversationHistoryApiV6 internal constructor() : ConversationHistoryApiV0()

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v6/authenticated/networkContainer/AuthenticatedNetworkContainerV6.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v6/authenticated/networkContainer/AuthenticatedNetworkContainerV6.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.network.api.base.authenticated.asset.AssetApi
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
 import com.wire.kalium.network.api.base.authenticated.connection.ConnectionApi
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
+import com.wire.kalium.network.api.base.authenticated.conversation.history.ConversationHistoryApi
 import com.wire.kalium.network.api.base.authenticated.e2ei.E2EIApi
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigApi
 import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageApi
@@ -62,6 +63,7 @@ import com.wire.kalium.network.api.v6.authenticated.PreKeyApiV6
 import com.wire.kalium.network.api.v6.authenticated.PropertiesApiV6
 import com.wire.kalium.network.api.v6.authenticated.SelfApiV6
 import com.wire.kalium.network.api.v6.authenticated.ServerTimeApiV6
+import com.wire.kalium.network.api.v6.authenticated.ConversationHistoryApiV6
 import com.wire.kalium.network.api.v6.authenticated.TeamsApiV6
 import com.wire.kalium.network.api.v6.authenticated.UpgradePersonalToTeamApiV6
 import com.wire.kalium.network.api.v6.authenticated.UserDetailsApiV6
@@ -143,6 +145,8 @@ internal class AuthenticatedNetworkContainerV6 internal constructor(
     override val propertiesApi: PropertiesApi get() = PropertiesApiV6(networkClient)
 
     override val wildCardApi: WildCardApi get() = WildCardApiImpl(networkClient)
+
+    override val conversationHistoryApi: ConversationHistoryApi get() = ConversationHistoryApiV6()
 
     override val upgradePersonalToTeamApi: UpgradePersonalToTeamApi
         get() = UpgradePersonalToTeamApiV6(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v7/authenticated/ConversationHistoryApiV7.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v7/authenticated/ConversationHistoryApiV7.kt
@@ -1,0 +1,23 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v7.authenticated
+
+import com.wire.kalium.network.api.v0.authenticated.ConversationHistoryApiV0
+
+internal open class ConversationHistoryApiV7 internal constructor() : ConversationHistoryApiV0()

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v7/authenticated/networkContainer/AuthenticatedNetworkContainerV7.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v7/authenticated/networkContainer/AuthenticatedNetworkContainerV7.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.network.api.base.authenticated.asset.AssetApi
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
 import com.wire.kalium.network.api.base.authenticated.connection.ConnectionApi
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
+import com.wire.kalium.network.api.base.authenticated.conversation.history.ConversationHistoryApi
 import com.wire.kalium.network.api.base.authenticated.e2ei.E2EIApi
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigApi
 import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageApi
@@ -62,6 +63,7 @@ import com.wire.kalium.network.api.v7.authenticated.PreKeyApiV7
 import com.wire.kalium.network.api.v7.authenticated.PropertiesApiV7
 import com.wire.kalium.network.api.v7.authenticated.SelfApiV7
 import com.wire.kalium.network.api.v7.authenticated.ServerTimeApiV7
+import com.wire.kalium.network.api.v7.authenticated.ConversationHistoryApiV7
 import com.wire.kalium.network.api.v7.authenticated.TeamsApiV7
 import com.wire.kalium.network.api.v7.authenticated.UpgradePersonalToTeamApiV7
 import com.wire.kalium.network.api.v7.authenticated.UserDetailsApiV7
@@ -152,6 +154,8 @@ internal class AuthenticatedNetworkContainerV7 internal constructor(
     override val propertiesApi: PropertiesApi get() = PropertiesApiV7(networkClient)
 
     override val wildCardApi: WildCardApi get() = WildCardApiImpl(networkClient)
+
+    override val conversationHistoryApi: ConversationHistoryApi get() = ConversationHistoryApiV7()
 
     override val upgradePersonalToTeamApi: UpgradePersonalToTeamApi
         get() = UpgradePersonalToTeamApiV7(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v8/authenticated/ConversationHistoryApiV8.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v8/authenticated/ConversationHistoryApiV8.kt
@@ -1,0 +1,23 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v8.authenticated
+
+import com.wire.kalium.network.api.v0.authenticated.ConversationHistoryApiV0
+
+internal open class ConversationHistoryApiV8 internal constructor() : ConversationHistoryApiV0()

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v8/authenticated/networkContainer/AuthenticatedNetworkContainerV8.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v8/authenticated/networkContainer/AuthenticatedNetworkContainerV8.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.network.api.base.authenticated.asset.AssetApi
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
 import com.wire.kalium.network.api.base.authenticated.connection.ConnectionApi
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
+import com.wire.kalium.network.api.base.authenticated.conversation.history.ConversationHistoryApi
 import com.wire.kalium.network.api.base.authenticated.e2ei.E2EIApi
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigApi
 import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageApi
@@ -62,6 +63,7 @@ import com.wire.kalium.network.api.v8.authenticated.PreKeyApiV8
 import com.wire.kalium.network.api.v8.authenticated.PropertiesApiV8
 import com.wire.kalium.network.api.v8.authenticated.SelfApiV8
 import com.wire.kalium.network.api.v8.authenticated.ServerTimeApiV8
+import com.wire.kalium.network.api.v8.authenticated.ConversationHistoryApiV8
 import com.wire.kalium.network.api.v8.authenticated.TeamsApiV8
 import com.wire.kalium.network.api.v8.authenticated.UpgradePersonalToTeamApiV8
 import com.wire.kalium.network.api.v8.authenticated.UserDetailsApiV8
@@ -153,6 +155,8 @@ internal class AuthenticatedNetworkContainerV8 internal constructor(
     override val propertiesApi: PropertiesApi get() = PropertiesApiV8(networkClient)
 
     override val wildCardApi: WildCardApi get() = WildCardApiImpl(networkClient)
+
+    override val conversationHistoryApi: ConversationHistoryApi get() = ConversationHistoryApiV8()
 
     override val upgradePersonalToTeamApi: UpgradePersonalToTeamApi
         get() = UpgradePersonalToTeamApiV8(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v9/authenticated/ConversationHistoryApiV9.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v9/authenticated/ConversationHistoryApiV9.kt
@@ -1,0 +1,23 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v9.authenticated
+
+import com.wire.kalium.network.api.v0.authenticated.ConversationHistoryApiV0
+
+internal open class ConversationHistoryApiV9 internal constructor() : ConversationHistoryApiV0()

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v9/authenticated/networkContainer/AuthenticatedNetworkContainerV9.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v9/authenticated/networkContainer/AuthenticatedNetworkContainerV9.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.network.api.base.authenticated.asset.AssetApi
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
 import com.wire.kalium.network.api.base.authenticated.connection.ConnectionApi
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
+import com.wire.kalium.network.api.base.authenticated.conversation.history.ConversationHistoryApi
 import com.wire.kalium.network.api.base.authenticated.e2ei.E2EIApi
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigApi
 import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageApi
@@ -62,6 +63,7 @@ import com.wire.kalium.network.api.v9.authenticated.PreKeyApiV9
 import com.wire.kalium.network.api.v9.authenticated.PropertiesApiV9
 import com.wire.kalium.network.api.v9.authenticated.SelfApiV9
 import com.wire.kalium.network.api.v9.authenticated.ServerTimeApiV9
+import com.wire.kalium.network.api.v9.authenticated.ConversationHistoryApiV9
 import com.wire.kalium.network.api.v9.authenticated.TeamsApiV9
 import com.wire.kalium.network.api.v9.authenticated.UpgradePersonalToTeamApiV9
 import com.wire.kalium.network.api.v9.authenticated.UserDetailsApiV9
@@ -154,6 +156,8 @@ internal class AuthenticatedNetworkContainerV9 internal constructor(
     override val propertiesApi: PropertiesApi get() = PropertiesApiV9(networkClient)
 
     override val wildCardApi: WildCardApi get() = WildCardApiImpl(networkClient)
+
+    override val conversationHistoryApi: ConversationHistoryApi get() = ConversationHistoryApiV9()
 
     override val upgradePersonalToTeamApi: UpgradePersonalToTeamApi
         get() = UpgradePersonalToTeamApiV9(

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/networkContainer/AuthenticatedNetworkContainer.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/networkContainer/AuthenticatedNetworkContainer.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.network.api.base.authenticated.asset.AssetApi
 import com.wire.kalium.network.api.base.authenticated.client.ClientApi
 import com.wire.kalium.network.api.base.authenticated.connection.ConnectionApi
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
+import com.wire.kalium.network.api.base.authenticated.conversation.history.ConversationHistoryApi
 import com.wire.kalium.network.api.base.authenticated.e2ei.E2EIApi
 import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigApi
 import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageApi
@@ -85,6 +86,8 @@ interface AuthenticatedNetworkContainer {
     val mlsMessageApi: MLSMessageApi
 
     val conversationApi: ConversationApi
+
+    val conversationHistoryApi: ConversationHistoryApi
 
     val keyPackageApi: KeyPackageApi
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18407" title="WPB-18407" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18407</a>  [Android] Modify conversation history settings - API
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

There is virtually no logic at all here. Just the skeleton of the new endpoints for conversation history.

I decided to create a new API interface and implementations, instead of polluting the `ConversationApi` even further.

The actual implementation of endpoints come in the next PR.