### PR TITLE
feat(conversation-history): allow customising conversation settings [WPB-18408]

### DIFF
--- a/conversation-history/build.gradle.kts
+++ b/conversation-history/build.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
                 implementation(projects.common)
                 implementation(projects.network)
                 implementation(projects.data)
+                implementation(projects.dataMappers)
                 implementation(projects.util)
                 implementation(projects.cryptography)
                 implementation(projects.persistence)

--- a/conversation-history/src/commonMain/kotlin/com/wire/kalium/conversation/history/data/ConversationHistoryMapper.kt
+++ b/conversation-history/src/commonMain/kotlin/com/wire/kalium/conversation/history/data/ConversationHistoryMapper.kt
@@ -1,0 +1,36 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.conversation.history.data
+
+import com.wire.kalium.logic.data.conversation.ConversationHistorySettings
+import com.wire.kalium.network.api.authenticated.conversation.ConversationHistorySettingsDTO
+
+public interface ConversationHistoryMapper {
+    public fun fromDomainToApi(conversationHistorySettings: ConversationHistorySettings): ConversationHistorySettingsDTO
+}
+
+internal fun ConversationHistoryMapper(): ConversationHistoryMapper = object : ConversationHistoryMapper {
+    override fun fromDomainToApi(
+        conversationHistorySettings: ConversationHistorySettings
+    ): ConversationHistorySettingsDTO = when (conversationHistorySettings) {
+        ConversationHistorySettings.Private -> ConversationHistorySettingsDTO.Private
+        is ConversationHistorySettings.ShareWithNewMembers -> ConversationHistorySettingsDTO.ShareWithNewMembers(
+            conversationHistorySettings.retention
+        )
+    }
+}

--- a/conversation-history/src/commonMain/kotlin/com/wire/kalium/conversation/history/data/ConversationHistoryRepository.kt
+++ b/conversation-history/src/commonMain/kotlin/com/wire/kalium/conversation/history/data/ConversationHistoryRepository.kt
@@ -1,0 +1,64 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.conversation.history.data
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.wrapApiRequest
+import com.wire.kalium.common.error.wrapStorageRequest
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.conversation.history.data.dao.ConversationHistoryDAO
+import com.wire.kalium.logic.data.conversation.ConversationHistorySettings
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.IdMapper
+import com.wire.kalium.network.api.base.authenticated.conversation.history.ConversationHistoryApi
+
+public interface ConversationHistoryRepository {
+    public suspend fun updateSettingsForConversation(
+        conversationId: ConversationId,
+        historySettings: ConversationHistorySettings
+    ): Either<CoreFailure, Unit>
+}
+
+public fun ConversationHistoryRepository(
+    historyApi: ConversationHistoryApi,
+    conversationHistoryDAO: ConversationHistoryDAO,
+    historyMapper: ConversationHistoryMapper = ConversationHistoryMapper(),
+    idMapper: IdMapper = IdMapper(),
+): ConversationHistoryRepository = object : ConversationHistoryRepository {
+    override suspend fun updateSettingsForConversation(
+        conversationId: ConversationId,
+        historySettings: ConversationHistorySettings
+    ) = wrapApiRequest {
+        historyApi.updateHistorySettingsForConversation(
+            conversationId = idMapper.toNetworkUserId(conversationId),
+            settings = historyMapper.fromDomainToApi(historySettings)
+        )
+    }.flatMap {
+        wrapStorageRequest {
+            val historyRetentionInSeconds = when (historySettings) {
+                ConversationHistorySettings.Private -> 0UL
+                is ConversationHistorySettings.ShareWithNewMembers -> historySettings.retention.inWholeSeconds.toULong()
+            }
+            conversationHistoryDAO.updateConversationHistorySettings(
+                conversationId = idMapper.fromDomainToDao(conversationId),
+                historyRetentionInSeconds = historyRetentionInSeconds
+            )
+        }
+    }
+}

--- a/conversation-history/src/commonMain/kotlin/com/wire/kalium/conversation/history/data/dao/ConversationHistoryDAO.kt
+++ b/conversation-history/src/commonMain/kotlin/com/wire/kalium/conversation/history/data/dao/ConversationHistoryDAO.kt
@@ -1,0 +1,27 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.conversation.history.data.dao
+
+import com.wire.kalium.persistence.dao.ConversationIDEntity
+
+public interface ConversationHistoryDAO {
+    public suspend fun updateConversationHistorySettings(
+        conversationId: ConversationIDEntity,
+        historyRetentionInSeconds: ULong
+    )
+}

