### PR TITLE
feat: handle cell urls expiration (WPB-21328)

### DIFF
--- a/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/CellAttachmentsDataSource.kt
+++ b/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/CellAttachmentsDataSource.kt
@@ -77,11 +77,12 @@ internal class CellAttachmentsDataSource(
     override suspend fun updateAttachment(
         assetId: String,
         contentUrl: String?,
+        contentUrlExpiresAt: Long?,
         hash: String?,
         remotePath: String,
     ) = withContext(dispatchers.io) {
         wrapStorageRequest {
-            messageAttachments.updateAttachment(assetId, contentUrl, hash, remotePath)
+            messageAttachments.updateAttachment(assetId, contentUrl, contentUrlExpiresAt, hash, remotePath)
         }
     }
 
@@ -145,6 +146,7 @@ private fun MessageAttachmentEntity.toModel(): MessageAttachment? =
             assetPath = assetPath,
             assetSize = assetSize,
             contentUrl = contentUrl,
+            contentUrlExpiresAt = contentExpiresAt,
             previewUrl = previewUrl?.takeIf { it.isNotEmpty() },
             localPath = localPath?.takeIf { it.isNotEmpty() },
             transferStatus = AssetTransferStatus.valueOf(assetTransferStatus),

--- a/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/model/CellNodeDTO.kt
+++ b/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/model/CellNodeDTO.kt
@@ -33,6 +33,7 @@ internal data class CellNodeDTO(
     val isRecycled: Boolean = false,
     val isDraft: Boolean = false,
     val contentUrl: String?,
+    val contentUrlExpiresAt: Long?,
     val contentHash: String?,
     val mimeType: String?,
     val previews: List<PreviewDto>? = null,
@@ -53,6 +54,7 @@ internal fun CellNodeDTO.toModel() = CellNode(
     isRecycled = isRecycled,
     isDraft = isDraft,
     contentUrl = contentUrl,
+    contentUrlExpiresAt = contentUrlExpiresAt,
     contentHash = contentHash,
     mimeType = mimeType,
     previews = previews?.map { it.toModel() },
@@ -73,6 +75,7 @@ internal fun CellNode.toDto() = CellNodeDTO(
     isRecycled = isRecycled,
     isDraft = isDraft,
     contentUrl = contentUrl,
+    contentUrlExpiresAt = contentUrlExpiresAt,
     contentHash = contentHash,
     mimeType = mimeType,
     ownerUserId = ownerUserId,
@@ -81,6 +84,7 @@ internal fun CellNode.toDto() = CellNodeDTO(
     tags = tags
 )
 
+@Suppress("MagicNumber")
 internal fun RestNode.toDto() = CellNodeDTO(
     uuid = uuid,
     versionId = versionMeta?.versionId ?: "",
@@ -92,6 +96,7 @@ internal fun RestNode.toDto() = CellNodeDTO(
     isRecycled = isRecycled ?: false,
     isDraft = isDraft ?: false,
     contentUrl = preSignedGET?.url,
+    contentUrlExpiresAt = preSignedGET?.expiresAt?.toLongOrNull()?.let { it * 1000 },
     contentHash = contentHash,
     mimeType = contentType,
     previews = previews.toDto(),

--- a/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/CellAttachmentsRepository.kt
+++ b/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/CellAttachmentsRepository.kt
@@ -31,7 +31,13 @@ internal interface CellAttachmentsRepository {
     suspend fun getAttachment(assetId: String): Either<StorageFailure, MessageAttachment>
     suspend fun savePreviewUrl(assetId: String, url: String?): Either<StorageFailure, Unit>
     suspend fun saveLocalPath(assetId: String, path: String?): Either<StorageFailure, Unit>
-    suspend fun updateAttachment(assetId: String, contentUrl: String?, hash: String?, remotePath: String): Either<StorageFailure, Unit>
+    suspend fun updateAttachment(
+        assetId: String,
+        contentUrl: String?,
+        contentUrlExpiresAt: Long?,
+        hash: String?,
+        remotePath: String
+    ): Either<StorageFailure, Unit>
     suspend fun getAttachments(messageId: String, conversationId: ConversationId): Either<StorageFailure, List<MessageAttachment>>
     suspend fun getAttachments(): Either<StorageFailure, List<MessageAttachment>>
     suspend fun saveStandaloneAssetPath(assetId: String, path: String, size: Long): Either<StorageFailure, Unit>

--- a/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/model/CellNode.kt
+++ b/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/model/CellNode.kt
@@ -29,6 +29,7 @@ public data class CellNode(
     val isRecycled: Boolean = false,
     val isDraft: Boolean = false,
     val contentUrl: String? = null,
+    val contentUrlExpiresAt: Long? = null,
     val contentHash: String? = null,
     val mimeType: String? = null,
     val previews: List<NodePreview>? = null,

--- a/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/usecase/RefreshCellAssetStateUseCase.kt
+++ b/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/usecase/RefreshCellAssetStateUseCase.kt
@@ -141,7 +141,13 @@ internal class RefreshCellAssetStateUseCaseImpl internal constructor(
             }
         }
 
-        attachmentsRepository.updateAttachment(attachment.id, node.contentUrl, node.contentHash, node.path)
+        attachmentsRepository.updateAttachment(
+            assetId = attachment.id,
+            contentUrl = node.contentUrl,
+            contentUrlExpiresAt = node.contentUrlExpiresAt,
+            hash = node.contentHash,
+            remotePath = node.path
+        )
 
         // Update transfer status for attachments previously marked as NOT_FOUND
         // This happens after we regain access to the file

--- a/cells/src/commonTest/kotlin/com/wire/kalium/cells/domain/usecase/RefreshNodeAssetStateUseCaseTest.kt
+++ b/cells/src/commonTest/kotlin/com/wire/kalium/cells/domain/usecase/RefreshNodeAssetStateUseCaseTest.kt
@@ -74,6 +74,7 @@ class RefreshNodeAssetStateUseCaseTest {
             ownerUserId = "ownerUserId",
             conversationId = "conversationId",
             publicLinkId = "publicLinkId",
+            contentUrlExpiresAt = null,
         )
         private val testAttachment = CellAssetContent(
             id = assetId,
@@ -154,7 +155,13 @@ class RefreshNodeAssetStateUseCaseTest {
         useCase.invoke(assetId)
 
         coVerify {
-            arrangement.attachmentsRepository.updateAttachment(assetId, testNode.contentUrl, testNode.contentHash, testNode.path)
+            arrangement.attachmentsRepository.updateAttachment(
+                assetId,
+                testNode.contentUrl,
+                testNode.contentUrlExpiresAt,
+                testNode.contentHash,
+                testNode.path
+            )
         }.wasInvoked(once)
     }
 
@@ -501,7 +508,7 @@ class RefreshNodeAssetStateUseCaseTest {
             coEvery { attachmentsRepository.setAssetTransferStatus(any(), any()) }.returns(Unit.right())
             coEvery { attachmentsRepository.saveLocalPath(any(), any()) }.returns(Unit.right())
             coEvery { attachmentsRepository.savePreviewUrl(any(), any()) }.returns(Unit.right())
-            coEvery { attachmentsRepository.updateAttachment(any(), any(), any(), any()) }.returns(Unit.right())
+            coEvery { attachmentsRepository.updateAttachment(any(), any(), any(), any(), any()) }.returns(Unit.right())
 
             return this to RefreshCellAssetStateUseCaseImpl(
                 cellsRepository = cellsRepository,

--- a/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/AssetContent.kt
+++ b/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/AssetContent.kt
@@ -119,6 +119,7 @@ data class CellAssetContent(
     val contentHash: String? = null,
     val localPath: String? = null,
     val contentUrl: String? = null,
+    val contentUrlExpiresAt: Long? = null,
     val previewUrl: String? = null,
     val metadata: AssetMetadata?,
     val transferStatus: AssetTransferStatus,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/attachment/MessageAttachmentMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/attachment/MessageAttachmentMapper.kt
@@ -92,6 +92,7 @@ fun MessageAttachmentEntity.toModel() =
             transferStatus = AssetTransferStatus.valueOf(assetTransferStatus),
             contentHash = contentHash?.takeIf { it.isNotEmpty() },
             contentUrl = contentUrl?.takeIf { it.isNotEmpty() },
+            contentUrlExpiresAt = contentExpiresAt,
         )
     } else {
         // TODO: implement support for regular assets WPB-16590

--- a/persistence/src/commonMain/db_user/com/wire/kalium/persistence/MessageAttachments.sq
+++ b/persistence/src/commonMain/db_user/com/wire/kalium/persistence/MessageAttachments.sq
@@ -29,6 +29,8 @@ CREATE TABLE MessageAttachments (
       asset_transfer_status TEXT NOT NULL DEFAULT 'NOT_DOWNLOADED',
       asset_index INTEGER AS Int,
 
+      content_url_expires_at INTEGER DEFAULT(NULL),
+
       FOREIGN KEY (message_id, conversation_id) REFERENCES Message(id, conversation_id) ON DELETE CASCADE ON UPDATE CASCADE,
       PRIMARY KEY (conversation_id, message_id, asset_id)
 );
@@ -70,7 +72,7 @@ setTransferStatus:
 UPDATE MessageAttachments SET asset_transfer_status = ? WHERE asset_id = ?;
 
 updateAttachment:
-UPDATE MessageAttachments SET content_url = ?, content_hash = ?, asset_path = ? WHERE asset_id = ?;
+UPDATE MessageAttachments SET content_url = ?, content_url_expires_at = ?, content_hash = ?, asset_path = ? WHERE asset_id = ?;
 
 getAttachments:
 SELECT * FROM MessageAttachments WHERE message_id = ? AND conversation_id = ?;

--- a/persistence/src/commonMain/db_user/migrations/120.sqm
+++ b/persistence/src/commonMain/db_user/migrations/120.sqm
@@ -1,14 +1,6 @@
-import com.wire.kalium.persistence.dao.QualifiedIDEntity;
-import com.wire.kalium.persistence.dao.message.MessageEntity.ContentType;
-import com.wire.kalium.persistence.dao.message.MessageEntity.LegalHoldType;
-import com.wire.kalium.persistence.dao.message.MessageEntity.MemberChangeType;
-import com.wire.kalium.persistence.dao.message.MessageEntity;
-import com.wire.kalium.persistence.dao.message.MessageEntityContent;
-import com.wire.kalium.persistence.dao.message.RecipientFailureTypeEntity;
-import kotlin.Boolean;
-import kotlin.Int;
-import kotlin.collections.List;
-import kotlinx.datetime.Instant;
+ALTER TABLE MessageAttachments ADD COLUMN content_url_expires_at INTEGER DEFAULT(NULL);
+
+DROP VIEW IF EXISTS MessageDetailsView;
 
 CREATE VIEW IF NOT EXISTS MessageDetailsView
 AS SELECT

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/attachment/MessageAttachmentEntity.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/attachment/MessageAttachmentEntity.kt
@@ -39,4 +39,5 @@ data class MessageAttachmentEntity(
     @SerialName("content_url") val contentUrl: String? = null,
     @SerialName("content_hash") val contentHash: String? = null,
     @SerialName("asset_index") val assetIndex: Int? = null,
+    @SerialName("content_url_expires_at") val contentExpiresAt: Long? = null,
 )

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/attachment/MessageAttachmentMapper.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/attachment/MessageAttachmentMapper.kt
@@ -39,6 +39,7 @@ data object MessageAttachmentMapper {
         assetDurationMs: Long?,
         assetTransferStatus: String,
         assetIndex: Int?,
+        contentUrlExpiresAt: Long?,
     ): MessageAttachmentEntity =
         MessageAttachmentEntity(
             assetId = assetId,
@@ -54,6 +55,7 @@ data object MessageAttachmentMapper {
             assetDuration = assetDurationMs,
             assetTransferStatus = assetTransferStatus,
             contentUrl = contentUrl,
+            contentExpiresAt = contentUrlExpiresAt,
             contentHash = contentHash,
             assetIndex = assetIndex,
         )

--- a/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/attachment/MessageAttachmentsDao.kt
+++ b/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/attachment/MessageAttachmentsDao.kt
@@ -34,7 +34,7 @@ interface MessageAttachmentsDao {
     suspend fun setPreviewUrl(assetId: String, previewUrl: String?)
     suspend fun setTransferStatus(assetId: String, status: String)
     suspend fun getAttachment(assetId: String): MessageAttachmentEntity
-    suspend fun updateAttachment(assetId: String, url: String?, hash: String?, remotePath: String)
+    suspend fun updateAttachment(assetId: String, url: String?, urlExpiresAt: Long?, hash: String?, remotePath: String)
     suspend fun getAttachments(messageId: String, conversationId: QualifiedIDEntity): List<MessageAttachmentEntity>
     suspend fun getAttachments(): List<MessageAttachmentEntity>
     suspend fun observeAttachments(): Flow<List<MessageAttachmentEntity>>
@@ -64,9 +64,9 @@ internal class MessageAttachmentsDaoImpl(
         queries.getAttachment(asset_id = assetId, ::toDao).executeAsOne()
     }
 
-    override suspend fun updateAttachment(assetId: String, url: String?, hash: String?, remotePath: String) =
+    override suspend fun updateAttachment(assetId: String, url: String?, urlExpiresAt: Long?, hash: String?, remotePath: String) =
         withContext(writeDispatcher.value) {
-            queries.updateAttachment(url, hash, remotePath, assetId)
+            queries.updateAttachment(url, urlExpiresAt, hash, remotePath, assetId)
         }
 
     override suspend fun getAssetPath(assetId: String): String? = withContext(readDispatcher.value) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21328" title="WPB-21328" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21328</a>  [Android]Photo fails to load after screen is idle for ~30 minutes
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

https://wearezeta.atlassian.net/browse/WPB-21328
# What's new in this PR?

Support for handling expiration time for cell content URLs. (see logic in https://github.com/wireapp/wire-android/pull/4417)
- Read contentUrlExpiresAt field from server response
- Store expiration time in database