### PR TITLE
fix: allow joining or establishing MLS group conversations with epoch 0 [WPB-20766]

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCaseTest.kt
@@ -127,12 +127,15 @@ class JoinExistingMLSConversationUseCaseTest {
     }
 
     @Test
-    fun givenGroupConversationWithZeroEpoch_whenInvokingUseCase_ThenDoNotEstablishMlsGroup() =
+    fun givenGroupConversationWithZeroEpoch_whenInvokingUseCase_ThenEstablishMlsGroup() =
         runTest {
+            val members = listOf(TestUser.USER_ID, TestUser.OTHER_USER_ID)
             val (arrangement, joinExistingMLSConversationsUseCase) = Arrangement(testKaliumDispatcher)
                 .withIsMLSSupported(true)
                 .withHasRegisteredMLSClient(true)
                 .withGetConversationsByIdSuccessful(Arrangement.MLS_UNESTABLISHED_GROUP_CONVERSATION)
+                .withGetConversationMembersSuccessful(members)
+                .withEstablishMLSGroupSuccessful(MLSAdditionResult(emptySet(), emptySet()))
                 .arrange()
 
             joinExistingMLSConversationsUseCase(
@@ -142,13 +145,13 @@ class JoinExistingMLSConversationUseCaseTest {
 
             coVerify {
                 arrangement.mlsConversationRepository.establishMLSGroup(
-                    groupID = Arrangement.GROUP_ID3,
-                    members = emptyList(),
-                    publicKeys = null,
-                    allowSkippingUsersWithoutKeyPackages = false,
-                    mlsContext = arrangement.mlsContext
+                    mlsContext = any(),
+                    groupID = eq(Arrangement.GROUP_ID3),
+                    members = eq(members),
+                    publicKeys = any(),
+                    allowSkippingUsersWithoutKeyPackages = eq(false)
                 )
-            }.wasNotInvoked()
+            }.wasInvoked(exactly = once)
         }
 
     @Test
@@ -197,11 +200,11 @@ class JoinExistingMLSConversationUseCaseTest {
 
             coVerify {
                 arrangement.mlsConversationRepository.establishMLSGroup(
-                    any(),
-                    eq(Arrangement.GROUP_ID_ONE_ON_ONE),
-                    eq(members),
-                    any(),
-                    eq(false)
+                    mlsContext = any(),
+                    groupID = eq(Arrangement.GROUP_ID_ONE_ON_ONE),
+                    members = eq(members),
+                    publicKeys = any(),
+                    allowSkippingUsersWithoutKeyPackages = eq(false)
                 )
             }.wasInvoked(once)
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20766" title="WPB-20766" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20766</a>  Android doesn't recover a from a partially resetted conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

If a MLS Group conversation is reset, but no commits are sent, the app fails to join such conversation after logging in.

### Causes 

We had an `else -> Either.Right(Unit)` in the `joinOrEstablishMlsGroup` function.

### Solutions

1. Add an extra condition for group conversation with `epoch=0`
2. Add logs in case of "else"


This still doesn't solve the issue when attempting to send a message.
This issue will be tackled in the following PRs.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution