### PR TITLE
feat: new cell feature system messages on conversation creation (WPB-20116)

### DIFF
--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
@@ -419,6 +419,13 @@ sealed interface Message {
                         "$acc, ${member.value.obfuscateId()}@${member.domain.obfuscateDomain()}"
                     }
                 )
+
+                MessageContent.NewConversationWithCellMessage -> mutableMapOf(
+                    typeKey to "newConversationWithCellMessage"
+                )
+                MessageContent.NewConversationWithCellSelfDeleteDisabledMessage -> mutableMapOf(
+                    typeKey to "newConversationWithCellSelfDeleteDisabledMessage"
+                )
             }
 
             val standardProperties = mapOf(

--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
@@ -398,6 +398,9 @@ sealed interface MessageContent {
         }
     }
 
+    data object NewConversationWithCellMessage : System
+    data object NewConversationWithCellSelfDeleteDisabledMessage : System
+
     data class InCallEmoji(
         val emojis: Map<String, Int>
     ) : Signaling
@@ -489,6 +492,8 @@ fun MessageContent?.getType() = when (this) {
     is MessageContent.History.ClientsResponse -> "History.ClientsResponse"
     is MessageContent.History.NewClientAvailable -> "History.NewClientAvailable"
     null -> "null"
+    MessageContent.NewConversationWithCellMessage -> "NewConversationWithCell"
+    MessageContent.NewConversationWithCellSelfDeleteDisabledMessage -> "NewConversationWithCellSelfDeleteDisabled"
 }
 
 sealed interface MessagePreviewContent {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
@@ -176,6 +176,8 @@ internal class ConversationGroupRepositoryImpl(
         }.flatMap {
             newGroupConversationSystemMessagesCreator.value.conversationStarted(conversationEntity)
         }.flatMap {
+            newGroupConversationSystemMessagesCreator.value.conversationCellStatus(conversationEntity)
+        }.flatMap {
             when (protocol) {
                 is Conversation.ProtocolInfo.Proteus -> Either.Right(setOf())
                 is Conversation.ProtocolInfo.MLSCapable ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -331,6 +331,8 @@ class MessageMapperImpl(
             MessageEntity.ContentType.CONVERSATION_PROTOCOL_CHANGED_DURING_CALL -> null
             MessageEntity.ContentType.CONVERSATION_STARTED_UNVERIFIED_WARNING -> null
             MessageEntity.ContentType.LEGAL_HOLD -> null
+            MessageEntity.ContentType.CONVERSATION_WITH_CELL -> null
+            MessageEntity.ContentType.CONVERSATION_WITH_CELL_SELF_DELETE_DISABLED -> null
 
             MessageEntity.ContentType.MULTIPART -> LocalNotificationMessage.Text(
                 messageId = message.id,
@@ -496,6 +498,9 @@ fun MessageEntityContent.System.toMessageContent(): MessageContent.System = when
                 MessageContent.LegalHold.ForMembers.Enabled(this.memberUserIdList.map { it.toModel() })
         }
     }
+    is MessageEntityContent.NewConversationWithCellMessage -> MessageContent.NewConversationWithCellMessage
+    is MessageEntityContent.NewConversationWithCellSelfDeleteDisabledMessage ->
+        MessageContent.NewConversationWithCellSelfDeleteDisabledMessage
 }
 
 fun Message.Visibility.toEntityVisibility(): MessageEntity.Visibility = when (this) {
@@ -794,6 +799,9 @@ fun MessageContent.System.toMessageEntityContent(): MessageEntityContent.System 
         is MessageContent.LegalHold.ForMembers.Enabled ->
             MessageEntityContent.LegalHold(this.members.map { it.toDao() }, MessageEntity.LegalHoldType.ENABLED_FOR_MEMBERS)
     }
+
+    MessageContent.NewConversationWithCellMessage -> MessageEntityContent.NewConversationWithCellMessage
+    MessageContent.NewConversationWithCellSelfDeleteDisabledMessage -> MessageEntityContent.NewConversationWithCellSelfDeleteDisabledMessage
 }
 
 fun MessageAssetStatus.toDao(): MessageAssetStatusEntity {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/PersistMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/PersistMessageUseCase.kt
@@ -132,6 +132,8 @@ internal class PersistMessageUseCaseImpl(
             is MessageContent.InCallEmoji -> false
             is MessageContent.Multipart -> true
             is MessageContent.History -> false
+            is MessageContent.NewConversationWithCellMessage -> false
+            is MessageContent.NewConversationWithCellSelfDeleteDisabledMessage -> false
         }
 
     @Suppress("ComplexMethod")
@@ -190,6 +192,8 @@ internal class PersistMessageUseCaseImpl(
             is MessageContent.TeamMemberRemoved,
             is MessageContent.DataTransfer,
             is MessageContent.InCallEmoji,
-            is MessageContent.History -> false
+            is MessageContent.History,
+            is MessageContent.NewConversationWithCellMessage,
+            is MessageContent.NewConversationWithCellSelfDeleteDisabledMessage -> false
         }
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
@@ -148,6 +148,7 @@ sealed interface MessageEntity {
         CONVERSATION_DEGRADED_PROTEUS, CONVERSATION_VERIFIED_MLS, CONVERSATION_VERIFIED_PROTEUS, COMPOSITE, FEDERATION,
         CONVERSATION_PROTOCOL_CHANGED, CONVERSATION_PROTOCOL_CHANGED_DURING_CALL,
         CONVERSATION_STARTED_UNVERIFIED_WARNING, LOCATION, LEGAL_HOLD, MULTIPART,
+        CONVERSATION_WITH_CELL, CONVERSATION_WITH_CELL_SELF_DELETE_DISABLED,
     }
 
     enum class MemberChangeType {
@@ -373,6 +374,9 @@ sealed class MessageEntityContent {
          */
         val quotedMessage: QuotedMessage? = null,
     ) : Regular()
+
+    data object NewConversationWithCellMessage : System()
+    data object NewConversationWithCellSelfDeleteDisabledMessage : System()
 }
 
 /**

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageInsertExtension.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageInsertExtension.kt
@@ -369,9 +369,16 @@ internal class MessageInsertExtensionImpl(
                     )
                 }
             }
+            is MessageEntityContent.NewConversationWithCellMessage -> {
+                /* no-op */
+            }
+            is MessageEntityContent.NewConversationWithCellSelfDeleteDisabledMessage -> {
+                /* no-op */
+            }
         }
     }
 
