### PR TITLE
fix(sync): handle throttled MLS join requests [WPB-24096]

### DIFF
--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
@@ -152,7 +152,7 @@ fun KaliumException.InvalidRequestError.isInvalidHandle(): Boolean {
 }
 
 fun KaliumException.InvalidRequestError.isTooManyRequests(): Boolean {
-    return errorResponse.code == HttpStatusCode.TooManyRequests.value
+    return errorResponse.code == HttpStatusCode.TooManyRequests.value || errorResponse.code == HTTP_STATUS_NGINZ_TOO_MANY_REQUESTS
 }
 
 fun KaliumException.InvalidRequestError.isHandleExists(): Boolean {
@@ -219,3 +219,5 @@ fun KaliumException.InvalidRequestError.isAccountPendingActivation(): Boolean = 
 
 fun KaliumException.ServerError.isEnterpriseServiceNotEnabled(): Boolean =
     errorResponse.code == HttpStatusCode.ServiceUnavailable.value && errorResponse.label == ENTERPRISE_SERVICE_NOT_ENABLED
+
+private const val HTTP_STATUS_NGINZ_TOO_MANY_REQUESTS = 420

--- a/data/network/src/commonTest/kotlin/com/wire/kalium/network/exceptions/KaliumExceptionTest.kt
+++ b/data/network/src/commonTest/kotlin/com/wire/kalium/network/exceptions/KaliumExceptionTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.exceptions
+
+import com.wire.kalium.network.api.model.ErrorResponse
+import io.ktor.http.HttpStatusCode
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class KaliumExceptionTest {
+
+    @Test
+    fun given429InvalidRequest_whenCheckingTooManyRequests_thenReturnsTrue() {
+        val subject = KaliumException.InvalidRequestError(
+            ErrorResponse(HttpStatusCode.TooManyRequests.value, "too-many-requests", "Please try again later.")
+        )
+
+        assertTrue(subject.isTooManyRequests())
+    }
+
+    @Test
+    fun given420InvalidRequest_whenCheckingTooManyRequests_thenReturnsTrue() {
+        val subject = KaliumException.InvalidRequestError(
+            ErrorResponse(420, "unknown status code", "nginx throttled request")
+        )
+
+        assertTrue(subject.isTooManyRequests())
+    }
+
+    @Test
+    fun givenNonThrottleInvalidRequest_whenCheckingTooManyRequests_thenReturnsFalse() {
+        val subject = KaliumException.InvalidRequestError(
+            ErrorResponse(HttpStatusCode.BadRequest.value, "bad-request", "Bad request")
+        )
+
+        assertFalse(subject.isTooManyRequests())
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationsUseCase.kt
@@ -32,9 +32,11 @@ import com.wire.kalium.logic.data.client.CryptoTransactionProvider
 import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo.MLSCapable.GroupState
 import com.wire.kalium.logic.featureFlags.FeatureSupport
 import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.network.exceptions.isTooManyRequests
 import io.mockative.Mockable
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 
 /**
  * Send an external commit to join all MLS conversations for which the user is a member,
@@ -51,8 +53,17 @@ internal class JoinExistingMLSConversationsUseCaseImpl(
     private val clientRepository: ClientRepository,
     private val conversationRepository: ConversationRepository,
     private val joinExistingMLSConversationUseCase: JoinExistingMLSConversationUseCase,
-    private val transactionProvider: CryptoTransactionProvider
+    private val transactionProvider: CryptoTransactionProvider,
+    private val maxConcurrentJoins: Int = DEFAULT_MAX_CONCURRENT_JOINS,
+    private val maxThrottleRetries: Int = DEFAULT_MAX_THROTTLE_RETRIES,
+    private val throttleRetryDelayMs: Long = DEFAULT_THROTTLE_RETRY_DELAY_MS,
 ) : JoinExistingMLSConversationsUseCase {
+
+    init {
+        require(maxConcurrentJoins > 0) { "maxConcurrentJoins must be greater than zero" }
+        require(maxThrottleRetries >= 0) { "maxThrottleRetries must not be negative" }
+        require(throttleRetryDelayMs >= 0) { "throttleRetryDelayMs must not be negative" }
+    }
 
     override suspend operator fun invoke(keepRetryingOnFailure: Boolean): Either<CoreFailure, Unit> =
         if (!featureSupport.isMLSSupported ||
@@ -64,56 +75,102 @@ internal class JoinExistingMLSConversationsUseCaseImpl(
             transactionProvider.transaction("JoinExistingMLSConversations") { transactionContext ->
                 conversationRepository.getConversationsByGroupState(GroupState.PENDING_JOIN).flatMap { pendingConversations ->
                     kaliumLogger.d("Requesting to re-join ${pendingConversations.size} existing MLS conversation(s)")
-                    coroutineScope {
-                        pendingConversations.map { conversation ->
-                            async {
-                                joinRetrying(transactionContext, conversation)
-                            }
-                        }
-                    }.foldToEitherWhileRight(Unit) { value, _ ->
-                        value.await() // Fail if one fails
+                    pendingConversations.chunked(maxConcurrentJoins).foldToEitherWhileRight(Unit) { batch, _ ->
+                        joinBatch(transactionContext, batch, keepRetryingOnFailure)
                     }
                 }
             }
         }
 
-    private suspend fun joinRetrying(transactionContext: CryptoTransactionContext, conversation: Conversation) =
-        joinExistingMLSConversationUseCase(transactionContext, conversation.id)
-            .flatMapLeft {
-                when (it) {
-                    is NetworkFailure -> {
-                        if (it is NetworkFailure.ServerMiscommunication
-                            && it.kaliumException is KaliumException.InvalidRequestError
-                        ) {
-                            kaliumLogger.w(
-                                "Failed to establish mls group for ${conversation.id.toLogString()} " +
-                                        "due to invalid request error, skipping."
-                            )
-                            Either.Right(Unit)
-                        } else {
-                            kaliumLogger.w(
-                                "Failed to establish mls group for ${conversation.id.toLogString()} " +
-                                        "due to network failure"
-                            )
-                            Either.Left(it)
-                        }
-                    }
+    private suspend fun joinBatch(
+        transactionContext: CryptoTransactionContext,
+        batch: List<Conversation>,
+        keepRetryingOnFailure: Boolean,
+    ): Either<CoreFailure, Unit> = coroutineScope {
+        batch.map { conversation ->
+            async {
+                joinRetrying(transactionContext, conversation, keepRetryingOnFailure)
+            }
+        }
+    }.foldToEitherWhileRight(Unit) { value, _ ->
+        value.await()
+    }
 
-                    is CoreFailure.MissingKeyPackages -> {
-                        kaliumLogger.w(
-                            "Failed to establish mls group for ${conversation.id.toLogString()} " +
-                                    "since some participants are out of key packages, skipping."
-                        )
-                        Either.Right(Unit)
-                    }
-
-                    else -> {
-                        kaliumLogger.w(
-                            "Failed to establish mls group for ${conversation.id.toLogString()} " +
-                                    "due to $it, skipping.."
-                        )
-                        Either.Right(Unit)
-                    }
+    private suspend fun joinRetrying(
+        transactionContext: CryptoTransactionContext,
+        conversation: Conversation,
+        keepRetryingOnFailure: Boolean,
+        attempt: Int = 0,
+    ): Either<CoreFailure, Unit> {
+        return when (val result = joinExistingMLSConversationUseCase(transactionContext, conversation.id)) {
+            is Either.Left -> {
+                val failure = result.value
+                if (keepRetryingOnFailure && failure.isThrottleFailure() && attempt < maxThrottleRetries) {
+                    val nextAttempt = attempt + 1
+                    val delayMs = throttleRetryDelayMs * nextAttempt
+                    kaliumLogger.w(
+                        "Failed to establish mls group for ${conversation.id.toLogString()} due to throttling; " +
+                            "retrying (${nextAttempt}/${maxThrottleRetries}) in ${delayMs}ms."
+                    )
+                    delay(delayMs)
+                    joinRetrying(transactionContext, conversation, keepRetryingOnFailure, nextAttempt)
+                } else {
+                    handleJoinFailure(failure, conversation)
                 }
             }
+
+            is Either.Right -> Either.Right(Unit)
+        }
+    }
+
+    private fun handleJoinFailure(failure: CoreFailure, conversation: Conversation): Either<CoreFailure, Unit> =
+        when (failure) {
+            is NetworkFailure -> {
+                if (failure.isThrottleFailure()) {
+                    kaliumLogger.w(
+                        "Failed to establish mls group for ${conversation.id.toLogString()} " +
+                            "due to throttling, propagating failure."
+                    )
+                    Either.Left(failure)
+                } else if (failure is NetworkFailure.ServerMiscommunication
+                    && failure.kaliumException is KaliumException.InvalidRequestError
+                ) {
+                    kaliumLogger.w(
+                        "Failed to establish mls group for ${conversation.id.toLogString()} " +
+                            "due to invalid request error, skipping."
+                    )
+                    Either.Right(Unit)
+                } else {
+                    kaliumLogger.w(
+                        "Failed to establish mls group for ${conversation.id.toLogString()} due to network failure"
+                    )
+                    Either.Left(failure)
+                }
+            }
+
+            is CoreFailure.MissingKeyPackages -> {
+                kaliumLogger.w(
+                    "Failed to establish mls group for ${conversation.id.toLogString()} " +
+                        "since some participants are out of key packages, skipping."
+                )
+                Either.Right(Unit)
+            }
+
+            else -> {
+                kaliumLogger.w(
+                    "Failed to establish mls group for ${conversation.id.toLogString()} due to $failure, skipping.."
+                )
+                Either.Right(Unit)
+            }
+        }
+
+    private fun CoreFailure.isThrottleFailure(): Boolean =
+        this is NetworkFailure.ServerMiscommunication &&
+            (kaliumException as? KaliumException.InvalidRequestError)?.isTooManyRequests() == true
+
+    private companion object {
+        const val DEFAULT_MAX_CONCURRENT_JOINS = 4
+        const val DEFAULT_MAX_THROTTLE_RETRIES = 3
+        const val DEFAULT_THROTTLE_RETRY_DELAY_MS = 250L
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationsUseCase.kt
@@ -22,7 +22,6 @@ import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
-import com.wire.kalium.common.functional.flatMapLeft
 import com.wire.kalium.common.functional.foldToEitherWhileRight
 import com.wire.kalium.common.functional.getOrElse
 import com.wire.kalium.common.logger.kaliumLogger
@@ -110,7 +109,7 @@ internal class JoinExistingMLSConversationsUseCaseImpl(
                     val delayMs = throttleRetryDelayMs * nextAttempt
                     kaliumLogger.w(
                         "Failed to establish mls group for ${conversation.id.toLogString()} due to throttling; " +
-                            "retrying (${nextAttempt}/${maxThrottleRetries}) in ${delayMs}ms."
+                            "retrying ($nextAttempt/$maxThrottleRetries) in ${delayMs}ms."
                     )
                     delay(delayMs)
                     joinRetrying(transactionContext, conversation, keepRetryingOnFailure, nextAttempt)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCaseTest.kt
@@ -44,6 +44,7 @@ import io.mockative.coEvery
 import io.mockative.coVerify
 import io.mockative.every
 import io.mockative.mock
+import io.mockative.once
 import io.mockative.twice
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -133,12 +134,12 @@ class JoinExistingMLSConversationsUseCaseTest {
     }
 
     @Test
-    fun givenServerMiscommunicationWithInvalidRequestError_WhenJoiningMLSConversation_ThenSkipConversation() = runTest {
+    fun givenServerMiscommunicationWithNonThrottleInvalidRequestError_WhenJoiningMLSConversation_ThenSkipConversation() = runTest {
         val (arrangement, joinExistingMLSConversationsUseCase) = Arrangement()
             .withIsMLSSupported(true)
             .withHasRegisteredMLSClient(true)
             .withGetConversationsByGroupStateSuccessful()
-            .withJoinExistingMLSConversationReturningServerMiscommunication()
+            .withJoinExistingMLSConversationReturningInvalidRequestServerMiscommunication()
             .arrange()
 
         joinExistingMLSConversationsUseCase().shouldSucceed()
@@ -152,7 +153,50 @@ class JoinExistingMLSConversationsUseCaseTest {
         }.wasNotInvoked()
     }
 
-    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    @Test
+    fun givenThrottleInvalidRequestErrorWithoutRetry_WhenJoiningMLSConversation_ThenPropagateFailure() = runTest {
+        val (arrangement, joinExistingMLSConversationsUseCase) = Arrangement()
+            .withIsMLSSupported(true)
+            .withHasRegisteredMLSClient(true)
+            .withGetConversationsByGroupStateSuccessful(listOf(Arrangement.MLS_CONVERSATION1))
+            .withJoinExistingMLSConversationReturningThrottleServerMiscommunication()
+            .arrange()
+
+        joinExistingMLSConversationsUseCase(keepRetryingOnFailure = false).shouldFail {
+            assertIs<NetworkFailure.ServerMiscommunication>(it)
+        }
+
+        coVerify {
+            arrangement.joinExistingMLSConversationUseCase.invoke(any(), any(), any())
+        }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenThrottleInvalidRequestErrorWithRetry_WhenJoiningMLSConversation_ThenRetryBeforePropagatingFailure() = runTest {
+        val (arrangement, joinExistingMLSConversationsUseCase) = Arrangement(
+            maxThrottleRetries = 2,
+            throttleRetryDelayMs = 1,
+        )
+            .withIsMLSSupported(true)
+            .withHasRegisteredMLSClient(true)
+            .withGetConversationsByGroupStateSuccessful(listOf(Arrangement.MLS_CONVERSATION1))
+            .withJoinExistingMLSConversationReturningThrottleServerMiscommunication()
+            .arrange()
+
+        joinExistingMLSConversationsUseCase().shouldFail {
+            assertIs<NetworkFailure.ServerMiscommunication>(it)
+        }
+
+        coVerify {
+            arrangement.joinExistingMLSConversationUseCase.invoke(any(), any(), any())
+        }.wasInvoked(exactly = 3)
+    }
+
+    private class Arrangement(
+        private val maxConcurrentJoins: Int = 4,
+        private val maxThrottleRetries: Int = 3,
+        private val throttleRetryDelayMs: Long = 250L,
+    ) : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
         val featureSupport = mock(FeatureSupport::class)
         val clientRepository = mock(ClientRepository::class)
         val conversationRepository = mock(ConversationRepository::class)
@@ -160,7 +204,14 @@ class JoinExistingMLSConversationsUseCaseTest {
         val joinExistingMLSConversationUseCase = mock(JoinExistingMLSConversationUseCase::class)
 
         suspend fun arrange() = this to JoinExistingMLSConversationsUseCaseImpl(
-            featureSupport, clientRepository, conversationRepository, joinExistingMLSConversationUseCase, cryptoTransactionProvider
+            featureSupport = featureSupport,
+            clientRepository = clientRepository,
+            conversationRepository = conversationRepository,
+            joinExistingMLSConversationUseCase = joinExistingMLSConversationUseCase,
+            transactionProvider = cryptoTransactionProvider,
+            maxConcurrentJoins = maxConcurrentJoins,
+            maxThrottleRetries = maxThrottleRetries,
+            throttleRetryDelayMs = throttleRetryDelayMs,
         ).also {
             withTransactionReturning(Either.Right(Unit))
         }
@@ -210,7 +261,7 @@ class JoinExistingMLSConversationsUseCaseTest {
             }.returns(Either.Right(result))
         }
 
-        suspend fun withJoinExistingMLSConversationReturningServerMiscommunication() = apply {
+        suspend fun withJoinExistingMLSConversationReturningInvalidRequestServerMiscommunication() = apply {
             coEvery {
                 joinExistingMLSConversationUseCase.invoke(any(), any(), any())
             }.returns(
@@ -218,6 +269,20 @@ class JoinExistingMLSConversationsUseCaseTest {
                     NetworkFailure.ServerMiscommunication(
                         KaliumException.InvalidRequestError(
                             errorResponse = ErrorResponse(400, "Invalid LeafNode signature", "mls-protocol-error")
+                        )
+                    )
+                )
+            )
+        }
+
+        suspend fun withJoinExistingMLSConversationReturningThrottleServerMiscommunication() = apply {
+            coEvery {
+                joinExistingMLSConversationUseCase.invoke(any(), any(), any())
+            }.returns(
+                Either.Left(
+                    NetworkFailure.ServerMiscommunication(
+                        KaliumException.InvalidRequestError(
+                            errorResponse = ErrorResponse(420, "unknown status code", "throttled by ingress")
                         )
                     )
                 )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24096
<!--jira-description-action-hidden-marker-end-->
## Summary
- treat Wire throttling responses consistently during MLS join flows by recognizing both ingress `420` and backend `429` as too-many-requests conditions
- avoid unbounded `PENDING_JOIN` fan-out by processing existing MLS joins in smaller batches with conservative retry behavior for throttled requests
- keep non-throttle invalid-request handling unchanged while adding focused tests for throttle classification and MLS join behavior

## Why
Wire deployments can signal request pressure from more than one layer. Backend services use `429`, while ingress may reject bursty authenticated traffic with `420`. Kalium previously only recognized `429` as rate limiting, and the MLS existing-group join path treated generic invalid-request failures as skippable.

In practice that means bursty MLS join work can misclassify throttling as a generic invalid request, skip affected conversations, and continue with a partially recovered account state. This change makes throttling explicit in the MLS join path and reduces request pressure so recovery behaves more predictably under load.

## Details
- extends `InvalidRequestError.isTooManyRequests()` to cover Wire ingress `420` alongside `429`
- updates `JoinExistingMLSConversationsUseCase` to:
  - process pending joins with bounded concurrency
  - retry throttled failures conservatively when retrying is enabled
  - propagate throttled failures instead of silently treating them as generic invalid-request success
- adds targeted tests for throttle detection and MLS join retry/propagation behavior