### PR TITLE
chore: remove 3rd party UUID library [WPB-20000]

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -54,7 +54,6 @@ android {
 
     kotlinOptions {
         jvmTarget = "17"
-        freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
     }
 
     packaging {

--- a/buildSrc/src/main/kotlin/com/wire/kalium/plugins/CommonJvmConfig.kt
+++ b/buildSrc/src/main/kotlin/com/wire/kalium/plugins/CommonJvmConfig.kt
@@ -25,7 +25,6 @@ fun KotlinJvmTarget.commonJvmConfig(includeNativeInterop: Boolean, enableIntegra
     compilations.all {
         compileTaskProvider.configure {
             compilerOptions.jvmTarget.set(JvmTarget.JVM_17)
-            compilerOptions.freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
         }
     }
     testRuns.getByName("test").executionTask.configure {

--- a/buildSrc/src/main/kotlin/com/wire/kalium/plugins/Multiplatform.kt
+++ b/buildSrc/src/main/kotlin/com/wire/kalium/plugins/Multiplatform.kt
@@ -47,6 +47,10 @@ fun Project.configureDefaultMultiplatform(
         "No multiplatform extension found. Is the Kotlin Multiplatform plugin applied to this module?"
     }
     kotlinExtension.apply {
+        compilerOptions {
+            optIn.add("kotlin.RequiresOptIn")
+            optIn.add("kotlin.uuid.ExperimentalUuidApi")
+        }
         jvmToolchain {
             languageVersion.set(JavaLanguageVersion.of(JavaVersion.VERSION_17.majorVersion))
         }

--- a/cells/build.gradle.kts
+++ b/cells/build.gradle.kts
@@ -40,7 +40,6 @@ kotlin {
                 implementation(libs.coroutines.core)
                 implementation(libs.ktor.authClient)
                 implementation(libs.okio.core)
-                implementation(libs.benAsherUUID)
                 implementation(libs.sqldelight.androidxPaging)
                 implementation(libs.wire.cells.sdk)
             }

--- a/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/CellUploadManagerImpl.kt
+++ b/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/CellUploadManagerImpl.kt
@@ -17,7 +17,7 @@
  */
 package com.wire.kalium.cells.data
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.cells.domain.CellUploadEvent
 import com.wire.kalium.cells.domain.CellUploadInfo
 import com.wire.kalium.cells.domain.CellUploadManager
@@ -61,8 +61,8 @@ internal class CellUploadManagerImpl internal constructor(
             }
 
             CellNode(
-                uuid = uuid4().toString(),
-                versionId = uuid4().toString(),
+                uuid = Uuid.random().toString(),
+                versionId = Uuid.random().toString(),
                 path = path,
                 size = assetSize,
                 isDraft = true,

--- a/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/usecase/AddAttachmentDraftUseCase.kt
+++ b/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/usecase/AddAttachmentDraftUseCase.kt
@@ -17,7 +17,7 @@
  */
 package com.wire.kalium.cells.domain.usecase
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.cells.domain.CellConversationRepository
 import com.wire.kalium.cells.domain.CellUploadEvent
 import com.wire.kalium.cells.domain.CellUploadManager
@@ -97,7 +97,7 @@ internal class AddAttachmentDraftUseCaseImpl internal constructor(
                     conversationId = conversationId,
                     assetPath = assetPath,
                     node = CellNode(
-                        uuid = uuid4().toString(),
+                        uuid = Uuid.random().toString(),
                         versionId = "",
                         path = fileName,
                         size = assetSize,

--- a/cells/src/commonTest/kotlin/com/wire/kalium/cells/domain/usecase/RemoveAttachmentDraftUseCaseTest.kt
+++ b/cells/src/commonTest/kotlin/com/wire/kalium/cells/domain/usecase/RemoveAttachmentDraftUseCaseTest.kt
@@ -17,7 +17,7 @@
  */
 package com.wire.kalium.cells.domain.usecase
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.cells.domain.CellUploadManager
 import com.wire.kalium.cells.domain.CellsRepository
 import com.wire.kalium.cells.domain.MessageAttachmentDraftRepository
@@ -39,7 +39,7 @@ class RemoveAttachmentDraftUseCaseTest {
 
     @Test
     fun given_attachment_with_UPLOADING_status_when_removing_then_upload_is_cancelled() = runTest {
-        val uuid = uuid4().toString()
+        val uuid = Uuid.random().toString()
         val (arrangement, removeAttachment) = Arrangement()
             .withRepository()
             .withUploadManager()
@@ -56,7 +56,7 @@ class RemoveAttachmentDraftUseCaseTest {
 
     @Test
     fun given_attachment_with_UPLOADING_status_when_removing_then_attachment_is_removed() = runTest {
-        val uuid = uuid4().toString()
+        val uuid = Uuid.random().toString()
         val (arrangement, removeAttachment) = Arrangement()
             .withRepository()
             .withUploadManager()
@@ -73,7 +73,7 @@ class RemoveAttachmentDraftUseCaseTest {
 
     @Test
     fun given_attachment_with_UPLOADED_status_when_removing_then_attachment_draft_is_cancelled() = runTest {
-        val uuid = uuid4().toString()
+        val uuid = Uuid.random().toString()
         val (arrangement, removeAttachment) = Arrangement()
             .withRepository()
             .withUploadManager()
@@ -90,7 +90,7 @@ class RemoveAttachmentDraftUseCaseTest {
 
     @Test
     fun given_attachment_with_UPLOADED_status_when_removing_then_attachment_is_removed() = runTest {
-        val uuid = uuid4().toString()
+        val uuid = Uuid.random().toString()
         val (arrangement, removeAttachment) = Arrangement()
             .withRepository()
             .withUploadManager()
@@ -107,7 +107,7 @@ class RemoveAttachmentDraftUseCaseTest {
 
     @Test
     fun given_attachment_with_FAILED_status_when_removing_then_attachment_is_removed() = runTest {
-        val uuid = uuid4().toString()
+        val uuid = Uuid.random().toString()
         val (arrangement, removeAttachment) = Arrangement()
             .withRepository()
             .withUploadManager()
@@ -124,7 +124,7 @@ class RemoveAttachmentDraftUseCaseTest {
 
     @Test
     fun given_attachment_not_found_when_removing_then_error_is_returned() = runTest {
-        val uuid = uuid4().toString()
+        val uuid = Uuid.random().toString()
         val (_, removeAttachment) = Arrangement()
             .withRepository()
             .withUploadManager()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,6 @@ android-test-core = "1.6.1"
 androidx-arch = "2.2.0"
 androidx-test-orchestrator = "1.5.1"
 androidx-sqlite = "2.4.0"
-benasher-uuid = "0.8.4"
 ktx-datetime = { strictly = "0.5.0" }
 ktx-serialization = "1.8.1"
 ktx-atomicfu = "0.26.1"
@@ -224,7 +223,6 @@ pbandk-runtime-iosSimulatorArm64 = { module = "pro.streem.pbandk:pbandk-runtime-
 pbandk-runtime-macX64 = { module = "pro.streem.pbandk:pbandk-runtime-macosx64", version.ref = "pbandk" }
 pbandk-runtime-macArm64 = { module = "pro.streem.pbandk:pbandk-runtime-macosarm64", version.ref = "pbandk" }
 pbandk-runtime-common = { module = "pro.streem.pbandk:pbandk-runtime", version.ref = "pbandk" }
-benAsherUUID = { module = "com.benasher44:uuid", version.ref = "benasher-uuid" }
 apacheTika = { module = "org.apache.tika:tika-core", version.ref = "apache-tika" }
 faker = { module = "io.github.serpro69:kotlin-faker", version.ref = "faker" }
 concurrentCollections = { module = "co.touchlab:stately-concurrent-collections", version.ref = "stately" }

--- a/logic/build.gradle.kts
+++ b/logic/build.gradle.kts
@@ -54,7 +54,6 @@ kotlin {
                 implementation(libs.coroutines.core)
                 implementation(libs.ktxSerialization)
                 implementation(libs.ktxDateTime)
-                implementation(libs.benAsherUUID)
 
                 // ktor mockk engine
                 implementation(libs.ktor.mock)

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/CallingMessageSender.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/CallingMessageSender.kt
@@ -18,7 +18,7 @@
 
 package com.wire.kalium.logic.feature.call.scenario
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.sun.jna.Pointer
 import com.wire.kalium.calling.Calling
 import com.wire.kalium.calling.types.Handle
@@ -165,7 +165,7 @@ internal fun CallingMessageSender(
         val messageContent = MessageContent.Calling(data, callHostConversationId)
         val date = Clock.System.now()
         val message = Message.Signaling(
-            id = uuid4().toString(),
+            id = Uuid.random().toString(),
             content = messageContent,
             conversationId = transportConversationId,
             date = date,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfigRepositoryExtension.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfigRepositoryExtension.kt
@@ -17,7 +17,7 @@
  */
 package com.wire.kalium.logic.configuration.server
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.error.wrapApiRequest
@@ -58,7 +58,7 @@ internal abstract class ServerConfigRepositoryExtension(
                 storedConfigId
             } else {
                 // otherwise insert new config
-                val newId = uuid4().toString()
+                val newId = Uuid.random().toString()
                 serverConfigurationDAO.insert(
                     ServerConfigurationDAO.InsertData(
                         id = newId,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
@@ -19,7 +19,7 @@
 package com.wire.kalium.logic.data.call
 
 import co.touchlab.stately.collections.ConcurrentMutableMap
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.wrapApiRequest
 import com.wire.kalium.common.error.wrapMLSRequest
@@ -232,7 +232,7 @@ internal class CallDataSource(
 
         val callEntity = callMapper.toCallEntity(
             conversationId = conversationId,
-            id = uuid4().toString(),
+            id = Uuid.random().toString(),
             type = type,
             status = status,
             conversationType = conversation.conversation.type,
@@ -353,7 +353,7 @@ internal class CallDataSource(
             val qualifiedUserId = qualifiedIdMapper.fromStringToQualifiedID(callerId)
 
             val message = Message.System(
-                uuid4().toString(),
+                Uuid.random().toString(),
                 MessageContent.MissedCall,
                 conversationId,
                 Clock.System.now(),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/NewGroupConversationSystemMessagesCreator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/NewGroupConversationSystemMessagesCreator.kt
@@ -17,7 +17,7 @@
  */
 package com.wire.kalium.logic.data.conversation
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.fold
@@ -100,7 +100,7 @@ internal class NewGroupConversationSystemMessagesCreatorImpl(
         instant: Instant = Clock.System.now()
     ) = persistMessage(
         Message.System(
-            id = uuid4().toString(),
+            id = Uuid.random().toString(),
             content = MessageContent.ConversationCreated,
             conversationId = conversationId,
             date = instant,
@@ -143,7 +143,7 @@ internal class NewGroupConversationSystemMessagesCreatorImpl(
         instant: Instant = Clock.System.now()
     ) = persistMessage(
         Message.System(
-            id = uuid4().toString(),
+            id = Uuid.random().toString(),
             content = MessageContent.NewConversationReceiptMode(receiptMode = receiptMode),
             conversationId = conversationId,
             date = instant,
@@ -162,7 +162,7 @@ internal class NewGroupConversationSystemMessagesCreatorImpl(
         if (validUsers.isNotEmpty()) {
             persistMessage(
                 Message.System(
-                    id = uuid4().toString(),
+                    id = Uuid.random().toString(),
                     content = MessageContent.MemberChange.CreationAdded(validUsers.toList()),
                     conversationId = conversationId.toModel(),
                     date = instant,
@@ -184,7 +184,7 @@ internal class NewGroupConversationSystemMessagesCreatorImpl(
         if (userIdList.isNotEmpty()) {
             persistMessage(
                 Message.System(
-                    uuid4().toString(),
+                    Uuid.random().toString(),
                     MessageContent.MemberChange.FailedToAdd(userIdList, type),
                     conversationId,
                     Clock.System.now(),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/folders/ConversationFolderRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/folders/ConversationFolderRepository.kt
@@ -17,7 +17,7 @@
  */
 package com.wire.kalium.logic.data.conversation.folders
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.common.error.wrapApiRequest
@@ -118,7 +118,7 @@ internal class ConversationFolderDataSource internal constructor(
                 kaliumLogger.withFeatureId(CONVERSATIONS_FOLDERS).v("Favorite label not found, creating a new one")
                 folders.add(
                     FolderWithConversations(
-                        id = uuid4().toString(),
+                        id = Uuid.random().toString(),
                         name = "", // name will be handled by localization
                         type = FolderType.FAVORITE,
                         conversationIdList = emptyList()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventGenerator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventGenerator.kt
@@ -17,7 +17,7 @@
  */
 package com.wire.kalium.logic.data.event
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.functional.onSuccess
 import com.wire.kalium.common.functional.right
 import com.wire.kalium.cryptography.CryptoClientId
@@ -88,7 +88,7 @@ class EventGenerator(
     ): PlainMessageBlob {
         return protoContentMapper.encodeToProtobuf(
             ProtoContent.Readable(
-                messageUid = uuid4().toString(),
+                messageUid = Uuid.random().toString(),
                 messageContent = messageContent,
                 expectsReadConfirmation = true,
                 legalHoldStatus = Conversation.LegalHoldStatus.DISABLED,
@@ -129,7 +129,7 @@ class EventGenerator(
 
     private fun generateEventResponse(event: EventContentDTO): EventResponse {
         return EventResponse(
-            id = uuid4().toString(), // TODO jacob (should actually be UUIDv1)
+            id = Uuid.random().toString(), // TODO jacob (should actually be UUIDv1)
             payload = listOf(event),
             transient = true // All events are transient to avoid persisting an incorrect last event id
         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt
@@ -19,7 +19,7 @@
 package com.wire.kalium.logic.data.event
 
 import co.touchlab.stately.concurrency.AtomicReference
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.common.error.StorageFailure
@@ -207,7 +207,7 @@ class EventDataSource(
         }
 
     private suspend fun consumeLiveEventsFlow(clientId: ClientId): Either<NetworkFailure, Flow<IncrementalSyncPhase>> {
-        sentinelMarker.set(SentinelMarker.Marker(uuid4().toString()))
+        sentinelMarker.set(SentinelMarker.Marker(Uuid.random().toString()))
         kaliumLogger.d("$TAG Creating new sentinel marker [${sentinelMarker.get().getMarker()}] for this session.")
         return wrapApiRequest {
             notificationApi.consumeLiveEvents(clientId = clientId.value, markerId = sentinelMarker.get().getMarker())
@@ -291,7 +291,7 @@ class EventDataSource(
 
                         ConsumableNotificationResponse.MissedNotification -> {
                             wrapStorageRequest {
-                                val eventId = uuid4().toString()
+                                val eventId = Uuid.random().toString()
                                 eventDAO.insertEvents(
                                     listOf(
                                         NewEventEntity(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/SystemMessageInserter.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/SystemMessageInserter.kt
@@ -17,7 +17,6 @@
  */
 package com.wire.kalium.logic.data.message
 
-import com.benasher44.uuid.uuid4
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
@@ -27,6 +26,7 @@ import com.wire.kalium.persistence.dao.message.LocalId
 import io.mockative.Mockable
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
+import kotlin.uuid.Uuid
 
 @Mockable
 internal interface SystemMessageInserter {
@@ -60,7 +60,7 @@ internal class SystemMessageInserterImpl(
         protocol: Conversation.Protocol
     ) {
         val message = Message.System(
-            uuid4().toString(),
+            Uuid.random().toString(),
             MessageContent.ConversationProtocolChanged(
                 protocol = protocol
             ),
@@ -80,7 +80,7 @@ internal class SystemMessageInserterImpl(
         senderUserId: UserId
     ) {
         val message = Message.System(
-            uuid4().toString(),
+            Uuid.random().toString(),
             MessageContent.ConversationProtocolChangedDuringACall,
             conversationId,
             Clock.System.now(),
@@ -95,7 +95,7 @@ internal class SystemMessageInserterImpl(
 
     override suspend fun insertHistoryLostProtocolChangedSystemMessage(conversationId: ConversationId) {
         val message = Message.System(
-            uuid4().toString(),
+            Uuid.random().toString(),
             MessageContent.HistoryLostProtocolChanged,
             conversationId,
             Clock.System.now(),
@@ -110,7 +110,7 @@ internal class SystemMessageInserterImpl(
 
     override suspend fun insertLostCommitSystemMessage(conversationId: ConversationId, instant: Instant): Either<CoreFailure, Unit> {
         val mlsEpochWarningMessage = Message.System(
-            id = uuid4().toString(),
+            id = Uuid.random().toString(),
             content = MessageContent.MLSWrongEpochWarning,
             conversationId = conversationId,
             date = instant,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/analytics/AnalyticsIdentifierManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/analytics/AnalyticsIdentifierManager.kt
@@ -17,7 +17,7 @@
  */
 package com.wire.kalium.logic.feature.analytics
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.configuration.UserConfigRepository
@@ -84,7 +84,7 @@ internal fun AnalyticsIdentifierManager(
                 selfConversationIdList.foldToEitherWhileRight(Unit) { selfConversationId, _ ->
                     val date = Clock.System.now()
                     val message = Message.Signaling(
-                        id = uuid4().toString(),
+                        id = Uuid.random().toString(),
                         content = messageContent,
                         conversationId = selfConversationId,
                         date = date,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/analytics/ObserveAnalyticsTrackingIdentifierStatusUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/analytics/ObserveAnalyticsTrackingIdentifierStatusUseCase.kt
@@ -17,7 +17,7 @@
  */
 package com.wire.kalium.logic.feature.analytics
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.analytics.AnalyticsIdentifierResult
@@ -80,7 +80,7 @@ internal fun ObserveAnalyticsTrackingIdentifierStatusUseCase(
                         AnalyticsIdentifierResult.ExistingIdentifier(
                             identifier = currentIdentifier
                         )
-                    } ?: uuid4().toString().let { trackingIdentifier: String ->
+                    } ?: Uuid.random().toString().let { trackingIdentifier: String ->
                         logger.i("$TAG Generating new Tracking Identifier value.")
                         userConfigRepository.setCurrentTrackingIdentifier(
                             newIdentifier = trackingIdentifier

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/ScheduleNewAssetMessageUseCase.kt
@@ -19,7 +19,7 @@
 
 package com.wire.kalium.logic.feature.asset
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.cryptography.utils.AES256Key
 import com.wire.kalium.cryptography.utils.SHA256Key
 import com.wire.kalium.cryptography.utils.generateRandomAES256Key
@@ -149,7 +149,7 @@ internal class ScheduleNewAssetMessageUseCaseImpl(
             it is SlowSyncStatus.Complete
         }
         // Create a unique message ID
-        val generatedMessageUuid = uuid4().toString()
+        val generatedMessageUuid = Uuid.random().toString()
         val expectsReadConfirmation = userPropertyRepository.getReadReceiptsStatus()
 
         val messageTimer = selfDeleteTimer(conversationId, true)
@@ -224,7 +224,7 @@ internal class ScheduleNewAssetMessageUseCaseImpl(
         expectsReadConfirmation: Boolean
     ): Either<CoreFailure, Pair<AssetMessageMetadata, Message.Regular>> = currentClientIdProvider().flatMap { currentClientId ->
         // Create a temporary asset key and domain
-        val (generatedAssetUuid, tempAssetDomain) = uuid4().toString() to ""
+        val (generatedAssetUuid, tempAssetDomain) = Uuid.random().toString() to ""
         withContext(dispatcher.io) {
             assetDataSource.persistAsset(generatedAssetUuid, tempAssetDomain, assetDataPath, assetDataSize, assetName.fileExtension())
                 .flatMap { persistedAssetDataPath ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LoginUseCase.kt
@@ -18,7 +18,7 @@
 
 package com.wire.kalium.logic.feature.auth
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.logic.configuration.server.ServerConfig
@@ -100,7 +100,7 @@ interface LoginUseCase {
         userIdentifier: String,
         password: String,
         shouldPersistClient: Boolean,
-        cookieLabel: String? = uuid4().toString(),
+        cookieLabel: String? = Uuid.random().toString(),
         secondFactorVerificationCode: String? = null,
     ): AuthenticationResult
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/sso/ValidateSSOCodeUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/sso/ValidateSSOCodeUseCase.kt
@@ -18,12 +18,13 @@
 
 package com.wire.kalium.logic.feature.auth.sso
 
-import com.benasher44.uuid.uuidFrom
 import com.wire.kalium.logic.feature.auth.sso.ValidateSSOCodeUseCase.Companion.SSO_CODE_WIRE_PREFIX
 import io.mockative.Mockable
+import kotlin.uuid.Uuid
 
 /**
- * Validates a SSO code
+ * Validates a SSO code.
+ * The code is valid if it starts with [SSO_CODE_WIRE_PREFIX] and contains **a valid UUID with hex-and-dash format**.
  */
 @Mockable
 interface ValidateSSOCodeUseCase {
@@ -43,7 +44,8 @@ internal class ValidateSSOCodeUseCaseImpl : ValidateSSOCodeUseCase {
         if (!ssoCode.startsWith(SSO_CODE_WIRE_PREFIX)) ValidateSSOCodeResult.Invalid
         else ssoCode.removePrefix(SSO_CODE_WIRE_PREFIX).let { uuid ->
             try {
-                uuidFrom(uuid).let { ValidateSSOCodeResult.Valid(uuid) }
+                val result = Uuid.parse(uuid).toString()
+                ValidateSSOCodeResult.Valid(result)
             } catch (e: IllegalArgumentException) {
                 ValidateSSOCodeResult.Invalid
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ClearConversationContentUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ClearConversationContentUseCase.kt
@@ -18,7 +18,7 @@
 
 package com.wire.kalium.logic.feature.conversation
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.data.conversation.ConversationRepository
@@ -69,7 +69,7 @@ internal class ClearConversationContentUseCaseImpl(
             selfConversationIdProvider().flatMap { selfConversationIds ->
                 selfConversationIds.foldToEitherWhileRight(Unit) { selfConversationId, _ ->
                     val regularMessage = Message.Signaling(
-                        id = uuid4().toString(),
+                        id = Uuid.random().toString(),
                         content = MessageContent.Cleared(
                             conversationId = conversationId,
                             time = DateTimeUtil.currentInstant(),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
@@ -18,7 +18,7 @@
 
 package com.wire.kalium.logic.feature.conversation
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.cache.SelfConversationIdProvider
@@ -103,7 +103,7 @@ class UpdateConversationReadDateUseCase internal constructor(
         selfConversationId: QualifiedID,
         time: Instant
     ): Either<CoreFailure, Unit> {
-        val generatedMessageUuid = uuid4().toString()
+        val generatedMessageUuid = Uuid.random().toString()
 
         return currentClientIdProvider().flatMap { currentClientId ->
             val regularMessage = Message.Signaling(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReceiptModeUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReceiptModeUseCase.kt
@@ -18,7 +18,7 @@
 
 package com.wire.kalium.logic.feature.conversation
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
@@ -70,7 +70,7 @@ internal class UpdateConversationReceiptModeUseCaseImpl(
         receiptMode: Conversation.ReceiptMode
     ) {
         val message = Message.System(
-            uuid4().toString(),
+            Uuid.random().toString(),
             MessageContent.ConversationReceiptModeChanged(
                 receiptMode = receiptMode == Conversation.ReceiptMode.ENABLED
             ),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/folder/CreateConversationFolderUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/folder/CreateConversationFolderUseCase.kt
@@ -18,7 +18,7 @@
 
 package com.wire.kalium.logic.feature.conversation.folder
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.data.conversation.ConversationFolder
 import com.wire.kalium.logic.data.conversation.FolderType
@@ -52,7 +52,7 @@ internal class CreateConversationFolderUseCaseImpl(
 ) : CreateConversationFolderUseCase {
     override suspend fun invoke(folderName: String): CreateConversationFolderUseCase.Result = withContext(dispatchers.io) {
         val folder = ConversationFolder(
-            id = uuid4().toString(),
+            id = Uuid.random().toString(),
             name = folderName,
             type = FolderType.USER
         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/guestroomlink/GenerateGuestRoomLinkUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/guestroomlink/GenerateGuestRoomLinkUseCase.kt
@@ -18,7 +18,7 @@
 
 package com.wire.kalium.logic.feature.conversation.guestroomlink
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.logic.data.conversation.ConversationGroupRepository
 import com.wire.kalium.logic.data.event.Event
@@ -48,7 +48,7 @@ class GenerateGuestRoomLinkUseCaseImpl internal constructor(
                 val event = Event.Conversation.CodeUpdated(
                     conversationId = it.qualifiedConversation.toModel(),
                     code = it.data.code,
-                    id = uuid4().toString(),
+                    id = Uuid.random().toString(),
                     isPasswordProtected = it.data.hasPassword,
                     key = it.data.key,
                     uri = it.data.uri

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/SendBrokenAssetMessageUseCaseImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/SendBrokenAssetMessageUseCaseImpl.kt
@@ -19,7 +19,7 @@
 @file:Suppress("MaximumLineLength")
 package com.wire.kalium.logic.feature.debug
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.cryptography.utils.AES256Key
 import com.wire.kalium.cryptography.utils.SHA256Key
 import com.wire.kalium.cryptography.utils.generateRandomAES256Key
@@ -116,7 +116,7 @@ internal class SendBrokenAssetMessageUseCaseImpl(
 
         return currentClientIdProvider().flatMap { currentClientId ->
             // Create a unique message ID
-            val generatedMessageUuid = uuid4().toString()
+            val generatedMessageUuid = Uuid.random().toString()
 
             message = Message.Regular(
                 id = generatedMessageUuid,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/SendConfirmationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/SendConfirmationUseCase.kt
@@ -18,7 +18,7 @@
 
 package com.wire.kalium.logic.feature.debug
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
@@ -57,7 +57,7 @@ class SendConfirmationUseCase internal constructor(
             it is SlowSyncStatus.Complete
         }
 
-        val generatedMessageUuid = uuid4().toString()
+        val generatedMessageUuid = Uuid.random().toString()
 
         return currentClientIdProvider().flatMap { currentClientId ->
             val message = Message.Signaling(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/FetchMLSVerificationStatusUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/e2ei/usecase/FetchMLSVerificationStatusUseCase.kt
@@ -17,7 +17,7 @@
  */
 package com.wire.kalium.logic.feature.e2ei.usecase
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.wrapMLSRequest
 import com.wire.kalium.common.functional.Either
@@ -207,7 +207,7 @@ internal class FetchMLSVerificationStatusUseCaseImpl(
         else MessageContent.ConversationDegradedMLS
 
         val conversationDegradedMessage = Message.System(
-            id = uuid4().toString(),
+            id = Uuid.random().toString(),
             content = content,
             conversationId = conversationId,
             date = Clock.System.now(),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/incallreaction/SendInCallReactionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/incallreaction/SendInCallReactionUseCase.kt
@@ -17,7 +17,7 @@
  */
 package com.wire.kalium.logic.feature.incallreaction
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
@@ -47,7 +47,7 @@ class SendInCallReactionUseCase(
     suspend operator fun invoke(conversationId: ConversationId, reaction: String): Either<CoreFailure, Unit> =
         scope.async(dispatchers.io) {
 
-            val generatedMessageUuid = uuid4().toString()
+            val generatedMessageUuid = Uuid.random().toString()
 
             provideClientId().flatMap { clientId ->
                 val message = Message.Signaling(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/AddSystemMessageToAllConversationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/AddSystemMessageToAllConversationsUseCase.kt
@@ -18,7 +18,7 @@
 
 package com.wire.kalium.logic.feature.message
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
@@ -41,7 +41,7 @@ class AddSystemMessageToAllConversationsUseCaseImpl internal constructor(
 ) : AddSystemMessageToAllConversationsUseCase {
     override suspend operator fun invoke() {
         kaliumLogger.w("persist HistoryLost system message after recovery for all conversations")
-        val generatedMessageUuid = uuid4().toString()
+        val generatedMessageUuid = Uuid.random().toString()
         val message = Message.System(
             id = generatedMessageUuid,
             content = MessageContent.HistoryLost,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/DeleteMessageUseCase.kt
@@ -18,7 +18,7 @@
 
 package com.wire.kalium.logic.feature.message
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.cells.domain.usecase.DeleteMessageAttachmentsUseCase
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.functional.Either
@@ -90,7 +90,7 @@ class DeleteMessageUseCase internal constructor(
                             selfConversationIdProvider().flatMap { selfConversationIds ->
                                 selfConversationIds.foldToEitherWhileRight(Unit) { selfConversationId, _ ->
                                     val regularMessage = Message.Signaling(
-                                        id = uuid4().toString(),
+                                        id = Uuid.random().toString(),
                                         content = if (deleteForEveryone) MessageContent.DeleteMessage(messageId) else
                                             MessageContent.DeleteForMe(
                                                 messageId,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/RetryFailedMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/RetryFailedMessageUseCase.kt
@@ -19,7 +19,7 @@
 
 package com.wire.kalium.logic.feature.message
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.cells.domain.MessageAttachmentDraftRepository
 import com.wire.kalium.cells.domain.usecase.PublishAttachmentsUseCase
 import com.wire.kalium.common.error.CoreFailure
@@ -139,7 +139,7 @@ class RetryFailedMessageUseCase internal constructor(
                     newMentions = content.mentions
                 )
                 // Create new unique message ID
-                val generatedMessageUuid = uuid4().toString()
+                val generatedMessageUuid = Uuid.random().toString()
                 val editMessage = Message.Signaling(
                     id = generatedMessageUuid,
                     content = editContent,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendEditTextMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendEditTextMessageUseCase.kt
@@ -19,7 +19,7 @@
 
 package com.wire.kalium.logic.feature.message
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
@@ -71,7 +71,7 @@ class SendEditTextMessageUseCase internal constructor(
         originalMessageId: String,
         text: String,
         mentions: List<MessageMention> = emptyList(),
-        editedMessageId: String = uuid4().toString()
+        editedMessageId: String = Uuid.random().toString()
     ): Either<CoreFailure, Unit> = withContext(dispatchers.io) {
         slowSyncRepository.slowSyncStatus.first {
             it is SlowSyncStatus.Complete

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendKnockUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendKnockUseCase.kt
@@ -18,7 +18,7 @@
 
 package com.wire.kalium.logic.feature.message
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
@@ -66,7 +66,7 @@ class SendKnockUseCase internal constructor(
             it is SlowSyncStatus.Complete
         }
 
-        val generatedMessageUuid = uuid4().toString()
+        val generatedMessageUuid = Uuid.random().toString()
         val messageTimer: Duration? = selfDeleteTimer(conversationId, true)
             .first()
             .duration

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendLocationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendLocationUseCase.kt
@@ -18,7 +18,7 @@
 
 package com.wire.kalium.logic.feature.message
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
@@ -76,7 +76,7 @@ class SendLocationUseCase internal constructor(
             it is SlowSyncStatus.Complete
         }
 
-        val generatedMessageUuid = uuid4().toString()
+        val generatedMessageUuid = Uuid.random().toString()
         val messageTimer: Duration? = selfDeleteTimer(conversationId, true)
             .first()
             .duration

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendMultipartMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendMultipartMessageUseCase.kt
@@ -17,7 +17,7 @@
  */
 package com.wire.kalium.logic.feature.message
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.cells.domain.MessageAttachmentDraftRepository
 import com.wire.kalium.cells.domain.model.AttachmentDraft
 import com.wire.kalium.cells.domain.usecase.PublishAttachmentsUseCase
@@ -109,7 +109,7 @@ class SendMultipartMessageUseCase internal constructor(
             it is SlowSyncStatus.Complete
         }
 
-        val generatedMessageUuid = uuid4().toString()
+        val generatedMessageUuid = Uuid.random().toString()
 
         val isCellEnabled = conversationRepository.isCellEnabled(conversationId).getOrFail { error ->
             return@async error.left()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
@@ -18,7 +18,7 @@
 
 package com.wire.kalium.logic.feature.message
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
@@ -78,7 +78,7 @@ class SendTextMessageUseCase internal constructor(
             it is SlowSyncStatus.Complete
         }
 
-        val generatedMessageUuid = uuid4().toString()
+        val generatedMessageUuid = Uuid.random().toString()
         val expectsReadConfirmation = userPropertyRepository.getReadReceiptsStatus()
         val messageTimer: Duration? = selfDeleteTimer(conversationId, true)
             .first()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SessionResetSender.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SessionResetSender.kt
@@ -18,7 +18,7 @@
 
 package com.wire.kalium.logic.feature.message
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Recipient
@@ -60,7 +60,7 @@ class SessionResetSenderImpl internal constructor(
         slowSyncRepository.slowSyncStatus.first {
             it is SlowSyncStatus.Complete
         }
-        val generatedMessageUuid = uuid4().toString()
+        val generatedMessageUuid = Uuid.random().toString()
 
         provideClientId().flatMap { selfClientId ->
             val message = Message.Signaling(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ToggleReactionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ToggleReactionUseCase.kt
@@ -18,7 +18,7 @@
 
 package com.wire.kalium.logic.feature.message
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.ConversationId
@@ -112,7 +112,7 @@ class ToggleReactionUseCase internal constructor(
         return reactionRepository
             .persistReaction(messageId, conversationId, userId, date, newReaction).flatMap {
                 val regularMessage = Message.Signaling(
-                    id = uuid4().toString(),
+                    id = Uuid.random().toString(),
                     content = MessageContent.Reaction(messageId = messageId, emojiSet = currentReactions + newReaction),
                     conversationId = conversationId,
                     date = date,
@@ -141,7 +141,7 @@ class ToggleReactionUseCase internal constructor(
         return reactionRepository.deleteReaction(messageId, conversationId, userId, removedReaction)
             .flatMap {
                 val regularMessage = Message.Signaling(
-                    id = uuid4().toString(),
+                    id = Uuid.random().toString(),
                     content = MessageContent.Reaction(messageId = messageId, emojiSet = currentReactions - removedReaction),
                     conversationId = conversationId,
                     date = date,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/composite/SendButtonActionConfirmationMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/composite/SendButtonActionConfirmationMessageUseCase.kt
@@ -17,7 +17,7 @@
  */
 package com.wire.kalium.logic.feature.message.composite
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.Message
@@ -53,7 +53,7 @@ class SendButtonActionConfirmationMessageUseCase internal constructor(
     ): Result = syncManager.waitUntilLiveOrFailure().flatMap {
             currentClientIdProvider().flatMap { currentClientId ->
                 val regularMessage = Message.Signaling(
-                    id = uuid4().toString(),
+                    id = Uuid.random().toString(),
                     content = MessageContent.ButtonActionConfirmation(
                         referencedMessageId = messageId,
                         buttonId = buttonId

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/composite/SendButtonActionMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/composite/SendButtonActionMessageUseCase.kt
@@ -17,7 +17,7 @@
  */
 package com.wire.kalium.logic.feature.message.composite
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.functional.flatMap
 import com.wire.kalium.common.functional.fold
@@ -60,7 +60,7 @@ class SendButtonActionMessageUseCase internal constructor(
         ).flatMap { _ ->
             currentClientIdProvider().flatMap { currentClientId ->
                 val regularMessage = Message.Signaling(
-                    id = uuid4().toString(),
+                    id = Uuid.random().toString(),
                     content = MessageContent.ButtonAction(
                         referencedMessageId = messageId,
                         buttonId = buttonId

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/composite/SendButtonMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/composite/SendButtonMessageUseCase.kt
@@ -17,7 +17,7 @@
  */
 package com.wire.kalium.logic.feature.message.composite
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
@@ -70,7 +70,7 @@ class SendButtonMessageUseCase internal constructor(
             it is SlowSyncStatus.Complete
         }
 
-        val generatedMessageUuid = uuid4().toString()
+        val generatedMessageUuid = Uuid.random().toString()
         val expectsReadConfirmation = userPropertyRepository.getReadReceiptsStatus()
 
         provideClientId().flatMap { clientId ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/confirmation/SendDeliverSignalUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/confirmation/SendDeliverSignalUseCase.kt
@@ -17,7 +17,7 @@
  */
 package com.wire.kalium.logic.feature.message.confirmation
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logger.obfuscateId
@@ -58,7 +58,7 @@ internal class SendDeliverSignalUseCaseImpl(
     ): Either<CoreFailure, Unit> = currentClientIdProvider()
         .flatMap { currentClientId ->
             val message = Message.Signaling(
-                id = uuid4().toString(),
+                id = Uuid.random().toString(),
                 content = MessageContent.Receipt(ReceiptType.DELIVERED, messages),
                 conversationId = conversation.id,
                 date = Clock.System.now(),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/DeleteEphemeralMessageForSelfUserAsReceiverUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/ephemeral/DeleteEphemeralMessageForSelfUserAsReceiverUseCase.kt
@@ -17,7 +17,7 @@
  */
 package com.wire.kalium.logic.feature.message.ephemeral
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.ASSETS
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.cache.SelfConversationIdProvider
@@ -107,7 +107,7 @@ internal class DeleteEphemeralMessageForSelfUserAsReceiverUseCaseImpl(
     ): Either<CoreFailure, Unit> = selfConversationIdProvider().flatMap { selfConversaionIdList ->
         selfConversaionIdList.foldToEitherWhileRight(Unit) { selfConversationId, _ ->
             Message.Signaling(
-                id = uuid4().toString(),
+                id = Uuid.random().toString(),
                 content = MessageContent.DeleteForMe(messageToDelete, conversationId),
                 conversationId = selfConversationId,
                 date = Clock.System.now(),
@@ -128,7 +128,7 @@ internal class DeleteEphemeralMessageForSelfUserAsReceiverUseCaseImpl(
         originalMessageSender: UserId,
         currentClientId: ClientId
     ) = Message.Signaling(
-        id = uuid4().toString(),
+        id = Uuid.random().toString(),
         content = MessageContent.DeleteMessage(messageToDelete),
         conversationId = conversationId,
         date = Clock.System.now(),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/receipt/SendConfirmationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/receipt/SendConfirmationUseCase.kt
@@ -18,7 +18,7 @@
 
 package com.wire.kalium.logic.feature.message.receipt
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.common.error.CoreFailure
@@ -99,7 +99,7 @@ internal fun SendConfirmationUseCase(
 
         return currentClientIdProvider().flatMap { currentClientId ->
             val message = Message.Signaling(
-                id = uuid4().toString(),
+                id = Uuid.random().toString(),
                 content = MessageContent.Receipt(ReceiptType.READ, messageIds),
                 conversationId = conversationId,
                 date = Clock.System.now(),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/register/RegisterAccountUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/register/RegisterAccountUseCase.kt
@@ -18,7 +18,7 @@
 
 package com.wire.kalium.logic.feature.register
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.common.functional.fold
@@ -52,7 +52,7 @@ sealed class RegisterParam(
         email: String,
         password: String,
         emailActivationCode: String,
-        cookieLabel: String? = uuid4().toString(),
+        cookieLabel: String? = Uuid.random().toString(),
     ) : RegisterParam("$firstName $lastName", email, password, emailActivationCode, cookieLabel) {
 
         override val name: String
@@ -69,7 +69,7 @@ sealed class RegisterParam(
         emailActivationCode: String,
         val teamName: String,
         val teamIcon: String,
-        cookieLabel: String? = uuid4().toString()
+        cookieLabel: String? = Uuid.random().toString()
     ) : RegisterParam("$firstName $lastName", email, password, emailActivationCode, cookieLabel) {
 
         override val name: String
@@ -81,7 +81,7 @@ sealed class RegisterParam(
         override val email: String,
         override val password: String,
         override val emailActivationCode: String,
-        override val cookieLabel: String? = uuid4().toString(),
+        override val cookieLabel: String? = Uuid.random().toString(),
     ) : RegisterParam(name, email, password, emailActivationCode, cookieLabel)
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateSelfAvailabilityStatusUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UpdateSelfAvailabilityStatusUseCase.kt
@@ -18,7 +18,7 @@
 
 package com.wire.kalium.logic.feature.user
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.functional.flatMap
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.id.QualifiedID
@@ -52,7 +52,7 @@ class UpdateSelfAvailabilityStatusUseCase internal constructor(
         withContext(dispatchers.io) {
             accountRepository.updateSelfUserAvailabilityStatus(status)
             provideClientId().flatMap { selfClientId ->
-                val id = uuid4().toString()
+                val id = Uuid.random().toString()
 
                 val message = BroadcastMessage(
                     id = id,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncManagerLogger.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncManagerLogger.kt
@@ -17,7 +17,7 @@
  */
 package com.wire.kalium.logic.sync
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.common.logger.logStructuredJson
@@ -94,6 +94,6 @@ internal enum class SyncType {
  */
 internal fun KaliumLogger.provideNewSyncManagerLogger(
     syncType: SyncType,
-    syncId: String = uuid4().toString(),
+    syncId: String = Uuid.random().toString(),
     syncStartedMoment: Instant = Clock.System.now()
 ) = SyncManagerLogger(this, syncId, syncType, syncStartedMoment)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
@@ -18,7 +18,7 @@
 
 package com.wire.kalium.logic.sync.incremental
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.SYNC
@@ -149,7 +149,7 @@ internal fun IncrementalSyncManager(
         incrementalSyncWorker
             .processEventsFlow()
             .cancellable()
-            .runningFold(uuid4().toString() to Clock.System.now()) { syncData, eventSource ->
+            .runningFold(Uuid.random().toString() to Clock.System.now()) { syncData, eventSource ->
                 val syncLogger = kaliumLogger.provideNewSyncManagerLogger(SyncType.INCREMENTAL, syncData.first)
                 val newState = when (eventSource) {
                     EventSource.PENDING -> {
@@ -167,7 +167,7 @@ internal fun IncrementalSyncManager(
                 incrementalSyncRepository.updateIncrementalSyncState(newState)
 
                 // when the source is LIVE, we need to generate a new syncId since it means the previous one is done
-                if (eventSource == EventSource.LIVE) uuid4().toString() to Clock.System.now() else syncData
+                if (eventSource == EventSource.LIVE) Uuid.random().toString() to Clock.System.now() else syncData
             }.collect()
         incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Pending)
         logger.i("IncrementalSync stopped.")

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/FederationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/FederationEventReceiver.kt
@@ -18,7 +18,7 @@
 
 package com.wire.kalium.logic.sync.receiver
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.conversation.ConversationDetails
@@ -179,7 +179,7 @@ class FederationEventReceiverImpl internal constructor(
 
     private suspend fun handleMemberRemovedEvent(conversationID: ConversationId, userIDList: List<UserId>) {
         val message = Message.System(
-            id = uuid4().toString(),
+            id = Uuid.random().toString(),
             content = MessageContent.MemberChange.FederationRemoved(members = userIDList),
             conversationId = conversationID,
             date = Clock.System.now(),
@@ -193,7 +193,7 @@ class FederationEventReceiverImpl internal constructor(
 
     private suspend fun handleFederationDeleteEvent(conversationID: ConversationId, domain: String) {
         val message = Message.System(
-            id = uuid4().toString(),
+            id = Uuid.random().toString(),
             content = MessageContent.FederationStopped.Removed(domain),
             conversationId = conversationID,
             date = Clock.System.now(),
@@ -207,7 +207,7 @@ class FederationEventReceiverImpl internal constructor(
 
     private suspend fun handleFederationConnectionRemovedEvent(conversationID: ConversationId, domainList: List<String>) {
         val message = Message.System(
-            id = uuid4().toString(),
+            id = Uuid.random().toString(),
             content = MessageContent.FederationStopped.ConnectionRemoved(domainList),
             conversationId = conversationID,
             date = Clock.System.now(),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/TeamEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/TeamEventReceiver.kt
@@ -18,7 +18,7 @@
 
 package com.wire.kalium.logic.sync.receiver
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.event.EventDeliveryInfo
@@ -63,7 +63,7 @@ internal class TeamEventReceiverImpl(
             .onSuccess {
                 it.forEach { conversationId ->
                     val message = Message.System(
-                        id = uuid4().toString(), // We generate a random uuid for this new system message
+                        id = Uuid.random().toString(), // We generate a random uuid for this new system message
                         content = MessageContent.MemberChange.RemovedFromTeam(listOf(removedUser)),
                         conversationId = conversationId,
                         date = event.dateTime,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandler.kt
@@ -18,7 +18,7 @@
 
 package com.wire.kalium.logic.sync.receiver.conversation
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.onFailure
@@ -126,7 +126,7 @@ internal class MemberJoinEventHandlerImpl(
 
     private suspend fun addMemberAddedSystemMessage(event: Event.Conversation.MemberJoin) {
         val message = Message.System(
-            id = event.id.ifEmpty { uuid4().toString() },
+            id = event.id.ifEmpty { Uuid.random().toString() },
             content = MessageContent.MemberChange.Added(members = event.members.map { it.id }),
             conversationId = event.conversationId,
             date = event.dateTime,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ReceiptModeUpdateEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ReceiptModeUpdateEventHandler.kt
@@ -18,7 +18,7 @@
 
 package com.wire.kalium.logic.sync.receiver.conversation
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ReceiptModeMapper
 import com.wire.kalium.logic.data.event.Event
@@ -52,7 +52,7 @@ internal class ReceiptModeUpdateEventHandlerImpl(
         updateReceiptMode(event)
             .onSuccess {
                 val message = Message.System(
-                    uuid4().toString(),
+                    Uuid.random().toString(),
                     MessageContent.ConversationReceiptModeChanged(
                         receiptMode = event.receiptMode == Conversation.ReceiptMode.ENABLED
                     ),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/legalhold/LegalHoldSystemMessagesHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/legalhold/LegalHoldSystemMessagesHandler.kt
@@ -17,7 +17,7 @@
  */
 package com.wire.kalium.logic.sync.receiver.handler.legalhold
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
@@ -119,7 +119,7 @@ internal class LegalHoldSystemMessagesHandlerImpl(
         date: Instant = Clock.System.now(),
     ): Message.System =
         Message.System(
-            id = uuid4().toString(),
+            id = Uuid.random().toString(),
             content = content,
             conversationId = conversationId,
             date = date,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -18,7 +18,6 @@
 
 package com.wire.kalium.logic.data.conversation
 
-import com.benasher44.uuid.uuid4
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.E2EIFailure
 import com.wire.kalium.common.error.StorageFailure
@@ -104,6 +103,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
 
 class MLSConversationRepositoryTest {
 
@@ -1748,7 +1748,7 @@ class MLSConversationRepositoryTest {
                     )
                 )
             val E2EI_CONVERSATION_CLIENT_INFO_ENTITY =
-                E2EIConversationClientInfoEntity(UserIDEntity(uuid4().toString(), "domain.com"), "clientId", "groupId")
+                E2EIConversationClientInfoEntity(UserIDEntity(Uuid.random().toString(), "domain.com"), "clientId", "groupId")
             val DECRYPTED_MESSAGE_BUNDLE = com.wire.kalium.cryptography.DecryptedMessageBundle(
                 message = null,
                 commitDelay = null,
@@ -1844,7 +1844,7 @@ class MLSConversationRepositoryTest {
             ConversationEntity.GroupState.PENDING_WELCOME_MESSAGE,
             ConversationEntity.GroupState.ESTABLISHED
         )
-        
+
         states.forEach { state ->
             val (arrangement, mlsConversationRepository) = Arrangement()
                 .withUpdateMLSGroupIdAndStateSuccessful()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/sso/ValidateSSOCodeUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/sso/ValidateSSOCodeUseCaseTest.kt
@@ -19,7 +19,8 @@
 package com.wire.kalium.logic.feature.auth.sso
 
 import kotlin.test.Test
-import kotlin.test.assertFalse
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class ValidateSSOCodeUseCaseTest {
@@ -27,18 +28,26 @@ class ValidateSSOCodeUseCaseTest {
     private val validateSSOCodeUseCase: ValidateSSOCodeUseCase = ValidateSSOCodeUseCaseImpl()
 
     @Test
-    fun givenValidateSSOCodeUseCaseIsInvoked_whenUUIDIsValid_thenReturnTrue() {
+    fun givenValidSSOCodes_whenValidating_thenReturnTrue() {
         VALID_SSO_CODES.forEach { code ->
-            assertTrue {
-                validateSSOCodeUseCase(code)
-                    .let { it is ValidateSSOCodeResult.Valid && it.uuid == code.removePrefix(ValidateSSOCodeUseCase.SSO_CODE_WIRE_PREFIX) }
-            }
+            val result = validateSSOCodeUseCase(code)
+            assertIs<ValidateSSOCodeResult.Valid>(
+                result,
+                "Expected SSO Code $code to be VALID. But UseCase returned ${result::class.simpleName}"
+            )
+            assertEquals(code.removePrefix(ValidateSSOCodeUseCase.SSO_CODE_WIRE_PREFIX), result.uuid)
         }
     }
 
     @Test
-    fun givenValidateSSOCodeUseCaseIsInvoked_whenUUIDIsInvalid_thenReturnFalse() {
-        INVALID_SSO_CODES.forEach { code -> assertTrue { validateSSOCodeUseCase(code) is ValidateSSOCodeResult.Invalid } }
+    fun givenInvalidSSOCodes_whenValidating_thenReturnFalse() {
+        INVALID_SSO_CODES.forEach { code ->
+            val result = validateSSOCodeUseCase(code)
+            assertIs<ValidateSSOCodeResult.Invalid>(
+                result,
+                "Expected SSO Code $code to be INVALID. But UseCase returned ${result::class.simpleName}"
+            )
+        }
     }
 
     private companion object {
@@ -46,15 +55,14 @@ class ValidateSSOCodeUseCaseTest {
             "wire-fd994b20-b9af-11ec-ae36-00163e9b33ca", // v1
             "wire-e61648fc-774d-3cf2-b09f-1c4b7468be73", // v3
             "wire-93162444-0d5f-4c4e-9634-e6c20d46c9c4", // v4
-            "wire-f64e3024-a3b4-5cdf-9c61-3dd40c27398b" // v5
+            "wire-f64e3024-a3b4-5cdf-9c61-3dd40c27398b", // v5
         )
 
         val INVALID_SSO_CODES = listOf(
             "",
             "wire-abc",
-            "wire-fd994b20b9af11ecae3600163e9b33ca",
             "wire_e61648fc_774d_3cf2_b09f_1c4b7468be73",
-            "f64e302-4a3b4-5cdf-9c61-3dd40c27398b"
+            "f64e302-4a3b4-5cdf-9c61-3dd40c27398b",
         )
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveSecurityClassificationLabelUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveSecurityClassificationLabelUseCaseTest.kt
@@ -18,7 +18,7 @@
 
 package com.wire.kalium.logic.feature.conversation
 
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.logic.configuration.ClassifiedDomainsStatus
 import com.wire.kalium.logic.configuration.UserConfigRepository
@@ -193,7 +193,7 @@ class ObserveSecurityClassificationLabelUseCaseTest {
             domains.map { domain ->
                 MemberDetails(
                     user = TestUser.OTHER.copy(
-                        UserId(uuid4().toString(), domain),
+                        UserId(Uuid.random().toString(), domain),
                         expiresAt = expiresAt
                     ),
                     role = Conversation.Member.Role.Member

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/confirmation/ConfirmationDeliveryHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/confirmation/ConfirmationDeliveryHandlerTest.kt
@@ -18,7 +18,7 @@
 package com.wire.kalium.logic.feature.message.confirmation
 
 import co.touchlab.stately.collections.ConcurrentMutableMap
-import com.benasher44.uuid.uuid4
+import kotlin.uuid.Uuid
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.logic.data.conversation.Conversation
@@ -148,12 +148,12 @@ class ConfirmationDeliveryHandlerTest {
 
         val messagesCount = 500
         launch {
-            repeat(messagesCount) { sut.enqueueConfirmationDelivery(TestConversation.ID, uuid4().toString()) }
+            repeat(messagesCount) { sut.enqueueConfirmationDelivery(TestConversation.ID, Uuid.random().toString()) }
             delay(2000)
         }
         advanceTimeBy(1000L)
         launch {
-            repeat(messagesCount) { sut.enqueueConfirmationDelivery(TestConversation.ID, uuid4().toString()) }
+            repeat(messagesCount) { sut.enqueueConfirmationDelivery(TestConversation.ID, Uuid.random().toString()) }
             delay(2000)
         }
         advanceTimeBy(2000L)
@@ -177,7 +177,7 @@ class ConfirmationDeliveryHandlerTest {
         advanceUntilIdle()
 
         repeat(100) {
-            sut.enqueueConfirmationDelivery(TestConversation.ID, uuid4().toString())
+            sut.enqueueConfirmationDelivery(TestConversation.ID, Uuid.random().toString())
         }
         advanceUntilIdle()
         job.cancel()

--- a/network/build.gradle.kts
+++ b/network/build.gradle.kts
@@ -66,9 +66,6 @@ kotlin {
                 // Okio
                 implementation(libs.okio.core)
                 implementation(libs.okio.test)
-
-                // UUIDs
-                implementation(libs.benAsherUUID)
             }
         }
         val commonTest by getting {

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/message/EnvelopeProtoMapper.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/message/EnvelopeProtoMapper.kt
@@ -19,8 +19,6 @@
 package com.wire.kalium.network.api.base.authenticated.message
 
 import com.wire.kalium.protobuf.otr.ClientId
-import com.benasher44.uuid.bytes
-import com.benasher44.uuid.uuidFrom
 import com.wire.kalium.network.api.authenticated.message.Parameters
 import com.wire.kalium.network.api.authenticated.message.QualifiedMessageOption
 import com.wire.kalium.protobuf.otr.ClientMismatchStrategy
@@ -31,6 +29,7 @@ import com.wire.kalium.protobuf.otr.UserEntry
 import com.wire.kalium.protobuf.otr.UserId
 import pbandk.ByteArr
 import pbandk.encodeToByteArray
+import kotlin.uuid.Uuid
 
 interface EnvelopeProtoMapper {
     fun encodeToProtobuf(envelopeParameters: Parameters.QualifiedDefaultParameters): ByteArray
@@ -45,7 +44,7 @@ internal class EnvelopeProtoMapperImpl : EnvelopeProtoMapper {
         val qualifiedEntries = envelopeParameters.recipients.entries.groupBy({ it.key.domain }) { userEntry ->
             val clientEntries = userEntry.value.entries.map(otrClientEntryMapper::toOtrClientEntry)
             UserEntry(
-                user = UserId(ByteArr(uuidFrom(userEntry.key.value).bytes)),
+                user = UserId(ByteArr(Uuid.parse(userEntry.key.value).toByteArray())),
                 clients = clientEntries
             )
         }.entries.map { (domain, userEntries) ->


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20000" title="WPB-20000" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20000</a>  [Android] remove third party UUID lib after updating to kotlin 2.x
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

[benasher44/uuid](https://github.com/benasher44/uuid) is archived, since Kotlin 2.0 has added UUID support to the stdlib.

This PR removes the dependency completely, using Kotlin's implementation instead.

Just a bit of housekeeping :)