+    @Suppress("LongMethod")
     private fun insertUnreadEvent(message: MessageEntity) {
         val lastRead = conversationsQueries.getConversationLastReadDate(message.conversationId).executeAsOneOrNull()
             ?: Instant.DISTANT_PAST
@@ -430,6 +437,8 @@ internal class MessageInsertExtensionImpl(
                 MessageEntityContent.ConversationStartedUnverifiedWarning,
                 is MessageEntityContent.TeamMemberRemoved,
                 is MessageEntityContent.LegalHold,
+                is MessageEntityContent.NewConversationWithCellMessage,
+                is MessageEntityContent.NewConversationWithCellSelfDeleteDisabledMessage,
                     -> {
                     /* no-op */
                 }
@@ -531,5 +540,8 @@ internal class MessageInsertExtensionImpl(
         is MessageEntityContent.Location -> MessageEntity.ContentType.LOCATION
         is MessageEntityContent.LegalHold -> MessageEntity.ContentType.LEGAL_HOLD
         is MessageEntityContent.Multipart -> MessageEntity.ContentType.MULTIPART
+        is MessageEntityContent.NewConversationWithCellMessage -> MessageEntity.ContentType.CONVERSATION_WITH_CELL
+        is MessageEntityContent.NewConversationWithCellSelfDeleteDisabledMessage ->
+            MessageEntity.ContentType.CONVERSATION_WITH_CELL_SELF_DELETE_DISABLED
     }
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
@@ -250,6 +250,8 @@ object MessageMapper {
                     messageBody = text.requireField("text")
                 )
             }
+            MessageEntity.ContentType.CONVERSATION_WITH_CELL -> MessagePreviewEntityContent.Unknown
+            MessageEntity.ContentType.CONVERSATION_WITH_CELL_SELF_DELETE_DISABLED -> MessagePreviewEntityContent.Unknown
         }
     }
 
@@ -717,6 +719,10 @@ object MessageMapper {
                 },
                 attachments = messageAttachmentsFromJsonString(attachments),
             )
+
+            MessageEntity.ContentType.CONVERSATION_WITH_CELL -> MessageEntityContent.NewConversationWithCellMessage
+            MessageEntity.ContentType.CONVERSATION_WITH_CELL_SELF_DELETE_DISABLED ->
+                MessageEntityContent.NewConversationWithCellSelfDeleteDisabledMessage
         }
 
         val sender = UserDetailsEntity(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20116" title="WPB-20116" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20116</a>  [Android] Self-deleting messages: Restore feature, add disable option instead of removal
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-20116
----

# What's new in this PR?

Support for new system messages on group / channel creation.
See https://github.com/wireapp/wire-android/pull/4261