### PR TITLE
chore(js): enable JS on more modules [WPB-20082]

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -173,6 +173,7 @@ ktor-utils = { module = "io.ktor:ktor-utils", version.ref = "ktor" }
 ktor-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor-okHttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-iosHttp = { module = "io.ktor:ktor-client-ios", version.ref = "ktor" }
+ktor-jsClient = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
 ktor-encoding = { module = "io.ktor:ktor-client-encoding", version.ref = "ktor" }
 ktor-server = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
 ktor-serverNetty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }

--- a/mocks/build.gradle.kts
+++ b/mocks/build.gradle.kts
@@ -24,9 +24,7 @@ plugins {
 }
 
 kaliumLibrary {
-    multiplatform {
-        enableJs.set(false)
-    }
+    multiplatform()
 }
 
 kotlin {

--- a/network-util/build.gradle.kts
+++ b/network-util/build.gradle.kts
@@ -25,9 +25,7 @@ plugins {
 }
 
 kaliumLibrary {
-    multiplatform {
-        enableJs.set(false)
-    }
+    multiplatform()
 }
 
 kotlin {

--- a/network/build.gradle.kts
+++ b/network/build.gradle.kts
@@ -25,12 +25,18 @@ plugins {
 }
 
 kaliumLibrary {
-    multiplatform {
-        enableJs.set(false)
-    }
+    multiplatform()
 }
 
 kotlin {
+    js {
+        browser {
+            testTask {
+                // Network is currently broken for JS. But should be fixed with ktor 3.0
+                isEnabled = false
+            }
+        }
+    }
     sourceSets {
         val commonMain by getting {
             dependencies {
@@ -97,6 +103,11 @@ kotlin {
         val appleMain by getting {
             dependencies {
                 implementation(libs.ktor.iosHttp)
+            }
+        }
+        val jsMain by getting {
+            dependencies {
+                implementation(libs.ktor.jsClient)
             }
         }
     }

--- a/network/src/jsMain/kotlin/com/wire/kalium/network/api/base/unauthenticated/appVersioning/AppVersionBlackListResponse.kt
+++ b/network/src/jsMain/kotlin/com/wire/kalium/network/api/base/unauthenticated/appVersioning/AppVersionBlackListResponse.kt
@@ -16,37 +16,10 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-plugins {
-    alias(libs.plugins.kotlin.serialization)
-    id(libs.plugins.kalium.library.get().pluginId)
+package com.wire.kalium.network.api.base.unauthenticated.appVersioning
+
+actual class AppVersionBlackListResponse {
+    actual fun isAppNeedsToBeUpdated(currentAppVersion: Int): Boolean = false // TODO
 }
 
-kaliumLibrary {
-    multiplatform()
-}
-
-kotlin {
-    sourceSets {
-        val commonMain by getting {
-            dependencies {
-                implementation(projects.util)
-                api(projects.logger)
-
-                // serialization
-                implementation(libs.ktxSerialization)
-
-                // ktor
-                api(libs.ktor.core)
-
-                // KTX
-                implementation(libs.ktxDateTime)
-            }
-        }
-    }
-}
-
-android {
-    testOptions.unitTests.all {
-        it.enabled = false
-    }
-}
+actual fun appVersioningUrlPlatformPath(): String = "js"

--- a/network/src/jsMain/kotlin/com/wire/kalium/network/defaultHttpEngine.kt
+++ b/network/src/jsMain/kotlin/com/wire/kalium/network/defaultHttpEngine.kt
@@ -1,0 +1,46 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network
+
+import com.wire.kalium.network.api.model.ProxyCredentialsDTO
+import com.wire.kalium.network.api.unbound.configuration.ServerConfigDTO
+import com.wire.kalium.network.session.CertificatePinning
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.js.Js
+
+actual fun defaultHttpEngine(
+    serverConfigDTOApiProxy: ServerConfigDTO.ApiProxy?,
+    proxyCredentials: ProxyCredentialsDTO?,
+    ignoreSSLCertificates: Boolean,
+    certificatePinning: CertificatePinning
+): HttpClientEngine {
+    if (serverConfigDTOApiProxy != null || proxyCredentials != null) {
+        throw IllegalArgumentException("Proxy is not implemented on JS")
+    }
+
+    return Js.create {
+        pipelining = true
+
+        if (certificatePinning.isNotEmpty()) {
+            throw IllegalArgumentException("Certificate pinning is not implemented on JS")
+        }
+    }
+}
+
+actual fun clearTextTrafficEngine(): HttpClientEngine = Js.create()

--- a/network/src/jsTest/kotlin/com/wire/kalium/tools/IgnoreIOS.kt
+++ b/network/src/jsTest/kotlin/com/wire/kalium/tools/IgnoreIOS.kt
@@ -16,37 +16,7 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-plugins {
-    alias(libs.plugins.kotlin.serialization)
-    id(libs.plugins.kalium.library.get().pluginId)
-}
+package com.wire.kalium.api.tools
 
-kaliumLibrary {
-    multiplatform()
-}
-
-kotlin {
-    sourceSets {
-        val commonMain by getting {
-            dependencies {
-                implementation(projects.util)
-                api(projects.logger)
-
-                // serialization
-                implementation(libs.ktxSerialization)
-
-                // ktor
-                api(libs.ktor.core)
-
-                // KTX
-                implementation(libs.ktxDateTime)
-            }
-        }
-    }
-}
-
-android {
-    testOptions.unitTests.all {
-        it.enabled = false
-    }
-}
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+actual annotation class IgnoreIOS


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20082" title="WPB-20082" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20082</a>  Commonise mapping
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Just enable JS on a few more modules.

The main issue is `network`, which has many failing tests, which should be solved after we upgrade to Ktor 3.0