### PR TITLE
fix: update conversation new group id form the event to avoid race conditions [WPB-19900]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -219,6 +219,12 @@ interface MLSConversationRepository {
         conversationId: ConversationId,
         userIds: List<UserId>
     ): Either<CoreFailure, Map<UserId, List<WireIdentity>>>
+
+    suspend fun updateGroupIdAndState(
+        conversationId: ConversationId,
+        newGroupId: GroupID,
+        groupState: ConversationEntity.GroupState = ConversationEntity.GroupState.PENDING_JOIN
+    ): Either<CoreFailure, Unit>
 }
 
 private enum class CommitStrategy {
@@ -827,4 +833,17 @@ internal class MLSConversationDataSource(
             }
         }
     }
+
+    override suspend fun updateGroupIdAndState(
+        conversationId: ConversationId,
+        newGroupId: GroupID,
+        groupState: ConversationEntity.GroupState
+    ): Either<CoreFailure, Unit> =
+        wrapStorageRequest {
+            conversationDAO.updateMLSGroupIdAndState(
+                conversationId.toDao(),
+                idMapper.toCryptoModel(newGroupId),
+                groupState
+            )
+        }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -465,7 +465,7 @@ sealed class Event(open val id: String) {
             override val conversationId: ConversationId,
             val from: UserId,
             val groupID: GroupID,
-            val newGroupID: GroupID? = null,
+            val newGroupID: GroupID,
         ) : Conversation(id, conversationId) {
             override fun toLogMap() = mapOf(
                 typeKey to "Conversation.MlsReset",

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -457,7 +457,7 @@ class EventMapper(
         conversationId = eventContentDTO.qualifiedConversation.toModel(),
         from = eventContentDTO.qualifiedFrom.toModel(),
         groupID = GroupID(eventContentDTO.data.groupId),
-        newGroupID = eventContentDTO.data.newGroupId?.let { GroupID(it) },
+        newGroupID = GroupID(eventContentDTO.data.newGroupId),
     )
 
     private fun memberUpdate(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1728,10 +1728,7 @@ class UserSessionScope internal constructor(
 
     private val mlsResetConversationEventHandler: MLSResetConversationEventHandler
         get() = MLSResetConversationEventHandlerImpl(
-            selfUserId = userId,
-            conversationRepository = conversationRepository,
             mlsConversationRepository = mlsConversationRepository,
-            fetchConversation = fetchConversationUseCase,
         )
 
     private val conversationEventReceiver: ConversationEventReceiver by lazy {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSResetConversationEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSResetConversationEventHandler.kt
@@ -17,15 +17,11 @@
  */
 package com.wire.kalium.logic.sync.receiver.conversation
 
-import com.wire.kalium.common.functional.getOrNull
+import com.wire.kalium.common.functional.getOrElse
 import com.wire.kalium.cryptography.CryptoTransactionContext
-import com.wire.kalium.logic.data.conversation.Conversation
-import com.wire.kalium.logic.data.conversation.ConversationRepository
-import com.wire.kalium.logic.data.conversation.FetchConversationUseCase
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.event.Event
-import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 import io.mockative.Mockable
 
 @Mockable
@@ -34,33 +30,32 @@ interface MLSResetConversationEventHandler {
 }
 
 internal class MLSResetConversationEventHandlerImpl(
-    private val selfUserId: UserId,
-    private val conversationRepository: ConversationRepository,
     private val mlsConversationRepository: MLSConversationRepository,
-    private val fetchConversation: FetchConversationUseCase,
 ) : MLSResetConversationEventHandler {
     override suspend fun handle(transaction: CryptoTransactionContext, event: Event.Conversation.MLSReset) {
-        val isFromOtherUser = event.from != selfUserId
 
         // If the event is from same user do reset only if local group id does not match new group id.
-        if (isFromOtherUser || event.newGroupID != getCurrentGroupId(event.conversationId)) {
-            transaction.mls?.let { mlsContext ->
-                mlsConversationRepository.leaveGroup(mlsContext, event.groupID)
+        transaction.mls?.let { mlsContext ->
+            mlsConversationRepository.leaveGroup(mlsContext, event.groupID)
 
-                // Will be replaced by updating Group ID when it is added in a new
-                // version of mls-reset event.
-                fetchConversation(transaction, event.conversationId)
+            val hasEstablishedMLSGroup = mlsConversationRepository.hasEstablishedMLSGroup(
+                mlsContext,
+                event.newGroupID
+            ).getOrElse { false }
+
+            val newState = if (hasEstablishedMLSGroup) {
+                // already have the group, no need to join
+                // can mean that the welcome event arrived before the reset
+                ConversationEntity.GroupState.ESTABLISHED
+            } else {
+                // update local db with the new group id and set the conversation as not established
+                ConversationEntity.GroupState.PENDING_WELCOME_MESSAGE
             }
-        }
-    }
-
-    private suspend fun getCurrentGroupId(conversationId: ConversationId) =
-        conversationRepository.getConversationById(conversationId).getOrNull()?.mlsProtocolInfo()?.groupId
-
-    private fun Conversation.mlsProtocolInfo(): Conversation.ProtocolInfo.MLS? {
-        return when (this.protocol) {
-            is Conversation.ProtocolInfo.MLS -> this.protocol as? Conversation.ProtocolInfo.MLS
-            else -> null
+            mlsConversationRepository.updateGroupIdAndState(
+                event.conversationId,
+                event.newGroupID,
+                groupState = newState
+            )
         }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -1822,7 +1822,7 @@ class MLSConversationRepositoryTest {
     fun givenDAOFailure_whenUpdateGroupIdAndState_thenShouldPropagateError() = runTest {
         val conversationId = TestConversation.ID
         val newGroupId = GroupID("new_group_id")
-        val storageFailure = StorageFailure.Generic(Throwable("database error"))
+        val storageFailure = StorageFailure.Generic(Exception("database error"))
         val (arrangement, mlsConversationRepository) = Arrangement()
             .withUpdateMLSGroupIdAndStateFailing(storageFailure)
             .arrange()
@@ -1830,7 +1830,7 @@ class MLSConversationRepositoryTest {
         val result = mlsConversationRepository.updateGroupIdAndState(conversationId, newGroupId)
 
         result.shouldFail {
-            assertTrue(it is StorageFailure)
+            assertIs<StorageFailure.Generic>(it)
         }
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -54,6 +54,7 @@ import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.QualifiedClientID
 import com.wire.kalium.logic.data.id.toCrypto
+import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.keypackage.KeyPackageLimitsProvider
 import com.wire.kalium.logic.data.keypackage.KeyPackageRepository
 import com.wire.kalium.logic.data.mls.CipherSuite
@@ -102,6 +103,7 @@ import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 class MLSConversationRepositoryTest {
 
@@ -1675,6 +1677,18 @@ class MLSConversationRepositoryTest {
             }.returns(members)
         }
 
+        suspend fun withUpdateMLSGroupIdAndStateSuccessful() = apply {
+            coEvery {
+                conversationDAO.updateMLSGroupIdAndState(any(), any(), any())
+            }.returns(Unit)
+        }
+
+        suspend fun withUpdateMLSGroupIdAndStateFailing(failure: StorageFailure.Generic) = apply {
+            coEvery {
+                conversationDAO.updateMLSGroupIdAndState(any(), any(), any())
+            }.throws(failure.rootCause)
+        }
+
         companion object {
             val CIPHER_SUITE = CipherSuite.MLS_128_DHKEMP256_AES128GCM_SHA256_P256
             val TEST_FAILURE = Either.Left(CoreFailure.Unknown(Throwable("an error")))
@@ -1760,6 +1774,92 @@ class MLSConversationRepositoryTest {
             private val SIMPLE_CLIENT_RESPONSE = SimpleClientResponse("an ID", DeviceTypeDTO.Desktop)
 
             val CLIENTS_OF_USERS_RESPONSE = mapOf(TestUser.NETWORK_ID to listOf(SIMPLE_CLIENT_RESPONSE))
+        }
+    }
+
+    @Test
+    fun givenValidConversationAndGroupId_whenUpdateGroupIdAndState_thenShouldSucceed() = runTest {
+        val conversationId = TestConversation.ID
+        val newGroupId = GroupID("new_group_id")
+        val (arrangement, mlsConversationRepository) = Arrangement()
+            .withUpdateMLSGroupIdAndStateSuccessful()
+            .arrange()
+
+        val result = mlsConversationRepository.updateGroupIdAndState(conversationId, newGroupId)
+
+        result.shouldSucceed()
+        coVerify {
+            arrangement.conversationDAO.updateMLSGroupIdAndState(
+                conversationId.toDao(),
+                newGroupId.toCrypto(),
+                ConversationEntity.GroupState.PENDING_JOIN
+            )
+        }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenValidConversationAndGroupIdWithCustomState_whenUpdateGroupIdAndState_thenShouldSucceedWithCustomState() = runTest {
+        val conversationId = TestConversation.ID
+        val newGroupId = GroupID("new_group_id")
+        val customState = ConversationEntity.GroupState.ESTABLISHED
+        val (arrangement, mlsConversationRepository) = Arrangement()
+            .withUpdateMLSGroupIdAndStateSuccessful()
+            .arrange()
+
+        val result = mlsConversationRepository.updateGroupIdAndState(conversationId, newGroupId, customState)
+
+        result.shouldSucceed()
+        coVerify {
+            arrangement.conversationDAO.updateMLSGroupIdAndState(
+                conversationId.toDao(),
+                newGroupId.toCrypto(),
+                customState
+            )
+        }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenDAOFailure_whenUpdateGroupIdAndState_thenShouldPropagateError() = runTest {
+        val conversationId = TestConversation.ID
+        val newGroupId = GroupID("new_group_id")
+        val storageFailure = StorageFailure.Generic(Throwable("database error"))
+        val (arrangement, mlsConversationRepository) = Arrangement()
+            .withUpdateMLSGroupIdAndStateFailing(storageFailure)
+            .arrange()
+
+        val result = mlsConversationRepository.updateGroupIdAndState(conversationId, newGroupId)
+
+        result.shouldFail {
+            assertTrue(it is StorageFailure)
+        }
+    }
+
+    @Test
+    fun givenDifferentGroupStates_whenUpdateGroupIdAndState_thenShouldUpdateCorrectly() = runTest {
+        val conversationId = TestConversation.ID
+        val newGroupId = GroupID("new_group_id")
+        val states = listOf(
+            ConversationEntity.GroupState.PENDING_CREATION,
+            ConversationEntity.GroupState.PENDING_JOIN,
+            ConversationEntity.GroupState.PENDING_WELCOME_MESSAGE,
+            ConversationEntity.GroupState.ESTABLISHED
+        )
+        
+        states.forEach { state ->
+            val (arrangement, mlsConversationRepository) = Arrangement()
+                .withUpdateMLSGroupIdAndStateSuccessful()
+                .arrange()
+
+            val result = mlsConversationRepository.updateGroupIdAndState(conversationId, newGroupId, state)
+
+            result.shouldSucceed()
+            coVerify {
+                arrangement.conversationDAO.updateMLSGroupIdAndState(
+                    conversationId.toDao(),
+                    newGroupId.toCrypto(),
+                    state
+                )
+            }.wasInvoked(exactly = once)
         }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSResetConversationEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSResetConversationEventHandlerTest.kt
@@ -1,0 +1,298 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.receiver.conversation
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.id.GroupID
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.persistence.dao.conversation.ConversationEntity
+import io.mockative.any
+import io.mockative.coEvery
+import io.mockative.coVerify
+import io.mockative.eq
+import io.mockative.every
+import io.mockative.matches
+import io.mockative.mock
+import io.mockative.once
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class MLSResetConversationEventHandlerTest {
+
+    @Test
+    fun givenMLSContextIsNull_whenHandlingEvent_thenShouldDoNothing() = runTest {
+        val (arrangement, handler) = arrange {
+            withMLSContextNull()
+        }
+
+        handler.handle(arrangement.transactionContext, MLS_RESET_EVENT)
+
+        coVerify {
+            arrangement.mlsConversationRepository.leaveGroup(any(), any())
+        }.wasNotInvoked()
+
+        coVerify {
+            arrangement.mlsConversationRepository.hasEstablishedMLSGroup(any(), any())
+        }.wasNotInvoked()
+
+        coVerify {
+            arrangement.mlsConversationRepository.updateGroupIdAndState(any(), any(), any())
+        }.wasNotInvoked()
+    }
+
+    @Test
+    fun givenLeaveGroupFails_whenHandlingEvent_thenShouldStillUpdateGroupId() = runTest {
+        val failure = CoreFailure.Unknown(RuntimeException("Leave failed"))
+        val (arrangement, handler) = arrange {
+            withLeaveGroupFailing(failure)
+            withHasEstablishedMLSGroupReturning(false)
+            withUpdateGroupIdAndStateSucceeding()
+        }
+
+        handler.handle(arrangement.transactionContext, MLS_RESET_EVENT)
+
+        coVerify {
+            arrangement.mlsConversationRepository.leaveGroup(any(), eq(GROUP_ID))
+        }.wasInvoked(exactly = once)
+
+        coVerify {
+            arrangement.mlsConversationRepository.hasEstablishedMLSGroup(any(), eq(NEW_GROUP_ID))
+        }.wasInvoked(exactly = once)
+
+        coVerify {
+            arrangement.mlsConversationRepository.updateGroupIdAndState(
+                eq(CONVERSATION_ID),
+                eq(NEW_GROUP_ID),
+                eq(ConversationEntity.GroupState.PENDING_WELCOME_MESSAGE)
+            )
+        }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenNewGroupAlreadyEstablished_whenHandlingEvent_thenShouldUpdateWithEstablishedState() =
+        runTest {
+            val (arrangement, handler) = arrange {
+                withLeaveGroupSucceeding()
+                withHasEstablishedMLSGroupReturning(true)
+                withUpdateGroupIdAndStateSucceeding()
+            }
+
+            handler.handle(arrangement.transactionContext, MLS_RESET_EVENT)
+
+            coVerify {
+                arrangement.mlsConversationRepository.leaveGroup(any(), eq(GROUP_ID))
+            }.wasInvoked(exactly = once)
+
+            coVerify {
+                arrangement.mlsConversationRepository.hasEstablishedMLSGroup(
+                    any(),
+                    eq(NEW_GROUP_ID)
+                )
+            }.wasInvoked(exactly = once)
+
+            coVerify {
+                arrangement.mlsConversationRepository.updateGroupIdAndState(
+                    eq(CONVERSATION_ID),
+                    eq(NEW_GROUP_ID),
+                    eq(ConversationEntity.GroupState.ESTABLISHED)
+                )
+            }.wasInvoked(exactly = once)
+        }
+
+    @Test
+    fun givenNewGroupNotEstablished_whenHandlingEvent_thenShouldUpdateWithPendingWelcomeState() =
+        runTest {
+            val (arrangement, handler) = arrange {
+                withLeaveGroupSucceeding()
+                withHasEstablishedMLSGroupReturning(false)
+                withUpdateGroupIdAndStateSucceeding()
+            }
+
+            handler.handle(arrangement.transactionContext, MLS_RESET_EVENT)
+
+            coVerify {
+                arrangement.mlsConversationRepository.leaveGroup(any(), eq(GROUP_ID))
+            }.wasInvoked(exactly = once)
+
+            coVerify {
+                arrangement.mlsConversationRepository.hasEstablishedMLSGroup(
+                    any(),
+                    eq(NEW_GROUP_ID)
+                )
+            }.wasInvoked(exactly = once)
+
+            coVerify {
+                arrangement.mlsConversationRepository.updateGroupIdAndState(
+                    eq(CONVERSATION_ID),
+                    eq(NEW_GROUP_ID),
+                    eq(ConversationEntity.GroupState.PENDING_WELCOME_MESSAGE)
+                )
+            }.wasInvoked(exactly = once)
+        }
+
+    @Test
+    fun givenHasEstablishedGroupFails_whenHandlingEvent_thenShouldUpdateGroupIdWithNotEstablished() =
+        runTest {
+            val failure = CoreFailure.Unknown(RuntimeException("Has established failed"))
+            val event = MLS_RESET_EVENT
+            val (arrangement, handler) = arrange {
+                withLeaveGroupSucceeding()
+                withHasEstablishedMLSGroupFailing(failure)
+                withUpdateGroupIdAndStateSucceeding()
+            }
+
+            handler.handle(arrangement.transactionContext, event)
+
+            coVerify {
+                arrangement.mlsConversationRepository.leaveGroup(any(), eq(event.groupID))
+            }.wasInvoked(exactly = once)
+
+            coVerify {
+                arrangement.mlsConversationRepository.updateGroupIdAndState(
+                    matches { it == event.conversationId },
+                    matches { it == event.newGroupID },
+                    matches { it == ConversationEntity.GroupState.PENDING_WELCOME_MESSAGE }
+                )
+            }.wasInvoked(exactly = once)
+        }
+
+    @Test
+    fun givenUpdateGroupIdAndStateFails_whenHandlingEvent_thenShouldPropagateError() = runTest {
+        val failure = StorageFailure.DataNotFound
+        val (arrangement, handler) = arrange {
+            withLeaveGroupSucceeding()
+            withHasEstablishedMLSGroupReturning(false)
+            withUpdateGroupIdAndStateFailing(failure)
+        }
+
+        handler.handle(arrangement.transactionContext, MLS_RESET_EVENT)
+
+        coVerify {
+            arrangement.mlsConversationRepository.updateGroupIdAndState(
+                eq(CONVERSATION_ID),
+                eq(NEW_GROUP_ID),
+                eq(ConversationEntity.GroupState.PENDING_WELCOME_MESSAGE)
+            )
+        }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenAllSucceeds_whenHandlingEvent_thenShouldLeaveGroupAndUpdateState() = runTest {
+        val (arrangement, handler) = arrange {
+            withLeaveGroupSucceeding()
+            withHasEstablishedMLSGroupReturning(true)
+            withUpdateGroupIdAndStateSucceeding()
+        }
+
+        handler.handle(arrangement.transactionContext, MLS_RESET_EVENT)
+
+        coVerify {
+            arrangement.mlsConversationRepository.leaveGroup(any(), eq(GROUP_ID))
+        }.wasInvoked(exactly = once)
+
+        coVerify {
+            arrangement.mlsConversationRepository.hasEstablishedMLSGroup(any(), eq(NEW_GROUP_ID))
+        }.wasInvoked(exactly = once)
+
+        coVerify {
+            arrangement.mlsConversationRepository.updateGroupIdAndState(
+                eq(CONVERSATION_ID),
+                eq(NEW_GROUP_ID),
+                eq(ConversationEntity.GroupState.ESTABLISHED)
+            )
+        }.wasInvoked(exactly = once)
+    }
+
+    private class Arrangement(private val block: suspend Arrangement.() -> Unit) :
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+
+        val mlsConversationRepository = mock(MLSConversationRepository::class)
+
+        suspend fun withLeaveGroupSucceeding() = apply {
+            coEvery {
+                mlsConversationRepository.leaveGroup(any(), any())
+            }.returns(Either.Right(Unit))
+        }
+
+        suspend fun withLeaveGroupFailing(failure: CoreFailure) = apply {
+            coEvery {
+                mlsConversationRepository.leaveGroup(any(), any())
+            }.returns(Either.Left(failure))
+        }
+
+        suspend fun withHasEstablishedMLSGroupReturning(hasGroup: Boolean) = apply {
+            coEvery {
+                mlsConversationRepository.hasEstablishedMLSGroup(any(), any())
+            }.returns(Either.Right(hasGroup))
+        }
+
+        suspend fun withHasEstablishedMLSGroupFailing(failure: CoreFailure) = apply {
+            coEvery {
+                mlsConversationRepository.hasEstablishedMLSGroup(any(), any())
+            }.returns(Either.Left(failure))
+        }
+
+        suspend fun withUpdateGroupIdAndStateSucceeding() = apply {
+            coEvery {
+                mlsConversationRepository.updateGroupIdAndState(any(), any(), any())
+            }.returns(Either.Right(Unit))
+        }
+
+        suspend fun withUpdateGroupIdAndStateFailing(failure: CoreFailure) = apply {
+            coEvery {
+                mlsConversationRepository.updateGroupIdAndState(any(), any(), any())
+            }.returns(Either.Left(failure))
+        }
+
+        suspend fun withMLSContextNull() = apply {
+            every { transactionContext.mls }.returns(null)
+        }
+
+        suspend fun arrange() = run {
+            block()
+            this@Arrangement to MLSResetConversationEventHandlerImpl(
+                mlsConversationRepository = mlsConversationRepository
+            )
+        }
+    }
+
+    private companion object {
+        suspend fun arrange(configuration: suspend Arrangement.() -> Unit) =
+            Arrangement(configuration).arrange()
+
+        val GROUP_ID = GroupID("old_group_id")
+        val NEW_GROUP_ID = GroupID("new_group_id")
+        val CONVERSATION_ID = TestConversation.ID
+        val USER_ID = TestUser.USER_ID
+
+        val MLS_RESET_EVENT = Event.Conversation.MLSReset(
+            id = "event_id",
+            conversationId = CONVERSATION_ID,
+            from = USER_ID,
+            groupID = GROUP_ID,
+            newGroupID = NEW_GROUP_ID,
+        )
+    }
+}

--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/notification/conversation/MlsConversationResetData.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/notification/conversation/MlsConversationResetData.kt
@@ -25,5 +25,5 @@ data class MlsConversationResetData(
     @SerialName("group_id")
     val groupId: String,
     @SerialName("new_group_id")
-    val newGroupId: String? = null, // Will be added in new event version
+    val newGroupId: String
 )

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -131,6 +131,12 @@ UPDATE Conversation
 SET mls_group_state = :mls_group_state, mls_cipher_suite = :mls_cipher_suite
 WHERE mls_group_id = :mls_group_id;
 
+updateMLSGroupIdAndState:
+UPDATE Conversation
+SET mls_group_id = :new_group_id, 
+    mls_group_state = :group_state
+WHERE qualified_id = :conversation_id;
+
 updateConversationNotificationsDateWithTheLastMessage:
 UPDATE Conversation
 SET last_notified_date = (

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
@@ -34,14 +34,14 @@ data class ProposalTimerEntity(
 @Mockable
 interface ConversationDAO {
     val platformExtensions: ConversationExtensions
-    //region Get/Observe by ID
+    // region Get/Observe by ID
 
     suspend fun observeConversationById(qualifiedID: QualifiedIDEntity): Flow<ConversationEntity?>
     suspend fun getConversationById(qualifiedID: QualifiedIDEntity): ConversationEntity?
     suspend fun getConversationDetailsById(qualifiedID: QualifiedIDEntity): ConversationViewEntity?
     suspend fun observeConversationDetailsById(conversationId: QualifiedIDEntity): Flow<ConversationViewEntity?>
     suspend fun isAChannel(conversationId: QualifiedIDEntity): Boolean
-    //endregion
+    // endregion
 
     suspend fun getSelfConversationId(protocol: ConversationEntity.Protocol): QualifiedIDEntity?
     suspend fun getE2EIConversationClientInfoByClientId(clientId: String): E2EIConversationClientInfoEntity?
@@ -55,6 +55,7 @@ interface ConversationDAO {
         cipherSuite: ConversationEntity.CipherSuite,
         groupId: String
     )
+
     suspend fun updateConversationModifiedDate(qualifiedID: QualifiedIDEntity, date: Instant)
     suspend fun updateConversationNotificationDate(qualifiedID: QualifiedIDEntity)
     suspend fun updateConversationReadDate(conversationID: QualifiedIDEntity, date: Instant)
@@ -66,6 +67,7 @@ interface ConversationDAO {
         onlyInteractionEnabled: Boolean = false,
         newActivitiesOnTop: Boolean = false,
     ): Flow<List<ConversationDetailsWithEventsEntity>>
+
     suspend fun getConversationIds(
         type: ConversationEntity.Type,
         protocol: ConversationEntity.Protocol,
@@ -125,6 +127,7 @@ interface ConversationDAO {
         link: String,
         isPasswordProtected: Boolean
     )
+
     suspend fun updateChannelAddPermission(
         conversationId: QualifiedIDEntity,
         channelAddPermission: ConversationEntity.ChannelAddPermission
@@ -148,6 +151,12 @@ interface ConversationDAO {
     suspend fun observeLegalHoldStatusChangeNotified(conversationId: QualifiedIDEntity): Flow<Boolean>
     suspend fun getMLSGroupIdByUserId(userId: UserIDEntity): String?
     suspend fun getMLSGroupIdByConversationId(conversationId: QualifiedIDEntity): String?
+    suspend fun updateMLSGroupIdAndState(
+        conversationId: QualifiedIDEntity,
+        newGroupId: String,
+        groupState: ConversationEntity.GroupState
+    )
+
     suspend fun getEstablishedSelfMLSGroupId(): String?
 
     suspend fun selectGroupStatusMembersNamesAndHandles(groupID: String): EpochChangesDataEntity?

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
@@ -249,6 +249,14 @@ internal class ConversationDAOImpl internal constructor(
         conversationQueries.updateMlsGroupStateAndCipherSuite(groupState, cipherSuite, groupId)
     }
 
+    override suspend fun updateMLSGroupIdAndState(
+        conversationId: QualifiedIDEntity,
+        newGroupId: String,
+        groupState: ConversationEntity.GroupState
+    ) = withContext(coroutineContext) {
+        conversationQueries.updateMLSGroupIdAndState(newGroupId, groupState, conversationId)
+    }
+
     override suspend fun updateConversationModifiedDate(qualifiedID: QualifiedIDEntity, date: Instant) = withContext(coroutineContext) {
         conversationQueries.updateConversationModifiedDate(date, qualifiedID)
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19900" title="WPB-19900" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19900</a>  [Android] Issues with broken conversation after MLS reset
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

after mls reset the group is left broken this can happen sometimes but not always

### Causes (Optional)

the code follows exactly what the docs say however we implemented this feature before the backend added the new group id to the event data, and we fetch the conversation info from the server 

m,y theory is when using a limited QA server the event is 
1. sent not in guaranteed order (meaning the MLS welcome event is sent before the mls reset event)
2. in the mls reset event we wipe from CC the old group ID
3. fetch the data from server 
4. server did not update its DB yet so it responded with the old group ID 
5. this will make the app thinks that the conversation is not established (technicly this is correct since the old group id is what we get)
6. the user need to reopen the app which will lead to the app checking for pending groups and joining via external commit 

### Solutions

change the flow to
1. wipe old cond 
2. check if the new group id is established 
3. if true (in case the welcome is sent first)
4. then update the DB to the new group id and make it as established
5. if not then udpate teh DB to the new group ID and mark it as pending welcome 

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
