### PR TITLE
feat: edit multipart message text (WPB-22308)

### DIFF
--- a/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
+++ b/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/Message.kt
@@ -196,6 +196,10 @@ sealed interface Message {
                     typeKey to "textEdit"
                 )
 
+                is MessageContent.MultipartEdited -> mutableMapOf(
+                    typeKey to "multipartEdit"
+                )
+
                 is MessageContent.Calling -> mutableMapOf(
                     typeKey to "calling"
                 )

--- a/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
+++ b/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
@@ -214,6 +214,13 @@ sealed interface MessageContent {
         val newButtonList: List<Button> = listOf()
     ) : Signaling
 
+    data class MultipartEdited(
+        val editMessageId: String,
+        val newTextContent: String? = null,
+        val newMentions: List<MessageMention> = listOf(),
+        val newAttachments: List<MessageAttachment> = emptyList(),
+    ) : Signaling
+
     data class Knock(val hotKnock: Boolean) : Regular()
 
     data class Composite(
@@ -504,6 +511,7 @@ fun MessageContent?.getType() = when (this) {
     MessageContent.NewConversationWithCellMessage -> "NewConversationWithCell"
     MessageContent.NewConversationWithCellSelfDeleteDisabledMessage -> "NewConversationWithCellSelfDeleteDisabled"
     is MessageContent.ConversationAppsEnabledChanged -> "ConversationAppsEnabledChanged"
+    is MessageContent.MultipartEdited -> "MultipartEdited"
 }
 
 sealed interface MessagePreviewContent {

--- a/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContentLogging.kt
+++ b/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContentLogging.kt
@@ -47,4 +47,5 @@ inline fun MessageContent.FromProto.typeDescription(): String = when (this) {
     MessageContent.History.ClientsRequest -> "History.ClientsRequest"
     is MessageContent.History.ClientsResponse -> "History.ClientsResponse"
     is MessageContent.History.NewClientAvailable -> "History.NewClientAvailable"
+    is MessageContent.MultipartEdited -> "MultipartEdited"
 }

--- a/domain/cells/src/commonMain/kotlin/com/wire/kalium/cells/CellsScope.kt
+++ b/domain/cells/src/commonMain/kotlin/com/wire/kalium/cells/CellsScope.kt
@@ -57,6 +57,8 @@ import com.wire.kalium.cells.domain.usecase.GetFoldersUseCase
 import com.wire.kalium.cells.domain.usecase.GetFoldersUseCaseImpl
 import com.wire.kalium.cells.domain.usecase.GetMessageAttachmentUseCase
 import com.wire.kalium.cells.domain.usecase.GetMessageAttachmentUseCaseImpl
+import com.wire.kalium.cells.domain.usecase.GetMessageAttachmentsUseCase
+import com.wire.kalium.cells.domain.usecase.GetMessageAttachmentsUseCaseImpl
 import com.wire.kalium.cells.domain.usecase.GetPaginatedNodesUseCase
 import com.wire.kalium.cells.domain.usecase.GetPaginatedNodesUseCaseImpl
 import com.wire.kalium.cells.domain.usecase.IsAtLeastOneCellAvailableUseCase
@@ -253,6 +255,10 @@ public class CellsScope(
 
     public val getMessageAttachmentUseCase: GetMessageAttachmentUseCase by lazy {
         GetMessageAttachmentUseCaseImpl(cellAttachmentsRepository)
+    }
+
+    public val getMessageAttachmentsUseCase: GetMessageAttachmentsUseCase by lazy {
+        GetMessageAttachmentsUseCaseImpl(cellAttachmentsRepository)
     }
 
     public val getCellFileUseCase: GetCellFileUseCase by lazy {

--- a/domain/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/usecase/GetMessageAttachmentsUseCase.kt
+++ b/domain/cells/src/commonMain/kotlin/com/wire/kalium/cells/domain/usecase/GetMessageAttachmentsUseCase.kt
@@ -1,0 +1,43 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.cells.domain.usecase
+
+import com.wire.kalium.cells.domain.CellAttachmentsRepository
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.MessageAttachment
+import io.mockative.Mockable
+
+/**
+ * Use case to get all attachments for a message.
+ */
+@Mockable
+public fun interface GetMessageAttachmentsUseCase {
+    public suspend operator fun invoke(messageId: String, conversationId: ConversationId): Either<StorageFailure, List<MessageAttachment>>
+}
+
+internal class GetMessageAttachmentsUseCaseImpl(
+    private val repository: CellAttachmentsRepository,
+) : GetMessageAttachmentsUseCase {
+
+    override suspend operator fun invoke(
+        messageId: String,
+        conversationId: ConversationId
+    ): Either<StorageFailure, List<MessageAttachment>> = repository.getAttachments(messageId, conversationId)
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/PersistMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/PersistMessageUseCase.kt
@@ -88,6 +88,7 @@ internal class PersistMessageUseCaseImpl(
             is MessageContent.DeleteMessage -> false
             is MessageContent.TextEdited -> false
             is MessageContent.CompositeEdited -> false
+            is MessageContent.MultipartEdited -> false
             is MessageContent.RestrictedAsset -> true
             is MessageContent.DeleteForMe -> false
             is MessageContent.Unknown -> false
@@ -154,6 +155,7 @@ internal class PersistMessageUseCaseImpl(
             is MessageContent.DeleteMessage,
             is MessageContent.TextEdited,
             is MessageContent.CompositeEdited,
+            is MessageContent.MultipartEdited,
             is MessageContent.DeleteForMe,
             is MessageContent.Unknown,
             is MessageContent.Availability,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/ProtoContentMapper.kt
@@ -152,6 +152,7 @@ class ProtoContentMapperImpl(
             is MessageContent.Receipt -> packReceipt(readableContent)
             is MessageContent.ClientAction -> packClientAction()
             is MessageContent.TextEdited -> packEdited(readableContent)
+            is MessageContent.MultipartEdited -> packEdited(readableContent)
             is MessageContent.CompositeEdited,
             is MessageContent.FailedDecryption,
             is MessageContent.RestrictedAsset,
@@ -204,33 +205,8 @@ class ProtoContentMapperImpl(
             Quote(it.quotedMessageId, it.quotedMessageSha256?.let { hash -> ByteArr(hash) })
         }
         val protoLegalHoldStatus = toProtoLegalHoldStatus(legalHoldStatus)
-        val attachments = readableContent.attachments.map { attachment ->
-            when (attachment) {
-                is AssetContent ->
-                    Attachment(
-                        content = Attachment.Content.Asset(
-                            asset = assetMapper.fromAssetContentToProtoAssetMessage(
-                                messageContent = MessageContent.Asset(value = attachment),
-                                expectsReadConfirmation = expectsReadConfirmation,
-                                legalHoldStatus = toProtoLegalHoldStatus(legalHoldStatus),
-                            )
-                        )
-                    )
+        val attachments = packMultipartAttachments(readableContent.attachments, expectsReadConfirmation, legalHoldStatus)
 
-                is CellAssetContent ->
-                    Attachment(
-                        content = Attachment.Content.CellAsset(
-                            cellAsset = CellAsset(
-                                uuid = attachment.id,
-                                contentType = attachment.mimeType,
-                                initialName = attachment.assetPath,
-                                initialSize = attachment.assetSize,
-                                initialMetaData = attachment.metadata?.toProto()
-                            )
-                        )
-                    )
-            }
-        }
         return GenericMessage.Content.Multipart(
             Multipart(
                 text = Text(
@@ -244,6 +220,38 @@ class ProtoContentMapperImpl(
                 attachments = attachments,
             )
         )
+    }
+
+    private fun packMultipartAttachments(
+        attachments: List<MessageAttachment>,
+        expectsReadConfirmation: Boolean,
+        legalHoldStatus: Conversation.LegalHoldStatus
+    ): List<Attachment> = attachments.map { attachment ->
+        when (attachment) {
+            is AssetContent ->
+                Attachment(
+                    content = Attachment.Content.Asset(
+                        asset = assetMapper.fromAssetContentToProtoAssetMessage(
+                            messageContent = MessageContent.Asset(value = attachment),
+                            expectsReadConfirmation = expectsReadConfirmation,
+                            legalHoldStatus = toProtoLegalHoldStatus(legalHoldStatus),
+                        )
+                    )
+                )
+
+            is CellAssetContent ->
+                Attachment(
+                    content = Attachment.Content.CellAsset(
+                        cellAsset = CellAsset(
+                            uuid = attachment.id,
+                            contentType = attachment.mimeType,
+                            initialName = attachment.assetPath,
+                            initialSize = attachment.assetSize,
+                            initialMetaData = attachment.metadata?.toProto()
+                        )
+                    )
+                )
+        }
     }
 
     private fun packLocation(
@@ -364,6 +372,7 @@ class ProtoContentMapperImpl(
             is MessageContent.ButtonActionConfirmation,
             is MessageContent.TextEdited,
             is MessageContent.CompositeEdited,
+            is MessageContent.MultipartEdited,
             is MessageContent.DataTransfer,
             is MessageContent.InCallEmoji,
             is MessageContent.History,
@@ -520,11 +529,14 @@ class ProtoContentMapperImpl(
             )
         },
         quotedMessageDetails = null,
-        attachments = protoContent.attachments.mapNotNull { attachment ->
+        attachments = unpackMultipartAttachments(protoContent.attachments),
+    )
+
+    private fun unpackMultipartAttachments(attachments: List<Attachment>): List<MessageAttachment> =
+        attachments.mapNotNull { attachment ->
             when (val content = attachment.content) {
                 is Attachment.Content.Asset -> {
-                    // TODO: implement support for regular assets WPB-16590
-                    return MessageContent.Ignored
+                    null
                 }
 
                 is Attachment.Content.CellAsset -> CellAssetContent(
@@ -539,8 +551,7 @@ class ProtoContentMapperImpl(
 
                 null -> null
             }
-        },
-    )
+        }
 
     private fun unpackLocation(
         protoContent: GenericMessage.Content.Location
@@ -666,6 +677,24 @@ class ProtoContentMapperImpl(
         )
     }
 
+    private fun packEdited(readableContent: MessageContent.MultipartEdited): GenericMessage.Content.Edited {
+        val mentions = readableContent.newMentions.map { messageMentionMapper.fromModelToProto(it) }
+        return GenericMessage.Content.Edited(
+            MessageEdit(
+                replacingMessageId = readableContent.editMessageId,
+                content = MessageEdit.Content.Multipart(
+                    Multipart(
+                        text = Text(
+                            content = readableContent.newTextContent ?: "",
+                            mentions = mentions,
+                        ),
+                        attachments = packMultipartAttachments(readableContent.newAttachments, false, Conversation.LegalHoldStatus.UNKNOWN)
+                    )
+                )
+            )
+        )
+    }
+
     private fun unpackEdited(protoContent: GenericMessage.Content.Edited, genericMessage: GenericMessage): MessageContent.FromProto {
         val replacingMessageId = protoContent.value.replacingMessageId
         return when (val editContent = protoContent.value.content) {
@@ -687,6 +716,19 @@ class ProtoContentMapperImpl(
                     editMessageId = replacingMessageId,
                     newTextContent = editedText,
                     newButtonList = unpackButtonList(editContent.value.items),
+                )
+            }
+
+            is MessageEdit.Content.Multipart -> {
+                val editedText = editContent.value.text?.let(::unpackText)
+                val editedMentions = editedText?.mentions
+                val editedAttachments = editContent.value.attachments.let(::unpackMultipartAttachments)
+
+                MessageContent.MultipartEdited(
+                    editMessageId = replacingMessageId,
+                    newTextContent = editedText?.value,
+                    newAttachments = editedAttachments,
+                    newMentions = editedMentions ?: emptyList(),
                 )
             }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/notification/LocalNotificationMessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/notification/LocalNotificationMessageMapper.kt
@@ -42,6 +42,7 @@ interface LocalNotificationMessageMapper {
 
     fun fromMessageToMessageDeletedLocalNotification(message: Message): LocalNotification
     fun fromMessageToMessageEditedLocalNotification(message: Message, messageContent: MessageContent.TextEdited): LocalNotification
+    fun fromMessageToMessageEditedLocalNotification(message: Message, messageContent: MessageContent.MultipartEdited): LocalNotification
     fun toConversationSeen(conversationId: ConversationId): LocalNotification
     fun fromEntitiesToLocalNotifications(
         list: List<NotificationMessageEntity>,
@@ -115,6 +116,16 @@ class LocalNotificationMessageMapperImpl : LocalNotificationMessageMapper {
             message.conversationId,
             messageContent.editMessageId,
             LocalNotificationUpdateMessageAction.Edit(messageContent.newContent, message.id)
+        )
+
+    override fun fromMessageToMessageEditedLocalNotification(
+        message: Message,
+        messageContent: MessageContent.MultipartEdited
+    ): LocalNotification =
+        LocalNotification.UpdateMessage(
+            message.conversationId,
+            messageContent.editMessageId,
+            LocalNotificationUpdateMessageAction.Edit(messageContent.newTextContent ?: "", message.id)
         )
 
     override fun fromEntitiesToLocalNotifications(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/notification/NotificationEventsManagerImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/notification/NotificationEventsManagerImpl.kt
@@ -60,6 +60,14 @@ object NotificationEventsManagerImpl : NotificationEventsManager {
         ephemeralNotifications.emit(localNotification)
     }
 
+    override suspend fun scheduleEditMessageNotification(
+        message: Message,
+        messageContent: MessageContent.MultipartEdited
+    ) {
+        val localNotification = mapper.fromMessageToMessageEditedLocalNotification(message, messageContent)
+        ephemeralNotifications.emit(localNotification)
+    }
+
     override suspend fun scheduleConversationSeenNotification(conversationId: ConversationId) {
         val localNotification = mapper.toConversationSeen(conversationId)
         ephemeralNotifications.emit(localNotification)
@@ -99,6 +107,8 @@ interface NotificationEventsManager {
      * Schedule the notification that some message was edited (if the notification about that message is displayed it should be edited)
      */
     suspend fun scheduleEditMessageNotification(message: Message, messageContent: MessageContent.TextEdited)
+
+    suspend fun scheduleEditMessageNotification(message: Message, messageContent: MessageContent.MultipartEdited)
 
     /**
      * Schedule the notification that informs that some conversation been seen by self-user on another device.

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -491,6 +491,7 @@ import com.wire.kalium.logic.sync.receiver.handler.DeleteMessageHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.EnableUserProfileQRCodeConfigHandler
 import com.wire.kalium.logic.sync.receiver.handler.LastReadContentHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.MessageCompositeEditHandlerImpl
+import com.wire.kalium.logic.sync.receiver.handler.MessageMultipartEditHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.MessageTextEditHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.ReceiptMessageHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.TypingIndicatorHandler
@@ -1584,6 +1585,7 @@ class UserSessionScope internal constructor(
             persistMessage,
             persistReaction,
             MessageTextEditHandlerImpl(messageRepository, NotificationEventsManagerImpl),
+            MessageMultipartEditHandlerImpl(messageRepository, NotificationEventsManagerImpl),
             LastReadContentHandlerImpl(
                 conversationRepository,
                 userId,
@@ -2203,6 +2205,7 @@ class UserSessionScope internal constructor(
             staleEpochVerifier,
             legalHoldHandler,
             observeFileSharingStatus,
+            cells.getMessageAttachmentsUseCase,
             cells.publishAttachments,
             cells.removeAttachments,
             cells.deleteAttachmentsUseCase,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.logic.feature.message
 import com.wire.kalium.cells.domain.MessageAttachmentDraftRepository
 import com.wire.kalium.cells.domain.usecase.DeleteMessageAttachmentsUseCase
 import com.wire.kalium.cells.domain.usecase.GetMessageAttachmentUseCase
+import com.wire.kalium.cells.domain.usecase.GetMessageAttachmentsUseCase
 import com.wire.kalium.cells.domain.usecase.PublishAttachmentsUseCase
 import com.wire.kalium.cells.domain.usecase.RemoveAttachmentDraftsUseCase
 import com.wire.kalium.logger.KaliumLogger
@@ -146,6 +147,7 @@ class MessageScope internal constructor(
     private val staleEpochVerifier: StaleEpochVerifier,
     private val legalHoldHandler: LegalHoldHandler,
     private val observeFileSharingStatusUseCase: ObserveFileSharingStatusUseCase,
+    private val getMessageAttachmentsUseCase: GetMessageAttachmentsUseCase,
     private val publishAttachmentsUseCase: PublishAttachmentsUseCase,
     private val removeAttachmentDraftsUseCase: RemoveAttachmentDraftsUseCase,
     private val deleteMessageAttachmentsUseCase: DeleteMessageAttachmentsUseCase,
@@ -296,6 +298,17 @@ class MessageScope internal constructor(
             slowSyncRepository,
             messageSender,
             messageSendFailureHandler
+        )
+
+    val sendEditMultipartMessage: SendEditMultipartMessageUseCase
+        get() = SendEditMultipartMessageUseCase(
+            messageRepository = messageRepository,
+            selfUserId = selfUserId,
+            provideClientId = currentClientIdProvider,
+            slowSyncRepository = slowSyncRepository,
+            messageSender = messageSender,
+            messageSendFailureHandler = messageSendFailureHandler,
+            getMessageAttachments = getMessageAttachmentsUseCase,
         )
 
     private val getAssetMessageTransferStatus: GetAssetMessageTransferStatusUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendEditMultipartMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendEditMultipartMessageUseCase.kt
@@ -1,0 +1,132 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+@file:Suppress("konsist.useCasesShouldNotAccessDaoLayerDirectly")
+
+package com.wire.kalium.logic.feature.message
+
+import com.wire.kalium.cells.domain.usecase.GetMessageAttachmentsUseCase
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.common.functional.getOrElse
+import com.wire.kalium.common.functional.onFailure
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.CurrentClientIdProvider
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageAttachment
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.data.message.mention.MessageMention
+import com.wire.kalium.logic.data.sync.SlowSyncRepository
+import com.wire.kalium.logic.data.sync.SlowSyncStatus
+import com.wire.kalium.messaging.sending.MessageSender
+import com.wire.kalium.persistence.dao.message.MessageEntity
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
+import kotlin.uuid.Uuid
+
+/**
+ * Edits a multipart message
+ */
+@Suppress("LongParameterList")
+class SendEditMultipartMessageUseCase internal constructor(
+    private val messageRepository: MessageRepository,
+    private val selfUserId: QualifiedID,
+    private val provideClientId: CurrentClientIdProvider,
+    private val slowSyncRepository: SlowSyncRepository,
+    private val messageSender: MessageSender,
+    private val messageSendFailureHandler: MessageSendFailureHandler,
+    private val getMessageAttachments: GetMessageAttachmentsUseCase,
+    private val dispatchers: KaliumDispatcher = KaliumDispatcherImpl
+) {
+
+    /**
+     * Operation to edit a multipart message.
+     *
+     * @param conversationId the id of the conversation the message belongs to
+     * @param originalMessageId the id of the message to edit
+     * @param text the edited content of the message
+     * @param mentions the edited mentions in the message
+     * @return [Either] [CoreFailure] or [Unit] //fixme: we should not return [Either]
+     */
+    suspend operator fun invoke(
+        conversationId: ConversationId,
+        originalMessageId: String,
+        text: String,
+        mentions: List<MessageMention> = emptyList(),
+        editedMessageId: String = Uuid.random().toString()
+    ): Either<CoreFailure, Unit> = withContext(dispatchers.io) {
+        slowSyncRepository.slowSyncStatus.first {
+            it is SlowSyncStatus.Complete
+        }
+
+        // Send all existing message attachments
+        // Will be updated later with sending updated list of attachments
+        val attachments: List<MessageAttachment> = getMessageAttachments(originalMessageId, conversationId)
+            .getOrElse {
+                emptyList()
+            }
+
+        provideClientId().flatMap { clientId ->
+            val content = MessageContent.MultipartEdited(
+                editMessageId = originalMessageId,
+                newTextContent = text,
+                newMentions = mentions,
+                newAttachments = attachments
+            )
+            val message = Message.Signaling(
+                id = editedMessageId,
+                content = content,
+                conversationId = conversationId,
+                date = Clock.System.now(),
+                senderUserId = selfUserId,
+                senderClientId = clientId,
+                status = Message.Status.Pending,
+                isSelfMessage = true,
+                expirationData = null
+            )
+            // until the edit send is completed and accepted by the backend, we don't change the message id to be able to handle any
+            // incoming edits from other clients that happened in the meantime and already changed the message id
+            messageRepository.updateMultipartMessage(
+                conversationId = message.conversationId,
+                messageContent = content,
+                newMessageId = originalMessageId,
+                editInstant = message.date
+            ).flatMap {
+                messageRepository.updateMessageStatus(
+                    messageStatus = MessageEntity.Status.PENDING,
+                    conversationId = message.conversationId,
+                    messageUuid = originalMessageId
+                )
+            }
+                .flatMap {
+                    messageSender.sendMessage(message)
+                }
+        }.onFailure {
+            messageSendFailureHandler.handleFailureAndUpdateMessageStatus(it, conversationId, originalMessageId, TYPE)
+        }
+    }
+
+    companion object {
+        const val TYPE = "MultipartEdited"
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
@@ -48,6 +48,7 @@ import com.wire.kalium.logic.sync.receiver.handler.DeleteForMeHandler
 import com.wire.kalium.logic.sync.receiver.handler.DeleteMessageHandler
 import com.wire.kalium.logic.sync.receiver.handler.LastReadContentHandler
 import com.wire.kalium.logic.sync.receiver.handler.MessageCompositeEditHandler
+import com.wire.kalium.logic.sync.receiver.handler.MessageMultipartEditHandler
 import com.wire.kalium.logic.sync.receiver.handler.MessageTextEditHandler
 import com.wire.kalium.logic.sync.receiver.handler.ReceiptMessageHandler
 import com.wire.kalium.logic.util.MessageContentEncoder
@@ -90,6 +91,7 @@ internal class ApplicationMessageHandlerImpl(
     private val persistMessage: PersistMessageUseCase,
     private val persistReaction: PersistReactionUseCase,
     private val editTextHandler: MessageTextEditHandler,
+    private val editMultipartHandler: MessageMultipartEditHandler,
     private val lastReadContentHandler: LastReadContentHandler,
     private val clearConversationContentHandler: ClearConversationContentHandler,
     private val deleteForMeHandler: DeleteForMeHandler,
@@ -224,6 +226,8 @@ internal class ApplicationMessageHandlerImpl(
             )
 
             is MessageContent.CompositeEdited -> messageCompositeEditHandler.handle(signaling, content)
+
+            is MessageContent.MultipartEdited -> editMultipartHandler.handle(signaling, content)
 
             is MessageContent.History -> TODO("HISTORY CLIENTS ARE NOT HANDLED YET")
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/MessageMultipartEditHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/MessageMultipartEditHandler.kt
@@ -1,0 +1,104 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.sync.receiver.handler
+
+import com.wire.kalium.logger.obfuscateId
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.data.notification.NotificationEventsManager
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.common.logger.kaliumLogger
+import com.wire.kalium.persistence.dao.message.MessageEntity
+import io.mockative.Mockable
+
+@Mockable
+internal interface MessageMultipartEditHandler {
+    suspend fun handle(
+        message: Message.Signaling,
+        messageContent: MessageContent.MultipartEdited
+    ): Either<CoreFailure, Unit>
+}
+
+internal class MessageMultipartEditHandlerImpl internal constructor(
+    private val messageRepository: MessageRepository,
+    private val notificationEventsManager: NotificationEventsManager,
+) : MessageMultipartEditHandler {
+
+    override suspend fun handle(
+        message: Message.Signaling,
+        messageContent: MessageContent.MultipartEdited
+    ) = messageRepository.getMessageById(message.conversationId, messageContent.editMessageId).flatMap { currentMessage ->
+
+        if (currentMessage.senderUserId != message.senderUserId) {
+            val obfuscatedId = message.senderUserId.toString().obfuscateId()
+            kaliumLogger.w(
+                message = "User '$obfuscatedId' attempted to edit a message from another user. Ignoring the edit completely"
+            )
+            // Same as message not found. _i.e._ not found for the original sender at least
+            return@flatMap Either.Left(StorageFailure.DataNotFound)
+        }
+
+        val editStatus = (currentMessage as? Message.Regular)?.editStatus
+        val content = currentMessage.content
+        if (currentMessage is Message.Regular && content is MessageContent.Multipart && editStatus is Message.EditStatus.Edited) {
+            // if the locally stored message is also already edited, we check which one is newer
+            if (editStatus.lastEditInstant > message.date) {
+                // our local pending or failed edit is newer than one we got from the backend so we update locally only message id and date
+                messageRepository.updateMultipartMessage(
+                    conversationId = message.conversationId,
+                    messageContent = messageContent.copy(
+                        newTextContent = content.value,
+                        newMentions = content.mentions,
+                        newAttachments = content.attachments
+                    ),
+                    newMessageId = message.id,
+                    editInstant = editStatus.lastEditInstant
+                )
+            } else {
+                notificationEventsManager.scheduleEditMessageNotification(message, messageContent)
+                // incoming edit from the backend is newer than the one we have locally so we update the whole message and change the status
+                messageRepository.updateMultipartMessage(
+                    conversationId = message.conversationId,
+                    messageContent = messageContent,
+                    newMessageId = message.id,
+                    editInstant = message.date
+                ).flatMap {
+                    messageRepository.updateMessageStatus(
+                        messageStatus = MessageEntity.Status.SENT,
+                        conversationId = message.conversationId,
+                        messageUuid = message.id
+                    )
+                }
+            }
+        } else {
+            notificationEventsManager.scheduleEditMessageNotification(message, messageContent)
+
+            messageRepository.updateMultipartMessage(
+                conversationId = message.conversationId,
+                messageContent = messageContent,
+                newMessageId = message.id,
+                editInstant = message.date
+            )
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/fakes/FakeMessageRepository.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/fakes/FakeMessageRepository.kt
@@ -1,0 +1,270 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.fakes
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.right
+import com.wire.kalium.logic.data.asset.AssetMessage
+import com.wire.kalium.logic.data.asset.AssetTransferStatus
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.BroadcastMessageOption
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageAssetStatus
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.message.MessageEnvelope
+import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.data.message.MessageRepositoryExtensions
+import com.wire.kalium.logic.data.message.MessageSent
+import com.wire.kalium.logic.data.notification.LocalNotification
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.framework.TestMessage
+import com.wire.kalium.messaging.sending.MessageTarget
+import com.wire.kalium.network.api.base.authenticated.message.MLSMessageApi
+import com.wire.kalium.persistence.dao.message.InsertMessageResult
+import com.wire.kalium.persistence.dao.message.MessageEntity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.datetime.Instant
+
+internal open class FakeMessageRepository : MessageRepository {
+
+    override val extensions: MessageRepositoryExtensions
+        get() = FakeMessageRepositoryExtensions()
+
+    override suspend fun persistMessage(
+        message: Message.Standalone,
+        updateConversationModifiedDate: Boolean
+    ): Either<CoreFailure, InsertMessageResult> = InsertMessageResult.INSERTED_INTO_MUTED_CONVERSATION.right()
+
+    override suspend fun persistSystemMessageToAllConversations(message: Message.System): Either<CoreFailure, Unit> = Unit.right()
+
+    override suspend fun deleteMessage(
+        messageUuid: String,
+        conversationId: ConversationId
+    ): Either<CoreFailure, Unit> = Unit.right()
+
+    override suspend fun markMessageAsDeleted(
+        messageUuid: String,
+        conversationId: ConversationId
+    ): Either<StorageFailure, Unit> = Unit.right()
+
+    override suspend fun updateMessageStatus(
+        messageStatus: MessageEntity.Status,
+        conversationId: ConversationId,
+        messageUuid: String
+    ): Either<CoreFailure, Unit> = Unit.right()
+
+    override suspend fun updateMessagesStatus(
+        messageStatus: MessageEntity.Status,
+        conversationId: ConversationId,
+        messageUuids: List<String>
+    ): Either<CoreFailure, Unit> = Unit.right()
+
+    override suspend fun updateAssetMessageTransferStatus(
+        transferStatus: AssetTransferStatus,
+        conversationId: ConversationId,
+        messageUuid: String
+    ): Either<CoreFailure, Unit> = Unit.right()
+
+    override suspend fun getMessageById(
+        conversationId: ConversationId,
+        messageUuid: String
+    ): Either<StorageFailure, Message> = TestMessage.TEXT_MESSAGE.right()
+
+    override suspend fun observeMessageById(
+        conversationId: ConversationId,
+        messageUuid: String
+    ): Flow<Either<StorageFailure, Message>> = flowOf(TestMessage.TEXT_MESSAGE.right())
+
+    override suspend fun getMessagesByConversationIdAndVisibility(
+        conversationId: ConversationId,
+        limit: Int,
+        offset: Int,
+        visibility: List<Message.Visibility>
+    ): Flow<List<Message>> = flowOf(emptyList())
+
+    override suspend fun getLastMessagesForConversationIds(
+        conversationIdList: List<ConversationId>
+    ): Either<StorageFailure, Map<ConversationId, Message>> = emptyMap<ConversationId, Message>().right()
+
+    override suspend fun getNotificationMessage(messageSizePerConversation: Int): Either<CoreFailure, List<LocalNotification>> =
+        emptyList<LocalNotification>().right()
+
+    override suspend fun getMessagesByConversationIdAndVisibilityAfterDate(
+        conversationId: ConversationId,
+        date: String,
+        visibility: List<Message.Visibility>
+    ): Flow<List<Message>> = flowOf(emptyList())
+
+    override suspend fun sendEnvelope(
+        conversationId: ConversationId,
+        envelope: MessageEnvelope,
+        messageTarget: MessageTarget
+    ): Either<CoreFailure, MessageSent> = TestMessage.TEST_MESSAGE_SENT.right()
+
+
+    override suspend fun broadcastEnvelope(
+        envelope: MessageEnvelope,
+        messageOption: BroadcastMessageOption
+    ): Either<CoreFailure, Instant> = TestMessage.TEST_DATE.right()
+
+    override suspend fun sendMLSMessage(message: MLSMessageApi.Message): Either<CoreFailure, MessageSent> =
+        TestMessage.TEST_MESSAGE_SENT.right()
+
+    override suspend fun getAllPendingMessagesFromUser(senderUserId: UserId): Either<CoreFailure, List<Message>> =
+        emptyList<Message>().right()
+
+
+    override suspend fun getPendingConfirmationMessagesByConversationAfterDate(
+        conversationId: ConversationId,
+        afterDateTime: Instant,
+        untilDateTime: Instant,
+        visibility: List<Message.Visibility>
+    ): Either<CoreFailure, List<String>> = emptyList<String>().right()
+
+    override suspend fun updateTextMessage(
+        conversationId: ConversationId,
+        messageContent: MessageContent.TextEdited,
+        newMessageId: String,
+        editInstant: Instant
+    ): Either<CoreFailure, Unit> = Unit.right()
+
+    override suspend fun updateLegalHoldMessageMembers(
+        messageId: String,
+        conversationId: ConversationId,
+        newMembers: List<UserId>
+    ): Either<CoreFailure, Unit> = Unit.right()
+
+    override suspend fun updateMultipartMessage(
+        conversationId: ConversationId,
+        messageContent: MessageContent.MultipartEdited,
+        newMessageId: String,
+        editInstant: Instant
+    ): Either<CoreFailure, Unit> = Unit.right()
+
+    override suspend fun resetAssetTransferStatus() {}
+
+    override suspend fun markMessagesAsDecryptionResolved(
+        conversationId: ConversationId,
+        userId: UserId,
+        clientId: ClientId
+    ): Either<CoreFailure, Unit> = Unit.right()
+
+    override suspend fun getReceiptModeFromGroupConversationByQualifiedID(
+        conversationId: ConversationId
+    ): Either<CoreFailure, Conversation.ReceiptMode?> = null.right()
+
+    override suspend fun promoteMessageToSentUpdatingServerTime(
+        conversationId: ConversationId,
+        messageUuid: String,
+        serverDate: Instant?,
+        millis: Long
+    ): Either<CoreFailure, Unit> = Unit.right()
+
+    override suspend fun getAllPendingEphemeralMessages(): Either<CoreFailure, List<Message>> = emptyList<Message>().right()
+
+    override suspend fun getAllAlreadyEndedEphemeralMessages(): Either<CoreFailure, List<Message>> = emptyList<Message>().right()
+
+    override suspend fun markSelfDeletionEndDate(
+        conversationId: ConversationId,
+        messageUuid: String,
+        deletionEndDate: Instant
+    ): Either<CoreFailure, Unit> = Unit.right()
+
+    override suspend fun observeMessageVisibility(
+        messageUuid: String,
+        conversationId: ConversationId
+    ): Flow<Either<StorageFailure, MessageEntity.Visibility>> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun persistRecipientsDeliveryFailure(
+        conversationId: ConversationId,
+        messageUuid: String,
+        usersWithFailedDeliveryList: List<UserId>
+    ): Either<CoreFailure, Unit> = Unit.right()
+
+    override suspend fun persistNoClientsToDeliverFailure(
+        conversationId: ConversationId,
+        messageUuid: String,
+        usersWithFailedDeliveryList: List<UserId>
+    ): Either<CoreFailure, Unit> = Unit.right()
+
+    override suspend fun moveMessagesToAnotherConversation(
+        originalConversation: ConversationId,
+        targetConversation: ConversationId
+    ): Either<StorageFailure, Unit> = Unit.right()
+
+    override suspend fun getSearchedConversationMessagePosition(
+        conversationId: ConversationId,
+        messageId: String
+    ): Either<StorageFailure, Int> = 0.right()
+
+    override suspend fun getImageAssetMessagesByConversationId(
+        conversationId: ConversationId,
+        limit: Int,
+        offset: Int
+    ): List<AssetMessage> = emptyList()
+
+    override suspend fun observeAssetStatuses(conversationId: ConversationId): Flow<Either<StorageFailure, List<MessageAssetStatus>>> =
+        flowOf(emptyList<MessageAssetStatus>().right())
+
+    override suspend fun getMessageAssetTransferStatus(
+        messageId: String,
+        conversationId: ConversationId
+    ): Either<StorageFailure, AssetTransferStatus> = AssetTransferStatus.NOT_DOWNLOADED.right()
+
+    override suspend fun getAllAssetIdsFromConversationId(conversationId: ConversationId): Either<StorageFailure, List<String>> =
+        emptyList<String>().right()
+
+    override suspend fun getSenderNameByMessageId(
+        conversationId: ConversationId,
+        messageId: String
+    ): Either<CoreFailure, String> = "".right()
+
+    override suspend fun getNextAudioMessageInConversation(
+        conversationId: ConversationId,
+        messageId: String
+    ): Either<CoreFailure, String>  = "".right()
+
+    override suspend fun updateMessagesStatusIfNotRead(
+        messageStatus: MessageEntity.Status,
+        conversationId: ConversationId,
+        messageIds: List<String>
+    ): Either<CoreFailure, Unit> = Unit.right()
+
+    override suspend fun updateCompositeMessage(
+        conversationId: ConversationId,
+        messageContent: MessageContent.CompositeEdited,
+        newMessageId: String,
+        editInstant: Instant
+    ): Either<StorageFailure, Unit> = Unit.right()
+
+    override suspend fun observeAssetStatuses(): Flow<Either<StorageFailure, List<AssetTransferStatus>>> =
+        flowOf(emptyList<AssetTransferStatus>().right())
+
+    override suspend fun updateAudioMessageNormalizedLoudness(
+        conversationId: ConversationId,
+        messageId: String,
+        normalizedLoudness: ByteArray
+    ): Either<CoreFailure, Unit> = Unit.right()
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/fakes/FakeMessageRepositoryExtensions.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/fakes/FakeMessageRepositoryExtensions.kt
@@ -1,0 +1,55 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.fakes
+
+import app.cash.paging.PagingConfig
+import app.cash.paging.PagingData
+import com.wire.kalium.logic.data.asset.AssetMessage
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageRepositoryExtensions
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+
+internal open class FakeMessageRepositoryExtensions : MessageRepositoryExtensions {
+    override suspend fun getPaginatedMessagesByConversationIdAndVisibility(
+        conversationId: ConversationId,
+        visibility: List<Message.Visibility>,
+        pagingConfig: PagingConfig,
+        startingOffset: Long
+    ): Flow<PagingData<Message.Standalone>> = emptyFlow()
+
+    override suspend fun getPaginatedMessagesSearchBySearchQueryAndConversationId(
+        searchQuery: String,
+        conversationId: ConversationId,
+        pagingConfig: PagingConfig,
+        startingOffset: Long
+    ): Flow<PagingData<Message.Standalone>> = emptyFlow()
+
+    override suspend fun getPaginatedMessageAssetsWithoutImageByConversationId(
+        conversationId: ConversationId,
+        pagingConfig: PagingConfig,
+        startingOffset: Long
+    ): Flow<PagingData<Message.Standalone>> = emptyFlow()
+
+    override suspend fun observePaginatedMessageAssetImageByConversationId(
+        conversationId: ConversationId,
+        pagingConfig: PagingConfig,
+        startingOffset: Long
+    ): Flow<PagingData<AssetMessage>> = emptyFlow()
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/fakes/FakeNotificationEventsManager.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/fakes/FakeNotificationEventsManager.kt
@@ -1,0 +1,52 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.fakes
+
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.notification.EphemeralConversationNotification
+import com.wire.kalium.logic.data.notification.LocalNotification
+import com.wire.kalium.logic.data.notification.NotificationEventsManager
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+
+open class FakeNotificationEventsManager : NotificationEventsManager {
+
+    override suspend fun observeEphemeralNotifications(): Flow<LocalNotification> = emptyFlow()
+
+    override suspend fun scheduleDeleteConversationNotification(ephemeralConversationNotification: EphemeralConversationNotification) {}
+
+    override suspend fun scheduleDeleteMessageNotification(message: Message) {}
+
+    override suspend fun scheduleEditMessageNotification(
+        message: Message,
+        messageContent: MessageContent.TextEdited
+    ) {}
+
+    override suspend fun scheduleEditMessageNotification(
+        message: Message,
+        messageContent: MessageContent.MultipartEdited
+    ) {}
+
+    override suspend fun scheduleConversationSeenNotification(conversationId: ConversationId) {}
+
+    override suspend fun scheduleRegularNotificationChecking() {}
+
+    override suspend fun observeRegularNotificationsChecking(): Flow<Unit> = emptyFlow()
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/fakes/sync/FakeSlowSyncRepository.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/fakes/sync/FakeSlowSyncRepository.kt
@@ -1,0 +1,42 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.fakes.sync
+
+import com.wire.kalium.logic.data.sync.SlowSyncRepository
+import com.wire.kalium.logic.data.sync.SlowSyncStatus
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.datetime.Instant
+
+open class FakeSlowSyncRepository(
+    override val slowSyncStatus: StateFlow<SlowSyncStatus> = MutableStateFlow<SlowSyncStatus>(SlowSyncStatus.Complete).asStateFlow()
+) : SlowSyncRepository {
+    override suspend fun setLastSlowSyncCompletionInstant(instant: Instant) {}
+    override suspend fun clearLastSlowSyncCompletionInstant() {}
+    override suspend fun setNeedsToRecoverMLSGroups(value: Boolean) {}
+    override suspend fun needsToRecoverMLSGroups(): Boolean = false
+    override suspend fun setNeedsToPersistHistoryLostMessage(value: Boolean) {}
+    override suspend fun needsToPersistHistoryLostMessage(): Boolean = false
+    override suspend fun observeLastSlowSyncCompletionInstant(): Flow<Instant?> = emptyFlow()
+    override fun updateSlowSyncStatus(slowSyncStatus: SlowSyncStatus) {}
+    override suspend fun setSlowSyncVersion(version: Int) {}
+    override suspend fun getSlowSyncVersion(): Int? = null
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendEditMultipartMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendEditMultipartMessageUseCaseTest.kt
@@ -1,0 +1,223 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.message
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.left
+import com.wire.kalium.common.functional.right
+import com.wire.kalium.cryptography.CryptoTransactionContext
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.CurrentClientIdProvider
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageAttachment
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.failure.ProteusSendMessageFailure
+import com.wire.kalium.logic.fakes.FakeMessageRepository
+import com.wire.kalium.logic.fakes.sync.FakeSlowSyncRepository
+import com.wire.kalium.logic.framework.TestClient
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.test_util.TestKaliumDispatcher
+import com.wire.kalium.logic.test_util.testKaliumDispatcher
+import com.wire.kalium.logic.util.shouldFail
+import com.wire.kalium.logic.util.shouldSucceed
+import com.wire.kalium.messaging.sending.BroadcastMessage
+import com.wire.kalium.messaging.sending.BroadcastMessageTarget
+import com.wire.kalium.messaging.sending.MessageSender
+import com.wire.kalium.messaging.sending.MessageTarget
+import com.wire.kalium.persistence.dao.message.MessageEntity
+import com.wire.kalium.util.KaliumDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SendEditMultipartMessageUseCaseTest {
+
+    @Test
+    fun givenAValidMessage_whenSendingEditMultipartIsSuccessful_thenMarkMessageAsSentAndReturnSuccess() = runTest {
+
+        val originalMessageId = "message id"
+        val editedMessageId = "edited message id"
+        val editedMessageText = "text"
+
+        var updateCalled = 0
+        var updateStatusCalled = 0
+        var handleFailureCalled = 0
+        var sendCalled = 0
+
+        // Given
+        val (_, sendEditTextMessage) = Arrangement(testKaliumDispatcher)
+            .withUpdateMessage { messageId ->
+                if (messageId == originalMessageId) updateCalled++
+            }
+            .withUpdateMessageStatus { status->
+                if (status == MessageEntity.Status.PENDING) updateStatusCalled++
+            }
+            .withHandleMessageFailure { handleFailureCalled++ }
+            .withSendMessage {
+                sendCalled++
+                Unit.right()
+            }
+            .arrange()
+
+        // When
+        val result = sendEditTextMessage(TestConversation.ID, originalMessageId, editedMessageText, listOf(), editedMessageId)
+
+        // Then
+        result.shouldSucceed()
+
+        assertEquals(1, updateCalled)
+        assertEquals(1, updateStatusCalled)
+        assertEquals(0, handleFailureCalled)
+        assertEquals(1, sendCalled)
+    }
+
+    @Test
+    fun givenAValidMessage_whenSendingEditMultipartIsFailed_thenMarkMessageAsFailedAndReturnFailure() = runTest {
+
+
+        val originalMessageId = "message id"
+        val editedMessageId = "edited message id"
+        val editedMessageText = "text"
+
+        var updateCalled = 0
+        var updateStatusCalled = 0
+        var handleFailureCalled = 0
+        var sendCalled = 0
+
+        // Given
+        val (_, sendEditTextMessage) = Arrangement(testKaliumDispatcher)
+            .withUpdateMessage { messageId ->
+                if (messageId == originalMessageId) {
+                    updateCalled++
+                } else {
+                    error("Must not happen in this test")
+                }
+            }
+            .withUpdateMessageStatus { status->
+                if (status == MessageEntity.Status.PENDING) updateStatusCalled++
+            }
+            .withHandleMessageFailure { handleFailureCalled++ }
+            .withSendMessage {
+                sendCalled++
+                CoreFailure.Unknown(IllegalStateException("Test exception")).left()
+            }
+            .arrange()
+
+        // When
+        val result = sendEditTextMessage(TestConversation.ID, originalMessageId, editedMessageText, listOf(), editedMessageId)
+
+        // Then
+        result.shouldFail()
+
+        assertEquals(1, updateCalled)
+        assertEquals(1, updateStatusCalled)
+        assertEquals(1, handleFailureCalled)
+        assertEquals(1, sendCalled)
+    }
+
+    private class Arrangement(var dispatcher: KaliumDispatcher = TestKaliumDispatcher) {
+
+        private var sendMessage: () -> Either<CoreFailure, Unit> = { Unit.right() }
+        private var handleMessageFailure: () -> Unit = {}
+        private var updateMessage: (String) -> Unit = {}
+        private var updateMessageStatus: (MessageEntity.Status) -> Unit = {}
+
+        private val messageRepository: MessageRepository = object : FakeMessageRepository() {
+            override suspend fun updateMultipartMessage(
+                conversationId: ConversationId,
+                messageContent: MessageContent.MultipartEdited,
+                newMessageId: String,
+                editInstant: Instant
+            ): Either<CoreFailure, Unit> {
+                return updateMessage(newMessageId).right()
+            }
+
+            override suspend fun updateMessageStatus(
+                messageStatus: MessageEntity.Status,
+                conversationId: ConversationId,
+                messageUuid: String
+            ): Either<CoreFailure, Unit> {
+                return updateMessageStatus(messageStatus).right()
+            }
+        }
+        private val clientIdProvider = CurrentClientIdProvider { TestClient.CLIENT_ID.right() }
+
+        private val messageSender = object : MessageSender {
+            override suspend fun sendPendingMessage(conversationId: ConversationId, messageUuid: String) = Unit.right()
+            override suspend fun sendMessage(
+                message: Message.Sendable,
+                messageTarget: MessageTarget
+            ): Either<CoreFailure, Unit> {
+                return sendMessage()
+            }
+
+            override suspend fun broadcastMessage(message: BroadcastMessage, target: BroadcastMessageTarget) = Unit.right()
+        }
+
+        private val sendFailureHandler = object : MessageSendFailureHandler {
+            override suspend fun handleClientsHaveChangedFailure(
+                transactionContext: CryptoTransactionContext,
+                sendFailure: ProteusSendMessageFailure,
+                conversationId: ConversationId?
+            ) = Unit.right()
+
+            override suspend fun handleFailureAndUpdateMessageStatus(
+                failure: CoreFailure,
+                conversationId: ConversationId,
+                messageId: String,
+                messageType: String,
+                scheduleResendIfNoNetwork: Boolean
+            ) {
+                handleMessageFailure()
+            }
+        }
+
+        fun withSendMessage(block: () -> Either<CoreFailure, Unit>) = apply {
+            sendMessage = block
+        }
+
+        fun withUpdateMessage(block: (String) -> Unit) = apply {
+            updateMessage = block
+        }
+
+        fun withUpdateMessageStatus(block: (MessageEntity.Status) -> Unit) = apply {
+            updateMessageStatus = block
+        }
+
+        fun withHandleMessageFailure(block: () -> Unit) = apply {
+            handleMessageFailure = block
+        }
+
+        fun arrange() = this to SendEditMultipartMessageUseCase(
+            messageRepository = messageRepository,
+            selfUserId = TestUser.SELF.id,
+            provideClientId = clientIdProvider,
+            slowSyncRepository = FakeSlowSyncRepository(),
+            messageSender = messageSender,
+            messageSendFailureHandler = sendFailureHandler,
+            getMessageAttachments = { _, _ -> emptyList<MessageAttachment>().right() },
+            dispatchers = dispatcher
+        )
+        
+    }
+
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/MessageMultipartEditHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/MessageMultipartEditHandlerTest.kt
@@ -1,0 +1,250 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.receiver.handler
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.right
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.fakes.FakeMessageRepository
+import com.wire.kalium.logic.fakes.FakeNotificationEventsManager
+import com.wire.kalium.logic.framework.TestMessage
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.persistence.dao.message.MessageEntity
+import com.wire.kalium.util.time.UNIX_FIRST_DATE
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.minutes
+
+class MessageMultipartEditHandlerTest {
+
+    @Test
+    fun givenEditMatchesOriginalSender_whenHandling_thenShouldUpdateContentWithCorrectParameters() = runTest {
+        var called = 0
+        val (_, handler) = Arrangement()
+            .withUpdateMultipartMessage { called++ }
+            .arrange()
+
+        handler.handle(EDIT_MESSAGE.copy(senderUserId = ORIGINAL_SENDER_USER_ID), EDIT_CONTENT)
+
+        assertEquals(1, called)
+    }
+
+    @Test
+    fun givenEditDoesNOTMatchesOriginalSender_whenHandling_thenShouldNOTUpdateContent() = runTest {
+        var called = 0
+        val (_, handler) = Arrangement()
+            .withUpdateMultipartMessage { called++ }
+            .arrange()
+
+        handler.handle(EDIT_MESSAGE.copy(senderUserId = TestUser.OTHER_USER_ID), EDIT_CONTENT)
+
+        assertEquals(0, called)
+    }
+
+    @Test
+    fun givenEditIsNewerThanLocalPendingStoredEdit_whenHandling_thenShouldUpdateTheWholeMessageDataAndStatus() = runTest {
+        var updateCalled = 0
+        var updateStatusCalled = 0
+        var scheduleNotificationCalled = 0
+
+        val originalContent = TestMessage.multipartMessage().content
+        val originalEditStatus = Message.EditStatus.Edited(Instant.UNIX_FIRST_DATE)
+        val originalMessage = ORIGINAL_MESSAGE.copy(
+            editStatus = originalEditStatus,
+            content = originalContent,
+            status = Message.Status.Pending
+        )
+        val editContent = EDIT_CONTENT
+        val editMessage = EDIT_MESSAGE.copy(
+            date = Instant.UNIX_FIRST_DATE,
+            content = editContent
+        )
+        val (_, handler) = Arrangement()
+            .withGetMessageById(originalMessage)
+            .withUpdateMultipartMessage { updateCalled++ }
+            .withUpdateMessageStatus { updateStatusCalled++ }
+            .withScheduleNotification { scheduleNotificationCalled++ }
+            .arrange()
+
+        handler.handle(editMessage, editContent)
+
+        assertEquals(1, updateCalled)
+        assertEquals(1, updateStatusCalled)
+        assertEquals(1, scheduleNotificationCalled)
+    }
+
+    @Test
+    fun givenEditIsOlderThanLocalPendingStoredEdit_whenHandling_thenShouldUpdateOnlyMessageIdAndDate() = runTest {
+        var updateCalled = 0
+        var updateStatusCalled = 0
+        val originalContent = TestMessage.multipartMessage().content as MessageContent.Multipart
+        val originalEditStatus = Message.EditStatus.Edited(Instant.DISTANT_FUTURE) // original message date is newer than edit date
+        val originalMessage = ORIGINAL_MESSAGE.copy(
+            editStatus = originalEditStatus,
+            content = originalContent,
+            status = Message.Status.Pending
+
+        )
+        val editContent = EDIT_CONTENT
+        val editMessage = EDIT_MESSAGE.copy(
+            date = originalEditStatus.lastEditInstant - 10.minutes, // edit date is older than original message date
+            content = editContent
+        )
+        val expectedContent = MessageContent.MultipartEdited(
+            editMessageId = editContent.editMessageId,
+            newTextContent = originalContent.value,
+            newMentions = originalContent.mentions,
+            newAttachments = originalContent.attachments,
+        )
+        val (_, handler) = Arrangement()
+            .withGetMessageById(originalMessage)
+            .withUpdateMultipartMessage { content, editInstant ->
+                if (content == expectedContent && editInstant == originalEditStatus.lastEditInstant) {
+                    updateCalled++
+                }
+            }
+            .withUpdateMessageStatus { updateStatusCalled++ }
+            .arrange()
+
+        handler.handle(editMessage, editContent)
+
+        assertEquals(1, updateCalled)
+        assertEquals(0, updateStatusCalled)
+    }
+
+    @Test
+    fun givenAnAlreadyEditedMessage_whenNewEditIsInTheFuture_thenMessageContentIsUpdated() = runTest {
+        var updateCalled = 0
+        var updateStatusCalled = 0
+        val originalContent = TestMessage.multipartMessage().content
+        val originalEditStatus = Message.EditStatus.Edited(Instant.UNIX_FIRST_DATE)
+        val originalMessage = ORIGINAL_MESSAGE.copy(
+            editStatus = originalEditStatus,
+            content = originalContent,
+            status = Message.Status.Sent
+        )
+        val editContent = EDIT_CONTENT
+        val editMessage = EDIT_MESSAGE.copy(
+            date = Instant.UNIX_FIRST_DATE + 10.minutes,
+            content = editContent
+        )
+        val expectedContent = MessageContent.MultipartEdited(
+            editMessageId = editContent.editMessageId,
+            newTextContent = editContent.newTextContent,
+            newMentions = editContent.newMentions,
+            newAttachments = editContent.newAttachments,
+        )
+        val (_, messageTextEditHandler) = Arrangement()
+            .withGetMessageById(originalMessage)
+            .withUpdateMultipartMessage { content, editInstant ->
+                if (content == expectedContent && editInstant == editMessage.date) {
+                    updateCalled++
+                }
+            }
+            .withUpdateMessageStatus { updateStatusCalled++ }
+            .arrange()
+
+        messageTextEditHandler.handle(editMessage, editContent)
+
+        assertEquals(1, updateCalled)
+        assertEquals(1, updateStatusCalled)
+    }
+
+    private class Arrangement {
+
+        private var message: Message = ORIGINAL_MESSAGE
+        private var updateMultipartMessage: (MessageContent.MultipartEdited, Instant) -> Unit = { _, _ -> }
+        private var updateMessageStatus: () -> Unit = {}
+        private var scheduleMessageNotification: () -> Unit = {}
+
+        private val repository: MessageRepository = object : FakeMessageRepository() {
+
+            override suspend fun getMessageById(conversationId: ConversationId, messageUuid: String): Either<StorageFailure, Message> {
+                return message.right()
+            }
+
+            override suspend fun updateMultipartMessage(
+                conversationId: ConversationId,
+                messageContent: MessageContent.MultipartEdited,
+                newMessageId: String,
+                editInstant: Instant
+            ): Either<CoreFailure, Unit> {
+                return updateMultipartMessage(messageContent, editInstant).right()
+            }
+
+            override suspend fun updateMessageStatus(
+                messageStatus: MessageEntity.Status,
+                conversationId: ConversationId,
+                messageUuid: String
+            ): Either<CoreFailure, Unit> {
+                return updateMessageStatus().right()
+            }
+        }
+
+        private val notificationEventsManager = object : FakeNotificationEventsManager() {
+            override suspend fun scheduleEditMessageNotification(message: Message, messageContent: MessageContent.MultipartEdited) {
+                scheduleMessageNotification()
+            }
+        }
+
+        fun withGetMessageById(message: Message) = apply {
+            this.message = message
+        }
+
+        fun withUpdateMultipartMessage(block: (MessageContent.MultipartEdited, Instant) -> Unit) = apply {
+            updateMultipartMessage = block
+        }
+
+        fun withUpdateMultipartMessage(block: () -> Unit) = apply {
+            updateMultipartMessage = { _, _ -> block() }
+        }
+
+        fun withUpdateMessageStatus(block: () -> Unit) = apply {
+            updateMessageStatus = block
+        }
+
+        fun withScheduleNotification(block: () -> Unit) = apply {
+            scheduleMessageNotification = block
+        }
+
+        fun arrange() = this to MessageMultipartEditHandlerImpl(
+            messageRepository = repository,
+            notificationEventsManager = notificationEventsManager,
+        )
+    }
+    private companion object {
+        val ORIGINAL_MESSAGE = TestMessage.multipartMessage()
+        val ORIGINAL_MESSAGE_ID = ORIGINAL_MESSAGE.id
+        val ORIGINAL_SENDER_USER_ID = ORIGINAL_MESSAGE.senderUserId
+        val EDIT_CONTENT = MessageContent.MultipartEdited(
+            editMessageId = ORIGINAL_MESSAGE_ID,
+            newTextContent = "some new content",
+            newMentions = listOf()
+        )
+        val EDIT_MESSAGE = TestMessage.signalingMessage(
+            content = EDIT_CONTENT
+        )
+    }
+}

--- a/tools/protobuf-codegen/src/main/proto/messages.proto
+++ b/tools/protobuf-codegen/src/main/proto/messages.proto
@@ -221,6 +221,7 @@ message MessageEdit {
     oneof content {
         Text text = 2;
         Composite composite = 3;
+        Multipart multipart = 4;
         // Reply can also be edited, but the edit will only affect the Text part
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22308" title="WPB-22308" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22308</a>  [Android] Multipart message edit protocol update
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

https://wearezeta.atlassian.net/browse/WPB-22308

# What's new in this PR?

### Issues
Multipart messages have both text and file attachments. Existing implementation for editing text in multipart message was reusing existing EditMessage with Text content.
This approach had two issues:
- Not possible to handle correctly on iOS client
- Works only for text. Will not support changing message attachments.

### Solutions
- Add new content type for MessageEdit protocol message: Multipart
- Update protocol mappers
- Add handler for new edit content type
- Add use case for sending new MessageEdit for multipart messages

Note: currently only text editing is supported. Editing attachments will be implemented later.
Sending existing attachments list in the MessageEdit is done to simplify handling on the iOS client.
