### PR TITLE
fix(mls): attempt to rejoin/reestablish MLS group when sending messages [WPB-20766]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -2110,6 +2110,7 @@ class UserSessionScope internal constructor(
             messageRepository,
             conversationRepository,
             mlsConversationRepository,
+            { joinExistingMLSConversationUseCase },
             clientRepository,
             clientRemoteRepository,
             clientIdProvider,
@@ -2172,6 +2173,7 @@ class UserSessionScope internal constructor(
             fetchConversationUseCase,
             cryptoTransactionProvider,
             compositeMessageRepository,
+            { joinExistingMLSConversationUseCase },
             this,
             userScopedLogger,
         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.data.client.CryptoTransactionProvider
 import com.wire.kalium.logic.data.client.remote.ClientRemoteRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.FetchConversationUseCase
+import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCase
 import com.wire.kalium.logic.data.conversation.LegalHoldStatusMapperImpl
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.event.EventRepository
@@ -77,6 +78,7 @@ class DebugScope internal constructor(
     internal val messageRepository: MessageRepository,
     private val conversationRepository: ConversationRepository,
     private val mlsConversationRepository: MLSConversationRepository,
+    private val joinExistingMLSConversationUseCaseProvider: () -> JoinExistingMLSConversationUseCase,
     private val clientRepository: ClientRepository,
     private val clientRemoteRepository: ClientRemoteRepository,
     private val currentClientIdProvider: CurrentClientIdProvider,
@@ -169,6 +171,8 @@ class DebugScope internal constructor(
         get() = MLSMessageCreatorImpl(
             conversationRepository = conversationRepository,
             legalHoldStatusMapper = LegalHoldStatusMapperImpl,
+            mlsConversationRepository = mlsConversationRepository,
+            joinExistingConversationUseCase = joinExistingMLSConversationUseCaseProvider(),
             selfUserId = userId,
             protoContentMapper = protoContentMapper
         )
@@ -181,7 +185,6 @@ class DebugScope internal constructor(
         get() = MessageSenderImpl(
             messageRepository,
             conversationRepository,
-            mlsConversationRepository,
             syncManager,
             messageSendFailureHandler,
             legalHoldHandler,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MLSMessageCreator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MLSMessageCreator.kt
@@ -22,10 +22,15 @@ package com.wire.kalium.logic.feature.message
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.wrapMLSRequest
 import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.flatMap
 import com.wire.kalium.common.logger.kaliumLogger
+import com.wire.kalium.cryptography.CryptoTransactionContext
 import com.wire.kalium.cryptography.MlsCoreCryptoContext
+import com.wire.kalium.logic.data.client.wrapInMLSContext
 import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCase
 import com.wire.kalium.logic.data.conversation.LegalHoldStatusMapper
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.message.Message
@@ -40,23 +45,45 @@ import kotlinx.coroutines.flow.first
 @Mockable
 interface MLSMessageCreator {
 
-    suspend fun createOutgoingMLSMessage(
-        mlsContext: MlsCoreCryptoContext,
+    suspend fun cleanMLSGroupStateAndCreateOutgoingMLSMessage(
+        transactionContext: CryptoTransactionContext,
         groupId: GroupID,
         message: Message.Sendable
     ): Either<CoreFailure, MLSMessageApi.Message>
 
 }
 
-class MLSMessageCreatorImpl(
+@Suppress("LongParameterList")
+internal class MLSMessageCreatorImpl(
     private val conversationRepository: ConversationRepository,
     private val legalHoldStatusMapper: LegalHoldStatusMapper,
+    private val mlsConversationRepository: MLSConversationRepository,
+    private val joinExistingConversationUseCase: JoinExistingMLSConversationUseCase,
     private val selfUserId: UserId,
     private val protoContentMapper: ProtoContentMapper = MapperProvider.protoContentMapper(selfUserId = selfUserId),
     private val idMapper: IdMapper = MapperProvider.idMapper()
 ) : MLSMessageCreator {
 
-    override suspend fun createOutgoingMLSMessage(
+    override suspend fun cleanMLSGroupStateAndCreateOutgoingMLSMessage(
+        transactionContext: CryptoTransactionContext,
+        groupId: GroupID,
+        message: Message.Sendable
+    ): Either<CoreFailure, MLSMessageApi.Message> = transactionContext.wrapInMLSContext { mlsContext ->
+        val doesConversationExist = mlsContext.conversationExists(idMapper.toCryptoModel(groupId))
+        if (doesConversationExist) {
+            mlsConversationRepository.commitPendingProposals(mlsContext, groupId)
+        } else {
+            joinExistingConversationUseCase(transactionContext, message.conversationId)
+        }.flatMap {
+            createOutgoingMLSMessage(
+                mlsContext = mlsContext,
+                groupId = groupId,
+                message = message
+            )
+        }
+    }
+
+    private suspend fun createOutgoingMLSMessage(
         mlsContext: MlsCoreCryptoContext,
         groupId: GroupID,
         message: Message.Sendable

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MLSMessageCreator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MLSMessageCreator.kt
@@ -45,7 +45,7 @@ import kotlinx.coroutines.flow.first
 @Mockable
 interface MLSMessageCreator {
 
-    suspend fun cleanMLSGroupStateAndCreateOutgoingMLSMessage(
+    suspend fun prepareMLSGroupAndCreateOutgoingMLSMessage(
         transactionContext: CryptoTransactionContext,
         groupId: GroupID,
         message: Message.Sendable
@@ -64,7 +64,7 @@ internal class MLSMessageCreatorImpl(
     private val idMapper: IdMapper = MapperProvider.idMapper()
 ) : MLSMessageCreator {
 
-    override suspend fun cleanMLSGroupStateAndCreateOutgoingMLSMessage(
+    override suspend fun prepareMLSGroupAndCreateOutgoingMLSMessage(
         transactionContext: CryptoTransactionContext,
         groupId: GroupID,
         message: Message.Sendable

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.logic.data.client.remote.ClientRemoteRepository
 import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.FetchConversationUseCase
+import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCase
 import com.wire.kalium.logic.data.conversation.LegalHoldStatusMapper
 import com.wire.kalium.logic.data.conversation.LegalHoldStatusMapperImpl
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
@@ -137,6 +138,7 @@ class MessageScope internal constructor(
     private val fetchConversationUseCase: FetchConversationUseCase,
     private val transactionProvider: CryptoTransactionProvider,
     private val compositeMessageRepository: CompositeMessageRepository,
+    private val joinExistingConversationUseCaseProvider: () -> JoinExistingMLSConversationUseCase,
     private val scope: CoroutineScope,
     kaliumLogger: KaliumLogger,
     internal val dispatcher: KaliumDispatcher = KaliumDispatcherImpl,
@@ -168,6 +170,8 @@ class MessageScope internal constructor(
         get() = MLSMessageCreatorImpl(
             conversationRepository = conversationRepository,
             legalHoldStatusMapper = legalHoldStatusMapper,
+            mlsConversationRepository = mlsConversationRepository,
+            joinExistingConversationUseCase = joinExistingConversationUseCaseProvider(),
             selfUserId = selfUserId,
             protoContentMapper = protoContentMapper
         )
@@ -215,7 +219,6 @@ class MessageScope internal constructor(
         get() = MessageSenderImpl(
             messageRepository,
             conversationRepository,
-            mlsConversationRepository,
             syncManager,
             messageSendFailureHandler,
             legalHoldHandler,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSenderImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSenderImpl.kt
@@ -280,7 +280,7 @@ internal class MessageSenderImpl internal constructor(
     ): Either<CoreFailure, Instant> {
         return transactionContext
             .wrapInMLSContext { mlsContext ->
-                mlsMessageCreator.cleanMLSGroupStateAndCreateOutgoingMLSMessage(transactionContext, protocolInfo.groupId, message)
+                mlsMessageCreator.prepareMLSGroupAndCreateOutgoingMLSMessage(transactionContext, protocolInfo.groupId, message)
             }
             .flatMap { mlsMessage ->
                 messageRepository.sendMLSMessage(mlsMessage).fold({

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MLSMessageCreatorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MLSMessageCreatorTest.kt
@@ -63,7 +63,7 @@ class MLSMessageCreatorTest {
             .withMLSEncryptMessage(encryptedData)
             .arrange {}
 
-        creator.cleanMLSGroupStateAndCreateOutgoingMLSMessage(arrangement.transactionContext, GROUP_ID, TestMessage.TEXT_MESSAGE)
+        creator.prepareMLSGroupAndCreateOutgoingMLSMessage(arrangement.transactionContext, GROUP_ID, TestMessage.TEXT_MESSAGE)
             .shouldSucceed {}
 
         coVerify {
@@ -97,7 +97,7 @@ class MLSMessageCreatorTest {
             .withMLSEncryptMessage(encryptedData)
             .arrange {}
 
-        creator.cleanMLSGroupStateAndCreateOutgoingMLSMessage(arrangement.transactionContext, GROUP_ID, TestMessage.TEXT_MESSAGE)
+        creator.prepareMLSGroupAndCreateOutgoingMLSMessage(arrangement.transactionContext, GROUP_ID, TestMessage.TEXT_MESSAGE)
             .shouldSucceed {}
 
         coVerify {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
@@ -1095,7 +1095,7 @@ class MessageSenderTest {
 
         suspend fun withCreateOutgoingMlsMessage(failing: Boolean = false) = apply {
             coEvery {
-                mlsMessageCreator.cleanMLSGroupStateAndCreateOutgoingMLSMessage(any(), any(), any())
+                mlsMessageCreator.prepareMLSGroupAndCreateOutgoingMLSMessage(any(), any(), any())
             }.returns(if (failing) Either.Left(TEST_CORE_FAILURE) else Either.Right(TEST_MLS_MESSAGE))
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
@@ -24,7 +24,6 @@ import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
-import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.conversation.Recipient
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.GroupID
@@ -231,7 +230,6 @@ class MessageSenderTest {
         // given
         val failure = CoreFailure.Unknown(Throwable("some exception"))
         val (arrangement, messageSender) = arrange {
-            withCommitPendingProposals()
             withSendMlsMessage(sendMlsMessageWithResult = Either.Left(failure))
         }
 
@@ -308,7 +306,6 @@ class MessageSenderTest {
     fun givenReceivingStaleMessageError_whenSendingMlsMessage_thenVerifyStaleEpoch() {
         // given
         val (arrangement, messageSender) = arrange {
-            withCommitPendingProposals()
             withSendMlsMessage()
             withSendOutgoingMlsMessage(Either.Left(Arrangement.MLS_STALE_MESSAGE_FAILURE), times = 1)
             withWaitUntilLiveOrFailure()
@@ -332,7 +329,6 @@ class MessageSenderTest {
     fun givenReceivingStaleMessageError_whenSendingMlsMessage_thenRetryAfterSyncIsLive() {
         // given
         val (arrangement, messageSender) = arrange {
-            withCommitPendingProposals()
             withSendMlsMessage()
             withSendOutgoingMlsMessage(Either.Left(Arrangement.MLS_STALE_MESSAGE_FAILURE), times = 1)
             withWaitUntilLiveOrFailure()
@@ -353,32 +349,9 @@ class MessageSenderTest {
     }
 
     @Test
-    fun givenPendingProposals_whenSendingMlsMessage_thenProposalsAreCommitted() {
-        // given
-        val (arrangement, messageSender) = arrange {
-            withCommitPendingProposals()
-            withSendMlsMessage()
-            withSendOutgoingMlsMessage()
-            withPromoteMessageToSentUpdatingServerTime()
-        }
-
-        arrangement.testScope.runTest {
-            // when
-            val result = messageSender.sendPendingMessage(Arrangement.TEST_CONVERSATION_ID, Arrangement.TEST_MESSAGE_UUID)
-
-            // then
-            result.shouldSucceed()
-            coVerify {
-                arrangement.mlsConversationRepository.commitPendingProposals(any(), eq(Arrangement.GROUP_ID))
-            }.wasInvoked(once)
-        }
-    }
-
-    @Test
     fun givenReceivingStaleMessageError_whenSendingMlsMessage_thenGiveUpIfSyncIsPending() {
         // given
         val (arrangement, messageSender) = arrange {
-            withCommitPendingProposals()
             withSendMlsMessage(sendMlsMessageWithResult = Either.Left(Arrangement.MLS_STALE_MESSAGE_FAILURE))
             withWaitUntilLiveOrFailure(failing = true)
             withVerifyEpoch(Either.Right(Unit))
@@ -530,7 +503,6 @@ class MessageSenderTest {
         // given
         val failure = FEDERATION_MESSAGE_FAILURE
         val (arrangement, messageSender) = arrange {
-            withCommitPendingProposals()
             withWaitUntilLiveOrFailure()
             withSendMlsMessage(sendMlsMessageWithResult = Either.Left(failure))
         }
@@ -893,7 +865,6 @@ class MessageSenderTest {
     fun givenARemoteMlsConversationPartiallyFails_whenSendingAMessage_ThenReturnSuccessAndPersistFailedToSendUsers() {
         // given
         val (arrangement, messageSender) = arrange {
-            withCommitPendingProposals()
             withSendMlsMessage(
                 sendMlsMessageWithResult = Either.Right(MessageSent(MESSAGE_SENT_TIME, listOf(TEST_MEMBER_2))),
             )
@@ -1021,7 +992,6 @@ class MessageSenderTest {
         val messageRepository: MessageRepository = mock(MessageRepository::class)
         val messageSendFailureHandler: MessageSendFailureHandler = mock(MessageSendFailureHandler::class)
         val conversationRepository: ConversationRepository = mock(ConversationRepository::class)
-        val mlsConversationRepository: MLSConversationRepository = mock(MLSConversationRepository::class)
         val sessionEstablisher = mock(SessionEstablisher::class)
         val messageEnvelopeCreator: MessageEnvelopeCreator = mock(MessageEnvelopeCreator::class)
         val mlsMessageCreator: MLSMessageCreator = mock(MLSMessageCreator::class)
@@ -1046,7 +1016,6 @@ class MessageSenderTest {
             this@Arrangement to MessageSenderImpl(
                 messageRepository = messageRepository,
                 conversationRepository = conversationRepository,
-                mlsConversationRepository = mlsConversationRepository,
                 syncManager = syncManager,
                 messageSendFailureHandler = messageSendFailureHandler,
                 legalHoldHandler = legalHoldHandler,
@@ -1100,12 +1069,6 @@ class MessageSenderTest {
             }.returns(if (failing) Either.Left(TEST_CORE_FAILURE) else Either.Right(usersFailing))
         }
 
-        suspend fun withCommitPendingProposals(failing: Boolean = false) = apply {
-            coEvery {
-                mlsConversationRepository.commitPendingProposals(any(), any())
-            }.returns(if (failing) Either.Left(TEST_CORE_FAILURE) else Either.Right(Unit))
-        }
-
         suspend fun withCreateOutgoingEnvelope(failing: Boolean = false) = apply {
             coEvery {
                 messageEnvelopeCreator.createOutgoingEnvelope(any(), any(), any())
@@ -1132,7 +1095,7 @@ class MessageSenderTest {
 
         suspend fun withCreateOutgoingMlsMessage(failing: Boolean = false) = apply {
             coEvery {
-                mlsMessageCreator.createOutgoingMLSMessage(any(), any(), any())
+                mlsMessageCreator.cleanMLSGroupStateAndCreateOutgoingMLSMessage(any(), any(), any())
             }.returns(if (failing) Either.Left(TEST_CORE_FAILURE) else Either.Right(TEST_MLS_MESSAGE))
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20766" title="WPB-20766" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20766</a>  Android doesn't recover a from a partially resetted conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

App can't send messages in MLS conversations after they are half-reset / pending reestablish.

### Causes

Logic was never put in there.

### Solutions

#### Move MLS-related logic from `MessageSender` to `MlsMessMLSMessageCreator`

Less protocol-specific actions in the generic message sender.

Now the `MLSMessageCreator` handles more MLS logic before sending it:
- Checks if the MLS conversation/group exists with CoreCrypto before sending
  - If it does: commit pending proposals
  - Otherwise: try to join the existing conversation, which joins by external commit or establishes the group if mid-reset.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

