### PR TITLE
feat: precheck when renaming file (WPB-20937)

### DIFF
--- a/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/usecase/RenameNodeUseCase.kt
+++ b/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/usecase/RenameNodeUseCase.kt
@@ -19,31 +19,47 @@ package com.wire.kalium.cells.domain.usecase
 
 import com.wire.kalium.cells.domain.CellAttachmentsRepository
 import com.wire.kalium.cells.domain.CellsRepository
+import com.wire.kalium.cells.domain.model.PreCheckResult
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.functional.Either
-import com.wire.kalium.common.functional.map
+import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.common.functional.getOrElse
+import com.wire.kalium.common.functional.left
+import com.wire.kalium.common.functional.mapLeft
 
 public interface RenameNodeUseCase {
-    public suspend operator fun invoke(uuid: String, path: String, newName: String): Either<CoreFailure, Unit>
+    public suspend operator fun invoke(uuid: String, path: String, newName: String): Either<RenameNodeFailure, Unit>
 }
 
 internal class RenameNodeUseCaseImpl(
     private val cellsRepository: CellsRepository,
     private val attachmentsRepository: CellAttachmentsRepository,
 ) : RenameNodeUseCase {
-    override suspend fun invoke(uuid: String, path: String, newName: String): Either<CoreFailure, Unit> {
+
+    @Suppress("ReturnCount")
+    override suspend fun invoke(uuid: String, path: String, newName: String): Either<RenameNodeFailure, Unit> {
 
         val targetPath = "${path.substringBeforeLast("/")}/$newName"
 
-        return cellsRepository.renameNode(
-            uuid = uuid,
-            path = path,
-            targetPath = targetPath
-        ).map {
-            attachmentsRepository.updateAssetPath(
-                assetId = uuid,
-                remotePath = targetPath
-            )
+        val preCheck = cellsRepository.preCheck(targetPath).getOrElse {
+            return RenameNodeFailure.Other(it).left()
         }
+
+        if (preCheck is PreCheckResult.FileExists) {
+            return RenameNodeFailure.FileAlreadyExists.left()
+        }
+
+        return cellsRepository.renameNode(uuid = uuid, path = path, targetPath = targetPath)
+            .flatMap {
+                attachmentsRepository.updateAssetPath(assetId = uuid, remotePath = targetPath)
+            }
+            .mapLeft {
+                RenameNodeFailure.Other(it)
+            }
     }
+}
+
+public sealed interface RenameNodeFailure {
+    public object FileAlreadyExists : RenameNodeFailure
+    public data class Other(val error: CoreFailure) : RenameNodeFailure
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20937" title="WPB-20937" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20937</a>  [Android] Check if filename exists when renaming
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-20937

# What's new in this PR?

### Issues
When renaming a file user can enter name of already existing file. No error displayed and the name is changed. New file name will have a "-1" suffix added.

### Solutions
Call pre-check method to check if file with this name already exist on server and return FileAlreadyExists error.
