### PR TITLE
feat: implement validation for single active Nomad user session (part 24) [WPB-24067]

### DIFF
--- a/data/persistence/src/commonMain/db_global/com/wire/kalium/persistence/Accounts.sq
+++ b/data/persistence/src/commonMain/db_global/com/wire/kalium/persistence/Accounts.sq
@@ -102,3 +102,6 @@ FROM Accounts
 INNER JOIN ServerConfiguration
     ON Accounts.server_config_id = ServerConfiguration.id
 WHERE Accounts.logout_reason IS NULL;
+
+doesValidNomadAccountExist:
+SELECT EXISTS(SELECT 1 FROM Accounts WHERE logout_reason IS NULL AND nomad_service_url IS NOT NULL);

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/daokaliumdb/AccountsDAO.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/daokaliumdb/AccountsDAO.kt
@@ -185,6 +185,7 @@ interface AccountsDAO {
     suspend fun getAllValidAccountPersistentWebSocketStatus(): Flow<List<PersistentWebSocketStatusEntity>>
     suspend fun getAccountManagedBy(userIDEntity: UserIDEntity): ManagedByEntity?
     suspend fun validAccountWithServerConfigId(): Map<UserIDEntity, ServerConfigEntity>
+    suspend fun doesValidNomadAccountExist(): Boolean
 }
 
 @Suppress("TooManyFunctions")
@@ -341,4 +342,8 @@ internal class AccountsDAOImpl internal constructor(
 
     override fun fullAccountInfo(userIDEntity: UserIDEntity): FullAccountEntity? =
         queries.fullAccountInfo(userIDEntity, mapper = mapper::fromFullAccountInfo).executeAsOneOrNull()
+
+    override suspend fun doesValidNomadAccountExist(): Boolean = withContext(queriesContext) {
+        queries.doesValidNomadAccountExist().executeAsOne()
+    }
 }

--- a/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/globalDB/AccountsDAOTest.kt
+++ b/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/globalDB/AccountsDAOTest.kt
@@ -397,6 +397,42 @@ class AccountsDAOTest : GlobalDBBaseTest() {
         assertNull(reInsertedAccount?.nomadServiceUrl)
     }
 
