### PR TITLE
feat: reply to multipart (WPB-16897)

### DIFF
--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
@@ -149,6 +149,10 @@ sealed interface MessageContent {
 
         data object Deleted : Content
 
+        data class Multipart(
+            val text: String?,
+        ) : Content
+
         data object Invalid : Content
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -720,6 +720,12 @@ private fun quotedContentFromEntity(it: MessageEntityContent.Text.QuotedMessage)
         )
     }
 
+    it.contentType == MessageEntity.ContentType.MULTIPART -> {
+        MessageContent.QuotedMessageDetails.Multipart(
+            text = it.textBody,
+        )
+    }
+
     // If a new content type can be replied to (Pings, for example), fallback to Invalid
     else -> MessageContent.QuotedMessageDetails.Invalid
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16897" title="WPB-16897" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16897</a>  [Android] Support reply for multipart message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-16897

# What's new in this PR?

Small update to allow showing replies to multipart messages in messages list.