### PR TITLE
chore: use typesafe project accessors across build scripts [WPB-8645]

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -63,9 +63,9 @@ android {
 }
 
 dependencies {
-    implementation(project(":network"))
-    implementation(project(":cryptography"))
-    implementation(project(":logic"))
+    implementation(projects.network)
+    implementation(projects.cryptography)
+    implementation(projects.logic)
     implementation(libs.bundles.android)
     coreLibraryDesugaring(libs.desugarJdkLibs)
 }

--- a/backup-verification/build.gradle.kts
+++ b/backup-verification/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":backup"))
+    implementation(projects.backup)
     implementation(compose.desktop.currentOs)
     implementation(compose.materialIconsExtended)
     implementation(kotlin("reflect"))

--- a/backup/build.gradle.kts
+++ b/backup/build.gradle.kts
@@ -71,7 +71,7 @@ kotlin {
         }
         val commonMain by getting {
             dependencies {
-                implementation(project(":protobuf"))
+                implementation(projects.protobuf)
                 implementation(libs.pbandk.runtime.common)
 
                 implementation(libs.coroutines.core)

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -24,8 +24,8 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(project(":persistence"))
-                implementation(project(":logic"))
+                implementation(projects.persistence)
+                implementation(projects.logic)
                 implementation(libs.coroutines.core)
                 implementation(libs.ktxDateTime)
                 implementation(libs.kotlinx.benchmark.runtime)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -123,15 +123,15 @@ rootProject.plugins.withType(org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPlu
 }
 
 dependencies {
-    kover(project(":logic"))
-    kover(project(":cryptography"))
-    kover(project(":util"))
-    kover(project(":network"))
-    kover(project(":network-util"))
-    kover(project(":persistence"))
-    kover(project(":logger"))
-    kover(project(":calling"))
-    kover(project(":protobuf"))
+    kover(projects.logic)
+    kover(projects.cryptography)
+    kover(projects.util)
+    kover(projects.network)
+    kover(projects.networkUtil)
+    kover(projects.persistence)
+    kover(projects.logger)
+    kover(projects.calling)
+    kover(projects.protobuf)
 }
 
 rootProject.plugins.withType<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin> {

--- a/cells/build.gradle.kts
+++ b/cells/build.gradle.kts
@@ -32,11 +32,11 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(project(":common"))
-                implementation(project(":network"))
-                implementation(project(":data"))
-                implementation(project(":util"))
-                implementation(project(":persistence"))
+                implementation(projects.common)
+                implementation(projects.network)
+                implementation(projects.data)
+                implementation(projects.util)
+                implementation(projects.persistence)
                 implementation(libs.coroutines.core)
                 implementation(libs.ktor.authClient)
                 implementation(libs.okio.core)

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -65,10 +65,10 @@ kotlin {
     sourceSets {
         val commonMain by sourceSets.getting {
             dependencies {
-                implementation(project(":network"))
-                implementation(project(":cryptography"))
-                implementation(project(":logic"))
-                implementation(project(":util"))
+                implementation(projects.network)
+                implementation(projects.cryptography)
+                implementation(projects.logic)
+                implementation(projects.util)
 
                 implementation(libs.cliKt)
                 implementation(libs.ktor.utils)

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -30,13 +30,13 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project(":data"))
-                implementation(project(":logger"))
-                implementation(project(":util"))
-                implementation(project(":persistence"))
-                implementation(project(":network"))
-                implementation(project(":network-util"))
-                implementation(project(":cryptography"))
+                implementation(projects.data)
+                implementation(projects.logger)
+                implementation(projects.util)
+                implementation(projects.persistence)
+                implementation(projects.network)
+                implementation(projects.networkUtil)
+                implementation(projects.cryptography)
                 implementation(libs.ktxSerialization)
                 implementation(libs.coroutines.core)
             }

--- a/conversation-history/build.gradle.kts
+++ b/conversation-history/build.gradle.kts
@@ -30,12 +30,12 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(project(":common"))
-                implementation(project(":network"))
-                implementation(project(":data"))
-                implementation(project(":util"))
-                implementation(project(":cryptography"))
-                implementation(project(":persistence"))
+                implementation(projects.common)
+                implementation(projects.network)
+                implementation(projects.data)
+                implementation(projects.util)
+                implementation(projects.cryptography)
+                implementation(projects.persistence)
                 implementation(libs.coroutines.core)
                 implementation(libs.sqldelight.coroutinesExtension)
                 implementation(libs.ktxDateTime)
@@ -43,11 +43,11 @@ kotlin {
         }
         val commonTest by getting {
             dependencies {
-                implementation(project(":data-mocks"))
+                implementation(projects.dataMocks)
                 // coroutines
                 implementation(libs.coroutines.test)
                 implementation(libs.turbine)
-                implementation(project(":persistence-test"))
+                implementation(projects.persistenceTest)
             }
         }
 

--- a/cryptography/build.gradle.kts
+++ b/cryptography/build.gradle.kts
@@ -54,7 +54,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                api(project(":logger"))
+                api(projects.logger)
                 // coroutines
                 implementation(libs.coroutines.core)
                 api(libs.ktor.core)

--- a/data-mappers/build.gradle.kts
+++ b/data-mappers/build.gradle.kts
@@ -31,12 +31,12 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(project(":data"))
-                implementation(project(":protobuf"))
-                implementation(project(":persistence"))
-                implementation(project(":cryptography"))
-                implementation(project(":network-model"))
-                implementation(project(":util"))
+                implementation(projects.data)
+                implementation(projects.protobuf)
+                implementation(projects.persistence)
+                implementation(projects.cryptography)
+                implementation(projects.networkModel)
+                implementation(projects.util)
 
                 implementation(libs.coroutines.core)
                 implementation(libs.ktxDateTime)

--- a/data-mocks/build.gradle.kts
+++ b/data-mocks/build.gradle.kts
@@ -31,10 +31,10 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(project(":data"))
-                implementation(project(":persistence"))
-                implementation(project(":network-model"))
-                implementation(project(":util"))
+                implementation(projects.data)
+                implementation(projects.persistence)
+                implementation(projects.networkModel)
+                implementation(projects.util)
 
                 implementation(libs.ktor.utils)
                 implementation(libs.coroutines.core)

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -31,8 +31,8 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(project(":network-model"))
-                implementation(project(":util"))
+                implementation(projects.networkModel)
+                implementation(projects.util)
 
                 implementation(libs.ktor.utils)
                 implementation(libs.coroutines.core)

--- a/logic/build.gradle.kts
+++ b/logic/build.gradle.kts
@@ -37,19 +37,19 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                api(project(":common"))
-                implementation(project(":network"))
-                api(project(":data"))
-                implementation(project(":data-mappers"))
-                api(project(":network-util"))
-                implementation(project(":cryptography"))
-                implementation(project(":persistence"))
-                implementation(project(":protobuf"))
-                api(project(":logger"))
-                api(project(":calling"))
-                implementation(project(":util"))
-                implementation(project(":cells"))
-                implementation(project(":backup"))
+                api(projects.common)
+                implementation(projects.network)
+                api(projects.data)
+                implementation(projects.dataMappers)
+                api(projects.networkUtil)
+                implementation(projects.cryptography)
+                implementation(projects.persistence)
+                implementation(projects.protobuf)
+                api(projects.logger)
+                api(projects.calling)
+                implementation(projects.util)
+                implementation(projects.cells)
+                implementation(projects.backup)
 
                 // coroutines
                 implementation(libs.coroutines.core)
@@ -76,9 +76,9 @@ kotlin {
         }
         val commonTest by getting {
             dependencies {
-                implementation(project(":common"))
-                implementation(project(":persistence-test"))
-                implementation(project(":data-mocks"))
+                implementation(projects.common)
+                implementation(projects.persistenceTest)
+                implementation(projects.dataMocks)
                 // coroutines
                 implementation(libs.coroutines.test)
                 implementation(libs.turbine)

--- a/mocks/build.gradle.kts
+++ b/mocks/build.gradle.kts
@@ -35,7 +35,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(project(":network-model"))
+                implementation(projects.networkModel)
 
                 implementation(libs.ktor.utils)
                 implementation(libs.coroutines.core)

--- a/monkeys/build.gradle.kts
+++ b/monkeys/build.gradle.kts
@@ -70,10 +70,10 @@ tasks.jar {
 sourceSets {
     val main by getting {
         dependencies {
-            implementation(project(":network"))
-            implementation(project(":cryptography"))
-            implementation(project(":logic"))
-            implementation(project(":util"))
+            implementation(projects.network)
+            implementation(projects.cryptography)
+            implementation(projects.logic)
+            implementation(projects.util)
 
             implementation(libs.cliKt)
             implementation(libs.ktor.utils)

--- a/network-model/build.gradle.kts
+++ b/network-model/build.gradle.kts
@@ -33,8 +33,8 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(project(":util"))
-                api(project(":logger"))
+                implementation(projects.util)
+                api(projects.logger)
 
                 // serialization
                 implementation(libs.ktxSerialization)

--- a/network-util/build.gradle.kts
+++ b/network-util/build.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                api(project(":logger"))
+                api(projects.logger)
 
                 implementation(libs.coroutines.core)
             }

--- a/network/build.gradle.kts
+++ b/network/build.gradle.kts
@@ -36,11 +36,11 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(project(":protobuf"))
-                implementation(project(":util"))
-                implementation(project(":network-util"))
-                api(project(":network-model"))
-                api(project(":logger"))
+                implementation(projects.protobuf)
+                implementation(projects.util)
+                implementation(projects.networkUtil)
+                api(projects.networkModel)
+                api(projects.logger)
 
                 // coroutines
                 implementation(libs.coroutines.core)
@@ -75,7 +75,7 @@ kotlin {
                 // ktor test
                 implementation(libs.ktor.mock)
                 // mocks
-                implementation(project(":mocks"))
+                implementation(projects.mocks)
             }
         }
 

--- a/persistence-test/build.gradle.kts
+++ b/persistence-test/build.gradle.kts
@@ -32,7 +32,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(project(":persistence"))
+                implementation(projects.persistence)
                 implementation(libs.kotlin.test)
                 // coroutines
                 implementation(libs.coroutines.core)

--- a/persistence/build.gradle.kts
+++ b/persistence/build.gradle.kts
@@ -73,8 +73,8 @@ kotlin {
                 implementation(libs.ktxDateTime)
                 implementation(libs.sqldelight.androidxPaging)
 
-                implementation(project(":util"))
-                api(project(":logger"))
+                implementation(projects.util)
+                api(projects.logger)
             }
         }
         val commonTest by getting {

--- a/samples/build.gradle.kts
+++ b/samples/build.gradle.kts
@@ -33,10 +33,10 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(project(":backup"))
-                implementation(project(":cryptography"))
-                implementation(project(":protobuf"))
-                implementation(project(":logger"))
+                implementation(projects.backup)
+                implementation(projects.cryptography)
+                implementation(projects.protobuf)
+                implementation(projects.logger)
 
                 implementation(libs.coroutines.core)
                 implementation(libs.okio.core)
@@ -46,24 +46,24 @@ kotlin {
         val nonJsMain by creating {
             dependsOn(commonMain)
             dependencies {
-                implementation(project(":network"))
-                implementation(project(":persistence"))
+                implementation(projects.network)
+                implementation(projects.persistence)
             }
         }
 
         val jvmMain by getting {
             dependsOn(nonJsMain)
             dependencies {
-                implementation(project(":logic"))
-                implementation(project(":calling"))
+                implementation(projects.logic)
+                implementation(projects.calling)
             }
         }
 
         val androidMain by getting {
             dependsOn(nonJsMain)
             dependencies {
-                implementation(project(":logic"))
-                implementation(project(":calling"))
+                implementation(projects.logic)
+                implementation(projects.calling)
             }
         }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,6 +25,7 @@
 rootDir
     .walk()
     .maxDepth(1)
+    .filter { it != rootDir }
     .filter {
         it.name != "buildSrc" && it.isDirectory &&
                 file("${it.absolutePath}/build.gradle.kts").exists()
@@ -67,3 +68,5 @@ dependencyResolutionManagement {
         }
     }
 }
+
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")

--- a/tango-tests/build.gradle.kts
+++ b/tango-tests/build.gradle.kts
@@ -31,11 +31,11 @@ kotlin {
         val test by getting {
             kotlin.srcDir("src/integrationTest/kotlin")
             dependencies {
-                implementation(project(":network"))
-                implementation(project(":logic"))
-                implementation(project(":persistence"))
-                implementation(project(":mocks"))
-                implementation(project(":cryptography"))
+                implementation(projects.network)
+                implementation(projects.logic)
+                implementation(projects.persistence)
+                implementation(projects.mocks)
+                implementation(projects.cryptography)
                 implementation(libs.kotlin.test)
                 implementation(libs.settings.kmpTest)
 

--- a/testservice/build.gradle.kts
+++ b/testservice/build.gradle.kts
@@ -76,13 +76,13 @@ dependencies {
     add("implementation", "io.prometheus:simpleclient_dropwizard:${Versions.prometheus_simpleclient}")
     add("implementation", "io.prometheus:simpleclient_servlet:${Versions.prometheus_simpleclient}")
 
-    add("implementation", project(":network")) {
+    implementation(projects.network) {
         exclude("org.slf4j", "slf4j-api")
     }
-    add("implementation", project(":cryptography")) {
+    implementation(projects.cryptography) {
         exclude("org.slf4j", "slf4j-api")
     }
-    add("implementation", project(":logic")) {
+    implementation(projects.logic) {
         exclude("org.slf4j", "slf4j-api")
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8645" title="WPB-8645" target="_blank"><img alt="Epic" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10807?size=medium" />WPB-8645</a>  [Android] Infrastructure code and developer experience
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Enabled type-safe project accessors, and replace `project(":module")` with equivalent `projects.module` everywhere applicable.