### PR TITLE
chore(conversation-history): add endpoint stubs [WPB-18407]

### DIFF
--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/conversation/ConversationHistory.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/conversation/ConversationHistory.kt
@@ -1,0 +1,84 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.authenticated.conversation
+
+import com.wire.kalium.network.api.authenticated.notification.EventContentDTO
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlin.jvm.JvmInline
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+@Serializable
+sealed interface ConversationHistorySettingsDTO {
+    /**
+     * Conversation's history should not be shared with new members.
+     */
+    @Serializable
+    data object Private : ConversationHistorySettingsDTO
+
+    /**
+     * Conversation's history should be shared with new members.
+     * All messages that are less than [depth] old should be shared with new members when they join.
+     */
+    @Serializable
+    data class SharedWithNewMembers(
+        @Serializable(with = ConversationHistoryDepthSerializer::class)
+        @SerialName("depth") val depth: Duration
+    ) : ConversationHistorySettingsDTO
+}
+
+@JvmInline
+value class HistoryClientId(val value: String) {
+    init {
+        require(value.isNotBlank()) { "HistoryClient id cannot be blank!" }
+    }
+}
+
+/**
+ * Response from the server containing a page of conversation history.
+ * @param events List of events on the page.
+ * @param nextOffset Offset of the next page. Null if there is no next page.
+ */
+@Serializable
+data class ConversationHistoryResponse(
+    @SerialName("events")
+    val events: List<EventContentDTO>,
+    @SerialName("nextOffset")
+    val nextOffset: ULong? = null,
+)
+
+@OptIn(ExperimentalSerializationApi::class)
+class ConversationHistoryDepthSerializer : KSerializer<Duration> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("Duration", PrimitiveKind.LONG)
+
+    override fun serialize(encoder: Encoder, value: Duration) {
+        encoder.encodeLong(value.inWholeSeconds)
+    }
+
+    override fun deserialize(decoder: Decoder): Duration {
+        return decoder.decodeLong().seconds
+    }
+}

--- a/network-model/src/commonTest/kotlin/com/wire/kalium/network/api/authenticated/conversation/ConversationHistoryDepthSerializerTest.kt
+++ b/network-model/src/commonTest/kotlin/com/wire/kalium/network/api/authenticated/conversation/ConversationHistoryDepthSerializerTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.authenticated.conversation
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+class ConversationHistoryDepthSerializerTest {
+
+    @Test
+    fun `should serialize and deserialize duration correctly`() {
+        val original = ConversationHistorySettingsDTO.SharedWithNewMembers(92.days + 42.hours + 24.minutes + 11.seconds)
+        val json = Json { }
+
+        val string = json.encodeToString(original)
+        val result = json.decodeFromString<ConversationHistorySettingsDTO.SharedWithNewMembers>(string)
+
+        assertEquals(original, result)
+    }
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/history/ConversationHistoryApi.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/history/ConversationHistoryApi.kt
@@ -17,8 +17,30 @@
  */
 package com.wire.kalium.network.api.base.authenticated.conversation.history
 
+import com.wire.kalium.network.api.authenticated.conversation.ConversationHistoryResponse
+import com.wire.kalium.network.api.authenticated.conversation.ConversationHistorySettingsDTO
+import com.wire.kalium.network.api.authenticated.conversation.HistoryClientId
 import com.wire.kalium.network.api.base.authenticated.BaseApi
+import com.wire.kalium.network.api.model.ConversationId
+import com.wire.kalium.network.utils.NetworkResponse
 import io.mockative.Mockable
 
 @Mockable
-interface ConversationHistoryApi : BaseApi
+interface ConversationHistoryApi : BaseApi {
+    suspend fun updateHistorySettingsForConversation(
+        conversationId: ConversationId,
+        settings: ConversationHistorySettingsDTO,
+    ): NetworkResponse<Unit>
+
+    /**
+     * Retrieves messages from a conversation for a given history client, in a paginated fashion.
+     * @param offset The number of messages to skip in this request.
+     * @param size The size of a page. Must be between 1 and 1000. Defaults to 100.
+     */
+    suspend fun getPageOfMessagesForHistoryClient(
+        conversationId: ConversationId,
+        historyClientId: HistoryClientId,
+        offset: ULong,
+        size: UInt = 100u,
+    ): NetworkResponse<ConversationHistoryResponse>
+}

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/ConversationHistoryApiV0.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/ConversationHistoryApiV0.kt
@@ -18,6 +18,25 @@
 
 package com.wire.kalium.network.api.v0.authenticated
 
+import com.wire.kalium.network.api.authenticated.conversation.ConversationHistoryResponse
+import com.wire.kalium.network.api.authenticated.conversation.ConversationHistorySettingsDTO
+import com.wire.kalium.network.api.authenticated.conversation.HistoryClientId
 import com.wire.kalium.network.api.base.authenticated.conversation.history.ConversationHistoryApi
+import com.wire.kalium.network.api.model.ConversationId
+import com.wire.kalium.network.utils.NetworkResponse
 
-internal open class ConversationHistoryApiV0 internal constructor() : ConversationHistoryApi
+internal open class ConversationHistoryApiV0 internal constructor() : ConversationHistoryApi {
+    @Suppress("MagicNumber")
+    override suspend fun updateHistorySettingsForConversation(
+        conversationId: ConversationId,
+        settings: ConversationHistorySettingsDTO
+    ): NetworkResponse<Unit> = getApiNotSupportedError(::updateHistorySettingsForConversation.name, 11)
+
+    @Suppress("MagicNumber")
+    override suspend fun getPageOfMessagesForHistoryClient(
+        conversationId: ConversationId,
+        historyClientId: HistoryClientId,
+        offset: ULong,
+        size: UInt
+    ): NetworkResponse<ConversationHistoryResponse> = getApiNotSupportedError(::getPageOfMessagesForHistoryClient.name, 11)
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18407" title="WPB-18407" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18407</a>  [Android] Modify conversation history settings - API
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Add the API structure for new endpoints and relevant DTOs.

There is still more to come, just splitting the work in smaller PRs.