### PR TITLE
fix: execute missed notifications on async missed (WPB-20497)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -140,7 +140,7 @@ class EventMapper(
             is EventContentDTO.Conversation.ProtocolUpdate -> conversationProtocolUpdate(id, eventContentDTO)
             is EventContentDTO.Conversation.ChannelAddPermissionUpdate -> conversationChannelPermissionUpdate(id, eventContentDTO)
             is EventContentDTO.Conversation.MlsResetConversationDTO -> mlsConversationReset(id, eventContentDTO)
-            EventContentDTO.AsyncMissedNotification -> Event.AsyncMissed(id)
+            is EventContentDTO.AsyncMissedNotification -> Event.AsyncMissed(id)
         }
 
     private fun conversationTyping(
@@ -568,6 +568,7 @@ class EventMapper(
             id,
             featureConfigMapper.fromDTO(featureConfigUpdatedDTO.data as FeatureConfigData.AllowedGlobalOperations)
         )
+
         is FeatureConfigData.Cells -> Event.FeatureConfig.CellsConfigUpdated(
             id,
             featureConfigMapper.fromDTO(featureConfigUpdatedDTO.data as FeatureConfigData.Cells)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -140,7 +140,7 @@ class EventMapper(
             is EventContentDTO.Conversation.ProtocolUpdate -> conversationProtocolUpdate(id, eventContentDTO)
             is EventContentDTO.Conversation.ChannelAddPermissionUpdate -> conversationChannelPermissionUpdate(id, eventContentDTO)
             is EventContentDTO.Conversation.MlsResetConversationDTO -> mlsConversationReset(id, eventContentDTO)
-            is EventContentDTO.AsyncMissedNotification -> Event.AsyncMissed(id)
+            EventContentDTO.AsyncMissedNotification -> Event.AsyncMissed(id)
         }
 
     private fun conversationTyping(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1858,6 +1858,7 @@ class UserSessionScope internal constructor(
             slowSyncRequester = { syncExecutor.request { waitUntilLiveOrFailure() } },
             slowSyncRepository = slowSyncRepository,
             eventRepository = eventRepository,
+            logger = userScopedLogger
         )
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/MissedNotificationsEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/MissedNotificationsEventReceiverTest.kt
@@ -19,6 +19,7 @@ package com.wire.kalium.logic.sync.receiver
 
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.right
+import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.logic.data.event.EventRepository
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.framework.TestEvent
@@ -79,7 +80,8 @@ class MissedNotificationsEventReceiverTest {
             this to MissedNotificationsEventReceiverImpl(
                 slowSyncRequester = slowSyncExecutorProvider,
                 slowSyncRepository = slowSyncRepository,
-                eventRepository = eventRepository
+                eventRepository = eventRepository,
+                logger = kaliumLogger
             )
         }
     }

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Events.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Events.sq
@@ -51,3 +51,7 @@ LIMIT 500;
 deleteUnprocessedLiveEventsByIds:
 DELETE FROM Events
 WHERE is_processed = 0 AND is_live = 1 AND event_id IN ?;
+
+deleteUnprocessedTransientEvents:
+DELETE FROM Events
+WHERE is_processed = 0 AND transient = 1;

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/event/EventDAO.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/event/EventDAO.kt
@@ -32,4 +32,5 @@ interface EventDAO {
     suspend fun getUnprocessedEvents(): List<EventEntity>
     suspend fun setAllUnprocessedEventsAsPending()
     suspend fun deleteUnprocessedLiveEventsByIds(ids: List<String>)
+    suspend fun deleteUnprocessedTransientEvents()
 }

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/event/EventDAOImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/event/EventDAOImpl.kt
@@ -51,6 +51,10 @@ class EventDAOImpl(
         eventsQueries.deleteUnprocessedLiveEventsByIds(ids)
     }
 
+    override suspend fun deleteUnprocessedTransientEvents() = withContext(queriesContext) {
+        eventsQueries.deleteUnprocessedTransientEvents()
+    }
+
     override suspend fun insertEvents(events: List<NewEventEntity>) {
         withContext(queriesContext) {
             eventsQueries.transaction {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20497" title="WPB-20497" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20497</a>  [Android] App Stuck after failing to process missed_events
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Regression on notifications missed is not being executed after introducing persistence of events and raw parser.

### Causes (Optional)

- Parser of async missed was persisting the payload as empty.
- Stuck on decrypting because of `flowCollector` in event repository was never changing from `CatchingUp`.

### Solutions

Fix those, and add more logs for async processor event.

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

Pending to write some unit tests ☝️☝️☝️☝️ 

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
