### PR TITLE
fix: update file path after renaming (WPB-20786)

### DIFF
--- a/cells/src/commonMain/kotlin/com/wire/kalium/cells/CellsScope.kt
+++ b/cells/src/commonMain/kotlin/com/wire/kalium/cells/CellsScope.kt
@@ -223,7 +223,7 @@ public class CellsScope(
         RemoveNodeTagsUseCaseImpl(cellsRepository)
     }
     public val renameNodeUseCase: RenameNodeUseCase by lazy {
-        RenameNodeUseCaseImpl(cellsRepository)
+        RenameNodeUseCaseImpl(cellsRepository, cellAttachmentsRepository)
     }
 
     public val isCellAvailable: IsAtLeastOneCellAvailableUseCase by lazy {

--- a/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/CellAttachmentsDataSource.kt
+++ b/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/CellAttachmentsDataSource.kt
@@ -53,6 +53,15 @@ internal class CellAttachmentsDataSource(
         }
     }
 
+    override suspend fun updateAssetPath(
+        assetId: String,
+        remotePath: String
+    ): Either<StorageFailure, Unit> = withContext(dispatchers.io) {
+        wrapStorageRequest {
+            messageAttachments.setAssetPath(assetId, remotePath)
+        }
+    }
+
     override suspend fun setAssetTransferStatus(assetId: String, status: AssetTransferStatus) = withContext(dispatchers.io) {
         wrapStorageRequest {
             messageAttachments.setTransferStatus(assetId, status.name)

--- a/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/CellAttachmentsRepository.kt
+++ b/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/CellAttachmentsRepository.kt
@@ -37,4 +37,5 @@ internal interface CellAttachmentsRepository {
     suspend fun saveStandaloneAssetPath(assetId: String, path: String, size: Long): Either<StorageFailure, Unit>
     suspend fun getStandaloneAssetPaths(): Either<StorageFailure, List<Pair<String, String>>>
     suspend fun deleteStandaloneAsset(assetId: String): Either<StorageFailure, Unit>
+    suspend fun updateAssetPath(assetId: String, remotePath: String): Either<StorageFailure, Unit>
 }

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/MessageAttachments.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/MessageAttachments.sq
@@ -63,6 +63,9 @@ UPDATE MessageAttachments SET local_path = ? WHERE asset_id = ?;
 getAssetPath:
 SELECT asset_path FROM MessageAttachments WHERE asset_id = ?;
 
+setAssetPath:
+UPDATE MessageAttachments SET asset_path = ? WHERE asset_id = ?;
+
 setTransferStatus:
 UPDATE MessageAttachments SET asset_transfer_status = ? WHERE asset_id = ?;
 

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/attachment/MessageAttachmentsDao.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/attachment/MessageAttachmentsDao.kt
@@ -34,6 +34,7 @@ interface MessageAttachmentsDao {
     suspend fun getAttachments(messageId: String, conversationId: QualifiedIDEntity): List<MessageAttachmentEntity>
     suspend fun getAttachments(): List<MessageAttachmentEntity>
     suspend fun observeAttachments(): Flow<List<MessageAttachmentEntity>>
+    suspend fun setAssetPath(assetId: String, path: String)
 }
 
 internal class MessageAttachmentsDaoImpl(
@@ -58,6 +59,10 @@ internal class MessageAttachmentsDaoImpl(
 
     override suspend fun getAssetPath(assetId: String): String? =
         queries.getAssetPath(asset_id = assetId).executeAsOneOrNull()?.asset_path
+
+    override suspend fun setAssetPath(assetId: String, path: String) {
+        queries.setAssetPath(asset_id = assetId, asset_path = path)
+    }
 
     override suspend fun setLocalPath(assetId: String, path: String?) {
         queries.setLocalPath(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20786" title="WPB-20786" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20786</a>  [Android] File shows the old name in the conversation view after renaming
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-20786
----

# What's new in this PR?

### Issues
After renaming a file (Wire Cells) it is still displayed with the old name in the conversation until user re-opens conversation.

### Causes (Optional)
File name is only updated when user opens conversation and file attachment is displayed. After renaming file name in the database is not updated.

### Solutions
Update file name in the database if rename operation is success.

