### PR TITLE
fix: refresh node status after restore (WPB-20001)

### DIFF
--- a/cells/src/commonMain/kotlin/com/wire/kalium/cells/CellsScope.kt
+++ b/cells/src/commonMain/kotlin/com/wire/kalium/cells/CellsScope.kt
@@ -211,7 +211,7 @@ public class CellsScope(
         GetFoldersUseCaseImpl(cellsRepository)
     }
     public val restoreNodeFromRecycleBin: RestoreNodeFromRecycleBinUseCase by lazy {
-        RestoreNodeFromRecycleBinUseCaseImpl(cellsRepository)
+        RestoreNodeFromRecycleBinUseCaseImpl(cellsRepository, cellAttachmentsRepository)
     }
     public val getAllTags: GetAllTagsUseCase by lazy {
         GetAllTagsUseCaseImpl(cellsRepository)

--- a/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/CellsApiImpl.kt
+++ b/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/CellsApiImpl.kt
@@ -272,11 +272,11 @@ internal class CellsApiImpl(
         )
     }.mapSuccess {}
 
-    override suspend fun restoreNode(path: String): NetworkResponse<Unit> = wrapCellsResponse {
+    override suspend fun restoreNode(uuid: String): NetworkResponse<Unit> = wrapCellsResponse {
         nodeServiceApi.performAction(
             name = NodeServiceApi.NamePerformAction.restore,
             parameters = RestActionParameters(
-                nodes = listOf(RestNodeLocator(path)),
+                nodes = listOf(RestNodeLocator(uuid = uuid)),
                 awaitStatus = JobsTaskStatus.Finished,
                 awaitTimeout = AWAIT_TIMEOUT
             )

--- a/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/CellsDataSource.kt
+++ b/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/CellsDataSource.kt
@@ -230,10 +230,10 @@ internal class CellsDataSource internal constructor(
             }
         }
 
-    override suspend fun restoreNode(path: String): Either<NetworkFailure, Unit> =
+    override suspend fun restoreNode(uuid: String): Either<NetworkFailure, Unit> =
         withContext(dispatchers.io) {
             wrapApiRequest {
-                cellsApi.restoreNode(path = path)
+                cellsApi.restoreNode(uuid = uuid)
             }
         }
 

--- a/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/CellsApi.kt
+++ b/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/CellsApi.kt
@@ -56,7 +56,7 @@ internal interface CellsApi {
         path: String,
         targetPath: String,
     ): NetworkResponse<Unit>
-    suspend fun restoreNode(path: String): NetworkResponse<Unit>
+    suspend fun restoreNode(uuid: String): NetworkResponse<Unit>
     suspend fun getAllTags(): NetworkResponse<List<String>>
     suspend fun updateNodeTags(uuid: String, tags: List<String>): NetworkResponse<Unit>
     suspend fun removeTagsFromNode(uuid: String): NetworkResponse<Unit>

--- a/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/CellsRepository.kt
+++ b/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/CellsRepository.kt
@@ -60,7 +60,7 @@ internal interface CellsRepository {
     suspend fun createFolder(folderName: String): Either<NetworkFailure, List<CellNode>>
     suspend fun moveNode(uuid: String, path: String, targetPath: String): Either<NetworkFailure, Unit>
     suspend fun renameNode(uuid: String, path: String, targetPath: String): Either<NetworkFailure, Unit>
-    suspend fun restoreNode(path: String): Either<NetworkFailure, Unit>
+    suspend fun restoreNode(uuid: String): Either<NetworkFailure, Unit>
     suspend fun getAllTags(): Either<NetworkFailure, List<String>>
     suspend fun updateNodeTags(uuid: String, tags: List<String>): Either<NetworkFailure, Unit>
     suspend fun removeNodeTags(uuid: String): Either<NetworkFailure, Unit>

--- a/cells/src/commonTest/kotlin/com/wire/kalium/cells/domain/usecase/RestoreNodeFromRecycleBinUseCaseTest.kt
+++ b/cells/src/commonTest/kotlin/com/wire/kalium/cells/domain/usecase/RestoreNodeFromRecycleBinUseCaseTest.kt
@@ -1,0 +1,119 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.cells.domain.usecase
+
+import com.wire.kalium.cells.domain.CellAttachmentsRepository
+import com.wire.kalium.cells.domain.CellsRepository
+import com.wire.kalium.common.error.NetworkFailure
+import com.wire.kalium.common.functional.left
+import com.wire.kalium.common.functional.right
+import com.wire.kalium.logic.data.asset.AssetTransferStatus
+import com.wire.kalium.logic.data.message.CellAssetContent
+import io.mockative.any
+import io.mockative.coEvery
+import io.mockative.coVerify
+import io.mockative.mock
+import io.mockative.once
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class RestoreNodeFromRecycleBinUseCaseTest {
+
+    @Test
+    fun givenRestoreSuccessAndLocalFileAvailable_whenRestoreNode_thenLocalFileStatusIsUpdated() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withNodeRestoreSuccess()
+            .withLocalAttachment()
+            .arrange()
+
+        useCase("assetId")
+
+        coVerify {
+            arrangement.attachmentsRepository.setAssetTransferStatus("assetId", AssetTransferStatus.SAVED_INTERNALLY)
+        }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenRestoreSuccessAndLocalFileNotAvailable_whenRestoreNode_thenLocalFileStatusIsUpdated() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withNodeRestoreSuccess()
+            .withLocalAttachment(testAttachment.copy(localPath = null))
+            .arrange()
+
+        useCase("assetId")
+
+        coVerify {
+            arrangement.attachmentsRepository.setAssetTransferStatus("assetId", AssetTransferStatus.NOT_DOWNLOADED)
+        }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenRestoreFailure_whenRestoreNode_thenLocalFileStatusIsNotUpdated() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withNodeRestoreFailure()
+            .arrange()
+
+        useCase("assetId")
+
+        coVerify {
+            arrangement.attachmentsRepository.setAssetTransferStatus(any(), any())
+        }.wasNotInvoked()
+    }
+
+    private class Arrangement {
+
+        val cellsRepository = mock(CellsRepository::class)
+        val attachmentsRepository = mock(CellAttachmentsRepository::class)
+
+        suspend fun withNodeRestoreSuccess() = apply {
+            coEvery { cellsRepository.restoreNode(any()) } returns Unit.right()
+        }
+
+        suspend fun withNodeRestoreFailure() = apply {
+            coEvery { cellsRepository.restoreNode(any()) } returns NetworkFailure.NoNetworkConnection(null).left()
+        }
+
+        suspend fun withLocalAttachment(attachment: CellAssetContent = testAttachment) = apply {
+            coEvery { attachmentsRepository.getAttachment(any()) }.returns(attachment.right())
+        }
+
+        suspend fun arrange(): Pair<Arrangement, RestoreNodeFromRecycleBinUseCase> {
+
+            coEvery { attachmentsRepository.setAssetTransferStatus(any(), any()) } returns Unit.right()
+
+            return this to RestoreNodeFromRecycleBinUseCaseImpl(
+                cellsRepository = cellsRepository,
+                attachmentsRepository = attachmentsRepository,
+            )
+        }
+    }
+}
+
+private val testAttachment = CellAssetContent(
+    id = "assetId",
+    versionId = "versionId",
+    mimeType = "image/png",
+    assetPath = "assetPath",
+    assetSize = 1024,
+    contentHash = "contentHash",
+    localPath = "localPath",
+    contentUrl = "http://contentUrl",
+    previewUrl = "http://previewUrl",
+    metadata = null,
+    transferStatus = AssetTransferStatus.SAVED_INTERNALLY
+)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20001" title="WPB-20001" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20001</a>  [Android] Restored files still appear as "Not Available" in conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-20001
# What's new in this PR?

### Issues
Attachment in messages list stays in "File not available" state after restoring deleted file from recycle bin.

### Solutions
Update the local attachment status in database. In case the restore operation failure (runs async on server side) the status will be updated when conversation is re-opened.