### PR TITLE
fix(backup): failure to export universal backup [WPB-19611]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/backup/BackupRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/backup/BackupRepository.kt
@@ -33,7 +33,6 @@ import com.wire.kalium.persistence.dao.conversation.ConversationDAO
 import com.wire.kalium.persistence.dao.message.MessageDAO
 import com.wire.kalium.persistence.dao.message.MessageEntity
 import io.mockative.Mockable
-import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -105,12 +104,7 @@ internal class BackupDataSource(
                     )
                 )
             }
-            awaitClose {
-                // TODO(refactor): support cancellation.
-                //                 We need to stop `getMessagesPaged`, so it doesn't try to send more data,
-                //                 so we can cancel gracefully
-                channel.close()
-            }
+            channel.close()
         }
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/backup/BackupDataSourceTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/backup/BackupDataSourceTest.kt
@@ -1,0 +1,93 @@
+package com.wire.kalium.logic.data.backup
+
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestMessage
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.persistence.TestUserDatabase
+import com.wire.kalium.persistence.dao.UserIDEntity
+import com.wire.kalium.util.time.UNIX_FIRST_DATE
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+
+class BackupDataSourceTest {
+
+    private val userId = UserId("userId", "domain")
+    private val testDatabase = TestUserDatabase(UserIDEntity(userId.value, userId.domain))
+    private val subject =
+        BackupDataSource(userId, testDatabase.builder.userDAO, testDatabase.builder.messageDAO, testDatabase.builder.conversationDAO)
+
+    @Test
+    fun givenUsersInDatabase_whenGettingUsers_thenShouldExportThemProperly() = runTest {
+        // Given
+        val testUsers = listOf(createTestUser("1"), createTestUser("2"))
+        subject.insertUsers(testUsers)
+
+        // When
+        val result = subject.getUsers()
+
+        // Then
+        assertEquals(testUsers, result)
+    }
+
+    @Test
+    fun givenConversationsInDatabase_whenGettingConversations_thenShouldExportThemProperly() = runTest {
+        // Given
+        val testConversations = listOf(createTestConversation("1"), createTestConversation("2")).sortedBy { it.id.value }
+        subject.insertConversations(testConversations)
+
+        // When
+        val result = subject.getConversations().sortedBy { it.id.value }
+
+        // Then
+        assertContentEquals(testConversations, result)
+    }
+
+    @Test
+    fun givenMessagesInDatabase_whenGettingMessages_thenShouldExportThemProperly() = runTest {
+        // Given
+        val testConversations = listOf(createTestConversation("1"), createTestConversation("2"))
+        val testMessages = listOf(
+            createTestMessage(testConversations.first().id, "1", userId),
+            createTestMessage(testConversations.first().id, "2", userId),
+        )
+        subject.insertUsers(listOf(createTestUser(userId.value)))
+        subject.insertConversations(testConversations)
+        subject.insertMessages(testMessages)
+
+        // When
+        val result = subject.getMessages().first()
+
+        // Then
+        assertEquals(testMessages.size, result.messages.size)
+        assertTrue(result.totalPages > 0)
+    }
+
+    private fun createTestUser(id: String) = TestUser.OTHER.copy(id = UserId(id, userId.domain))
+
+    private fun createTestConversation(id: String) =
+        TestConversation.GROUP().copy(
+            id = QualifiedID(id, userId.domain),
+            creatorId = userId.value,
+            lastModifiedDate = Instant.UNIX_FIRST_DATE,
+        )
+
+    private fun createTestMessage(
+        conversationId: QualifiedID,
+        id: String,
+        senderId: UserId,
+    ) = TestMessage.TEXT_MESSAGE.copy(
+        conversationId = conversationId,
+        id = id,
+        senderUserId = senderId
+    )
+
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19611" title="WPB-19611" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19611</a>  [Android] Backup creation fails with "Something went wrong" error for everyone
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Actually fix what I couldn't here:
- https://github.com/wireapp/kalium/pull/3589

All we need to do is close the channel/flow once all the pages from the database are consumed, so it doesn't warn us that we might have left a flow/callback open.

Added tests to make sure it is working.