--- a/conversation-history/src/commonMain/kotlin/com/wire/kalium/conversation/history/data/dao/HistoryClientDAO.kt
+++ b/conversation-history/src/commonMain/kotlin/com/wire/kalium/conversation/history/data/dao/HistoryClientDAO.kt
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-package com.wire.kalium.conversation.history.data
+package com.wire.kalium.conversation.history.data.dao
 
 import com.wire.kalium.logic.data.history.HistoryClient
 import com.wire.kalium.persistence.dao.QualifiedIDEntity

--- a/conversation-history/src/commonMain/kotlin/com/wire/kalium/conversation/history/data/dao/SQLiteConversationHistoryDAO.kt
+++ b/conversation-history/src/commonMain/kotlin/com/wire/kalium/conversation/history/data/dao/SQLiteConversationHistoryDAO.kt
@@ -1,0 +1,35 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.conversation.history.data.dao
+
+import com.wire.kalium.persistence.ConversationHistoryQueries
+import com.wire.kalium.persistence.dao.ConversationIDEntity
+
+internal class SQLiteConversationHistoryDAO(
+    private val conversationHistoryQueries: ConversationHistoryQueries
+) : ConversationHistoryDAO {
+    override suspend fun updateConversationHistorySettings(
+        conversationId: ConversationIDEntity,
+        historyRetentionInSeconds: ULong
+    ) {
+        conversationHistoryQueries.updateConversationHistoryRetention(
+            historyRetentionInSeconds.toLong(),
+            conversationId
+        )
+    }
+}

--- a/conversation-history/src/commonMain/kotlin/com/wire/kalium/conversation/history/data/dao/SQLiteHistoryClientDAO.kt
+++ b/conversation-history/src/commonMain/kotlin/com/wire/kalium/conversation/history/data/dao/SQLiteHistoryClientDAO.kt
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-package com.wire.kalium.conversation.history.data
+package com.wire.kalium.conversation.history.data.dao
 
 import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList

--- a/conversation-history/src/commonMain/kotlin/com/wire/kalium/conversation/history/domain/UpdateConversationHistorySettingsUseCase.kt
+++ b/conversation-history/src/commonMain/kotlin/com/wire/kalium/conversation/history/domain/UpdateConversationHistorySettingsUseCase.kt
@@ -1,0 +1,53 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.conversation.history.domain
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.conversation.history.data.ConversationHistoryRepository
+import com.wire.kalium.logic.data.conversation.ConversationHistorySettings
+import com.wire.kalium.logic.data.id.QualifiedID
+
+/**
+ * Use case responsible for updating the conversation history settings for a specific conversation.
+ *
+ * This operation allows modifying how the history of a conversation is managed,
+ * such as enabling or disabling history sharing or configuring the retention period for shared messages.
+ *
+ * @param conversationId The unique identifier of the conversation for which the history settings should be updated.
+ * @param historySettings The desired history settings to be applied to the conversation.
+ * @return Either a [CoreFailure] indicating an issue that occurred during the operation, or [Unit] upon success.
+ */
+public interface UpdateConversationHistorySettingsUseCase {
+    public suspend operator fun invoke(
+        conversationId: QualifiedID,
+        historySettings: ConversationHistorySettings
+    ): Either<CoreFailure, Unit>
+}
+
+public fun UpdateConversationHistorySettingsUseCase(
+    conversationHistoryRepository: ConversationHistoryRepository
+): UpdateConversationHistorySettingsUseCase = object : UpdateConversationHistorySettingsUseCase {
+    override suspend fun invoke(
+        conversationId: QualifiedID,
+        historySettings: ConversationHistorySettings
+    ): Either<CoreFailure, Unit> = conversationHistoryRepository.updateSettingsForConversation(
+        conversationId,
+        historySettings
+    )
+}

