### PR TITLE
chore(conversation-history): add implementation of new endpoints [WPB-18407] [WPB-18556]

### DIFF
--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/conversation/ConversationHistory.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/conversation/ConversationHistory.kt
@@ -37,6 +37,7 @@ sealed interface ConversationHistorySettingsDTO {
      * Conversation's history should not be shared with new members.
      */
     @Serializable
+    @SerialName("private")
     data object Private : ConversationHistorySettingsDTO
 
     /**
@@ -44,6 +45,7 @@ sealed interface ConversationHistorySettingsDTO {
      * All messages that are less than [depth] old should be shared with new members when they join.
      */
     @Serializable
+    @SerialName("shared")
     data class SharedWithNewMembers(
         @Serializable(with = ConversationHistoryDepthSerializer::class)
         @SerialName("depth") val depth: Duration

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/v11/authenticated/networkContainer/AuthenticatedNetworkContainerV11.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/v11/authenticated/networkContainer/AuthenticatedNetworkContainerV11.kt
@@ -158,7 +158,7 @@ internal class AuthenticatedNetworkContainerV11 internal constructor(
 
     override val wildCardApi: WildCardApi get() = WildCardApiImpl(networkClient)
 
-    override val conversationHistoryApi: ConversationHistoryApi get() = ConversationHistoryApiV11()
+    override val conversationHistoryApi: ConversationHistoryApi get() = ConversationHistoryApiV11(networkClient)
 
     override val upgradePersonalToTeamApi: UpgradePersonalToTeamApi
         get() = UpgradePersonalToTeamApiV11(

--- a/network/src/commonTest/kotlin/com/wire/kalium/api/v11/ConversationHistoryApiV11Test.kt
+++ b/network/src/commonTest/kotlin/com/wire/kalium/api/v11/ConversationHistoryApiV11Test.kt
@@ -1,0 +1,106 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.api.v11
+
+import com.wire.kalium.api.ApiTest
+import com.wire.kalium.network.api.authenticated.conversation.ConversationHistorySettingsDTO
+import com.wire.kalium.network.api.authenticated.conversation.HistoryClientId
+import com.wire.kalium.network.api.model.ConversationId
+import com.wire.kalium.network.api.v11.authenticated.ConversationHistoryApiV11
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.fullPath
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.seconds
+
+internal class ConversationHistoryApiV11Test : ApiTest() {
+
+    @Test
+    fun givenConversationId_whenUpdatingConversationHistorySettings_thenShouldPassPathParametersCorrectly() = runTest {
+        val conversationId = ConversationId("conversation_id", "domain")
+        val networkClient = mockAuthenticatedNetworkClient(
+            statusCode = HttpStatusCode.Accepted,
+            responseBody = "",
+            assertion = {
+                assertTrue("Url should end with conversation domain, id and history") {
+                    url.fullPath.endsWith("${conversationId.domain}/${conversationId.value}/history")
+                }
+            }
+        )
+        val api = ConversationHistoryApiV11(networkClient)
+        api.updateHistorySettingsForConversation(conversationId, ConversationHistorySettingsDTO.Private)
+    }
+
+    @Test
+    fun givenPrivateParameters_whenUpdatingConversationHistorySettings_thenShouldSerializeBodyProperly() = runTest {
+        val settings = ConversationHistorySettingsDTO.Private
+        val expectedJson = """{"type":"private"}"""
+        assertHistorySettingsJsonSerialization(settings, expectedJson)
+    }
+
+    @Test
+    fun givenSharedParameters_whenUpdatingConversationHistorySettings_thenShouldSerializeBodyProperly() = runTest {
+        val settings = ConversationHistorySettingsDTO.SharedWithNewMembers(42.days + 32.hours + 2.seconds)
+        val expectedJson = """{"type":"shared","depth":${settings.depth.inWholeSeconds}}"""
+        assertHistorySettingsJsonSerialization(settings, expectedJson)
+    }
+
+    private suspend fun assertHistorySettingsJsonSerialization(
+        settings: ConversationHistorySettingsDTO,
+        expectedJson: String
+    ) {
+        val conversationId = ConversationId("conversation_id", "domain")
+        val networkClient = mockAuthenticatedNetworkClient(
+            statusCode = HttpStatusCode.Accepted,
+            responseBody = "",
+            assertion = {
+                assertJsonBodyContent(expectedJson)
+            }
+        )
+
+        val api = ConversationHistoryApiV11(networkClient)
+        api.updateHistorySettingsForConversation(conversationId, settings)
+    }
+
+    @Test
+    fun givenConversationId_whenFetching_thenShouldPassPathParametersCorrectly() = runTest {
+        val conversationId = ConversationId("conversation_id", "domain")
+        val offset = 14UL
+        val size = 42U
+        val historyClientId = HistoryClientId("hClientId")
+        val networkClient = mockAuthenticatedNetworkClient(
+            statusCode = HttpStatusCode.OK,
+            responseBody = """{"type":"private"}""",
+            assertion = {
+                val expectedPathSegments = listOf("history", conversationId.domain, conversationId.value, historyClientId.value)
+                val actualPathSegments = url.pathSegments.filter { it.isNotBlank() && it != "v1" }
+                assertContentEquals(expectedPathSegments, actualPathSegments)
+                assertEquals(offset.toString(), url.parameters["offset"], "Offset was not set correctly.")
+                assertEquals(size.toString(), url.parameters["size"], "Size was not set correctly.")
+            }
+        )
+
+        val api = ConversationHistoryApiV11(networkClient)
+        api.getPageOfMessagesForHistoryClient(conversationId, historyClientId, offset, size)
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18407" title="WPB-18407" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18407</a>  [Android] Modify conversation history settings - API
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Just simple implementation of new endpoints for setting conversation history and getting the pages of conversations.