### PR TITLE
fix: keep decrypting banner until pending events are fully drained [WPB-23396]

### DIFF
--- a/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Events.sq
+++ b/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Events.sq
@@ -51,3 +51,9 @@ LIMIT 500;
 deleteUnprocessedLiveEventsByIds:
 DELETE FROM Events
 WHERE is_processed = 0 AND is_live = 1 AND event_id IN ?;
+
+hasUnprocessedPendingEvents:
+SELECT EXISTS(
+    SELECT 1 FROM Events
+    WHERE is_processed = 0 AND is_live = 0
+);

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/event/EventDAO.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/event/EventDAO.kt
@@ -33,4 +33,5 @@ interface EventDAO {
     suspend fun setAllUnprocessedEventsAsPending()
     suspend fun deleteUnprocessedLiveEventsByIds(ids: List<String>)
     suspend fun markEventsAsProcessed(eventIds: List<String>)
+    suspend fun hasUnprocessedPendingEvents(): Boolean
 }

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/event/EventDAOImpl.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/event/EventDAOImpl.kt
@@ -111,6 +111,10 @@ class EventDAOImpl(
         }
     }
 
+    override suspend fun hasUnprocessedPendingEvents(): Boolean = withContext(readDispatcher.value) {
+        eventsQueries.hasUnprocessedPendingEvents().executeAsOne()
+    }
+
     override suspend fun setAllUnprocessedEventsAsPending() {
         withContext(writeDispatcher.value) {
             eventsQueries.setAllUnprocessedEventsAsPending()

--- a/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/event/EventDAOTest.kt
+++ b/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/event/EventDAOTest.kt
@@ -205,4 +205,33 @@ class EventDAOTest : BaseDatabaseTest() {
         }
     }
 
+    @Test
+    fun givenNoEvents_whenCheckingHasUnprocessedPendingEvents_thenReturnsFalse() = runTest {
+        assertFalse(dao.hasUnprocessedPendingEvents())
+    }
+
+    @Test
+    fun givenOnlyUnprocessedLiveEvents_whenCheckingHasUnprocessedPendingEvents_thenReturnsFalse() = runTest {
+        dao.insertEvents(
+            listOf(
+                NewEventEntity(eventId = "live-1", payload = "{}", isLive = true, transient = false),
+                NewEventEntity(eventId = "live-2", payload = "{}", isLive = true, transient = true)
+            )
+        )
+
+        assertFalse(dao.hasUnprocessedPendingEvents())
+    }
+
+    @Test
+    fun givenAtLeastOneUnprocessedPendingEvent_whenCheckingHasUnprocessedPendingEvents_thenReturnsTrue() = runTest {
+        dao.insertEvents(
+            listOf(
+                NewEventEntity(eventId = "live-1", payload = "{}", isLive = true, transient = false),
+                NewEventEntity(eventId = "pending-1", payload = "{}", isLive = false, transient = false)
+            )
+        )
+
+        assertTrue(dao.hasUnprocessedPendingEvents())
+    }
+
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt
@@ -131,6 +131,7 @@ internal interface EventRepository {
     suspend fun fetchOldestAvailableEventId(): Either<CoreFailure, String>
     suspend fun observeEvents(): Flow<List<EventEnvelope>>
     suspend fun setEventsAsProcessed(eventIds: List<String>): Either<StorageFailure, Unit>
+    suspend fun hasUnprocessedPendingEvents(): Either<StorageFailure, Boolean>
 }
 
 @Suppress("TooManyFunctions", "LongParameterList")
@@ -486,6 +487,10 @@ internal class EventDataSource(
 
     override suspend fun setEventsAsProcessed(eventIds: List<String>): Either<StorageFailure, Unit> = wrapStorageRequest {
         eventDAO.markEventsAsProcessed(eventIds)
+    }
+
+    override suspend fun hasUnprocessedPendingEvents(): Either<StorageFailure, Boolean> = wrapStorageRequest {
+        eventDAO.hasUnprocessedPendingEvents()
     }
 
     private suspend fun getNextPendingEventsPage(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt
@@ -62,13 +62,25 @@ internal class IncrementalSyncWorkerImpl(
     override suspend fun processEventsFlow(): Flow<EventSource> = channelFlow {
         // We start as PENDING
         send(EventSource.PENDING)
+        var hasReachedLive = false
 
         kaliumLogger.d("$TAG gatherEvents starting...")
         eventGatherer.gatherEvents()
             // If we ever become Up-To-Date, move to LIVE
             .onEach { eventStreamData ->
-                if (eventStreamData is EventStreamData.IsUpToDate) {
-                    send(EventSource.LIVE) // We are LIVE!!!!!!
+                if (!hasReachedLive && eventStreamData is EventStreamData.IsUpToDate) {
+                    eventRepository.hasUnprocessedPendingEvents()
+                        .onSuccess { hasPendingEvents ->
+                            if (!hasPendingEvents) {
+                                hasReachedLive = true
+                                send(EventSource.LIVE) // We are LIVE!!!!!!
+                            } else {
+                                logger.i("Staying in PENDING state: unprocessed pending events still exist")
+                            }
+                        }
+                        .onFailure {
+                            throw KaliumSyncException("Failed to inspect pending events before LIVE transition", it)
+                        }
                 }
             }
             .filterIsInstance<EventStreamData.NewEvents>()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-23396
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- The "Decrypting messages" banner could disappear too early during incremental sync catch-up, even when pending events were still waiting to be processed/decrypted.
- This was especially visible with batched catch-up traffic (temporary gaps between pending pages) and unstable/slower network conditions.

### Causes (Optional)

- Sync was allowed to transition to `LIVE` when `IsUpToDate` was observed, but `IsUpToDate` can appear in temporary gaps between pending batches.
- The transition condition did not enforce a hard check that pending (`is_live = 0`) events were actually drained.
- After entering live mode, repeated `IsUpToDate` emissions could still trigger unnecessary checks.

### Solutions

- Made the `LIVE` transition state-based:
  - On `IsUpToDate`, we now verify whether unprocessed pending events still exist.
  - We only emit `LIVE` when pending events are truly empty.
- Added a dedicated DAO/repository check for pending backlog using SQL `EXISTS(...)` for minimal overhead (`hasUnprocessedPendingEvents`).
- Added a guard to avoid re-running pending checks after `LIVE` has already been reached in the same worker session.