### PR TITLE
chore(conversation-history): persist retention settings for channels [WPB-18408]

### DIFF
--- a/benchmarks/src/commonMain/kotlin/com/wire/kalium/benchmarks/persistence/DBTestSetup.kt
+++ b/benchmarks/src/commonMain/kotlin/com/wire/kalium/benchmarks/persistence/DBTestSetup.kt
@@ -79,5 +79,6 @@ object DBTestSetup {
         channelAccess = null,
         channelAddPermission = null,
         wireCell = null,
+        historySharingRetentionSeconds = 0
     )
 }

--- a/conversation-history/src/commonTest/kotlin/com/wire/kalium/conversation/history/data/SQLiteHistoryClientDAOTest.kt
+++ b/conversation-history/src/commonTest/kotlin/com/wire/kalium/conversation/history/data/SQLiteHistoryClientDAOTest.kt
@@ -49,23 +49,23 @@ class SQLiteHistoryClientDAOTest {
             historyClientQueries = testDatabase.builder.historyClientQueries,
             queriesContext = testDispatcher
         )
-        
+
         // Insert fake conversations to satisfy foreign key constraint
         insertFakeConversations()
     }
-    
+
     private suspend fun insertFakeConversations() {
         // Insert the test conversation used in most tests
         insertFakeConversation(TEST_CONVERSATION_ID)
-        
+
         // Insert the second test conversation used in some tests
         val secondConversationId = QualifiedIDEntity("conversation2", "domain")
         insertFakeConversation(secondConversationId)
     }
