### PR TITLE
feat: prevent MLS group status to go from PENDING_AFTER_RESET to other pending to avoid hiding it [WPB-20097] 

### DIFF
--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -95,7 +95,11 @@ type = excluded.type,
 team_id = excluded.team_id,
 mls_group_id = excluded.mls_group_id,
 mls_epoch = excluded.mls_epoch,
-mls_group_state = excluded.mls_group_state,
+mls_group_state = CASE
+    WHEN Conversation.mls_group_state = 'ESTABLISHED' THEN excluded.mls_group_state
+    WHEN excluded.mls_group_state IN ('ESTABLISHED', 'PENDING_AFTER_RESET') THEN excluded.mls_group_state
+    ELSE Conversation.mls_group_state
+END,
 protocol = excluded.protocol,
 muted_status = excluded.muted_status,
 muted_time = excluded.muted_time,
@@ -126,18 +130,31 @@ WHERE qualified_id = ?;
 
 updateConversationGroupState:
 UPDATE Conversation
-SET mls_group_state = ?
+SET mls_group_state = CASE
+    WHEN mls_group_state = 'ESTABLISHED' THEN :mls_group_state
+    WHEN :mls_group_state IN ('ESTABLISHED', 'PENDING_AFTER_RESET') THEN :mls_group_state
+    ELSE mls_group_state
+END
 WHERE mls_group_id = ?;
 
 updateMlsGroupStateAndCipherSuite:
 UPDATE Conversation
-SET mls_group_state = :mls_group_state, mls_cipher_suite = :mls_cipher_suite
+SET mls_group_state = CASE
+    WHEN mls_group_state = 'ESTABLISHED' THEN :mls_group_state
+    WHEN :mls_group_state IN ('ESTABLISHED', 'PENDING_AFTER_RESET') THEN :mls_group_state
+    ELSE mls_group_state
+END,
+mls_cipher_suite = :mls_cipher_suite
 WHERE mls_group_id = :mls_group_id;
 
 updateMLSGroupIdAndState:
 UPDATE Conversation
 SET mls_group_id = :new_group_id, 
-    mls_group_state = :group_state
+    mls_group_state = CASE
+        WHEN mls_group_state = 'ESTABLISHED' THEN :mls_group_state
+        WHEN :mls_group_state IN ('ESTABLISHED', 'PENDING_AFTER_RESET') THEN :mls_group_state
+        ELSE mls_group_state
+    END
 WHERE qualified_id = :conversation_id;
 
 updateConversationNotificationsDateWithTheLastMessage:


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

if a conversation is PENDING_AFTER_RESET it should not be updated to other pending states so it is not hidden again

because there is a case if the conv is PENDING_AFTER_RESET and we sync it again from the backend then it will be updated to another pending when opening it

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
