### PR TITLE
fix: recover from MLS invalid leaf [WPB-20765]

### DIFF
--- a/common/src/commonJvmAndroid/kotlin/com/wire/kalium/common/error/CoreCryptoExceptionMapper.kt
+++ b/common/src/commonJvmAndroid/kotlin/com/wire/kalium/common/error/CoreCryptoExceptionMapper.kt
@@ -35,7 +35,7 @@ actual fun mapMLSException(exception: Exception): MLSFailure {
             is MlsException.MessageEpochTooOld -> MLSFailure.MessageEpochTooOld
 
             is MlsException.Other -> {
-                val otherError = (exception.mlsError as MlsException.Other).message
+                val otherError = (exception.mlsError as MlsException.Other).msg
                 if (otherError.startsWith(COMMIT_FOR_MISSING_PROPOSAL)) {
                     MLSFailure.CommitForMissingProposal
                 } else if (otherError.startsWith(CONVERSATION_NOT_FOUND)) {
@@ -49,7 +49,7 @@ actual fun mapMLSException(exception: Exception): MLSFailure {
 
             is MlsException.OrphanWelcome -> MLSFailure.OrphanWelcome
             is MlsException.BufferedCommit -> MLSFailure.BufferedCommit
-            is MlsException.MessageRejected -> mapMessageRejected((exception.mlsError as MlsException.MessageRejected).message)
+            is MlsException.MessageRejected -> mapMessageRejected((exception.mlsError as MlsException.MessageRejected).reason)
         }
         // because there is a lack of multiplatform binding we need to catch generic exception
         // and map it to the appropriate failure to have proper tests
@@ -61,14 +61,13 @@ actual fun mapMLSException(exception: Exception): MLSFailure {
 }
 
 private fun mapMessageRejected(message: String): MLSFailure.MessageRejected {
-    val reason = message.replace("reason=", "")
-    return when (reason) {
-        "mls-stale-message" -> MLSFailure.MessageRejected.MlsStaleMessage
-        "mls-client-mismatch" -> MLSFailure.MessageRejected.MlsClientMismatch
-        "mls-commit-missing-references" -> MLSFailure.MessageRejected.MlsCommitMissingReferences
-        "mls-invalid-leaf-node-index" -> MLSFailure.MessageRejected.InvalidLeafNodeIndex
-        "mls-invalid-leaf-node-signature" -> MLSFailure.MessageRejected.InvalidLeafNodeIndex
-        else -> MLSFailure.MessageRejected.Other(reason = reason)
+    return when {
+        message.contains("mls-stale-message") -> MLSFailure.MessageRejected.MlsStaleMessage
+        message.contains("mls-client-mismatch") -> MLSFailure.MessageRejected.MlsClientMismatch
+        message.contains("mls-commit-missing-references") -> MLSFailure.MessageRejected.MlsCommitMissingReferences
+        message.contains("mls-invalid-leaf-node-index") -> MLSFailure.MessageRejected.InvalidLeafNodeIndex
+        message.contains("mls-invalid-leaf-node-signature") -> MLSFailure.MessageRejected.InvalidLeafNodeIndex
+        else -> MLSFailure.MessageRejected.Other(reason = message)
     }
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationUseCase.kt
@@ -179,7 +179,7 @@ internal class JoinExistingMLSConversationUseCaseImpl(
                                     leadingMessage = "Reset Conversation after join group failure",
                                     jsonStringKeyValues = conversation.logData(failure)
                                 )
-                                resetMLSConversation(conversation.id)
+                                resetMLSConversation(conversation.id, transactionContext)
                             }
                             else -> {
                                 logger.logStructuredJson(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
@@ -163,7 +163,7 @@ internal class NewMessageEventHandlerImpl(
 
                     MLSMessageFailureResolution.ResetConversation -> {
                         eventLogger.logFailure(it, "protocol" to "MLS", "mlsOutcome" to "OUT_OF_SYNC")
-                        resetMLSConversation(event.conversationId)
+                        resetMLSConversation(event.conversationId, transactionContext)
                     }
                 }
             }.onSuccess { batchResult ->


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20765" title="WPB-20765" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20765</a>  Android doesn't attempt to reset mls conversations it can't join on login
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->



----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When an MLS conversation is corrupted, we should reset the MLS conversation, but we are not doing it.

### Causes

#### Exception Message as error handling logic 😬
We are relying on exception messages to figure out what to do.
It is of course flaky, and it shows: CoreCrypto used to throw exceptions with "naked" exception messages.

Now it wraps the exception message using another field, for example:

```kotlin
class MessageRejected(
    val reason: String // This is a new field, which contains the "naked" message
) : MlsException() {
    override val message // We were using this field, which did not contain "reason=" prefix before
        get() = "reason=${reason}"
}
    
class Other(       
    val msg: String // This is a new field, which contains the "naked" message
) : MlsException() {
    override val message // We were using this field, and it did not contain "msg=" prefix before
        get() = "msg=${$msg}"
}
```

#### Transaction within a Transaction

`ResetMlsConversationUseCase` initialises a transaction.
Which sucks, because we may call it from within a transaction, leading to a deadlock.

### Solutions

1. Use the new exception fields instead of `exception.message`
2. Allow passing a transaction context to reset MLS conversations