-    
+
     private suspend fun insertFakeConversation(conversationId: QualifiedIDEntity) {
         val now = Instant.DISTANT_PAST
-        
+
         val conversationEntity = ConversationEntity(
             id = conversationId,
             name = "Test Conversation",
@@ -88,9 +88,10 @@ class SQLiteHistoryClientDAOTest {
             isChannel = false,
             channelAccess = null,
             channelAddPermission = null,
-            wireCell = null
+            wireCell = null,
+            historySharingRetentionSeconds = 0,
         )
-        
+
         testDatabase.builder.conversationDAO.insertConversation(conversationEntity)
     }
 
@@ -127,80 +128,82 @@ class SQLiteHistoryClientDAOTest {
     }
 
     @Test
-    fun givenMultipleHistoryClientsInserted_whenGettingAllForConversation_thenShouldReturnAllClientsForThatConversation() = runTest(testDispatcher) {
-        // Given
-        val conversationId1 = TEST_CONVERSATION_ID
-        val conversationId2 = QualifiedIDEntity("conversation2", "domain")
-        val clientId1 = "client1"
-        val clientId2 = "client2"
-        val secret1 = byteArrayOf(1, 2, 3, 4)
-        val secret2 = byteArrayOf(5, 6, 7, 8)
-        val baseInstant = Instant.DISTANT_PAST
-        val creationDate1 = baseInstant
-        val creationDate2 = baseInstant + 1.days // One day later
+    fun givenMultipleHistoryClientsInserted_whenGettingAllForConversation_thenShouldReturnAllClientsForThatConversation() =
+        runTest(testDispatcher) {
+            // Given
+            val conversationId1 = TEST_CONVERSATION_ID
+            val conversationId2 = QualifiedIDEntity("conversation2", "domain")
+            val clientId1 = "client1"
+            val clientId2 = "client2"
+            val secret1 = byteArrayOf(1, 2, 3, 4)
+            val secret2 = byteArrayOf(5, 6, 7, 8)
+            val baseInstant = Instant.DISTANT_PAST
+            val creationDate1 = baseInstant
+            val creationDate2 = baseInstant + 1.days // One day later
 
-        // Insert clients for first conversation
-        historyClientDAO.insertClient(
-            conversationId = conversationId1,
-            id = clientId1,
-            secret = secret1,
-            creationDate = creationDate1
-        )
+            // Insert clients for first conversation
+            historyClientDAO.insertClient(
+                conversationId = conversationId1,
+                id = clientId1,
+                secret = secret1,
+                creationDate = creationDate1
+            )
 
-        // Insert client for second conversation
-        historyClientDAO.insertClient(
-            conversationId = conversationId2,
-            id = clientId2,
-            secret = secret2,
-            creationDate = creationDate2
-        )
+            // Insert client for second conversation
+            historyClientDAO.insertClient(
+                conversationId = conversationId2,
+                id = clientId2,
+                secret = secret2,
+                creationDate = creationDate2
+            )
 
-        // When
-        val result1 = historyClientDAO.getAllForConversation(conversationId1)
-        val result2 = historyClientDAO.getAllForConversation(conversationId2)
+            // When
+            val result1 = historyClientDAO.getAllForConversation(conversationId1)
+            val result2 = historyClientDAO.getAllForConversation(conversationId2)
 
-        // Then
-        assertEquals(1, result1.size)
-        assertEquals(1, result2.size)
-        
-        with(result1.first()) {
-            assertEquals(clientId1, this.id)
+            // Then
+            assertEquals(1, result1.size)
+            assertEquals(1, result2.size)
+
+            with(result1.first()) {
+                assertEquals(clientId1, this.id)
+            }
+
+            with(result2.first()) {
+                assertEquals(clientId2, this.id)
+            }
         }
-        
-        with(result2.first()) {
-            assertEquals(clientId2, this.id)
-        }
-    }
 
     @Test
-    fun givenHistoryClientsWithDifferentDates_whenGettingAllFromDateOnwards_thenShouldReturnOnlyClientsFromThatDateOnwards() = runTest(testDispatcher) {
-        // Given
-        val conversationId = TEST_CONVERSATION_ID
-        val clientId1 = "client1"
-        val clientId2 = "client2"
-        val clientId3 = "client3"
-        val secret = byteArrayOf(1, 2, 3, 4)
-        
-        val baseInstant = Instant.DISTANT_PAST
-        val date1 = baseInstant
-        val date2 = baseInstant + 1.days // One day later
-        val date3 = baseInstant + 2.days // Two days later
+    fun givenHistoryClientsWithDifferentDates_whenGettingAllFromDateOnwards_thenShouldReturnOnlyClientsFromThatDateOnwards() =
+        runTest(testDispatcher) {
+            // Given
+            val conversationId = TEST_CONVERSATION_ID
+            val clientId1 = "client1"
+            val clientId2 = "client2"
+            val clientId3 = "client3"
+            val secret = byteArrayOf(1, 2, 3, 4)
 
-        // Insert clients with different dates
-        historyClientDAO.insertClient(conversationId, clientId1, secret, date1)
-        historyClientDAO.insertClient(conversationId, clientId2, secret, date2)
-        historyClientDAO.insertClient(conversationId, clientId3, secret, date3)
+            val baseInstant = Instant.DISTANT_PAST
+            val date1 = baseInstant
+            val date2 = baseInstant + 1.days // One day later
+            val date3 = baseInstant + 2.days // Two days later
 
-        // When - get clients from date2 onwards
-        val result = historyClientDAO.getAllForConversationFromDateOnwards(conversationId, date2)
+            // Insert clients with different dates
+            historyClientDAO.insertClient(conversationId, clientId1, secret, date1)
+            historyClientDAO.insertClient(conversationId, clientId2, secret, date2)
+            historyClientDAO.insertClient(conversationId, clientId3, secret, date3)
 
-        // Then
-        assertEquals(2, result.size)
-        val clientIds = result.map { it.id }.toSet()
-        assertTrue(clientIds.contains(clientId2))
-        assertTrue(clientIds.contains(clientId3))
-        assertTrue(!clientIds.contains(clientId1))
-    }
+            // When - get clients from date2 onwards
+            val result = historyClientDAO.getAllForConversationFromDateOnwards(conversationId, date2)
+
+            // Then
+            assertEquals(2, result.size)
+            val clientIds = result.map { it.id }.toSet()
+            assertTrue(clientIds.contains(clientId2))
+            assertTrue(clientIds.contains(clientId3))
+            assertTrue(!clientIds.contains(clientId1))
+        }
 
     @Test
     fun givenHistoryClientsInserted_whenObservingAllForConversation_thenShouldEmitClientsForThatConversation() = runTest(testDispatcher) {
@@ -210,27 +213,27 @@ class SQLiteHistoryClientDAOTest {
         val clientId2 = "client2"
         val secret = byteArrayOf(1, 2, 3, 4)
         val date = Instant.DISTANT_PAST
-        
+
         // Insert clients
         historyClientDAO.insertClient(conversationId, clientId1, secret, date)
-        
+
         // When - observe clients
         historyClientDAO.observeAllForConversation(conversationId).test {
             // Then - initial emission should contain the first client
             val initialClients = awaitItem()
             assertEquals(1, initialClients.size)
             assertEquals(clientId1, initialClients.first().id)
-            
+
             // When - insert another client
             historyClientDAO.insertClient(conversationId, clientId2, secret, date)
-            
+
             // Then - should emit updated list with both clients
             val updatedClients = awaitItem()
             assertEquals(2, updatedClients.size)
             val clientIds = updatedClients.map { it.id }.toSet()
             assertTrue(clientIds.contains(clientId1))
             assertTrue(clientIds.contains(clientId2))
-            
+
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/conversation-history/src/commonTest/kotlin/com/wire/kalium/conversation/history/domain/IsConversationHistorySupportedForConversationUseCaseTest.kt
+++ b/conversation-history/src/commonTest/kotlin/com/wire/kalium/conversation/history/domain/IsConversationHistorySupportedForConversationUseCaseTest.kt
@@ -19,7 +19,7 @@ package com.wire.kalium.conversation.history.domain
 
 import app.cash.turbine.test
 import com.wire.kalium.common.functional.Either
-import com.wire.kalium.logic.data.ConversationMock
+import com.wire.kalium.logic.data.MockConversation
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -31,11 +31,11 @@ class IsConversationHistorySupportedForConversationUseCaseTest {
     @Test
     fun givenConversationIsChannelAndEverythingElseIsEnabled_whenInvoking_thenShouldReturnTrue() = runTest {
         val subject = IsConversationHistorySupportedForConversationUseCase(
-            conversationByIdProvider = { flowOf(Either.Right(ConversationMock.channel())) },
+            conversationByIdProvider = { flowOf(Either.Right(MockConversation.channel())) },
             isBuildTimeAllowed = true
         )
         
-        subject(ConversationMock.id()).test { 
+        subject(MockConversation.id()).test {
             assertTrue(awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
@@ -44,11 +44,11 @@ class IsConversationHistorySupportedForConversationUseCaseTest {
     @Test
     fun givenConversationIsChannelButDisallowed_whenInvoking_thenShouldReturnFalse() = runTest {
         val subject = IsConversationHistorySupportedForConversationUseCase(
-            conversationByIdProvider = { flowOf(Either.Right(ConversationMock.channel())) },
+            conversationByIdProvider = { flowOf(Either.Right(MockConversation.channel())) },
             isBuildTimeAllowed = false
         )
 
-        subject(ConversationMock.id()).test {
+        subject(MockConversation.id()).test {
             assertFalse(awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
@@ -57,11 +57,11 @@ class IsConversationHistorySupportedForConversationUseCaseTest {
     @Test
     fun givenConversationIsOneOnOneAndEverythingElseIsEnabled_whenInvoking_thenShouldReturnFalse() = runTest {
         val subject = IsConversationHistorySupportedForConversationUseCase(
-            conversationByIdProvider = { flowOf(Either.Right(ConversationMock.oneOnOne())) },
+            conversationByIdProvider = { flowOf(Either.Right(MockConversation.oneOnOne())) },
             isBuildTimeAllowed = true
         )
 
-        subject(ConversationMock.id()).test {
+        subject(MockConversation.id()).test {
             assertFalse(awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
@@ -70,11 +70,11 @@ class IsConversationHistorySupportedForConversationUseCaseTest {
     @Test
     fun givenConversationIsGroupAndEverythingElseIsEnabled_whenInvoking_thenShouldReturnFalse() = runTest {
         val subject = IsConversationHistorySupportedForConversationUseCase(
-            conversationByIdProvider = { flowOf(Either.Right(ConversationMock.group())) },
+            conversationByIdProvider = { flowOf(Either.Right(MockConversation.group())) },
             isBuildTimeAllowed = true
         )
 
-        subject(ConversationMock.id()).test {
+        subject(MockConversation.id()).test {
             assertFalse(awaitItem())
             cancelAndIgnoreRemainingEvents()
         }

--- a/data-mocks/build.gradle.kts
+++ b/data-mocks/build.gradle.kts
@@ -32,6 +32,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(project(":data"))
+                implementation(project(":persistence"))
                 implementation(project(":network-model"))
                 implementation(project(":util"))
 

--- a/data-mocks/src/commonMain/kotlin/com/wire/kalium/logic/data/IdMock.kt
+++ b/data-mocks/src/commonMain/kotlin/com/wire/kalium/logic/data/IdMock.kt
@@ -1,0 +1,37 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+@file:OptIn(ExperimentalUuidApi::class)
+
+package com.wire.kalium.logic.data
+
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import kotlin.uuid.ExperimentalUuidApi
+
+fun QualifiedID.Companion.fake(base: Int) = QualifiedID(
+    value = "fakeId[$base]",
+    domain = "domain[$base]",
+)
+
+fun QualifiedIDEntity.Companion.fake(base: Int) = QualifiedIDEntity(
+    value = "fakeId[$base]",
+    domain = "domain[$base]",
+)
+
+fun QualifiedID.toEntity() = QualifiedIDEntity(value, domain)
+fun QualifiedIDEntity.toModel() = QualifiedID(value, domain)

--- a/data-mocks/src/commonMain/kotlin/com/wire/kalium/logic/data/MockConversation.kt
+++ b/data-mocks/src/commonMain/kotlin/com/wire/kalium/logic/data/MockConversation.kt
@@ -5,14 +5,19 @@ import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.TeamId
+import com.wire.kalium.persistence.dao.ConversationIDEntity
+import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 import kotlinx.datetime.Instant
 import kotlinx.datetime.toInstant
 
-object ConversationMock {
+object MockConversation {
     private const val conversationValue = "valueConvo"
     private const val conversationDomain = "domainConvo"
 
     val ID = ConversationId(conversationValue, conversationDomain)
+    val ENTITY_ID = QualifiedIDEntity(conversationValue, conversationDomain)
+
     fun id(suffix: Int = 0) = ConversationId("${conversationValue}_$suffix", conversationDomain)
 
     fun oneOnOne(protocolInfo: ProtocolInfo = ProtocolInfo.Proteus) = Conversation(
@@ -63,8 +68,8 @@ object ConversationMock {
         legalHoldStatus = Conversation.LegalHoldStatus.DISABLED
     )
 
-    fun group(protocolInfo: ProtocolInfo = ProtocolInfo.Proteus) = Conversation(
-        id = ID,
+    fun group(id: ConversationId = ID, protocolInfo: ProtocolInfo = ProtocolInfo.Proteus) = Conversation(
+        id = id,
         name = "GROUP Name",
         type = Conversation.Type.Group.Regular,
         teamId = TeamId("teamId"),
@@ -87,5 +92,36 @@ object ConversationMock {
         legalHoldStatus = Conversation.LegalHoldStatus.DISABLED
     )
 
-    fun channel(protocolInfo: ProtocolInfo = ProtocolInfo.Proteus) = group(protocolInfo).copy(type = Conversation.Type.Group.Channel)
+    fun channel(
+        protocolInfo: ProtocolInfo = ProtocolInfo.Proteus
+    ) = group(protocolInfo = protocolInfo).copy(type = Conversation.Type.Group.Channel)
+
+    fun entity(
+        id: ConversationIDEntity = ENTITY_ID,
+    ) = ConversationEntity(
+        id,
+        "convo name",
+        ConversationEntity.Type.SELF,
+        "teamId",
+        ConversationEntity.ProtocolInfo.Proteus,
+        creatorId = "someValue",
+        lastNotificationDate = null,
+        lastModifiedDate = "2022-03-30T15:36:00.000Z".toInstant(),
+        lastReadDate = "2022-03-30T15:36:00.000Z".toInstant(),
+        access = listOf(ConversationEntity.Access.LINK, ConversationEntity.Access.INVITE),
+        accessRole = listOf(ConversationEntity.AccessRole.NON_TEAM_MEMBER, ConversationEntity.AccessRole.TEAM_MEMBER),
+        receiptMode = ConversationEntity.ReceiptMode.DISABLED,
+        messageTimer = null,
+        userMessageTimer = null,
+        archived = false,
+        archivedInstant = null,
+        mlsVerificationStatus = ConversationEntity.VerificationStatus.NOT_VERIFIED,
+        proteusVerificationStatus = ConversationEntity.VerificationStatus.NOT_VERIFIED,
+        legalHoldStatus = ConversationEntity.LegalHoldStatus.DISABLED,
+        isChannel = false,
+        channelAccess = null,
+        channelAddPermission = null,
+        wireCell = null,
+        historySharingRetentionSeconds = 0,
+    )
 }

--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.logic.data.conversation.Conversation.AccessRole
 import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo
 import com.wire.kalium.logic.data.conversation.Conversation.ReceiptMode
 import com.wire.kalium.logic.data.conversation.Conversation.Type
+import com.wire.kalium.logic.data.history.HistoryClient
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.PlainId
@@ -353,7 +354,8 @@ sealed interface ConversationDetails {
             // TODO: Add channel-specific fields
 //         val isTeamAdmin: Boolean, TODO kubaz
             val access: ChannelAccess,
-            val permission: ChannelAddPermission
+            val permission: ChannelAddPermission,
+            val historySharing: ConversationHistorySharing,
         ) : Group {
             /**
              * An enum class that defines the permissions for adding participants to a channel,
@@ -405,6 +407,31 @@ sealed interface ConversationDetails {
                 proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
                 legalHoldStatus = Conversation.LegalHoldStatus.DISABLED
             )
+    }
+}
+
+sealed interface ConversationHistorySharing {
+    /**
+     * History Sharing is disabled.
+     * New members should *not* be able to retrieve and see messages sent before they have joined the conversation
+     */
+    data object Private : ConversationHistorySharing
+
+    /**
+     * Messages in the conversation that are newer than [retention] should be shared with new members.
+     * The [retention] must be strictly positive.
+     * For example:
+     * Message A is 10 days old
+     * Message B is 2 days old
+     * When [retention] is 5, and a new members joins the conversation, only Message B should be retrievable by the new user.
+     * @see HistoryClient
+     */
+    data class ShareWithNewMembers(val retention: Duration) : ConversationHistorySharing {
+        init {
+            require(retention.isPositive()) {
+                "history-sharing retention must be > 0"
+            }
+        }
     }
 }
 

--- a/logic/build.gradle.kts
+++ b/logic/build.gradle.kts
@@ -78,6 +78,7 @@ kotlin {
             dependencies {
                 implementation(project(":common"))
                 implementation(project(":persistence-test"))
+                implementation(project(":data-mocks"))
                 // coroutines
                 implementation(libs.coroutines.test)
                 implementation(libs.turbine)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepository.kt
@@ -319,6 +319,7 @@ internal class ConnectionDataSource(
                         channelAccess = null,
                         channelAddPermission = null,
                         wireCell = null,
+                        historySharingRetentionSeconds = 0,
                     )
                 )
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -43,6 +43,7 @@ import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.network.api.authenticated.conversation.ChannelAddPermissionTypeDTO
 import com.wire.kalium.network.api.authenticated.conversation.ConvProtocol
 import com.wire.kalium.network.api.authenticated.conversation.ConvTeamInfo
+import com.wire.kalium.network.api.authenticated.conversation.ConversationHistorySettingsDTO
 import com.wire.kalium.network.api.authenticated.conversation.ConversationResponse
 import com.wire.kalium.network.api.authenticated.conversation.CreateConversationRequest
 import com.wire.kalium.network.api.authenticated.conversation.GroupConversationType
@@ -66,6 +67,7 @@ import com.wire.kalium.util.time.UNIX_FIRST_DATE
 import io.mockative.Mockable
 import kotlinx.datetime.Instant
 import kotlinx.datetime.toInstant
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
@@ -76,6 +78,7 @@ interface ConversationMapper {
         mlsGroupState: GroupState?,
         selfUserTeamId: TeamId?,
     ): ConversationEntity
+
     fun fromApiModel(mlsPublicKeysDTO: MLSPublicKeysDTO?): MLSPublicKeys?
     fun fromDaoModel(daoModel: ConversationViewEntity): Conversation
     fun fromDaoModel(daoModel: ConversationEntity): Conversation
@@ -156,6 +159,10 @@ internal class ConversationMapperImpl(
             channelAccess = null, // TODO: implement when api is ready
             channelAddPermission = apiModel.channelAddUserPermissionTypeDTO?.toDAO(),
             wireCell = conversationId.toString().takeIf { apiModel.cellEnabled() }, // TODO refactor to boolean in WPB-16946
+            historySharingRetentionSeconds = when (val historySharingSettings = apiModel.historySharingSettings) {
+                ConversationHistorySettingsDTO.Private -> 0
+                is ConversationHistorySettingsDTO.SharedWithNewMembers -> historySharingSettings.depth.inWholeSeconds
+            }
         )
     }
 
@@ -297,7 +304,10 @@ internal class ConversationMapperImpl(
                             folder = folderId?.let { ConversationFolder(it, folderName ?: "", type = FolderType.USER) },
                             access = channelAccess?.toModelChannelAccess() ?: ChannelAccess.PRIVATE,
                             permission = channelAddPermission?.toModelChannelPermission()
-                                ?: ConversationDetails.Group.Channel.ChannelAddPermission.ADMINS
+                                ?: ChannelAddPermission.ADMINS,
+                            historySharing = daoModel.historySharingRetentionSeconds.takeIf { it > 0 }?.let {
+                                ConversationHistorySharing.ShareWithNewMembers(it.seconds)
+                            } ?: ConversationHistorySharing.Private
                         )
                     } else {
                         ConversationDetails.Group.Regular(
@@ -489,6 +499,7 @@ internal class ConversationMapperImpl(
             channelAccess = null,
             channelAddPermission = null,
             wireCell = null,
+            historySharingRetentionSeconds = 0, // There was no history sharing in old Android clients. So we can hard-code 0
         )
     }
 
@@ -524,6 +535,7 @@ internal class ConversationMapperImpl(
         channelAccess = null,
         channelAddPermission = null,
         wireCell = null,
+        historySharingRetentionSeconds = 0, // We can have no history sharing when they're failed.
     )
 
     private fun ConversationResponse.getProtocolInfo(mlsGroupState: GroupState?): ProtocolInfo {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryIntegrationTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryIntegrationTest.kt
@@ -1,0 +1,131 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.data.conversation
+
+import app.cash.turbine.test
+import com.wire.kalium.logic.data.MockConversation
+import com.wire.kalium.logic.data.fake
+import com.wire.kalium.logic.data.toModel
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.util.shouldSucceed
+import com.wire.kalium.logic.util.stubs.ClientApiStub
+import com.wire.kalium.logic.util.stubs.ConversationApiStub
+import com.wire.kalium.network.api.base.authenticated.client.ClientApi
+import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
+import com.wire.kalium.persistence.TestUserDatabase
+import com.wire.kalium.persistence.dao.ConversationIDEntity
+import com.wire.kalium.persistence.dao.conversation.ConversationEntity
+import com.wire.kalium.util.ConversationPersistenceApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+// Uses concrete DAOs backed by in-memory Database, and fake APIs, instead of mocks for 100% of the dependencies
+@OptIn(ConversationPersistenceApi::class)
+class ConversationRepositoryIntegrationTest {
+
+    private val userId = TestUser.USER_ID
+    private val userIdEntity = TestUser.ENTITY_ID
+    private val testDispatcher = StandardTestDispatcher()
+    private val database = TestUserDatabase(userIdEntity, testDispatcher)
+
+    private fun createSubject(
+        conversationApi: ConversationApi = ConversationApiStub(),
+        clientApi: ClientApi = ClientApiStub(),
+    ): ConversationRepository = ConversationDataSource(
+        selfUserId = userId,
+        conversationDAO = database.builder.conversationDAO,
+        memberDAO = database.builder.memberDAO,
+        conversationApi = conversationApi,
+        messageDAO = database.builder.messageDAO,
+        messageDraftDAO = database.builder.messageDraftDAO,
+        clientDAO = database.builder.clientDAO,
+        clientApi = clientApi,
+        conversationMetaDataDAO = database.builder.conversationMetaDataDAO,
+        metadataDAO = database.builder.metadataDAO,
+    )
+
+    @Test
+    fun givenPersistedConversations_whenGettingThem_thenShouldReturnWithCorrectBasicData() = runTest(testDispatcher) {
+        val conversations = listOf(
+            MockConversation.entity(id = ConversationIDEntity.fake(1)),
+        )
+        val subject = createSubject()
+
+        subject.persistConversations(conversations).shouldSucceed()
+
+        val firstConversation = conversations.first()
+        subject.getConversationById(firstConversation.id.toModel()).shouldSucceed {
+            assertEquals(firstConversation.id.toModel().value, it.id.value)
+            assertEquals(firstConversation.name, it.name)
+            assertEquals(firstConversation.type, it.type.toDAO())
+        }
+    }
+
+    @Test
+    fun givenPersistedChannelWithoutSharingRetention_whenGettingDetails_thenShouldReturnWithPrivateHistorySharing() =
+        runTest(testDispatcher) {
+            val conversationEntity = MockConversation.entity(
+                id = ConversationIDEntity.fake(1)
+            ).copy(
+                type = ConversationEntity.Type.GROUP,
+                isChannel = true,
+                historySharingRetentionSeconds = 0,
+            )
+            val conversations = listOf(conversationEntity)
+            val subject = createSubject()
+
+            subject.persistConversations(conversations)
+            subject.observeConversationDetailsById(conversations.first().id.toModel()).test {
+                awaitItem().shouldSucceed {
+                    assertIs<ConversationDetails.Group.Channel>(it)
+                    val historySharing = it.historySharing
+                    assertIs<ConversationHistorySharing.Private>(historySharing)
+                }
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun givenPersistedChannelWithSharingRetention_whenGettingDetails_thenShouldReturnWithCorrectHistorySharingSeconds() =
+        runTest(testDispatcher) {
+            val expectedSeconds = 42312L
+            val conversationEntity = MockConversation.entity(
+                id = ConversationIDEntity.fake(1)
+            ).copy(
+                type = ConversationEntity.Type.GROUP,
+                isChannel = true,
+                historySharingRetentionSeconds = expectedSeconds,
+            )
+            val conversations = listOf(conversationEntity)
+            val subject = createSubject()
+
+            subject.persistConversations(conversations)
+            subject.observeConversationDetailsById(conversations.first().id.toModel()).test {
+                awaitItem().shouldSucceed {
+                    assertIs<ConversationDetails.Group.Channel>(it)
+                    val historySharing = it.historySharing
+                    assertIs<ConversationHistorySharing.ShareWithNewMembers>(historySharing)
+                    assertEquals(expectedSeconds, historySharing.retention.inWholeSeconds)
+                }
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestConversation.kt
@@ -57,7 +57,7 @@ import kotlinx.datetime.toInstant
 
 @Deprecated(
     "Data-mocks module should be used to share test mocks across modules.",
-    ReplaceWith("com.wire.kalium.logic.data.ConversationMock")
+    ReplaceWith("com.wire.kalium.logic.data.MockConversation")
 )
 object TestConversation {
     private const val conversationValue = "valueConvo"
@@ -188,6 +188,7 @@ object TestConversation {
         channelAccess = null,
         channelAddPermission = null,
         wireCell = null,
+        historySharingRetentionSeconds = 0,
     )
 
     fun one_on_one(convId: ConversationId) = Conversation(
@@ -316,6 +317,7 @@ object TestConversation {
         channelAccess = null,
         channelAddPermission = null,
         wireCell = null,
+        historySharingRetentionSeconds = 0,
     )
     val ENTITY_GROUP = ENTITY.copy(
         type = ConversationEntity.Type.GROUP
@@ -371,6 +373,7 @@ object TestConversation {
         channelAccess = null,
         channelAddPermission = null,
         wireCell = null,
+        historySharingRetentionSeconds = 0,
     )
 
     val VIEW_ONE_ON_ONE = VIEW_ENTITY.copy(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/stubs/ClientApiStub.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/stubs/ClientApiStub.kt
@@ -1,0 +1,75 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.util.stubs
+
+import com.wire.kalium.network.api.authenticated.client.ClientDTO
+import com.wire.kalium.network.api.authenticated.client.RegisterClientRequest
+import com.wire.kalium.network.api.authenticated.client.SimpleClientResponse
+import com.wire.kalium.network.api.authenticated.client.UpdateClientCapabilitiesRequest
+import com.wire.kalium.network.api.authenticated.client.UpdateClientMlsPublicKeysRequest
+import com.wire.kalium.network.api.base.authenticated.client.ClientApi
+import com.wire.kalium.network.api.model.PushTokenBody
+import com.wire.kalium.network.api.model.UserId
+import com.wire.kalium.network.utils.NetworkResponse
+
+open class ClientApiStub: ClientApi {
+    override suspend fun registerClient(registerClientRequest: RegisterClientRequest): NetworkResponse<ClientDTO> {
+        TODO("Test stub function was not yet implemented")
+    }
+
+    override suspend fun listClientsOfUsers(userIds: List<UserId>): NetworkResponse<Map<UserId, List<SimpleClientResponse>>> {
+        TODO("Test stub function was not yet implemented")
+    }
+
+    override suspend fun fetchSelfUserClient(): NetworkResponse<List<ClientDTO>> {
+        TODO("Test stub function was not yet implemented")
+    }
+
+    override suspend fun deleteClient(
+        password: String?,
+        clientID: String
+    ): NetworkResponse<Unit> {
+        TODO("Test stub function was not yet implemented")
+    }
+
+    override suspend fun fetchClientInfo(clientID: String): NetworkResponse<ClientDTO> {
+        TODO("Test stub function was not yet implemented")
+    }
+
+    override suspend fun updateClientMlsPublicKeys(
+        updateClientMlsPublicKeysRequest: UpdateClientMlsPublicKeysRequest,
+        clientID: String
+    ): NetworkResponse<Unit> {
+        TODO("Test stub function was not yet implemented")
+    }
+
+    override suspend fun updateClientCapabilities(
+        updateClientCapabilitiesRequest: UpdateClientCapabilitiesRequest,
+        clientID: String
+    ): NetworkResponse<Unit> {
+        TODO("Test stub function was not yet implemented")
+    }
+
+    override suspend fun registerToken(body: PushTokenBody): NetworkResponse<Unit> {
+        TODO("Test stub function was not yet implemented")
+    }
+
+    override suspend fun deregisterToken(pid: String): NetworkResponse<Unit> {
+        TODO("Test stub function was not yet implemented")
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/stubs/ConversationApiStub.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/stubs/ConversationApiStub.kt
@@ -1,0 +1,231 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.util.stubs
+
+import com.wire.kalium.network.api.authenticated.conversation.AddConversationMembersRequest
+import com.wire.kalium.network.api.authenticated.conversation.AddServiceRequest
+import com.wire.kalium.network.api.authenticated.conversation.ConvProtocol
+import com.wire.kalium.network.api.authenticated.conversation.ConversationMemberAddedResponse
+import com.wire.kalium.network.api.authenticated.conversation.ConversationMemberRemovedResponse
+import com.wire.kalium.network.api.authenticated.conversation.ConversationPagingResponse
+import com.wire.kalium.network.api.authenticated.conversation.ConversationRenameResponse
+import com.wire.kalium.network.api.authenticated.conversation.ConversationResponse
+import com.wire.kalium.network.api.authenticated.conversation.ConversationResponseDTO
+import com.wire.kalium.network.api.authenticated.conversation.CreateConversationRequest
+import com.wire.kalium.network.api.authenticated.conversation.MemberUpdateDTO
+import com.wire.kalium.network.api.authenticated.conversation.SubconversationDeleteRequest
+import com.wire.kalium.network.api.authenticated.conversation.SubconversationResponse
+import com.wire.kalium.network.api.authenticated.conversation.TypingIndicatorStatusDTO
+import com.wire.kalium.network.api.authenticated.conversation.UpdateChannelAddPermissionResponse
+import com.wire.kalium.network.api.authenticated.conversation.UpdateConversationAccessRequest
+import com.wire.kalium.network.api.authenticated.conversation.UpdateConversationAccessResponse
+import com.wire.kalium.network.api.authenticated.conversation.UpdateConversationProtocolResponse
+import com.wire.kalium.network.api.authenticated.conversation.UpdateConversationReceiptModeResponse
+import com.wire.kalium.network.api.authenticated.conversation.channel.ChannelAddPermissionDTO
+import com.wire.kalium.network.api.authenticated.conversation.guestroomlink.ConversationInviteLinkResponse
+import com.wire.kalium.network.api.authenticated.conversation.model.ConversationCodeInfo
+import com.wire.kalium.network.api.authenticated.conversation.model.ConversationMemberRoleDTO
+import com.wire.kalium.network.api.authenticated.conversation.model.ConversationReceiptModeDTO
+import com.wire.kalium.network.api.authenticated.notification.EventContentDTO
+import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
+import com.wire.kalium.network.api.model.ConversationId
+import com.wire.kalium.network.api.model.QualifiedID
+import com.wire.kalium.network.api.model.ServiceAddedResponse
+import com.wire.kalium.network.api.model.SubconversationId
+import com.wire.kalium.network.api.model.UserId
+import com.wire.kalium.network.utils.NetworkResponse
+
+open class ConversationApiStub : ConversationApi {
+    override suspend fun fetchConversationsIds(pagingState: String?): NetworkResponse<ConversationPagingResponse> {
+        TODO("Test stub function was not implemented.")
+    }
+
+    override suspend fun fetchConversationsListDetails(conversationsIds: List<ConversationId>): NetworkResponse<ConversationResponseDTO> {
+        TODO("Test stub function was not implemented.")
+    }
+
+    override suspend fun fetchConversationDetails(conversationId: ConversationId): NetworkResponse<ConversationResponse> {
+        TODO("Test stub function was not implemented.")
+    }
+
+    override suspend fun createNewConversation(
+        createConversationRequest: CreateConversationRequest
+    ): NetworkResponse<ConversationResponse> {
+        TODO("Test stub function was not implemented.")
+    }
+
+    override suspend fun addMember(
+        addParticipantRequest: AddConversationMembersRequest,
+        conversationId: ConversationId
+    ): NetworkResponse<ConversationMemberAddedResponse> {
+        TODO("Test stub function was not implemented.")
+    }
+
+    override suspend fun addService(
+        addServiceRequest: AddServiceRequest,
+        conversationId: ConversationId
+    ): NetworkResponse<ServiceAddedResponse> {
+        TODO("Test stub function was not implemented.")
+    }
+
+    override suspend fun removeMember(
+        userId: UserId,
+        conversationId: ConversationId
+    ): NetworkResponse<ConversationMemberRemovedResponse> {
+        TODO("Test stub function was not implemented.")
+    }
+
+    override suspend fun updateConversationMemberState(
+        memberUpdateRequest: MemberUpdateDTO,
+        conversationId: ConversationId
+    ): NetworkResponse<Unit> {
+        TODO("Test stub function was not implemented.")
+    }
+
+    override suspend fun updateAccess(
+        conversationId: ConversationId,
+        updateConversationAccessRequest: UpdateConversationAccessRequest
+    ): NetworkResponse<UpdateConversationAccessResponse> {
+        TODO("Test stub function was not implemented.")
+    }
+
+    override suspend fun updateConversationMemberRole(
+        conversationId: ConversationId,
+        userId: UserId,
+        conversationMemberRoleDTO: ConversationMemberRoleDTO
+    ): NetworkResponse<Unit> {
+        TODO("Test stub function was not implemented.")
+    }
+
+    override suspend fun updateConversationName(
+        conversationId: QualifiedID,
+        conversationName: String
+    ): NetworkResponse<ConversationRenameResponse> {
+        TODO("Test stub function was not implemented.")
+    }
+
+    override suspend fun fetchGroupInfo(conversationId: QualifiedID): NetworkResponse<ByteArray> {
+        TODO("Test stub function was not implemented.")
+    }
+
+    override suspend fun joinConversation(
+        code: String,
+        key: String,
+        uri: String?,
+        password: String?
+    ): NetworkResponse<ConversationMemberAddedResponse> {
+        TODO("Test stub function was not implemented.")
+    }
+
+    override suspend fun fetchLimitedInformationViaCode(
+        code: String,
+        key: String
+    ): NetworkResponse<ConversationCodeInfo> {
+        TODO("Test stub function was not implemented.")
+    }
+
+    override suspend fun fetchMlsOneToOneConversation(userId: UserId): NetworkResponse<ConversationResponse> {
+        TODO("Test stub function was not implemented.")
+    }
+
+    override suspend fun fetchSubconversationDetails(
+        conversationId: ConversationId,
+        subconversationId: SubconversationId
+    ): NetworkResponse<SubconversationResponse> {
+        TODO("Test stub function was not implemented.")
+    }
+
+    override suspend fun fetchSubconversationGroupInfo(
+        conversationId: ConversationId,
+        subconversationId: SubconversationId
+    ): NetworkResponse<ByteArray> {
+        TODO("Test stub function was not implemented.")
+    }
+
+    override suspend fun deleteSubconversation(
+        conversationId: ConversationId,
+        subconversationId: SubconversationId,
+        deleteRequest: SubconversationDeleteRequest
+    ): NetworkResponse<Unit> {
+        TODO("Test stub function was not implemented.")
+    }
+
+    override suspend fun leaveSubconversation(
+        conversationId: ConversationId,
+        subconversationId: SubconversationId
+    ): NetworkResponse<Unit> {
+        TODO("Test stub function was not implemented.")
+    }
+
+    override suspend fun updateReceiptMode(
+        conversationId: ConversationId,
+        receiptMode: ConversationReceiptModeDTO
+    ): NetworkResponse<UpdateConversationReceiptModeResponse> {
+        TODO("Test stub function was not implemented.")
+    }
+
+    override suspend fun generateGuestRoomLink(
+        conversationId: ConversationId,
+        password: String?
+    ): NetworkResponse<EventContentDTO.Conversation.CodeUpdated> {
+        TODO("Test stub function was not implemented.")
+    }
+
+    override suspend fun revokeGuestRoomLink(conversationId: ConversationId): NetworkResponse<Unit> {
+        TODO("Test stub function was not implemented.")
+    }
+
+    override suspend fun updateMessageTimer(
+        conversationId: ConversationId,
+        messageTimer: Long?
+    ): NetworkResponse<EventContentDTO.Conversation.MessageTimerUpdate> {
+        TODO("Test stub function was not implemented.")
+    }
+
+    override suspend fun sendTypingIndicatorNotification(
+        conversationId: ConversationId,
+        typingIndicatorMode: TypingIndicatorStatusDTO
+    ): NetworkResponse<Unit> {
+        TODO("Test stub function was not implemented.")
+    }
+
+    override suspend fun updateProtocol(
+        conversationId: ConversationId,
+        protocol: ConvProtocol
+    ): NetworkResponse<UpdateConversationProtocolResponse> {
+        TODO("Test stub function was not implemented.")
+    }
+
+    override suspend fun updateChannelAddPermission(
+        conversationId: ConversationId,
+        channelAddPermission: ChannelAddPermissionDTO
+    ): NetworkResponse<UpdateChannelAddPermissionResponse> {
+        TODO("Test stub function was not implemented.")
+    }
+
+    override suspend fun guestLinkInfo(conversationId: ConversationId): NetworkResponse<ConversationInviteLinkResponse> {
+        TODO("Test stub function was not implemented.")
+    }
+
+    override suspend fun resetMlsConversation(
+        groupId: String,
+        epoch: ULong
+    ): NetworkResponse<Unit> {
+        TODO("Test stub function was not implemented.")
+    }
+}

--- a/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/conversation/ConversationResponse.kt
+++ b/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/conversation/ConversationResponse.kt
@@ -95,7 +95,7 @@ data class ConversationResponse(
 
     /**
      * Only groups are expected to have a non-null value.
-     * Since API V8
+     * @since API V8
      * @see GroupType
      */
     @SerialName("group_conv_type")
@@ -106,10 +106,19 @@ data class ConversationResponse(
 
     /**
      * Status of the wire cell for conversation: disabled, pending, ready
-     * Since API V8
+     * @since API V8
      */
     @SerialName("cells_state")
     val cellsState: String? = null,
+
+    /**
+     * History sharing settings for the conversation.
+     * Although the field was added on API V11, the value [ConversationHistorySettingsDTO.Private]
+     * is backwards-compatible value, and it is used as the default when the field is not present in the response.
+     * @since API V11
+     */
+    @SerialName("history")
+    val historySharingSettings: ConversationHistorySettingsDTO = ConversationHistorySettingsDTO.Private,
 ) {
 
     @Suppress("MagicNumber")

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationDetails.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationDetails.sq
@@ -112,6 +112,7 @@ LabeledConversation.folder_id IS NOT NULL AS isFavorite,
 CurrentFolder.id AS folderId,
 CurrentFolder.name AS folderName,
 Conversation.wire_cell AS wireCell,
+Conversation.history_sharing_retention_seconds AS historySharingRetentionSeconds,
 Conversation.deleted_locally AS deletedLocally
 FROM Conversation
 LEFT JOIN SelfUser

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -49,7 +49,8 @@ CREATE TABLE Conversation (
     channel_access TEXT AS ConversationEntity.ChannelAccess DEFAULT NULL,
     channel_add_permission TEXT AS ConversationEntity.ChannelAddPermission DEFAULT NULL,
     wire_cell TEXT,
-    deleted_locally INTEGER AS Boolean NOT NULL DEFAULT 0
+    deleted_locally INTEGER AS Boolean NOT NULL DEFAULT 0,
+    history_sharing_retention_seconds INTEGER NOT NULL DEFAULT 0 CHECK (history_sharing_retention_seconds >= 0)
 );
 
 CREATE TABLE ConversationLegalHoldStatusChangeNotified (
@@ -69,6 +70,7 @@ CREATE INDEX conversation_muted_status_index ON Conversation(muted_status);
 CREATE INDEX conversation_archived_type_channel_index ON Conversation(archived, type, is_channel);
 CREATE INDEX Conversation_idx_archived_protocol ON Conversation(archived, protocol);
 CREATE INDEX conversation_idx_wire_cell_notnull ON Conversation(wire_cell) WHERE wire_cell IS NOT NULL;
+CREATE INDEX conversation_history_sharing_retention ON Conversation(history_sharing_retention_seconds);
 
 conversationIDByGroupId:
 SELECT qualified_id, verification_status FROM Conversation WHERE mls_group_id = :groupId;
@@ -85,8 +87,8 @@ SET deleted_locally = 1
 WHERE qualified_id = ?;
 
 insertConversation:
-INSERT INTO Conversation(qualified_id, name, type, team_id, mls_group_id, mls_group_state, mls_epoch, protocol, muted_status, muted_time, creator_id, last_modified_date, last_notified_date, access_list, access_role_list, last_read_date, mls_last_keying_material_update_date, mls_cipher_suite, receipt_mode, message_timer, user_message_timer, incomplete_metadata, archived, archived_date_time, is_channel, channel_access, channel_add_permission, wire_cell)
-VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO Conversation(qualified_id, name, type, team_id, mls_group_id, mls_group_state, mls_epoch, protocol, muted_status, muted_time, creator_id, last_modified_date, last_notified_date, access_list, access_role_list, last_read_date, mls_last_keying_material_update_date, mls_cipher_suite, receipt_mode, message_timer, user_message_timer, incomplete_metadata, archived, archived_date_time, is_channel, channel_access, channel_add_permission, wire_cell, history_sharing_retention_seconds)
+VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(qualified_id) DO UPDATE SET
 name = excluded.name,
 type = excluded.type,
@@ -114,7 +116,8 @@ archived_date_time = excluded.archived_date_time,
 is_channel = excluded.is_channel,
 channel_access = excluded.channel_access,
 channel_add_permission = excluded.channel_add_permission,
-wire_cell = excluded.wire_cell;
+wire_cell = excluded.wire_cell,
+history_sharing_retention_seconds = excluded.history_sharing_retention_seconds;
 
 updateConversation:
 UPDATE Conversation

--- a/persistence/src/commonMain/db_user/migrations/114.sqm
+++ b/persistence/src/commonMain/db_user/migrations/114.sqm
@@ -1,0 +1,224 @@
+DROP VIEW IF EXISTS ConversationDetails;
+DROP VIEW IF EXISTS ConversationDetailsWithEvents;
+
+ALTER TABLE Conversation ADD COLUMN history_sharing_retention_seconds INTEGER NOT NULL DEFAULT 0 CHECK (history_sharing_retention_seconds >= 0);
+
+CREATE INDEX conversation_history_sharing_retention ON Conversation(history_sharing_retention_seconds);
+
+CREATE VIEW IF NOT EXISTS ConversationDetails AS
+SELECT
+Conversation.qualified_id AS qualifiedId,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.name
+    WHEN 'CONNECTION_PENDING' THEN connection_user.name
+    ELSE Conversation.name
+END AS name,
+Conversation.type,
+Call.status AS callStatus,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.preview_asset_id
+    WHEN 'CONNECTION_PENDING' THEN connection_user.preview_asset_id
+END AS previewAssetId,
+Conversation.muted_status AS mutedStatus,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN User.team
+    ELSE Conversation.team_id
+END AS teamId,
+CASE (Conversation.type)
+    WHEN 'CONNECTION_PENDING' THEN Connection.last_update_date
+    ELSE Conversation.last_modified_date
+END AS lastModifiedDate,
+Conversation.last_read_date AS lastReadDate,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.user_availability_status
+    WHEN 'CONNECTION_PENDING' THEN connection_user.user_availability_status
+END AS userAvailabilityStatus,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.user_type
+    WHEN 'CONNECTION_PENDING' THEN connection_user.user_type
+END AS userType,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.bot_service
+    WHEN 'CONNECTION_PENDING' THEN connection_user.bot_service
+END AS botService,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.deleted
+    WHEN 'CONNECTION_PENDING' THEN connection_user.deleted
+END AS userDeleted,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.defederated
+    WHEN 'CONNECTION_PENDING' THEN connection_user.defederated
+END AS userDefederated,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.supported_protocols
+    WHEN 'CONNECTION_PENDING' THEN connection_user.supported_protocols
+END AS userSupportedProtocols,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.connection_status
+    WHEN 'CONNECTION_PENDING' THEN connection_user.connection_status
+END AS connectionStatus,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN  User.qualified_id
+    WHEN 'CONNECTION_PENDING' THEN connection_user.qualified_id
+END AS otherUserId,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN User.active_one_on_one_conversation_id
+    WHEN 'CONNECTION_PENDING' THEN connection_user.active_one_on_one_conversation_id
+END AS otherUserActiveConversationId,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN coalesce(User.active_one_on_one_conversation_id = Conversation.qualified_id, 0)
+    ELSE 1
+END AS isActive,
+CASE (Conversation.type)
+    WHEN 'ONE_ON_ONE' THEN User.accent_id
+    ELSE 0
+END AS accentId,
+Conversation.last_notified_date AS lastNotifiedMessageDate,
+memberRole. role AS selfRole,
+Conversation.protocol,
+Conversation.mls_cipher_suite,
+Conversation.mls_epoch,
+Conversation.mls_group_id,
+Conversation.mls_last_keying_material_update_date,
+Conversation.mls_group_state,
+Conversation.access_list,
+Conversation.access_role_list,
+Conversation.mls_proposal_timer,
+Conversation.muted_time,
+Conversation.creator_id,
+Conversation.receipt_mode,
+Conversation.message_timer,
+Conversation.user_message_timer,
+Conversation.incomplete_metadata,
+Conversation.archived,
+Conversation.archived_date_time,
+Conversation.verification_status AS mls_verification_status,
+Conversation.proteus_verification_status,
+Conversation.legal_hold_status,
+Conversation.is_channel,
+Conversation.channel_access,
+Conversation.channel_add_permission,
+SelfUser.id AS selfUserId,
+CASE
+    WHEN Conversation.type = 'GROUP' THEN
+        CASE
+            WHEN memberRole.role IS NOT NULL THEN 1
+            ELSE 0
+        END
+    WHEN Conversation.type = 'ONE_ON_ONE' THEN
+        CASE
+            WHEN User.defederated = 1 THEN 0
+            WHEN User.deleted = 1 THEN 0
+            WHEN User.connection_status = 'BLOCKED' THEN 0
+            WHEN Conversation.legal_hold_status = 'DEGRADED' THEN 0
+            ELSE 1
+        END
+    ELSE 0
+END AS interactionEnabled,
+LabeledConversation.folder_id IS NOT NULL AS isFavorite,
+CurrentFolder.id AS folderId,
+CurrentFolder.name AS folderName,
+Conversation.wire_cell AS wireCell,
+Conversation.history_sharing_retention_seconds AS historySharingRetentionSeconds,
+Conversation.deleted_locally AS deletedLocally
+FROM Conversation
+LEFT JOIN SelfUser
+LEFT JOIN Member ON Conversation.qualified_id = Member.conversation
+    AND Conversation.type IS 'ONE_ON_ONE'
+    AND Member.user IS NOT SelfUser.id
+LEFT JOIN Member AS memberRole ON Conversation.qualified_id = memberRole.conversation
+    AND memberRole.user IS SelfUser.id
+LEFT JOIN User ON User.qualified_id = Member.user
+LEFT JOIN Connection ON Connection.qualified_conversation = Conversation.qualified_id
+    AND (Connection.status = 'SENT'
+         OR Connection.status = 'PENDING'
+         OR Connection.status = 'NOT_CONNECTED'
+         AND Conversation.type IS 'CONNECTION_PENDING')
+LEFT JOIN User AS connection_user ON Connection.qualified_to = connection_user.qualified_id
+LEFT JOIN Call ON Call.id IS (SELECT id FROM Call WHERE Call.conversation_id = Conversation.qualified_id AND Call.status IS 'STILL_ONGOING' ORDER BY created_at DESC LIMIT 1)
+LEFT JOIN ConversationFolder AS FavoriteFolder ON FavoriteFolder.folder_type IS 'FAVORITE'
+LEFT JOIN LabeledConversation ON LabeledConversation.conversation_id = Conversation.qualified_id AND LabeledConversation.folder_id = FavoriteFolder.id
+LEFT JOIN LabeledConversation AS ConversationLabel ON ConversationLabel.conversation_id = Conversation.qualified_id AND ConversationLabel.folder_id IS NOT FavoriteFolder.id
+LEFT JOIN ConversationFolder AS CurrentFolder ON CurrentFolder.id = ConversationLabel.folder_id AND CurrentFolder.folder_type IS NOT 'FAVORITE';
+
+CREATE VIEW IF NOT EXISTS ConversationDetailsWithEvents AS
+SELECT
+    ConversationDetails.*,
+    -- unread events
+    UnreadEventCountsGrouped.knocksCount AS unreadKnocksCount,
+    UnreadEventCountsGrouped.missedCallsCount AS unreadMissedCallsCount,
+    UnreadEventCountsGrouped.mentionsCount AS unreadMentionsCount,
+    UnreadEventCountsGrouped.repliesCount AS unreadRepliesCount,
+    UnreadEventCountsGrouped.messagesCount AS unreadMessagesCount,
+    CASE
+        WHEN ConversationDetails.callStatus = 'STILL_ONGOING' AND ConversationDetails.type = 'GROUP' THEN 1 -- if ongoing call in a group, move it to the top
+        WHEN ConversationDetails.mutedStatus = 'ALL_ALLOWED' THEN
+           CASE
+                WHEN (UnreadEventCountsGrouped.knocksCount + UnreadEventCountsGrouped.missedCallsCount + UnreadEventCountsGrouped.mentionsCount + UnreadEventCountsGrouped.repliesCount + UnreadEventCountsGrouped.messagesCount) > 0 THEN 1 -- if any unread events, move it to the top
+                WHEN ConversationDetails.type = 'CONNECTION_PENDING' AND ConversationDetails.connectionStatus = 'PENDING' THEN 1 -- if received connection request, move it to the top
+                ELSE 0
+            END
+        WHEN ConversationDetails.mutedStatus = 'ONLY_MENTIONS_AND_REPLIES_ALLOWED' THEN
+            CASE
+                WHEN (UnreadEventCountsGrouped.mentionsCount + UnreadEventCountsGrouped.repliesCount) > 0 THEN 1 -- only if unread mentions or replies, move it to the top
+                WHEN ConversationDetails.type = 'CONNECTION_PENDING' AND ConversationDetails.connectionStatus = 'PENDING' THEN 1 -- if received connection request, move it to the top
+                ELSE 0
+            END
+        ELSE 0
+    END AS hasNewActivitiesToShow,
+    -- draft message
+    MessageDraft.text AS messageDraftText,
+    MessageDraft.edit_message_id AS messageDraftEditMessageId,
+    MessageDraft.quoted_message_id AS messageDraftQuotedMessageId,
+    MessageDraft.mention_list AS messageDraftMentionList,
+    -- last message
+    Message.id AS lastMessageId,
+    Message.content_type AS lastMessageContentType,
+    Message.creation_date AS lastMessageDate,
+    Message.visibility AS lastMessageVisibility,
+    Message.sender_user_id AS lastMessageSenderUserId,
+    (Message.expire_after_millis IS NOT NULL) AS lastMessageIsEphemeral,
+    User.name AS lastMessageSenderName,
+    User.connection_status AS lastMessageSenderConnectionStatus,
+    User.deleted AS lastMessageSenderIsDeleted,
+    (Message.sender_user_id IS NOT NULL AND Message.sender_user_id == ConversationDetails.selfUserId) AS lastMessageIsSelfMessage,
+    MemberChangeContent.member_change_list AS lastMessageMemberChangeList,
+    MemberChangeContent.member_change_type AS lastMessageMemberChangeType,
+    ConversationNameChangedContent.conversation_name AS lastMessageUpdateConversationName,
+    COUNT(Mention.user_id) > 0 AS lastMessageIsMentioningSelfUser,
+    TextContent.is_quoting_self AS lastMessageIsQuotingSelfUser,
+    TextContent.text_body AS lastMessageText,
+    AssetContent.asset_mime_type AS lastMessageAssetMimeType
+FROM ConversationDetails
+LEFT JOIN UnreadEventCountsGrouped
+    ON UnreadEventCountsGrouped.conversationId = ConversationDetails.qualifiedId
+LEFT JOIN MessageDraft
+    ON ConversationDetails.qualifiedId = MessageDraft.conversation_id AND ConversationDetails.archived = 0 -- only return message draft for non-archived conversations
+LEFT JOIN LastMessage
+    ON LastMessage.conversation_id = ConversationDetails.qualifiedId AND ConversationDetails.archived = 0 -- only return last message for non-archived conversations
+LEFT JOIN Message
+    ON LastMessage.message_id = Message.id AND LastMessage.conversation_id = Message.conversation_id
+LEFT JOIN User
+    ON Message.sender_user_id = User.qualified_id
+LEFT JOIN MessageMemberChangeContent AS MemberChangeContent
+    ON LastMessage.message_id = MemberChangeContent.message_id AND LastMessage.conversation_id = MemberChangeContent.conversation_id
+LEFT JOIN MessageMention AS Mention
+    ON LastMessage.message_id == Mention.message_id AND ConversationDetails.selfUserId == Mention.user_id
+LEFT JOIN MessageConversationChangedContent AS ConversationNameChangedContent
+    ON LastMessage.message_id = ConversationNameChangedContent.message_id AND LastMessage.conversation_id = ConversationNameChangedContent.conversation_id
+LEFT JOIN MessageAssetContent AS AssetContent
+    ON LastMessage.message_id = AssetContent.message_id AND LastMessage.conversation_id = AssetContent.conversation_id
+LEFT JOIN MessageTextContent AS TextContent
+    ON LastMessage.message_id = TextContent.message_id AND LastMessage.conversation_id = TextContent.conversation_id
+WHERE
+    ConversationDetails.type IS NOT 'SELF'
+    AND (
+        ConversationDetails.type IS 'GROUP'
+        OR (ConversationDetails.type IS 'ONE_ON_ONE' AND (ConversationDetails.name IS NOT NULL AND ConversationDetails.otherUserId IS NOT NULL)) -- show 1:1 convos if they have user metadata
+        OR (ConversationDetails.type IS 'ONE_ON_ONE' AND ConversationDetails.userDeleted = 1) -- show deleted 1:1 convos to maintain prev, logic
+        OR (ConversationDetails.type IS 'CONNECTION_PENDING' AND ConversationDetails.otherUserId IS NOT NULL) -- show connection requests even without metadata
+    )
+    AND (ConversationDetails.protocol IS 'PROTEUS' OR ConversationDetails.protocol IS 'MIXED' OR (ConversationDetails.protocol IS 'MLS' AND ConversationDetails.mls_group_state IS 'ESTABLISHED'))
+    AND ConversationDetails.isActive
+    AND ConversationDetails.deletedLocally = 0
+GROUP BY ConversationDetails.qualifiedId;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
@@ -223,6 +223,7 @@ internal class ConversationDAOImpl internal constructor(
                 channel_access = channelAccess,
                 channel_add_permission = channelAddPermission,
                 wire_cell = wireCell,
+                history_sharing_retention_seconds = historySharingRetentionSeconds,
             )
         }
     }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDetailsWithEventsMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDetailsWithEventsMapper.kt
@@ -86,6 +86,7 @@ data object ConversationDetailsWithEventsMapper {
         folderId: String?,
         folderName: String?,
         wireCell: String?,
+        historySharingRetentionSeconds: Long,
         deletedLocally: Boolean,
         unreadKnocksCount: Long?,
         unreadMissedCallsCount: Long?,
@@ -168,6 +169,7 @@ data object ConversationDetailsWithEventsMapper {
             channelAddPermission = channelAddPermission,
             wireCell = wireCell,
             deletedLocally = deletedLocally,
+            historySharingRetentionSeconds = historySharingRetentionSeconds,
         ),
         unreadEvents = UnreadEventMapper.toConversationUnreadEntity(
             conversationId = qualifiedId,

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationEntity.kt
@@ -51,6 +51,7 @@ data class ConversationEntity(
     val channelAccess: ChannelAccess?,
     val channelAddPermission: ChannelAddPermission?,
     val wireCell: String?,
+    val historySharingRetentionSeconds: Long,
 ) {
     enum class AccessRole { TEAM_MEMBER, NON_TEAM_MEMBER, GUEST, SERVICE, EXTERNAL; }
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationMapper.kt
@@ -82,6 +82,7 @@ data object ConversationMapper {
         folderId: String?,
         folderName: String?,
         wireCell: String?,
+        historySharingRetentionSeconds: Long,
         deletedLocally: Boolean,
     ): ConversationViewEntity = ConversationViewEntity(
         id = qualifiedId,
@@ -139,6 +140,7 @@ data object ConversationMapper {
         channelAccess = channelAccess,
         channelAddPermission = channelAddPermission,
         wireCell = wireCell,
+        historySharingRetentionSeconds = historySharingRetentionSeconds,
     )
 
     @Suppress("LongParameterList", "UnusedParameter")
@@ -180,6 +182,7 @@ data object ConversationMapper {
         channelAddPermission: ConversationEntity.ChannelAddPermission?,
         wireCell: String?,
         deletedLocally: Boolean,
+        historySharingRetentionSeconds: Long,
     ) = ConversationEntity(
         id = qualifiedId,
         name = name,
@@ -213,6 +216,7 @@ data object ConversationMapper {
         channelAccess = channelAccess,
         channelAddPermission = channelAddPermission,
         wireCell = wireCell,
+        historySharingRetentionSeconds = historySharingRetentionSeconds,
     )
 
     @Suppress("LongParameterList", "UnusedParameter", "FunctionParameterNaming")
@@ -253,7 +257,8 @@ data object ConversationMapper {
         channel_access: ConversationEntity.ChannelAccess?,
         channel_add_permission: ConversationEntity.ChannelAddPermission?,
         wireCell: String?,
-        deleted_lcoally: Boolean,
+        deleted_locally: Boolean,
+        history_sharing_retention_seconds: Long,
     ) = ConversationEntity(
         id = qualified_id,
         name = name,
@@ -287,6 +292,7 @@ data object ConversationMapper {
         channelAccess = channel_access,
         channelAddPermission = channel_add_permission,
         wireCell = wireCell,
+        historySharingRetentionSeconds = history_sharing_retention_seconds
     )
 
     @Suppress("LongParameterList")

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationViewEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationViewEntity.kt
@@ -82,6 +82,7 @@ data class ConversationViewEntity(
     val channelAccess: ChannelAccess?,
     val channelAddPermission: ChannelAddPermission?,
     val wireCell: String?,
+    val historySharingRetentionSeconds: Long,
 ) {
     val isMember: Boolean get() = selfRole != null
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/DatabaseImporterTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/DatabaseImporterTest.kt
@@ -591,6 +591,7 @@ class DatabaseImporterTest : BaseDatabaseTest() {
                 channelAccess = ConversationEntity.ChannelAccess.PRIVATE,
                 channelAddPermission = ConversationEntity.ChannelAddPermission.EVERYONE,
                 wireCell = null,
+                historySharingRetentionSeconds = 0
             )
 
             conversationAdded.add(overlappingConversation)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/UserDatabaseDataGenerator.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/backup/UserDatabaseDataGenerator.kt
@@ -282,6 +282,7 @@ class UserDatabaseDataGenerator(
                     channelAccess = ConversationEntity.ChannelAccess.PRIVATE,
                     channelAddPermission = ConversationEntity.ChannelAddPermission.EVERYONE,
                     wireCell = null,
+                    historySharingRetentionSeconds = 0
                 )
             )
 
@@ -333,6 +334,7 @@ class UserDatabaseDataGenerator(
             channelAccess = ConversationEntity.ChannelAccess.PRIVATE,
             channelAddPermission = ConversationEntity.ChannelAddPermission.EVERYONE,
             wireCell = null,
+            historySharingRetentionSeconds = 0,
         )
         userDatabaseBuilder.conversationDAO.insertConversation(conversation)
         return conversation
@@ -408,6 +410,7 @@ class UserDatabaseDataGenerator(
                 channelAccess = ConversationEntity.ChannelAccess.PRIVATE,
                 channelAddPermission = ConversationEntity.ChannelAddPermission.EVERYONE,
                 wireCell = null,
+                historySharingRetentionSeconds = 0,
             )
 
             userDatabaseBuilder.conversationDAO.insertConversation(conversationEntity)
@@ -482,6 +485,7 @@ class UserDatabaseDataGenerator(
                     channelAccess = ConversationEntity.ChannelAccess.PRIVATE,
                     channelAddPermission = ConversationEntity.ChannelAddPermission.EVERYONE,
                     wireCell = null,
+                    historySharingRetentionSeconds = 0,
                 )
             )
 
@@ -534,6 +538,7 @@ class UserDatabaseDataGenerator(
                     channelAccess = ConversationEntity.ChannelAccess.PRIVATE,
                     channelAddPermission = ConversationEntity.ChannelAddPermission.EVERYONE,
                     wireCell = null,
+                    historySharingRetentionSeconds = 0,
                 )
             )
 

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -2541,6 +2541,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             channelAccess = ConversationEntity.ChannelAccess.PRIVATE,
             channelAddPermission = ConversationEntity.ChannelAddPermission.EVERYONE,
             wireCell = null,
+            historySharingRetentionSeconds = historySharingRetentionSeconds,
         )
     }
 
@@ -2590,6 +2591,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             channelAccess = ConversationEntity.ChannelAccess.PRIVATE,
             channelAddPermission = ConversationEntity.ChannelAddPermission.EVERYONE,
             wireCell = null,
+            historySharingRetentionSeconds = 0,
         )
         val conversationEntity2 = ConversationEntity(
             QualifiedIDEntity("2", "wire.com"),
@@ -2616,6 +2618,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             channelAccess = ConversationEntity.ChannelAccess.PRIVATE,
             channelAddPermission = ConversationEntity.ChannelAddPermission.EVERYONE,
             wireCell = null,
+            historySharingRetentionSeconds = 0,
         )
 
         val conversationEntity3 = ConversationEntity(
@@ -2645,6 +2648,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             channelAccess = ConversationEntity.ChannelAccess.PRIVATE,
             channelAddPermission = ConversationEntity.ChannelAddPermission.EVERYONE,
             wireCell = null,
+            historySharingRetentionSeconds = 0,
         )
 
         val conversationEntity4 = ConversationEntity(
@@ -2680,6 +2684,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             channelAccess = ConversationEntity.ChannelAccess.PRIVATE,
             channelAddPermission = ConversationEntity.ChannelAddPermission.EVERYONE,
             wireCell = null,
+            historySharingRetentionSeconds = 0,
         )
         val conversationEntity5 = ConversationEntity(
             QualifiedIDEntity("5", "wire.com"),
@@ -2706,6 +2711,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             channelAccess = ConversationEntity.ChannelAccess.PRIVATE,
             channelAddPermission = ConversationEntity.ChannelAddPermission.EVERYONE,
             wireCell = null,
+            historySharingRetentionSeconds = 0,
         )
         val conversationEntity6 = ConversationEntity(
             QualifiedIDEntity("6", "wire.com"),
@@ -2740,6 +2746,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             channelAccess = ConversationEntity.ChannelAccess.PRIVATE,
             channelAddPermission = ConversationEntity.ChannelAddPermission.EVERYONE,
             wireCell = null,
+            historySharingRetentionSeconds = 0,
         )
 
         val user1 = newUserEntity(id = "1").copy(team = teamId, activeOneOnOneConversationId = conversationEntity1.id)

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationMetaDataDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationMetaDataDAOTest.kt
@@ -92,6 +92,7 @@ class ConversationMetaDataDAOTest : BaseDatabaseTest() {
             channelAccess = ConversationEntity.ChannelAccess.PRIVATE,
             channelAddPermission = ConversationEntity.ChannelAddPermission.EVERYONE,
             wireCell = null,
+            historySharingRetentionSeconds = 0,
         )
     }
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOTest.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOTest.kt
@@ -535,6 +535,7 @@ class ClientDAOTest : BaseDatabaseTest() {
             channelAccess = ConversationEntity.ChannelAccess.PRIVATE,
             channelAddPermission = ConversationEntity.ChannelAddPermission.EVERYONE,
             wireCell = null,
+            historySharingRetentionSeconds = 0,
         )
     }
 }

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/ConversationStubs.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/ConversationStubs.kt
@@ -47,6 +47,7 @@ fun newConversationEntity(id: String = "test") = ConversationEntity(
     channelAccess = ConversationEntity.ChannelAccess.PRIVATE,
     channelAddPermission = ConversationEntity.ChannelAddPermission.EVERYONE,
     wireCell = null,
+    historySharingRetentionSeconds = 0,
 )
 
 fun newConversationEntity(
@@ -77,4 +78,5 @@ fun newConversationEntity(
     channelAccess = ConversationEntity.ChannelAccess.PRIVATE,
     channelAddPermission = ConversationEntity.ChannelAddPermission.EVERYONE,
     wireCell = null,
+    historySharingRetentionSeconds = 0,
 )

--- a/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/TestStubs.kt
+++ b/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/utils/stubs/TestStubs.kt
@@ -61,6 +61,7 @@ internal object TestStubs {
         channelAccess = ConversationEntity.ChannelAccess.PRIVATE,
         channelAddPermission = ConversationEntity.ChannelAddPermission.EVERYONE,
         wireCell = null,
+        historySharingRetentionSeconds = 0,
     )
     val conversationEntity2 = ConversationEntity(
         QualifiedIDEntity("2", "wire.com"),
@@ -93,6 +94,7 @@ internal object TestStubs {
         channelAccess = ConversationEntity.ChannelAccess.PRIVATE,
         channelAddPermission = ConversationEntity.ChannelAddPermission.EVERYONE,
         wireCell = null,
+        historySharingRetentionSeconds = 0,
     )
 
     val conversationEntity3 = ConversationEntity(
@@ -128,6 +130,7 @@ internal object TestStubs {
         channelAccess = ConversationEntity.ChannelAccess.PRIVATE,
         channelAddPermission = ConversationEntity.ChannelAddPermission.EVERYONE,
         wireCell = null,
+        historySharingRetentionSeconds = 0,
     )
 
     val conversationEntity4 = ConversationEntity(
@@ -163,6 +166,7 @@ internal object TestStubs {
         channelAccess = ConversationEntity.ChannelAccess.PRIVATE,
         channelAddPermission = ConversationEntity.ChannelAddPermission.EVERYONE,
         wireCell = null,
+        historySharingRetentionSeconds = 0,
     )
 
     val conversationEntity5 = ConversationEntity(
@@ -198,6 +202,7 @@ internal object TestStubs {
         channelAccess = ConversationEntity.ChannelAccess.PRIVATE,
         channelAddPermission = ConversationEntity.ChannelAddPermission.EVERYONE,
         wireCell = null,
+        historySharingRetentionSeconds = 0,
     )
 
     val member1 = MemberEntity(user1.id, MemberEntity.Role.Admin)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18408" title="WPB-18408" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18408</a>  [Android] Persist conversation history settings
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

We need to store the configurations of a history sharing for a conversation.

## Data structure to represent History Sharing:

- sealed interface: `ConversationHistorySharing`, which can be enabled or disabled (`Private` or `ShareWithNewMembers`).
- Currently, this value is only accessible for `Channel` `ConversationDetails`.

## Store history retention into the DB

- Add a column to the Conversation table: `historySharingRetentionSeconds` to represent the amount of seconds that a conversation history should be shared.

## Testing

Added integration tests for `ConversationDataSource`. Instead of mocking all the dependencies, just use a test database and do the proper end-to-end test: store and get the expected results back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Per-channel conversation history sharing added. Channel owners can keep history private or share recent messages with new members for a configurable retention period.
  - Conversation and channel details now reflect the current history-sharing setting.
  - Existing conversations default to private (no history sharing).

- Chores
  - Background data updates to support history-sharing settings (no user action required).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->