### PR TITLE
fix: default read receipts to true when mode is null or not set [WPB-23944]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/properties/UserPropertyRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/properties/UserPropertyRepository.kt
@@ -164,7 +164,7 @@ internal class UserPropertiesSyncDataSource(
         wrapApiRequest {
             propertiesApi.getPropertiesValues()
         }.flatMap { properties ->
-            val readReceiptsEnabled = properties.findIntValue(PropertyKey.WIRE_RECEIPT_MODE) == 1
+            val readReceiptsEnabled = properties.findIntValue(PropertyKey.WIRE_RECEIPT_MODE)?.let { it == 1 } ?: true
             val typingIndicatorEnabled = properties.findIntValue(PropertyKey.WIRE_TYPING_INDICATOR_MODE)?.let { it != 0 } ?: true
             val screenshotCensoringEnabled = properties.findIntValue(PropertyKey.WIRE_SCREENSHOT_CENSORING_MODE) == 1
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/properties/UserPropertyRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/properties/UserPropertyRepositoryTest.kt
@@ -145,7 +145,7 @@ class UserPropertyRepositoryTest {
 
     @Test
     fun whenSyncingPropertiesStatusesAndResponseIsEmptyJson_thenShouldPersistAllDefaults() = runTest {
-        // readReceipts defaults to false, typingIndicator defaults to true, screenshotCensoring defaults to false
+        // readReceipts defaults to true, typingIndicator defaults to true, screenshotCensoring defaults to false
         val (arrangement, repository) = Arrangement()
             .withGetPropertiesValuesReturning(JsonObject(emptyMap()))
             .withUpdateReadReceiptsLocallySuccess()
@@ -156,7 +156,7 @@ class UserPropertyRepositoryTest {
         val result = repository.syncPropertiesStatuses()
 
         result.shouldSucceed()
-        verifySuspend { arrangement.userConfigRepository.setReadReceiptsStatus(eq(false)) }
+        verifySuspend { arrangement.userConfigRepository.setReadReceiptsStatus(eq(true)) }
         verifySuspend { arrangement.userConfigRepository.setTypingIndicatorStatus(eq(true)) }
         verifySuspend { arrangement.userConfigRepository.setScreenshotCensoringConfig(eq(false)) }
     }
@@ -175,7 +175,7 @@ class UserPropertyRepositoryTest {
         val result = repository.syncPropertiesStatuses()
 
         result.shouldSucceed()
-        verifySuspend { arrangement.userConfigRepository.setReadReceiptsStatus(eq(false)) }
+        verifySuspend { arrangement.userConfigRepository.setReadReceiptsStatus(eq(true)) }
         verifySuspend { arrangement.userConfigRepository.setTypingIndicatorStatus(eq(false)) }
         verifySuspend { arrangement.userConfigRepository.setScreenshotCensoringConfig(eq(false)) }
     }
@@ -194,9 +194,52 @@ class UserPropertyRepositoryTest {
         val result = repository.syncPropertiesStatuses()
 
         result.shouldSucceed()
-        verifySuspend { arrangement.userConfigRepository.setReadReceiptsStatus(eq(false)) }
+        verifySuspend { arrangement.userConfigRepository.setReadReceiptsStatus(eq(true)) }
         verifySuspend { arrangement.userConfigRepository.setTypingIndicatorStatus(eq(true)) }
         verifySuspend { arrangement.userConfigRepository.setScreenshotCensoringConfig(eq(true)) }
+    }
+
+    @Test
+    fun whenSyncingPropertiesAndReadReceiptModeIsNull_thenShouldDefaultToTrue() = runTest {
+        val (arrangement, repository) = Arrangement()
+            .withGetPropertiesValuesReturning(
+                JsonObject(
+                    mapOf(
+                        PropertyKey.WIRE_TYPING_INDICATOR_MODE.key to JsonPrimitive(1),
+                        PropertyKey.WIRE_SCREENSHOT_CENSORING_MODE.key to JsonPrimitive(0),
+                    )
+                )
+            )
+            .withUpdateReadReceiptsLocallySuccess()
+            .withUpdateTypingIndicatorLocallySuccess()
+            .withUpdateScreenshotCensoringLocallySuccess()
+            .arrange()
+
+        val result = repository.syncPropertiesStatuses()
+
+        result.shouldSucceed()
+        verifySuspend { arrangement.userConfigRepository.setReadReceiptsStatus(eq(true)) }
+    }
+
+    @Test
+    fun whenSyncingPropertiesAndReadReceiptModeIsZero_thenShouldBeFalse() = runTest {
+        val (arrangement, repository) = Arrangement()
+            .withGetPropertiesValuesReturning(
+                JsonObject(
+                    mapOf(
+                        PropertyKey.WIRE_RECEIPT_MODE.key to JsonPrimitive(0),
+                    )
+                )
+            )
+            .withUpdateReadReceiptsLocallySuccess()
+            .withUpdateTypingIndicatorLocallySuccess()
+            .withUpdateScreenshotCensoringLocallySuccess()
+            .arrange()
+
+        val result = repository.syncPropertiesStatuses()
+
+        result.shouldSucceed()
+        verifySuspend { arrangement.userConfigRepository.setReadReceiptsStatus(eq(false)) }
     }
 
     @Test


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-23944
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

default read receipts to true when mode is null or not set
