### PR TITLE
feat: edit multipart message text (WPB-16899)

### DIFF
--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/draft/MessageDraft.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/draft/MessageDraft.kt
@@ -25,5 +25,6 @@ data class MessageDraft(
     val text: String,
     val editMessageId: String?,
     val quotedMessageId: String?,
-    val selectedMentionList: List<MessageMention>
+    val selectedMentionList: List<MessageMention>,
+    val isMultipartEdit: Boolean = false,
 )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -527,7 +527,7 @@ class MessageScope internal constructor(
         get() = SaveMessageDraftUseCaseImpl(messageDraftRepository)
 
     val getMessageDraftUseCase: GetMessageDraftUseCase
-        get() = GetMessageDraftUseCaseImpl(messageDraftRepository)
+        get() = GetMessageDraftUseCaseImpl(messageRepository, messageDraftRepository)
 
     val removeMessageDraftUseCase: RemoveMessageDraftUseCase
         get() = RemoveMessageDraftUseCaseImpl(messageDraftRepository)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/draft/GetMessageDraftUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/draft/GetMessageDraftUseCaseTest.kt
@@ -1,0 +1,146 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.message.draft
+
+import com.wire.kalium.common.functional.right
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.data.message.draft.MessageDraft
+import com.wire.kalium.logic.data.message.draft.MessageDraftRepository
+import com.wire.kalium.logic.framework.TestMessage
+import com.wire.kalium.logic.test_util.TestKaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcher
+import io.mockative.any
+import io.mockative.coEvery
+import io.mockative.coVerify
+import io.mockative.mock
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class GetMessageDraftUseCaseTest {
+
+    private val testDispatchers: KaliumDispatcher = TestKaliumDispatcher
+
+    @Test
+    fun givenNoDraft_whenUseCaseInvoked_thenNullReturned() = runTest(testDispatchers.io) {
+        val (_, useCase) = Arrangement()
+            .withNoDraft()
+            .arrange()
+
+        val result = useCase(CONVERSATION_ID)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun givenDraftIsNotEdit_whenUseCaseInvoked_thenMessageIsNotFetched() = runTest(testDispatchers.io) {
+        val (arrangement, useCase) = Arrangement()
+            .withDraft(MessageDraft(
+                conversationId = CONVERSATION_ID,
+                text = "text",
+                editMessageId = null,
+                quotedMessageId = null,
+                selectedMentionList = emptyList()
+            ))
+            .arrange()
+
+        useCase(CONVERSATION_ID)
+
+        coVerify {
+            arrangement.messageRepository.getMessageById(any(), any())
+        }.wasNotInvoked()
+    }
+
+    @Test
+    fun givenDraftIsEditRegular_whenUseCaseInvoked_thenCorrectValueReturned() = runTest(testDispatchers.io) {
+        val (_, useCase) = Arrangement()
+            .withRegularMessageEdit()
+            .withDraft(MessageDraft(
+                conversationId = CONVERSATION_ID,
+                text = "text",
+                editMessageId = "message_id",
+                quotedMessageId = null,
+                selectedMentionList = emptyList()
+            ))
+            .arrange()
+
+        val result = useCase(CONVERSATION_ID)
+
+        assertTrue(result?.isMultipartEdit == false)
+    }
+
+    @Test
+    fun givenDraftIsEditMultipart_whenUseCaseInvoked_thenCorrectValueReturned() = runTest(testDispatchers.io) {
+        val (_, useCase) = Arrangement()
+            .withMultipartMessageEdit()
+            .withDraft(MessageDraft(
+                conversationId = CONVERSATION_ID,
+                text = "text",
+                editMessageId = "message_id",
+                quotedMessageId = null,
+                selectedMentionList = emptyList()
+            ))
+            .arrange()
+
+        val result = useCase(CONVERSATION_ID)
+
+        assertTrue(result?.isMultipartEdit == true)
+    }
+
+    private inner class Arrangement {
+
+        val messageRepository: MessageRepository = mock(MessageRepository::class)
+        val messageDraftRepository: MessageDraftRepository = mock(MessageDraftRepository::class)
+
+        suspend fun withNoDraft() = apply {
+            coEvery {
+                messageDraftRepository.getMessageDraft(any())
+            } returns null
+        }
+
+        suspend fun withDraft(draft: MessageDraft) = apply {
+            coEvery {
+                messageDraftRepository.getMessageDraft(any())
+            } returns draft
+        }
+
+        suspend fun withRegularMessageEdit() = apply {
+            coEvery {
+                messageRepository.getMessageById(any(), any())
+            } returns TestMessage.TEXT_MESSAGE.right()
+        }
+
+        suspend fun withMultipartMessageEdit() = apply {
+            coEvery {
+                messageRepository.getMessageById(any(), any())
+            } returns TestMessage.multipartMessage(emptyList()).right()
+        }
+
+        fun arrange() = this to GetMessageDraftUseCaseImpl(
+            messageRepository = messageRepository,
+            messageDraftRepository = messageDraftRepository,
+            dispatcher = testDispatchers
+        )
+    }
+
+    private companion object {
+        val CONVERSATION_ID = QualifiedID("conversation_id", "domain")
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestMessage.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestMessage.kt
@@ -18,9 +18,12 @@
 
 package com.wire.kalium.logic.framework
 
+import com.wire.kalium.logic.data.asset.AssetTransferStatus
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.AssetContent
+import com.wire.kalium.logic.data.message.CellAssetContent
 import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageAttachment
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.message.MessageSent
@@ -87,6 +90,21 @@ object TestMessage {
         isSelfMessage = false
     )
 
+    fun multipartMessage(attachments: List<MessageAttachment> = TEST_ATTACHMENTS) = Message.Regular(
+        id = TEST_MESSAGE_ID,
+        content = MessageContent.Multipart(
+            value = TEXT_CONTENT.value,
+            attachments = attachments
+        ),
+        conversationId = ConversationId("conv", "id"),
+        date = TEST_DATE,
+        senderUserId = TEST_SENDER_USER_ID,
+        senderClientId = TEST_SENDER_CLIENT_ID,
+        status = Message.Status.Pending,
+        editStatus = Message.EditStatus.NotEdited,
+        isSelfMessage = false
+    )
+
     val ENTITY = MessageEntity.Regular(
         TEST_MESSAGE_ID,
         TestConversation.ENTITY_ID,
@@ -123,5 +141,26 @@ object TestMessage {
         status = Message.Status.Sent,
         isSelfMessage = false,
         expirationData = null
+    )
+
+    val TEST_ATTACHMENTS: List<MessageAttachment> = listOf(
+        CellAssetContent(
+            id = "assetId1",
+            versionId = "v1",
+            mimeType = "image/png",
+            assetPath = null,
+            assetSize = 1024,
+            metadata = null,
+            transferStatus = AssetTransferStatus.UPLOADED
+        ),
+        CellAssetContent(
+            id = "assetId2",
+            versionId = "v1",
+            mimeType = "video/mp4",
+            assetPath = null,
+            assetSize = 2048,
+            metadata = null,
+            transferStatus = AssetTransferStatus.UPLOADED
+        )
     )
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16899" title="WPB-16899" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16899</a>  [Android] Support edit for multipart message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

https://wearezeta.atlassian.net/browse/WPB-16899

# What's new in this PR?

Support for editing multipart message text (https://github.com/wireapp/wire-android/pull/4401).
When loading saved message draft need to set the isMultipartEdit flag when editing multipart message.