### PR TITLE
fix: mark api v11 as supported (WPB-19070)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/UpdateSelfClientCapabilityToConsumableNotificationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/UpdateSelfClientCapabilityToConsumableNotificationsUseCase.kt
@@ -124,4 +124,4 @@ internal class UpdateSelfClientCapabilityToConsumableNotificationsUseCaseImpl in
     }
 }
 
-internal const val MIN_API_VERSION_FOR_CONSUMABLE_NOTIFICATIONS = 9
+internal const val MIN_API_VERSION_FOR_CONSUMABLE_NOTIFICATIONS = 11

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/UpdateSelfClientCapabilityToConsumableNotificationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/UpdateSelfClientCapabilityToConsumableNotificationsUseCaseTest.kt
@@ -87,7 +87,7 @@ class UpdateSelfClientCapabilityToConsumableNotificationsUseCaseTest {
     @Test
     fun givenShouldUpdate_AndClientIsEnabledByAPI_thenTheClientCapabilitiesShouldBeUpdatedAndLocalStateUpdated() =
         runTest {
-            val config = newServerConfig(1).copy(metaData = ServerConfig.MetaData(false, CommonApiVersionType.Valid(9), "domain"))
+            val config = newServerConfig(1).copy(metaData = ServerConfig.MetaData(false, CommonApiVersionType.Valid(11), "domain"))
             val (arrangement, useCase) = Arrangement()
                 .withSyncDone()
                 .withShouldUpdateConsumableNotificationsCapabilityResult(true)
@@ -125,7 +125,7 @@ class UpdateSelfClientCapabilityToConsumableNotificationsUseCaseTest {
     @Test
     fun givenShouldUpdate_AndClientIsEnabledByAPIAndSyncFails_thenTheClientCapabilitiesShouldBeUpdatedAndLocalStateShouldNotUpdated() =
         runTest {
-            val config = newServerConfig(1).copy(metaData = ServerConfig.MetaData(false, CommonApiVersionType.Valid(9), "domain"))
+            val config = newServerConfig(1).copy(metaData = ServerConfig.MetaData(false, CommonApiVersionType.Valid(11), "domain"))
             val (arrangement, useCase) = Arrangement()
                 .withSyncDone()
                 .withShouldUpdateConsumableNotificationsCapabilityResult(true)

--- a/network/src/commonMain/kotlin/com/wire/kalium/network/BackendMetaDataUtil.kt
+++ b/network/src/commonMain/kotlin/com/wire/kalium/network/BackendMetaDataUtil.kt
@@ -24,11 +24,11 @@ import io.mockative.Mockable
 
 // They are not truly constants as set is not a primitive type, yet are treated as one in this context
 @Suppress("MagicNumber")
-val SupportedApiVersions: Set<Int> = setOf(0, 1, 2, 4, 5, 6, 7, 8, 9, 10)
+val SupportedApiVersions: Set<Int> = setOf(0, 1, 2, 4, 5, 6, 7, 8, 9, 10, 11)
 
 // They are not truly constants as set is not a primitive type, yet are treated as one in this context
 @Suppress("MagicNumber")
-val DevelopmentApiVersions: Set<Int> = setOf(11)
+val DevelopmentApiVersions: Set<Int> = setOf()
 
 // You can use scripts/generate_new_api_version.sh or gradle task network:generateNewApiVersion to
 // bump API version and generate all needed classes


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19070" title="WPB-19070" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-19070</a>  [Android] Finalize apiVersion 11
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Marking v11 as supported in order to public builds to start using it.
- Mark async notificacions enabled by api version

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
