### PR TITLE
ci: publish testservice image for release tags [WPB-22493]

### DIFF
--- a/.github/workflows/publish-testservice.yml
+++ b/.github/workflows/publish-testservice.yml
@@ -3,6 +3,7 @@ name: Build and publish image of Testservice to quay.io
 on:
   push:
     branches: ["develop"]
+    tags: ["android-v*", "test-service-v*"]
 
 jobs:
   quay_publish:
@@ -24,11 +25,20 @@ jobs:
           username: wire+testservice_kalium_bot
           password: ${{ secrets.QUAY_TESTSERVICE_PASSWORD }}
 
+      - name: Resolve image tags
+        id: image_tags
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            echo "tags=quay.io/wire/testservice:${GITHUB_REF_NAME},quay.io/wire/testservice:${GITHUB_SHA}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "tags=quay.io/wire/testservice:latest,quay.io/wire/testservice:${GITHUB_SHA}" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./tools/testservice/Dockerfile
           platforms: linux/amd64
+          tags: ${{ steps.image_tags.outputs.tags }}
           push: true
-          tags: quay.io/wire/testservice:latest,quay.io/wire/testservice:${{ github.sha }}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-22493
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- QA needed a faster and deterministic way to deploy specific `testservice` versions for verification and hotfix validation.
- The current image publishing flow only updated `quay.io/wire/testservice:latest`, which always follows `develop`, and did not provide release-tagged testservice images.
- This made it hard to quickly test or roll back a known Android-related testservice state in QA environments.

### Causes (Optional)

- The GitHub Actions workflow for testservice publishing was configured to push only `latest` on `develop`.
- There was no tag-based publishing path for release-aligned versions (for example Android release tags) or QA-specific ad-hoc tags.

### Solutions

- Updated the testservice publish workflow to trigger not only on `develop`, but also on tag pushes:
  - `android-v*`
  - `test-service-v*`
- Added dynamic image tagging logic:
  - On `develop`: push `quay.io/wire/testservice:latest` (and SHA tag, as already used on develop flow).
  - On tag builds: push `quay.io/wire/testservice:<tag>` (and SHA tag).
- Result:
  - `latest` remains the moving image from `develop`.
  - Android release tags can produce matching immutable testservice tags.
  - QA can also quickly push dedicated `test-service-v*` tags for fast validation of potential fixes without waiting for full Android release flow.