### PR TITLE
fix: Update EpochInfo in AVS for MLS calls on clients request [WPB-20158]

### DIFF
--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -632,7 +632,9 @@ class CallManagerImpl internal constructor(
                 val onClientsRequest = OnClientsRequest(
                     conversationClientsInCallUpdater = conversationClientsInCallUpdater,
                     qualifiedIdMapper = qualifiedIdMapper,
-                    callingScope = scope
+                    callingScope = scope,
+                    callRepository = callRepository,
+                    epochInfoUpdater = ::updateEpochInfo,
                 ).keepingStrongReference()
 
                 wcall_set_req_clients_handler(

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnClientsRequest.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnClientsRequest.kt
@@ -21,17 +21,31 @@ package com.wire.kalium.logic.feature.call.scenario
 import com.sun.jna.Pointer
 import com.wire.kalium.calling.callbacks.ClientsRequestHandler
 import com.wire.kalium.calling.types.Handle
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.common.functional.left
+import com.wire.kalium.common.functional.onFailure
+import com.wire.kalium.common.functional.onSuccess
+import com.wire.kalium.common.functional.right
 import com.wire.kalium.common.logger.callingLogger
 import com.wire.kalium.logger.obfuscateId
+import com.wire.kalium.logic.data.call.CallRepository
+import com.wire.kalium.logic.data.call.EpochInfo
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.feature.call.usecase.ConversationClientsInCallUpdater
+import io.mockative.Mockable
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 
 internal class OnClientsRequest(
     private val conversationClientsInCallUpdater: ConversationClientsInCallUpdater,
+    private val epochInfoUpdater: EpochInfoUpdater,
     private val qualifiedIdMapper: QualifiedIdMapper,
-    private val callingScope: CoroutineScope
+    private val callingScope: CoroutineScope,
+    private val callRepository: CallRepository,
 ) : ClientsRequestHandler {
 
     override fun onClientsRequest(inst: Handle, conversationId: String, arg: Pointer?) {
@@ -39,6 +53,30 @@ internal class OnClientsRequest(
             callingLogger.d("[OnClientsRequest] -> ConversationId: ${conversationId.obfuscateId()}")
             val conversationIdWithDomain = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
             conversationClientsInCallUpdater(conversationIdWithDomain)
+
+            // Update AVS with current EpochInfo for MLS calls when clients are requested
+            if (callRepository.getCallMetadata(conversationIdWithDomain)?.protocol is Conversation.ProtocolInfo.MLS) {
+                callRepository.observeEpochInfo(conversationIdWithDomain)
+                    .flatMap { it.firstOrNull()?.right() ?: StorageFailure.DataNotFound.left() }
+                    .onFailure {
+                        callingLogger.d(
+                            "[OnClientsRequest] -> Failure when trying to get current epoch info " +
+                                    "| ConversationId: ${conversationId.obfuscateId()} | Error: $it"
+                        )
+                    }
+                    .onSuccess { epochInfo: EpochInfo ->
+                        callingLogger.d(
+                            "[OnClientsRequest] -> Updating epoch info " +
+                                    "| ConversationId: ${conversationId.obfuscateId()} | Epoch info: $epochInfo"
+                        )
+                        epochInfoUpdater.updateEpochInfo(conversationIdWithDomain, epochInfo)
+                    }
+            }
         }
     }
+}
+
+@Mockable
+fun interface EpochInfoUpdater {
+    suspend fun updateEpochInfo(conversationId: ConversationId, epochInfo: EpochInfo)
 }

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/scenario/OnClientsRequestTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/scenario/OnClientsRequestTest.kt
@@ -1,0 +1,144 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.call.scenario
+
+import com.wire.kalium.calling.types.Handle
+import com.wire.kalium.common.functional.right
+import com.wire.kalium.logic.data.MockConversation
+import com.wire.kalium.logic.data.call.CallClientList
+import com.wire.kalium.logic.data.call.CallMetadata
+import com.wire.kalium.logic.data.call.CallRepository
+import com.wire.kalium.logic.data.call.EpochInfo
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.GroupID
+import com.wire.kalium.logic.data.id.QualifiedIdMapperImpl
+import com.wire.kalium.logic.data.mls.CipherSuite
+import com.wire.kalium.logic.feature.call.usecase.ConversationClientsInCallUpdater
+import com.wire.kalium.logic.framework.TestCall.oneOnOneCallMetadata
+import com.wire.kalium.logic.framework.TestUser
+import io.mockative.coEvery
+import io.mockative.coVerify
+import io.mockative.every
+import io.mockative.mock
+import io.mockative.once
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import org.junit.Test
+import kotlin.apply
+import kotlin.to
+import kotlin.toULong
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class OnClientsRequestTest {
+
+    val testScope = TestScope()
+
+    @Test
+    fun givenOngoingCall_whenClientsRequested_thenCallClientsInCallUpdater() = testScope.runTest() {
+        val (arrangement, callback) = Arrangement(testScope)
+            .withCallMetadata(conversationId, oneOnOneCallMetadata())
+            .arrange()
+
+        callback.onClientsRequest(inst = handle, conversationId = conversationId.toString(), arg = null)
+        advanceUntilIdle()
+
+        coVerify {
+            arrangement.conversationClientsInCallUpdater(conversationId)
+        }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenOngoingMLSCall_whenClientsRequested_thenCallEpochInfoUpdate() = testScope.runTest() {
+        val callMetadata = oneOnOneCallMetadata().copy(
+            protocol = Conversation.ProtocolInfo.MLS(
+                groupId = GroupID(""),
+                groupState = Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED,
+                epoch = ULong.MAX_VALUE,
+                keyingMaterialLastUpdate = Instant.DISTANT_FUTURE,
+                cipherSuite = CipherSuite.MLS_128_DHKEMP256_AES128GCM_SHA256_P256
+            )
+        )
+        val (arrangement, callback) = Arrangement(testScope)
+            .withCallMetadata(conversationId, callMetadata)
+            .withEpochInfo(conversationId, epochInfo)
+            .arrange()
+
+        callback.onClientsRequest(inst = handle, conversationId = conversationId.toString(), arg = null)
+        advanceUntilIdle()
+
+        coVerify {
+            arrangement.epochInfoUpdater.updateEpochInfo(conversationId, epochInfo)
+        }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenOngoingNonMLSCall_whenClientsRequested_thenDoNotCallEpochInfoUpdate() = testScope.runTest() {
+        val callMetadata = oneOnOneCallMetadata().copy(
+            protocol = Conversation.ProtocolInfo.Proteus
+        )
+        val (arrangement, callback) = Arrangement(testScope)
+            .withCallMetadata(conversationId, callMetadata)
+            .withEpochInfo(conversationId, epochInfo)
+            .arrange()
+
+        callback.onClientsRequest(inst = handle, conversationId = conversationId.toString(), arg = null)
+        advanceUntilIdle()
+
+        coVerify {
+            arrangement.epochInfoUpdater.updateEpochInfo(conversationId, epochInfo)
+        }.wasNotInvoked()
+    }
+
+    private class Arrangement(val testScope: TestScope) {
+        val callRepository: CallRepository = mock(CallRepository::class)
+        val conversationClientsInCallUpdater: ConversationClientsInCallUpdater = mock(ConversationClientsInCallUpdater::class)
+        val epochInfoUpdater: EpochInfoUpdater = mock(EpochInfoUpdater::class)
+        val qualifiedIdMapper = QualifiedIdMapperImpl(TestUser.SELF.id)
+
+        fun withCallMetadata(id: ConversationId, metadata: CallMetadata): Arrangement = apply {
+            every {
+                callRepository.getCallMetadata(id)
+            }.returns(metadata)
+        }
+
+        suspend fun withEpochInfo(id: ConversationId, epochInfo: EpochInfo): Arrangement = apply {
+            coEvery {
+                callRepository.observeEpochInfo(id)
+            }.returns(flowOf(epochInfo).right())
+        }
+
+        fun arrange() = this to OnClientsRequest(
+            conversationClientsInCallUpdater = conversationClientsInCallUpdater,
+            epochInfoUpdater = epochInfoUpdater,
+            qualifiedIdMapper = qualifiedIdMapper,
+            callingScope = testScope,
+            callRepository = callRepository,
+        )
+    }
+
+    companion object {
+        val handle = Handle(42)
+        val conversationId = MockConversation.ID
+        val epochInfo = EpochInfo(epoch = 1.toULong(), members = CallClientList(emptyList()), sharedSecret = byteArrayOf())
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20158" title="WPB-20158" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20158</a>  [Android] Video tile of other user shown in black if video ended while I was not in the call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Dropping and joining a video enabled group call, doesn't show other participant video.

### Causes (Optional)

When user starts a call before the "join" button appears, the call is switched to the ongoing call eventually, but setting epoch info is executed for the first one with a different hash, so after switching to the proper call, there's no epoch info set and keys cannot be matched.

### Solutions

Unified solution that needs to be implemented and executed the same way on all platforms is that the client needs to update AVS with current epoch info for MLS calls each time clients are requested, so in `onClientsRequest`.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

- Start a call with a few participants/clients
- Enable video on some other clients
- Kill/force stop the app
- Open the app again and navigate to that conversation for which the call is ongoing
- Click "start call" before "join" button appears
- Check whether other users videos are displayed or only black rectangles

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
