### PR TITLE
fix: duplicate MLS welcome handling on sync restart and map backend welcome time [WPB-24051]

### DIFF
--- a/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/notification/EventContentDTO.kt
+++ b/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/notification/EventContentDTO.kt
@@ -319,7 +319,8 @@ sealed class EventContentDTO {
             @SerialName("qualified_conversation") val qualifiedConversation: ConversationId,
             @SerialName("qualified_from") val qualifiedFrom: UserId,
             @SerialName("data") val message: String,
-            @SerialName("from") val from: String
+            @SerialName("from") val from: String,
+            @SerialName("time") val time: Instant? = null
         ) : Conversation()
 
         @Serializable

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -53,6 +53,8 @@ import com.wire.kalium.network.api.authenticated.properties.PropertyKey.WIRE_REC
 import com.wire.kalium.network.api.authenticated.properties.PropertyKey.WIRE_TYPING_INDICATOR_MODE
 import com.wire.kalium.network.api.model.getCompleteAssetOrNull
 import com.wire.kalium.network.api.model.getPreviewAssetOrNull
+import com.wire.kalium.util.DateTimeUtil
+import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.SerializationException
@@ -317,9 +319,9 @@ internal class EventMapper(
     ) = Event.Conversation.MLSWelcome(
         id,
         eventContentDTO.qualifiedConversation.toModel(),
-
         eventContentDTO.qualifiedFrom.toModel(),
         eventContentDTO.message,
+        timestampIso = eventContentDTO.time?.toIsoDateTimeString() ?: DateTimeUtil.currentIsoDateTimeString()
     )
 
     private fun newMessage(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt
@@ -76,38 +76,38 @@ internal class IncrementalSyncWorkerImpl(
             }
             .filterIsInstance<EventStreamData.NewEvents>()
             .collect { streamData ->
-                val envelopes = streamData.eventList
-                kaliumLogger.d("$TAG Received ${envelopes.size} events to process")
-                transactionProvider.transaction("processEvents") { context ->
-                    databaseBuilder.dbInvalidationController.runMuted {
-                        envelopes.map { envelope -> eventProcessor.processEvent(context, envelope) }
-                            .foldToEitherWhileRight(mutableListOf<String>()) { eventEither, acc ->
-                                eventEither.map { eventId ->
-                                    eventId?.let(acc::add)
-                                    acc
+                withContext(NonCancellable) {
+                    val envelopes = streamData.eventList
+                    kaliumLogger.d("$TAG Received ${envelopes.size} events to process")
+                    transactionProvider.transaction("processEvents") { context ->
+                        databaseBuilder.dbInvalidationController.runMuted {
+                            envelopes.map { envelope -> eventProcessor.processEvent(context, envelope) }
+                                .foldToEitherWhileRight(mutableListOf<String>()) { eventEither, acc ->
+                                    eventEither.map { eventId ->
+                                        eventId?.let(acc::add)
+                                        acc
+                                    }
                                 }
-                            }
-                            .flatMap { eventIds ->
-                                eventProcessor.flushPendingSideEffects().map { eventIds }
-                            }
-                    }
-                }
-                    .onSuccess { eventIds ->
-                        if (eventIds.isEmpty()) {
-                            logger.i("No events to mark as processed")
-                            return@onSuccess
+                                .flatMap { eventIds ->
+                                    eventProcessor.flushPendingSideEffects().map { eventIds }
+                                }
                         }
+                    }
+                        .onSuccess { eventIds ->
+                            if (eventIds.isEmpty()) {
+                                logger.i("No events to mark as processed")
+                                return@onSuccess
+                            }
 
-                        withContext(NonCancellable) {
                             eventRepository.setEventsAsProcessed(eventIds)
+                                .onSuccess {
+                                    logger.i("${eventIds.size} events set as processed")
+                                }
                         }
-                            .onSuccess {
-                                logger.i("${eventIds.size} events set as processed")
-                            }
-                    }
-                    .onFailure {
-                        throw KaliumSyncException("Processing failed", it)
-                    }
+                        .onFailure {
+                            throw KaliumSyncException("Processing failed", it)
+                        }
+                }
             }
         logger.withFeatureId(SYNC).i("SYNC Finished gathering and processing events")
     }.distinctUntilChanged()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandler.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.common.error.wrapMLSRequest
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
 import com.wire.kalium.common.functional.flatMapLeft
+import com.wire.kalium.common.functional.fold
 import com.wire.kalium.common.functional.map
 import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.common.functional.onSuccess
@@ -98,12 +99,20 @@ internal class MLSWelcomeEventHandlerImpl(
             .flatMapLeft {
                 when (it) {
                     is MLSFailure.OrphanWelcome -> {
-                        kaliumLogger.w("$TAG: Discarding welcome and joining existing conversation by external commit")
-                        joinExistingMLSConversation(
-                            transactionContext = transactionContext,
-                            conversationId = event.conversationId,
-                        ).map {
-                            kaliumLogger.d("$TAG: Successfully joined existing MLS conversation")
+                        if (isAlreadyEstablishedLocally(mlsContext, event.conversationId)) {
+                            kaliumLogger.w(
+                                "$TAG: OrphanWelcome for already established local MLS group. " +
+                                    "Treating as duplicate welcome and skipping external commit rejoin."
+                            )
+                            Unit.right()
+                        } else {
+                            kaliumLogger.w("$TAG: Discarding welcome and joining existing conversation by external commit")
+                            joinExistingMLSConversation(
+                                transactionContext = transactionContext,
+                                conversationId = event.conversationId,
+                            ).map {
+                                kaliumLogger.d("$TAG: Successfully joined existing MLS conversation")
+                            }
                         }
                     }
 
@@ -134,6 +143,20 @@ internal class MLSWelcomeEventHandlerImpl(
             }
             .onFailure { eventLogger.logFailure(it) }
     }
+
+    private suspend fun isAlreadyEstablishedLocally(
+        mlsContext: MlsCoreCryptoContext,
+        conversationId: ConversationId
+    ): Boolean = conversationRepository.getConversationProtocolInfo(conversationId)
+        .map { it as? Conversation.ProtocolInfo.MLSCapable }
+        .flatMap { mlsProtocol ->
+            when {
+                mlsProtocol == null -> Either.Right(false)
+                mlsProtocol.groupState != Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED -> Either.Right(false)
+                else -> wrapMLSRequest { mlsContext.conversationExists(mlsProtocol.groupId.toCrypto()) }
+            }
+        }
+        .fold({ false }, { it })
 
     private suspend fun processWelcomeMessageWithRecovery(
         mlsContext: MlsCoreCryptoContext,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorkerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorkerTest.kt
@@ -39,10 +39,12 @@ import io.mockative.coVerify
 import io.mockative.eq
 import io.mockative.mock
 import io.mockative.once
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -174,6 +176,40 @@ class IncrementalSyncWorkerTest {
         coVerify {
             arrangement.eventRepository.setEventsAsProcessed(any())
         }.wasNotInvoked()
+    }
+
+    @Test
+    fun givenCancellationDuringEventProcessing_whenPerformingIncrementalSync_thenWorkerMarksEventAsProcessed() = runTest {
+        val envelope = TestEvent.memberJoin().wrapInEnvelope()
+        val eventId = envelope.event.id
+        val processingStarted = CompletableDeferred<Unit>()
+        val allowProcessingToFinish = CompletableDeferred<Unit>()
+
+        val (arrangement, worker) = Arrangement()
+            .withEventGathererReturning(flowOf(EventStreamData.NewEvents(listOf(envelope))))
+            .withSetEventsAsProcessedReturning(Either.Right(Unit))
+            .arrange()
+
+        coEvery {
+            arrangement.eventProcessor.processEvent(any(), eq(envelope))
+        }.invokes {
+            processingStarted.complete(Unit)
+            allowProcessingToFinish.await()
+            Either.Right(eventId)
+        }
+
+        val job = launch {
+            worker.processEventsFlow().collect()
+        }
+
+        processingStarted.await()
+        job.cancel()
+        allowProcessingToFinish.complete(Unit)
+        job.join()
+
+        coVerify {
+            arrangement.eventRepository.setEventsAsProcessed(eq(listOf(eventId)))
+        }.wasInvoked(exactly = once)
     }
 
     private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandlerTest.kt
@@ -281,6 +281,64 @@ class MLSWelcomeEventHandlerTest {
         }.wasInvoked(exactly = twice)
     }
 
+    @Test
+    fun givenOrphanWelcomeAndLocalGroupAlreadyEstablished_whenHandlingWelcome_thenShouldSkipExternalCommitRejoin() = runTest {
+        val orphanWelcomeException = CommonizedMLSException(
+            MLSFailure.OrphanWelcome,
+            IllegalStateException("key package already deleted locally")
+        )
+        val (arrangement, mlsWelcomeEventHandler) = arrange {
+            withFetchConversationIfUnknownSucceeding()
+            withMLSClientProcessingOfWelcomeMessageFailsWith(orphanWelcomeException)
+            withConversationProtocolInfo(
+                Either.Right(
+                    TestConversation.MLS_PROTOCOL_INFO.copy(
+                        groupState = Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED
+                    )
+                )
+            )
+            withMLSConversationExists(true)
+            withRefillKeyPackagesReturning(RefillKeyPackagesResult.Success)
+        }
+
+        mlsWelcomeEventHandler.handle(arrangement.transactionContext, WELCOME_EVENT).shouldSucceed()
+
+        coVerify {
+            arrangement.joinExistingMLSConversation.invoke(any(), any(), any())
+        }.wasNotInvoked()
+
+        coVerify {
+            arrangement.conversationRepository.updateConversationGroupState(any(), any())
+        }.wasNotInvoked()
+    }
+
+    @Test
+    fun givenOrphanWelcomeAndLocalGroupNotEstablished_whenHandlingWelcome_thenShouldRejoinByExternalCommit() = runTest {
+        val orphanWelcomeException = CommonizedMLSException(
+            MLSFailure.OrphanWelcome,
+            IllegalStateException("key package already deleted locally")
+        )
+        val (arrangement, mlsWelcomeEventHandler) = arrange {
+            withFetchConversationIfUnknownSucceeding()
+            withMLSClientProcessingOfWelcomeMessageFailsWith(orphanWelcomeException)
+            withConversationProtocolInfo(
+                Either.Right(
+                    TestConversation.MLS_PROTOCOL_INFO.copy(
+                        groupState = Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN
+                    )
+                )
+            )
+            withJoinExistingMLSConversationReturning(Either.Right(Unit))
+            withRefillKeyPackagesReturning(RefillKeyPackagesResult.Success)
+        }
+
+        mlsWelcomeEventHandler.handle(arrangement.transactionContext, WELCOME_EVENT).shouldSucceed()
+
+        coVerify {
+            arrangement.joinExistingMLSConversation.invoke(any(), eq(CONVERSATION_ID), any())
+        }.wasInvoked(exactly = once)
+    }
+
     private class Arrangement(private val block: suspend Arrangement.() -> Unit) :
         ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
         FetchConversationIfUnknownUseCaseArrangement by FetchConversationIfUnknownUseCaseArrangementImpl(),
@@ -326,6 +384,18 @@ class MLSWelcomeEventHandlerTest {
             coEvery {
                 mlsContext.wipeConversation(any())
             }.returns(Unit)
+        }
+
+        suspend fun withMLSConversationExists(exists: Boolean) = apply {
+            coEvery {
+                mlsContext.conversationExists(any())
+            }.returns(exists)
+        }
+
+        suspend fun withJoinExistingMLSConversationReturning(result: Either<CoreFailure, Unit>) = apply {
+            coEvery {
+                joinExistingMLSConversation.invoke(any(), any(), any())
+            }.returns(result)
         }
 
         suspend fun withCheckRevocationListResult() {

--- a/test/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/NotificationEventsResponseJson.kt
+++ b/test/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/NotificationEventsResponseJson.kt
@@ -98,7 +98,8 @@ object NotificationEventsResponseJson {
             |     "domain": "${eventData.qualifiedFrom.domain}"
             |  },
             |  "data": "${eventData.message}",
-            |  "from": "${eventData.from}"
+            |  "from": "${eventData.from}",
+            |  "time": "${eventData.time}"
             |}
         """.trimMargin()
     }
@@ -108,7 +109,8 @@ object NotificationEventsResponseJson {
             ConversationId("e16babfa-308b-414e-b6e0-c59517f723db", "staging.zinfra.io"),
             QualifiedID("76ebeb16-a849-4be4-84a7-157654b492cf", "staging.zinfra.io"),
             "AQABAAAAibLvHZAyYCHDxb+y8axOIdEAILa77VeJo1Yd8AfJKE009zwUxXuu7mAamu",
-            "71ff8872e468a970"
+            "71ff8872e468a970",
+            Instant.parse("2022-04-12T13:57:02.414Z")
         ),
         mlsWelcomeSerializer
     )


### PR DESCRIPTION


----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
- The same `Conversation.MLSWelcome` event could be processed twice after incremental sync cancellation/restart, leading to `OrphanWelcome` and unnecessary recovery flow.
- `MLSWelcome` logs used a locally generated `timestampIso` when payload time was not mapped, making timeline/debugging misleading.
- In `OrphanWelcome` cases where the MLS group was already established locally, the client could still trigger external-commit rejoin.

### Causes (Optional)
- Event processing and `setEventsAsProcessed(...)` could be interrupted by sync cancellation before the event was marked as processed.
- `ConversationMLSWelcome` DTO did not map backend `time`, so mapper used local `now`.
- `OrphanWelcome` path did not differentiate between true first-time failure and duplicate welcome for an already established local group.

### Solutions
- Wrapped incremental event-batch processing in `NonCancellable` so marking events as processed completes even if sync is canceled.
- Added regression test: cancellation during event processing still results in `setEventsAsProcessed(...)`.
- Added backend `time` field to `ConversationMLSWelcome` DTO and mapped it to `MLSWelcome.timestampIso` (with fallback only if missing).
- Updated notification mock payloads/tests to include `time`.
- Improved `MLSWelcomeEventHandler` for `OrphanWelcome`: if group is already `ESTABLISHED` locally and exists in core-crypto, treat as duplicate and skip external-commit rejoin.
- Added tests for both `OrphanWelcome` branches: skip rejoin when already established, rejoin when not established.