+    @Test
+    fun givenNoAccounts_whenCallingDoesValidNomadAccountExist_thenFalseIsReturned() = runTest {
+        val result = globalDatabaseBuilder.accountsDAO.doesValidNomadAccountExist()
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun givenOnlyNormalAccounts_whenCallingDoesValidNomadAccountExist_thenFalseIsReturned() = runTest {
+        globalDatabaseBuilder.accountsDAO.insertOrReplace(
+            VALID_ACCOUNT.info.userIDEntity, VALID_ACCOUNT.ssoId, VALID_ACCOUNT.managedBy, VALID_ACCOUNT.serverConfigId, false
+        )
+        val result = globalDatabaseBuilder.accountsDAO.doesValidNomadAccountExist()
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun givenValidNomadAccount_whenCallingDoesValidNomadAccountExist_thenTrueIsReturned() = runTest {
+        globalDatabaseBuilder.accountsDAO.insertOrReplace(
+            VALID_ACCOUNT.info.userIDEntity, VALID_ACCOUNT.ssoId, VALID_ACCOUNT.managedBy, VALID_ACCOUNT.serverConfigId, false,
+            nomadServiceUrl = "https://nomad.example.com/service"
+        )
+        val result = globalDatabaseBuilder.accountsDAO.doesValidNomadAccountExist()
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun givenLoggedOutNomadAccount_whenCallingDoesValidNomadAccountExist_thenFalseIsReturned() = runTest {
+        globalDatabaseBuilder.accountsDAO.insertOrReplace(
+            VALID_ACCOUNT.info.userIDEntity, VALID_ACCOUNT.ssoId, VALID_ACCOUNT.managedBy, VALID_ACCOUNT.serverConfigId, false,
+            nomadServiceUrl = "https://nomad.example.com/service"
+        )
+        globalDatabaseBuilder.accountsDAO.markAccountAsInvalid(VALID_ACCOUNT.info.userIDEntity, LogoutReason.SELF_SOFT_LOGOUT)
+        val result = globalDatabaseBuilder.accountsDAO.doesValidNomadAccountExist()
+        assertEquals(false, result)
+    }
+
     private companion object {
 
         val VALID_ACCOUNT = FullAccountEntity(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/GlobalKaliumScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/GlobalKaliumScope.kt
@@ -57,6 +57,7 @@ import com.wire.kalium.logic.feature.server.ServerConfigForAccountUseCase
 import com.wire.kalium.logic.feature.server.UpdateApiVersionsUseCase
 import com.wire.kalium.logic.feature.server.UpdateApiVersionsUseCaseImpl
 import com.wire.kalium.logic.feature.session.DeleteSessionUseCase
+import com.wire.kalium.logic.feature.session.DoesValidNomadAccountExistUseCase
 import com.wire.kalium.logic.feature.session.DoesValidSessionExistUseCase
 import com.wire.kalium.logic.feature.session.GetAllSessionsUseCase
 import com.wire.kalium.logic.feature.session.GetSessionsUseCase
@@ -151,6 +152,7 @@ public class GlobalKaliumScope internal constructor(
     public val getSessions: GetSessionsUseCase get() = GetSessionsUseCase(sessionRepository)
     public val getAllSessions: GetAllSessionsUseCase get() = GetAllSessionsUseCase(sessionRepository)
     public val doesValidSessionExist: DoesValidSessionExistUseCase get() = DoesValidSessionExistUseCase(sessionRepository)
+    public val doesValidNomadAccountExist: DoesValidNomadAccountExistUseCase get() = DoesValidNomadAccountExistUseCase(sessionRepository)
     public val observeValidAccounts: ObserveValidAccountsUseCase by lazy {
         ObserveValidAccountsUseCaseImpl(
             sessionRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/SessionRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/session/SessionRepository.kt
@@ -80,6 +80,7 @@ internal interface SessionRepository {
     suspend fun cookieLabel(userId: UserId): Either<StorageFailure, String?>
     suspend fun isAccountReadOnly(userId: UserId): Either<StorageFailure, Boolean>
     suspend fun validSessionsWithServerConfig(): Either<StorageFailure, Map<UserId, ServerConfig>>
+    suspend fun doesValidNomadAccountExist(): Either<StorageFailure, Boolean>
 }
 
 public data class StoreSessionParam(
@@ -257,6 +258,9 @@ internal class SessionDataSource internal constructor(
             userId.toModel() to serverConfigMapper.fromEntity(serverConfig)
         }.toMap()
     }
+
+    override suspend fun doesValidNomadAccountExist(): Either<StorageFailure, Boolean> =
+        wrapStorageRequest { accountsDAO.doesValidNomadAccountExist() }
 
     internal fun ManagedByDTO.toDao() = when (this) {
         ManagedByDTO.WIRE -> ManagedByEntity.WIRE

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AddAuthenticatedUserUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AddAuthenticatedUserUseCase.kt
@@ -46,6 +46,7 @@ public class AddAuthenticatedUserUseCase internal constructor(
         public data class Success(val userId: UserId) : Result()
         public sealed class Failure : Result() {
             public data object UserAlreadyExists : Failure()
+            public data object NomadSingleUserViolation : Failure()
             public data class Generic(public val genericFailure: CoreFailure) : Failure()
         }
     }
@@ -53,21 +54,33 @@ public class AddAuthenticatedUserUseCase internal constructor(
     public suspend operator fun invoke(
         session: StoreSessionParam,
         replace: Boolean = false,
-    ): Result = sessionRepository.doesValidSessionExist(session.accountTokens.userId).fold(
-        {
-            Result.Failure.Generic(it)
-        },
-        { doesValidSessionExist ->
-            when (doesValidSessionExist) {
-                true -> onUserExist(
-                    session,
-                    replace,
-                )
-
-                false -> storeUser(session)
-            }
+    ): Result {
+        val isNomadLogin = !session.nomadServiceUrl.isNullOrBlank()
+        if (isNomadLogin) {
+            val validSessions = sessionRepository.allValidSessions()
+                .getOrElse { return Result.Failure.Generic(it) }
+            if (validSessions.isNotEmpty()) return Result.Failure.NomadSingleUserViolation
+        } else {
+            val nomadExists = sessionRepository.doesValidNomadAccountExist()
+                .getOrElse { return Result.Failure.Generic(it) }
+            if (nomadExists) return Result.Failure.NomadSingleUserViolation
         }
-    )
+        return sessionRepository.doesValidSessionExist(session.accountTokens.userId).fold(
+            {
+                Result.Failure.Generic(it)
+            },
+            { doesValidSessionExist ->
+                when (doesValidSessionExist) {
+                    true -> onUserExist(
+                        session,
+                        replace,
+                    )
+
+                    false -> storeUser(session)
+                }
+            }
+        )
+    }
 
     private suspend fun storeUser(session: StoreSessionParam): Result =
         sessionRepository.storeSession(session).onSuccess {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AddAuthenticatedUserUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AddAuthenticatedUserUseCase.kt
@@ -20,7 +20,9 @@
 
 package com.wire.kalium.logic.feature.auth
 import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.error.wrapStorageRequest
+import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.fold
 import com.wire.kalium.common.functional.getOrElse
 import com.wire.kalium.common.functional.map
@@ -54,33 +56,33 @@ public class AddAuthenticatedUserUseCase internal constructor(
     public suspend operator fun invoke(
         session: StoreSessionParam,
         replace: Boolean = false,
-    ): Result {
-        val isNomadLogin = !session.nomadServiceUrl.isNullOrBlank()
-        if (isNomadLogin) {
-            val validSessions = sessionRepository.allValidSessions()
-                .getOrElse { return Result.Failure.Generic(it) }
-            if (validSessions.isNotEmpty()) return Result.Failure.NomadSingleUserViolation
-        } else {
-            val nomadExists = sessionRepository.doesValidNomadAccountExist()
-                .getOrElse { return Result.Failure.Generic(it) }
-            if (nomadExists) return Result.Failure.NomadSingleUserViolation
+    ): Result = checkNomadViolation(session).fold(
+        { Result.Failure.Generic(it) },
+        { isViolation ->
+            if (isViolation) Result.Failure.NomadSingleUserViolation
+            else addSession(session, replace)
         }
-        return sessionRepository.doesValidSessionExist(session.accountTokens.userId).fold(
-            {
-                Result.Failure.Generic(it)
-            },
+    )
+
+    private suspend fun checkNomadViolation(session: StoreSessionParam): Either<StorageFailure, Boolean> {
+        val isNomadLogin = !session.nomadServiceUrl.isNullOrBlank()
+        return if (isNomadLogin) {
+            sessionRepository.allValidSessions().map { it.isNotEmpty() }
+        } else {
+            sessionRepository.doesValidNomadAccountExist()
+        }
+    }
+
+    private suspend fun addSession(session: StoreSessionParam, replace: Boolean): Result =
+        sessionRepository.doesValidSessionExist(session.accountTokens.userId).fold(
+            { Result.Failure.Generic(it) },
             { doesValidSessionExist ->
                 when (doesValidSessionExist) {
-                    true -> onUserExist(
-                        session,
-                        replace,
-                    )
-
+                    true -> onUserExist(session, replace)
                     false -> storeUser(session)
                 }
             }
         )
-    }
 
     private suspend fun storeUser(session: StoreSessionParam): Result =
         sessionRepository.storeSession(session).onSuccess {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/DoesValidNomadAccountExistUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/DoesValidNomadAccountExistUseCase.kt
@@ -1,0 +1,33 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.session
+
+import com.wire.kalium.common.functional.getOrElse
+import com.wire.kalium.logic.data.session.SessionRepository
+
+/**
+ * This use case checks whether a valid nomad account exists (i.e., an account with a non-null nomad_service_url
+ * that has not been logged out).
+ */
+public class DoesValidNomadAccountExistUseCase internal constructor(
+    private val sessionRepository: SessionRepository
+) {
+    public suspend operator fun invoke(): Boolean =
+        sessionRepository.doesValidNomadAccountExist().getOrElse { false }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/AddAuthenticatedUserUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/AddAuthenticatedUserUseCaseTest.kt
@@ -56,6 +56,7 @@ class AddAuthenticatedUserUseCaseTest {
         val tokens = TEST_AUTH_TOKENS
         val proxyCredentials = PROXY_CREDENTIALS
         val (arrangement, addAuthenticatedUserUseCase) = Arrangement()
+            .withDoesValidNomadAccountExistResult(Either.Right(false))
             .withDoesValidSessionExistResult(tokens.userId, Either.Right(false))
             .withStoreSessionResult(TEST_SERVER_CONFIG.id, TEST_SSO_ID, tokens, proxyCredentials, null, Either.Right(Unit))
             .withUpdateCurrentSessionResult(tokens.userId, Either.Right(Unit))
@@ -92,6 +93,7 @@ class AddAuthenticatedUserUseCaseTest {
         val proxyCredentials = PROXY_CREDENTIALS
 
         val (arrangement, addAuthenticatedUserUseCase) = Arrangement()
+            .withDoesValidNomadAccountExistResult(Either.Right(false))
             .withDoesValidSessionExistResult(tokens.userId, Either.Right(true))
             .arrange()
 
@@ -136,6 +138,7 @@ class AddAuthenticatedUserUseCaseTest {
         val proxyCredentials = PROXY_CREDENTIALS
 
         val (arrangement, addAuthenticatedUserUseCase) = Arrangement()
+            .withDoesValidNomadAccountExistResult(Either.Right(false))
             .withDoesValidSessionExistResult(newSession.userId, Either.Right(true))
             .withStoreSessionResult(TEST_SERVER_CONFIG.id, TEST_SSO_ID, newSession, proxyCredentials, null, Either.Right(Unit))
             .withUpdateCurrentSessionResult(newSession.userId, Either.Right(Unit))
@@ -202,6 +205,7 @@ class AddAuthenticatedUserUseCaseTest {
         val proxyCredentials = PROXY_CREDENTIALS
 
         val (arrangement, addAuthenticatedUserUseCase) = Arrangement()
+            .withDoesValidNomadAccountExistResult(Either.Right(false))
             .withDoesValidSessionExistResult(newSession.userId, Either.Right(true))
             .withConfigForUserIdSuccess(oldSession.userId.toDao(), oldSessionServerEntity)
             .withConfigByIdSuccess(newSessionServer.id, newSessionServerEntity)
@@ -249,6 +253,7 @@ class AddAuthenticatedUserUseCaseTest {
         val nomadServiceUrl = "https://nomad.example.com/service"
 
         val (arrangement, addAuthenticatedUserUseCase) = Arrangement()
+            .withAllValidSessionsResult(Either.Right(emptyList()))
             .withDoesValidSessionExistResult(tokens.userId, Either.Right(false))
             .withStoreSessionResult(
                 serverConfigId = TEST_SERVER_CONFIG.id,
@@ -290,6 +295,84 @@ class AddAuthenticatedUserUseCaseTest {
         }.wasInvoked(exactly = once)
     }
 
+    @Test
+    fun givenNomadSessionAndExistingValidSessions_whenInvoked_thenNomadSingleUserViolationIsReturned() = runTest {
+        val tokens = TEST_AUTH_TOKENS
+        val proxyCredentials = PROXY_CREDENTIALS
+
+        val (_, addAuthenticatedUserUseCase) = Arrangement()
+            .withAllValidSessionsResult(Either.Right(listOf(AccountInfo.Valid(UserId("other", "domain.de")))))
+            .arrange()
+
+        val actual = addAuthenticatedUserUseCase(
+            session = StoreSessionParam(
+                serverConfigId = TEST_SERVER_CONFIG.id,
+                ssoId = TEST_SSO_ID,
+                accountTokens = tokens,
+                proxyCredentials = proxyCredentials,
+                managedBy = null,
+                isPersistentWebSocketEnabled = false,
+                nomadServiceUrl = "https://nomad.example.com/service",
+            )
+        )
+
+        assertIs<AddAuthenticatedUserUseCase.Result.Failure.NomadSingleUserViolation>(actual)
+    }
+
+    @Test
+    fun givenNormalSessionAndNomadAccountExists_whenInvoked_thenNomadSingleUserViolationIsReturned() = runTest {
+        val tokens = TEST_AUTH_TOKENS
+        val proxyCredentials = PROXY_CREDENTIALS
+
+        val (_, addAuthenticatedUserUseCase) = Arrangement()
+            .withDoesValidNomadAccountExistResult(Either.Right(true))
+            .arrange()
+
+        val actual = addAuthenticatedUserUseCase(
+            session = StoreSessionParam(
+                serverConfigId = TEST_SERVER_CONFIG.id,
+                ssoId = TEST_SSO_ID,
+                accountTokens = tokens,
+                proxyCredentials = proxyCredentials,
+                managedBy = null,
+                isPersistentWebSocketEnabled = false,
+            )
+        )
+
+        assertIs<AddAuthenticatedUserUseCase.Result.Failure.NomadSingleUserViolation>(actual)
+    }
+
+    @Test
+    fun givenNomadSessionAndNoExistingSessions_whenInvoked_thenSuccessIsReturned() = runTest {
+        val tokens = TEST_AUTH_TOKENS
+        val proxyCredentials = PROXY_CREDENTIALS
+        val nomadServiceUrl = "https://nomad.example.com/service"
+
+        val (_, addAuthenticatedUserUseCase) = Arrangement()
+            .withAllValidSessionsResult(Either.Right(emptyList()))
+            .withDoesValidSessionExistResult(tokens.userId, Either.Right(false))
+            .withStoreSessionResult(
+                TEST_SERVER_CONFIG.id, TEST_SSO_ID, tokens, proxyCredentials, null, Either.Right(Unit),
+                nomadServiceUrl = nomadServiceUrl
+            )
+            .withUpdateCurrentSessionResult(tokens.userId, Either.Right(Unit))
+            .arrange()
+
+        val actual = addAuthenticatedUserUseCase(
+            session = StoreSessionParam(
+                serverConfigId = TEST_SERVER_CONFIG.id,
+                ssoId = TEST_SSO_ID,
+                accountTokens = tokens,
+                proxyCredentials = proxyCredentials,
+                managedBy = null,
+                isPersistentWebSocketEnabled = false,
+                nomadServiceUrl = nomadServiceUrl,
+            )
+        )
+
+        assertIs<AddAuthenticatedUserUseCase.Result.Success>(actual)
+    }
+
     private companion object {
         val TEST_USERID = UserId("user_id", "domain.de")
         val TEST_SERVER_CONFIG: ServerConfig = newServerConfig(1)
@@ -323,6 +406,18 @@ class AddAuthenticatedUserUseCaseTest {
             result: Either<StorageFailure, Boolean>
         ) = apply {
             coEvery { sessionRepository.doesValidSessionExist(userId) }.returns(result)
+        }
+
+        suspend fun withAllValidSessionsResult(
+            result: Either<StorageFailure, List<AccountInfo.Valid>>
+        ) = apply {
+            coEvery { sessionRepository.allValidSessions() }.returns(result)
+        }
+
+        suspend fun withDoesValidNomadAccountExistResult(
+            result: Either<StorageFailure, Boolean>
+        ) = apply {
+            coEvery { sessionRepository.doesValidNomadAccountExist() }.returns(result)
         }
 
         suspend fun withConfigForUserIdSuccess(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24067
<!--jira-description-action-hidden-marker-end-->
---

#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages
  - [x] contains a reference JIRA issue number
  - [x] answers the question: _If merged, this PR will: ..._

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability

---

# What's new in this PR?

### Issues

- When nomad (shared device) profiles are involved, the app must enforce a single-user-at-a-time policy. Previously, multiple accounts could be added freely up to `MAX_ACCOUNTS`, regardless of whether any were nomad accounts. This means a nomad device could end up with mixed or multiple sessions, breaking the shared device contract.

### Solutions

Enforce single-user login when any nomad account is involved, across three layers:

1. **Intent-level blocking (Cases 1 & 2):** `WireActivityViewModel.handleIntentsThatAreNotDeepLinks` now checks for existing valid sessions before proceeding with an automated nomad login. If any session exists, the login is blocked with a toast.

2. **Welcome screen blocking (Case 3):** `WelcomeViewModel` checks whether a valid nomad account is already logged in. If so, the Welcome screen shows a dialog informing the user to log out first, and navigation is blocked.

3. **Safety net in `AddAuthenticatedUserUseCase` (all cases):** Before storing a new session, the use case checks:
   - If the incoming session is nomad → block if *any* valid session exists
   - If the incoming session is normal → block if a *nomad* account is already logged in
   - Returns a new `NomadSingleUserViolation` failure type

A new `doesValidNomadAccountExist` query was added through the full stack (SQL → DAO → Repository → UseCase → DI).

#### Flow Diagram

```
┌─────────────────────────────────────────────────────────────────────┐
│                        Login Attempt                                │
└──────────────────────────────┬──────────────────────────────────────┘
                               │
                               ▼
                  ┌────────────────────────┐
                  │  Is this a nomad login │
                  │  (automated intent)?   │
                  └─────┬────────────┬─────┘
                   YES  │            │  NO (manual login via Welcome screen)
                        ▼            ▼
          ┌──────────────────┐  ┌──────────────────────────┐
          │ WireActivityVM:  │  │ WelcomeViewModel:        │
          │ Any valid session│  │ Does a valid nomad       │
          │ already exists?  │  │ account exist?           │
          └───┬─────────┬────┘  └───┬──────────────┬───────┘
           YES│         │NO      YES│              │NO
              ▼         │           ▼              │
     ┌────────────┐     │  ┌───────────────┐       │
     │ Show toast │     │  │ Show dialog:  │       │
     │ Block login│     │  │ "Log out the  │       │
     └────────────┘     │  │ managed       │       │
                        │  │ profile first"│       │
                        │  └───────────────┘       │
                        ▼                          ▼
              ┌──────────────────────────────────────────┐
              │     AddAuthenticatedUserUseCase           │
              │          (safety net)                     │
              └──────────────────┬───────────────────────┘
                                 │
                                 ▼
                  ┌──────────────────────────┐
                  │ Is incoming session nomad?│
                  └─────┬──────────────┬─────┘
                   YES  │              │  NO
                        ▼              ▼
          ┌──────────────────┐  ┌──────────────────────┐
          │ Any valid session│  │ Does valid nomad     │
          │ exists?          │  │ account exist?       │
          │ (allValidSessions│  │ (doesValidNomad-     │
          │  is not empty)   │  │  AccountExist)       │
          └───┬─────────┬────┘  └───┬──────────────┬───┘
           YES│         │NO      YES│              │NO
              ▼         │           ▼              │
   ┌──────────────────┐ │  ┌──────────────────┐    │
   │ NomadSingleUser  │ │  │ NomadSingleUser  │    │
   │ Violation         │ │  │ Violation         │    │
   └──────────────────┘ │  └──────────────────┘    │
                        ▼                          ▼
              ┌──────────────────────────────────────────┐
              │          Proceed with login               │
              │   (existing doesValidSessionExist check)  │
              └──────────────────────────────────────────┘
```

#### Case Matrix

| Existing Account | New Login | Result | Enforcement Point |
|---|---|---|---|
| None | Nomad | Allowed | — |
| None | Normal | Allowed | — |
| Normal | Normal | Allowed (up to MAX_ACCOUNTS) | Unchanged |
| Nomad | Nomad | **Blocked** | Intent-level toast + UseCase safety net |
| Normal | Nomad | **Blocked** | Intent-level toast + UseCase safety net |
| Nomad | Normal | **Blocked** | Welcome screen dialog + UseCase safety net |

### Testing

#### Test Coverage

- [x] I have added automated tests to this contribution

**New/updated tests:**

- `AccountsDAOTest` — 4 new tests: no accounts → false, normal accounts only → false, valid nomad → true, logged-out nomad → false
- `AddAuthenticatedUserUseCaseTest` — 3 new tests: nomad + existing sessions → violation, normal + nomad exists → violation, nomad + no sessions → success. Existing tests updated with nomad mocks.
- `WireActivityViewModelTest` — 1 new test: automated login intent with existing session → toast shown, login not dispatched
- `WelcomeViewModelTest` — 2 new tests: no nomad → `nomadAccountBlocksLogin` is false, nomad exists → `nomadAccountBlocksLogin` is true

#### How to Test

1. **Nomad + Nomad / Normal + Nomad (Cases 1 & 2):**
   - Log in with a nomad account (via automated intent/SSO)
   - Trigger another nomad login intent
   - Expected: toast "Cannot login while another account is active", login does not proceed

2. **Nomad + Normal (Case 3):**
   - Log in with a nomad account
   - Navigate to the Welcome screen (add account flow)
   - Expected: dialog "A managed profile is currently logged in. Please log out first before adding another account.", dismissed back

3. **Normal + Normal (unchanged):**
   - Log in with a normal account
   - Add another normal account via Welcome screen
   - Expected: works as before, up to MAX_ACCOUNTS

### Notes

- No database migration is needed — the `doesValidNomadAccountExist` query is read-only on the existing `nomad_service_url` column.
- The `NomadSingleUserViolation` failure is mapped to `UserAlreadyExists` in the existing login/registration UI error handlers since there is no distinct UI treatment needed at those layers — the earlier enforcement points (toast / dialog) handle the UX.