### PR TITLE
chore: detect connection error when loading file list (WPB-17314)

### DIFF
--- a/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/paging/FilePagingSource.kt
+++ b/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/paging/FilePagingSource.kt
@@ -25,6 +25,7 @@ import app.cash.paging.PagingSourceLoadResultPage
 import app.cash.paging.PagingState
 import com.wire.kalium.cells.domain.model.Node
 import com.wire.kalium.cells.domain.usecase.GetPaginatedNodesUseCase
+import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.common.functional.fold
 
 internal class FilePagingSource(
@@ -45,9 +46,9 @@ internal class FilePagingSource(
             onlyDeleted = onlyDeleted,
             tags = tags
         ).fold(
-            {
+            { error ->
                 PagingSourceLoadResultError<Int, Node>(
-                    throwable = Exception("Failed to load files")
+                    throwable = FileListLoadError(error is NetworkFailure.NoNetworkConnection)
                 ) as PagingSourceLoadResult<Int, Node>
             },
             { files ->
@@ -66,3 +67,5 @@ internal class FilePagingSource(
         }
     }
 }
+
+public data class FileListLoadError(val isConnectionError: Boolean) : Throwable()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17314" title="WPB-17314" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17314</a>  [Android] Handle no Internet connection case in all files screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-17314

# What's new in this PR?

### Issues
Detect and return connectivity error to the file list loader to show correct error message to user.
