### PR TITLE
fix: export backup performance [WPB-19611] [WPB-19675]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/CreateMPBackupUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/CreateMPBackupUseCase.kt
@@ -43,7 +43,6 @@ import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.withContext
 import okio.FileSystem
@@ -51,7 +50,6 @@ import okio.Path
 import okio.Path.Companion.toPath
 import okio.SYSTEM
 import okio.use
-import kotlin.time.Duration.Companion.milliseconds
 
 interface CreateMPBackupUseCase {
     /**

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/CreateMPBackupUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/CreateMPBackupUseCaseTest.kt
@@ -118,7 +118,7 @@ class CreateMPBackupUseCaseTest {
 
             override suspend fun getConversations(): List<Conversation> = listOf(TestConversation.CONVERSATION)
 
-            override fun getMessages(): Flow<PagedMessages> = flowOf(
+            override suspend fun getMessages(pageSize: Int): Flow<PagedMessages> = flowOf(
                 PagedMessages(
                     messages = backupMessages,
                     totalPages = 1,

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -508,7 +508,13 @@ countBackupMessages:
 SELECT count(*) FROM MessageDetailsView WHERE visibility = "VISIBLE" AND selfDeletionEndDate IS NULL AND contentType IN :contentType;
 
 selectForBackup:
-SELECT * FROM MessageDetailsView WHERE visibility = "VISIBLE" AND selfDeletionEndDate IS NULL AND contentType IN :contentType ORDER BY date ASC LIMIT :limit OFFSET :offset;
+SELECT * FROM MessageDetailsView
+WHERE visibility = "VISIBLE"
+    AND selfDeletionEndDate IS NULL
+    AND contentType IN :contentType
+    AND id > :afterId
+ORDER BY id ASC
+LIMIT :limit;
 
 selectLastMessagesByConversationIds:
 SELECT MessageDetailsView.*

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -167,7 +167,7 @@ interface MessageDAO {
     suspend fun getAllMessageAssetIdsForConversationId(conversationId: QualifiedIDEntity): List<String>
     suspend fun getSenderNameById(id: String, conversationId: QualifiedIDEntity): String?
     suspend fun getNextAudioMessageInConversation(prevMessageId: String, conversationId: QualifiedIDEntity): String?
-    suspend fun getMessagesPaged(
+    suspend fun getPagedMessagesFlow(
         contentTypes: Collection<MessageEntity.ContentType>,
         pageSize: Int,
     ): Flow<List<MessageEntity>>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19611" title="WPB-19611" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19611</a>  [Android] Backup creation fails with "Something went wrong" error for everyone
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1. Export backup is _super_ slow when there's a ton of messages in the DB.
2. If the app is put into the background while a backup is being exported, the Sync mechanism gets stuck

### Causes

For 1:
We're doing LIMIT + Offset based pagination, which means we ask SQLite to process unnecessary data in each page.

For 2:
We're doing the whole backup export inside a DB transaction, which blocks the Sync from working, now that Sync inserts events in the Database.

### Solutions

1. Remove the transaction, allowing the 
2. Use ID-based keyset pagination

This means: select ordered by ID, limit to some size. Use the last fetched ID to fetch the next page.

I've run some tests and benchmarks locally.

| Number of messages | Page size | Number of pages | **Before**             | **Now** 🚀 |
|--------------------|-----------|-----------------|------------------------|------------|
| 50_000             | 1_000     | 50              | **4.8s**               | **1.3s**   |
| 50_000             | 10        | 5_000           | **timeout after 1min** | **4.3s**   |
