### PR TITLE
chore: Move to npm Trusted Publishers (OIDC) [WPB-21110]

### DIFF
--- a/.github/workflows/backup-publish-web-npm.yml
+++ b/.github/workflows/backup-publish-web-npm.yml
@@ -8,6 +8,9 @@ jobs:
   publish-web:
     if: github.repository == 'wireapp/kalium'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v5
       - name: Force fetch the tag to work around actions/checkout#290
@@ -21,9 +24,11 @@ jobs:
       - name: Build JS/TS
         run: ./gradlew :backup:jsBrowserProductionLibraryDistribution
 
-      - name: Publish package to npm
-        uses: JS-DevTools/npm-publish@v3
+      - name: Setup Node for npm publish (Trusted Publisher)
+        uses: actions/setup-node@v6
         with:
-          token: ${{ secrets.NPM_TOKEN }}
-          access: public
-          package: "backup/build/dist/js/productionLibrary/package.json"
+          scope: "@wireapp"
+
+      - name: Publish package to npm (OIDC Trusted Publisher)
+        working-directory: backup/build/dist/js/productionLibrary
+        run: npm publish


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21110" title="WPB-21110" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21110</a>  [Web] Update npm tokens
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Switch npm publishing from NPM_TOKEN to npm Trusted Publishers (OIDC). No long‑lived secrets; provenance enabled.

References

- https://docs.npmjs.com/trusted-publishers
- https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management