### PR TITLE
fix(backup): failure when creating backup [WPB-19611]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/backup/BackupRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/backup/BackupRepository.kt
@@ -33,6 +33,7 @@ import com.wire.kalium.persistence.dao.conversation.ConversationDAO
 import com.wire.kalium.persistence.dao.message.MessageDAO
 import com.wire.kalium.persistence.dao.message.MessageEntity
 import io.mockative.Mockable
+import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -103,6 +104,12 @@ internal class BackupDataSource(
                         totalPages = totalPages
                     )
                 )
+            }
+            awaitClose {
+                // TODO(refactor): support cancellation.
+                //                 We need to stop `getMessagesPaged`, so it doesn't try to send more data,
+                //                 so we can cancel gracefully
+                channel.close()
             }
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/CreateMPBackupUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/CreateMPBackupUseCase.kt
@@ -42,8 +42,8 @@ import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.withContext
 import okio.FileSystem
 import okio.Path
@@ -80,31 +80,25 @@ internal class CreateMPBackupUseCaseImpl(
             var pageIndex = 0
 
             with(backupRepository) {
-                awaitAll(
-                    coroutineScope {
-                        async {
-                            getUsers().forEach { user ->
-                                mpBackupExporter.add(user.toBackupUser())
-                            }
+                coroutineScope {
+                    async {
+                        getUsers().forEach { user ->
+                            mpBackupExporter.add(user.toBackupUser())
                         }
-                    },
-                    coroutineScope {
-                        async {
-                            getConversations().forEach { conversation ->
-                                mpBackupExporter.add(conversation.toBackupConversation())
-                            }
+                    }
+                    async {
+                        getConversations().forEach { conversation ->
+                            mpBackupExporter.add(conversation.toBackupConversation())
                         }
-                    },
-                    coroutineScope {
-                        async {
-                            getMessages().collect { (page, totalPages) ->
-                                page.mapNotNull(Message::toBackupMessage)
-                                    .forEach { mpBackupExporter.add(it) }
-                                onProgress(pageIndex++.toFloat() / totalPages)
-                            }
+                    }
+                    async {
+                        getMessages().buffer().collect { (page, totalPages) ->
+                            page.mapNotNull(Message::toBackupMessage)
+                                .forEach { mpBackupExporter.add(it) }
+                            onProgress(pageIndex++.toFloat() / totalPages)
                         }
-                    },
-                )
+                    }
+                }
             }
 
             when (val result = mpBackupExporter.finalize(password)) {
@@ -113,6 +107,7 @@ internal class CreateMPBackupUseCaseImpl(
                         backupFilePath = result.pathToOutputFile.toPath(),
                         backupFileName = backupFileName,
                     )
+
                 else -> {
                     deleteBackupFiles(backupWorkDir)
                     Failure(CoreFailure.Unknown(null))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19611" title="WPB-19611" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19611</a>  [Android] Backup creation fails with "Something went wrong" error for everyone
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Failure happening when attempting to create a backup:

```
CoreLogic: Failed to create backup
CoreLogic: java.lang.IllegalStateException: 'awaitClose { yourCallbackOrListener.cancel() }' should be used in the end of callbackFlow block.
CoreLogic: Otherwise, a callback/listener may leak in case of external cancellation.
CoreLogic: See callbackFlow API documentation for the details.
CoreLogic: 	at Do.c.f(Unknown Source:82)
CoreLogic: 	at Eo.f.x(Unknown Source:32)
CoreLogic: 	at Pm.a.h(Unknown Source:8)
CoreLogic: 	at Ao.S.run(Unknown Source:114)
CoreLogic: 	at I.h.run(Unknown Source:1091)
CoreLogic: 	at Ho.j.run(Unknown Source:2)
CoreLogic: 	at Ho.a.run(Unknown Source:93)
```


"Fixed" by adding the `awaitClose()` there, but there is still room for improvement.
We could, maybe, provide a more complex callback to the DAO when requesting these pages.
This Callback could have a status, like `isActive`, which the DAO can check before emitting, and shortcircuit the whole operation.