### PR TITLE
fix: missed call notification for builds (WPB-19996)

### DIFF
--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnCloseCall.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnCloseCall.kt
@@ -106,9 +106,12 @@ class OnCloseCall(
     private fun shouldPersistMissedCall(callMetadata: CallMetadata?, callStatus: CallStatus): Boolean =
         when (callStatus) {
             CallStatus.MISSED -> true
-            CallStatus.CLOSED_INTERNALLY -> false
-            CallStatus.REJECTED -> false
-            CallStatus.CLOSED -> callMetadata?.establishedTime.isNullOrEmpty()
+            CallStatus.CLOSED -> callMetadata?.callStatus?.let { currentCallStatus ->
+                callMetadata.establishedTime.isNullOrEmpty() &&
+                        currentCallStatus != CallStatus.CLOSED_INTERNALLY &&
+                        currentCallStatus != CallStatus.REJECTED
+            } ?: false
+
             else -> false
         }
 

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/scenario/OnCloseCallTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/scenario/OnCloseCallTest.kt
@@ -143,35 +143,6 @@ class OnCloseCallTest {
         }
 
     @Test
-    fun givenCloseReasonIsEndedNormally_whenOnCloseCallBackHappens_thenDoNotPersistMissedCallAndUpdateStatus() =
-        testScope.runTest {
-
-            val reason = CallClosedReason.NORMAL.avsValue
-
-            onCloseCall.onClosedCall(
-                reason,
-                conversationIdString,
-                time,
-                userIdString,
-                clientId,
-                null
-            )
-            yield()
-
-            coVerify {
-                callRepository.persistMissedCall(eq(conversationId))
-            }.wasNotInvoked()
-
-            coVerify {
-                callRepository.updateCallStatusById(eq(conversationId), eq(CallStatus.CLOSED))
-            }.wasInvoked(once)
-
-            coVerify {
-                callRepository.leaveMlsConference(eq(conversationId))
-            }.wasNotInvoked()
-        }
-
-    @Test
     fun givenAnIncomingGroupCall_whenOnCloseCallBackHappens_thenPersistMissedCallAndUpdateStatus() =
         testScope.runTest {
             val incomingCall = callMetadata.copy(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19996" title="WPB-19996" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19996</a>  [Android] Federated 1:1 call no missed call notification
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

https://wearezeta.atlassian.net/browse/WPB-19996

# What's new in this PR?

### Issues
When 1:1 call is cancelled by caller before the call is established receiver does not get a "Missed call" message.

### Causes (Optional)
1:1 calls on c env are handled as conference calls. The client does not get a MISSED (AVS NORMAL) call status and call close logic does not handle this.

### Solutions
This is a workaround just for c builds, must not be merged back to develop.

1. Do not check the conversation type when checking the persist missed call condition.
2. Avoid overwriting REJECTED call status by STILL_ONGOING for 1:1 calls