--- a/conversation-history/src/commonTest/kotlin/com/wire/kalium/conversation/history/data/SQLiteHistoryClientDAOTest.kt
+++ b/conversation-history/src/commonTest/kotlin/com/wire/kalium/conversation/history/data/SQLiteHistoryClientDAOTest.kt
@@ -18,6 +18,7 @@
 package com.wire.kalium.conversation.history.data
 
 import app.cash.turbine.test
+import com.wire.kalium.conversation.history.data.dao.SQLiteHistoryClientDAO
 import com.wire.kalium.persistence.TestUserDatabase
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserIDEntity

--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -355,7 +355,7 @@ sealed interface ConversationDetails {
 //         val isTeamAdmin: Boolean, TODO kubaz
             val access: ChannelAccess,
             val permission: ChannelAddPermission,
-            val historySharing: ConversationHistorySharing,
+            val historySharing: ConversationHistorySettings,
         ) : Group {
             /**
              * An enum class that defines the permissions for adding participants to a channel,
@@ -410,12 +410,12 @@ sealed interface ConversationDetails {
     }
 }
 
-sealed interface ConversationHistorySharing {
+sealed interface ConversationHistorySettings {
     /**
      * History Sharing is disabled.
      * New members should *not* be able to retrieve and see messages sent before they have joined the conversation
      */
-    data object Private : ConversationHistorySharing
+    data object Private : ConversationHistorySettings
 
     /**
      * Messages in the conversation that are newer than [retention] should be shared with new members.
@@ -426,7 +426,7 @@ sealed interface ConversationHistorySharing {
      * When [retention] is 5, and a new members joins the conversation, only Message B should be retrievable by the new user.
      * @see HistoryClient
      */
-    data class ShareWithNewMembers(val retention: Duration) : ConversationHistorySharing {
+    data class ShareWithNewMembers(val retention: Duration) : ConversationHistorySettings {
         init {
             require(retention.isPositive()) {
                 "history-sharing retention must be > 0"

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -306,8 +306,8 @@ internal class ConversationMapperImpl(
                             permission = channelAddPermission?.toModelChannelPermission()
                                 ?: ChannelAddPermission.ADMINS,
                             historySharing = daoModel.historySharingRetentionSeconds.takeIf { it > 0 }?.let {
-                                ConversationHistorySharing.ShareWithNewMembers(it.seconds)
-                            } ?: ConversationHistorySharing.Private
+                                ConversationHistorySettings.ShareWithNewMembers(it.seconds)
+                            } ?: ConversationHistorySettings.Private
                         )
                     } else {
                         ConversationDetails.Group.Regular(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryIntegrationTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryIntegrationTest.kt
@@ -97,7 +97,7 @@ class ConversationRepositoryIntegrationTest {
                 awaitItem().shouldSucceed {
                     assertIs<ConversationDetails.Group.Channel>(it)
                     val historySharing = it.historySharing
-                    assertIs<ConversationHistorySharing.Private>(historySharing)
+                    assertIs<ConversationHistorySettings.Private>(historySharing)
                 }
                 cancelAndIgnoreRemainingEvents()
             }
@@ -122,7 +122,7 @@ class ConversationRepositoryIntegrationTest {
                 awaitItem().shouldSucceed {
                     assertIs<ConversationDetails.Group.Channel>(it)
                     val historySharing = it.historySharing
-                    assertIs<ConversationHistorySharing.ShareWithNewMembers>(historySharing)
+                    assertIs<ConversationHistorySettings.ShareWithNewMembers>(historySharing)
                     assertEquals(expectedSeconds, historySharing.retention.inWholeSeconds)
                 }
                 cancelAndIgnoreRemainingEvents()

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationHistory.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationHistory.sq
@@ -1,0 +1,5 @@
+
+updateConversationHistoryRetention:
+UPDATE Conversation
+SET history_sharing_retention_seconds = :retentionInSeconds
+WHERE Conversation.qualified_id = :conversationId;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18408" title="WPB-18408" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18408</a>  [Android] Persist conversation history settings
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# Dependencies on other PRs:

- #3615 
- #3612

# What's new in this PR?

## New UseCase: UpdateConversationHistorySettingsUseCase

It does... exactly that.

It relies on the new Repository: `ConversationHistoryRepository`, which will do more in the future as well, when we have to actually download history, send messages, etc.