### PR TITLE
feat: pass the shared-device cookie label through automated Nomad SSO flow (part 22) [WPB-24007]

### DIFF
--- a/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/unauthenticated/sso/InitiateParam.kt
+++ b/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/unauthenticated/sso/InitiateParam.kt
@@ -17,7 +17,12 @@
  */
 package com.wire.kalium.network.api.unauthenticated.sso
 
-sealed class InitiateParam(open val uuid: String) {
-    data class WithoutRedirect(override val uuid: String) : InitiateParam(uuid)
-    data class WithRedirect(val success: String, val error: String, override val uuid: String) : InitiateParam(uuid)
+sealed class InitiateParam(open val uuid: String, open val label: String? = null) {
+    data class WithoutRedirect(override val uuid: String, override val label: String? = null) : InitiateParam(uuid, label)
+    data class WithRedirect(
+        val success: String,
+        val error: String,
+        override val uuid: String,
+        override val label: String? = null,
+    ) : InitiateParam(uuid, label)
 }

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/SSOLoginApiV0.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/SSOLoginApiV0.kt
@@ -54,6 +54,7 @@ internal open class SSOLoginApiV0 internal constructor(
 
     override suspend fun initiate(param: InitiateParam): NetworkResponse<String> = HttpRequestBuilder().apply {
         url.appendPathSegments(PATH_SSO, PATH_INITIATE, param.uuid)
+        param.label?.let { parameter(QUERY_LABEL, it) }
         if (param is InitiateParam.WithRedirect) {
             parameter(QUERY_SUCCESS_REDIRECT, param.success)
             parameter(QUERY_ERROR_REDIRECT, param.error)
@@ -118,5 +119,6 @@ internal open class SSOLoginApiV0 internal constructor(
         const val PATH_SELF = "self"
         const val QUERY_SUCCESS_REDIRECT = "success_redirect"
         const val QUERY_ERROR_REDIRECT = "error_redirect"
+        const val QUERY_LABEL = "label"
     }
 }

--- a/data/network/src/commonTest/kotlin/com/wire/kalium/api/v0/user/login/SSOLoginApiV0Test.kt
+++ b/data/network/src/commonTest/kotlin/com/wire/kalium/api/v0/user/login/SSOLoginApiV0Test.kt
@@ -86,6 +86,29 @@ internal class SSOLoginApiV0Test : ApiTest() {
     }
 
     @Test
+    fun givenBEResponseSuccess_whenCallingInitiateSSOEndpointWithRedirectAndLabel_thenRequestConfiguredCorrectly() = runTest {
+        val uuid = "uuid"
+        val param =
+            InitiateParam.WithRedirect(uuid = uuid, success = "wire://success", error = "wire://error", label = "shared-device")
+        val expectedPathAndQuery =
+            "$PATH_SSO_INITIATE/$uuid?label=shared-device&success_redirect=wire%3A%2F%2Fsuccess&error_redirect=wire%3A%2F%2Ferror"
+        val networkClient = mockUnauthenticatedNetworkClient(
+            "",
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertHead()
+                assertPathAndQueryEqual(expectedPathAndQuery)
+            }
+        )
+        val ssoApi: SSOLoginApi = SSOLoginApiV0(networkClient)
+        val actual = ssoApi.initiate(param)
+
+        assertIs<NetworkResponse.Success<String>>(actual)
+        assertEquals(expectedPathAndQuery, Url(actual.value).encodedPathAndQuery)
+        assertEquals("${Url(TEST_BACKEND.links.api).protocolWithAuthority}$expectedPathAndQuery", actual.value)
+    }
+
+    @Test
     fun givenBEResponseSuccess_whenCallingFinalizeSSOEndpointWithRedirect_thenRequestConfiguredCorrectly() = runTest {
         val cookie = "cookie"
         val networkClient = mockUnauthenticatedNetworkClient(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/login/SSOLoginRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/login/SSOLoginRepository.kt
@@ -35,10 +35,11 @@ internal interface SSOLoginRepository {
     suspend fun initiate(
         uuid: String,
         successRedirect: String,
-        errorRedirect: String
+        errorRedirect: String,
+        cookieLabel: String? = null,
     ): Either<NetworkFailure, String>
 
-    suspend fun initiate(uuid: String): Either<NetworkFailure, String>
+    suspend fun initiate(uuid: String, cookieLabel: String? = null): Either<NetworkFailure, String>
 
     suspend fun finalize(cookie: String): Either<NetworkFailure, String>
 
@@ -58,13 +59,14 @@ internal class SSOLoginRepositoryImpl(
     override suspend fun initiate(
         uuid: String,
         successRedirect: String,
-        errorRedirect: String
+        errorRedirect: String,
+        cookieLabel: String?,
     ): Either<NetworkFailure, String> = wrapApiRequest {
-        ssoLogin.initiate(InitiateParam.WithRedirect(successRedirect, errorRedirect, uuid))
+        ssoLogin.initiate(InitiateParam.WithRedirect(successRedirect, errorRedirect, uuid, cookieLabel))
     }
 
-    override suspend fun initiate(uuid: String): Either<NetworkFailure, String> = wrapApiRequest {
-        ssoLogin.initiate(InitiateParam.WithoutRedirect(uuid))
+    override suspend fun initiate(uuid: String, cookieLabel: String?): Either<NetworkFailure, String> = wrapApiRequest {
+        ssoLogin.initiate(InitiateParam.WithoutRedirect(uuid, cookieLabel))
     }
 
     override suspend fun finalize(cookie: String): Either<NetworkFailure, String> = wrapApiRequest {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/sso/SSOInitiateLoginUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/sso/SSOInitiateLoginUseCase.kt
@@ -51,9 +51,10 @@ internal data class SSORedirects(val success: String, val error: String) {
 public interface SSOInitiateLoginUseCase {
     public sealed class Param {
         public abstract val ssoCode: String
+        public open val cookieLabel: String? = null
 
-        public data class WithoutRedirect(override val ssoCode: String) : Param()
-        public data class WithRedirect(override val ssoCode: String) : Param()
+        public data class WithoutRedirect(override val ssoCode: String, override val cookieLabel: String? = null) : Param()
+        public data class WithRedirect(override val ssoCode: String, override val cookieLabel: String? = null) : Param()
     }
 
     /**
@@ -77,13 +78,14 @@ internal class SSOInitiateLoginUseCaseImpl(
             }
         }
         when (this) {
-            is SSOInitiateLoginUseCase.Param.WithoutRedirect -> ssoLoginRepository.initiate(validUuid)
+            is SSOInitiateLoginUseCase.Param.WithoutRedirect -> ssoLoginRepository.initiate(validUuid, cookieLabel)
             is SSOInitiateLoginUseCase.Param.WithRedirect -> {
                 val redirects = SSORedirects(serverConfig.id)
                 ssoLoginRepository.initiate(
                     validUuid,
                     redirects.success,
-                    redirects.error
+                    redirects.error,
+                    cookieLabel,
                 )
             }
         }.fold({

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/sso/SSOInitiateLoginUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/sso/SSOInitiateLoginUseCaseTest.kt
@@ -133,9 +133,28 @@ class SSOInitiateLoginUseCaseTest {
             assertEquals(result, SSOInitiateLoginResult.Success(TEST_RESPONSE))
         }
 
+    @Test
+    fun givenCookieLabel_whenInitiatingWithRedirect_thenPassCookieLabelToRepository() =
+        runTest {
+            val expectedRedirects = SSORedirects(serverConfig.id)
+            every {
+                validateUUIDUseCase.invoke(TEST_CODE)
+            }.returns(ValidateSSOCodeResult.Valid(TEST_UUID))
+            coEvery {
+                ssoLoginRepository.initiate(TEST_UUID, expectedRedirects.success, expectedRedirects.error, TEST_COOKIE_LABEL)
+            }.returns(Either.Right(TEST_RESPONSE))
+
+            val result = ssoInitiateLoginUseCase(
+                SSOInitiateLoginUseCase.Param.WithRedirect(TEST_CODE, TEST_COOKIE_LABEL)
+            )
+
+            assertEquals(result, SSOInitiateLoginResult.Success(TEST_RESPONSE))
+        }
+
     private companion object {
         const val TEST_UUID = "fd994b20-b9af-11ec-ae36-00163e9b33ca"
         const val TEST_CODE = "wire-$TEST_UUID"
         const val TEST_RESPONSE = "wire/response"
+        const val TEST_COOKIE_LABEL = "shared-device"
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24007
<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

- Automated Nomad login did not pass the RFC-defined cookie label into the SSO initiate flow.
- The app therefore could not mark the issued SSO cookie as the shared-device Nomad cookie during the automated login path.

### Causes

- The automated Nomad app flow parsed the documented `automated_login` payload and carried the Nomad host, but it did not inject the shared-device cookie label into SSO initiation.
- The SSO initiate path supported redirects, but the Nomad label was not threaded through from the app flow into the request.

### Solutions

- Added an app-level constant for the Nomad cookie label: `shared-device`.
- Applied that label only for the automated Nomad login path.
- Threaded the label through the app navigation/login flow into SSO initiation.
- Updated the SSO initiate request so the backend receives `label=shared-device` as described in the RFC.
- Preserved the existing session-to-client-registration behavior so the stored cookie label is still available for later client registration.
- Added automated test coverage for:
  - parsing the documented automated Nomad login payload
  - injecting `shared-device` only for automated Nomad login
  - forwarding the label into SSO initiation
  - sending `label=shared-device` on the SSO initiate request

### Dependencies

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

#### How to Test

- Run the automated Nomad login flow with the documented `automated_login` payload:
```json
{
  "backendConfig": "https://example.com",
  "ssoCode": "wire-<uuid>",
  "nomadProfilesHost": "https://nomad.example.com",
  "sigNomadProfilesHost": "<signature>"
}
```

### Notes

- This PR only covers the automated Nomad SSO cookie-label/data-flow part of the RFC.
- It does not implement the later Nomad sync/backup/crypto-state sequencing described in the document.
- If the backend contract changes, the app constant should stay aligned with the RFC value `shared-device`.

### Attachments

#### Data Flow Diagram

```mermaid
flowchart TD
    A["external launcher"]
    B["automated_login intent"]
    C["IntentsProcessor"]
    D["WireActivityViewModel"]
    E["Inject app constant: shared-device"]
    F["OnAutomaticLogin / SSOCodeAutoLogin"]
    G["NewLoginViewModel or LoginSSOViewModel"]
    H["LoginSSOViewModelExtension"]
    I["SSOInitiateLoginUseCase"]
    J["SSOLoginRepository"]
    K["SSOLoginApiV0"]
    L["GET /sso/initiate-login/{id}?label=shared-device"]
    M["SSO cookie/session established"]
    N["Stored session keeps cookie label"]
    O["Existing client registration flow reuses stored cookie label"]

    A --> B
    B --> C
    C --> D
    D --> E
    E --> F
    F --> G
    G --> H
    H --> I
    I --> J
    J --> K
    K --> L
    L --> M
    M --> N
    N --> O

```
