### PR TITLE
feat(backup): add macOS native zip support via NSTask WPB-24078

### DIFF
--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/util/BackupUtils.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/util/BackupUtils.kt
@@ -156,9 +156,4 @@ private fun readCompressedEntry(
     return totalExtractedFilesSize
 }
 
-/**
- * Verification that the entry path is valid and does not contain any invalid characters leading to write in undesired directories.
- */
-internal fun isInvalidEntryPathDestination(entryName: String) = entryName.contains("../")
-
 private const val BUFFER_SIZE = 8192L

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/util/BackupPathValidation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/util/BackupPathValidation.kt
@@ -1,0 +1,22 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.util
+
+internal fun isInvalidEntryPathDestination(entryName: String): Boolean =
+    entryName.contains("../") || entryName.startsWith("/")

--- a/logic/src/iosMain/kotlin/com/wire/kalium/logic/util/BackupUtils.kt
+++ b/logic/src/iosMain/kotlin/com/wire/kalium/logic/util/BackupUtils.kt
@@ -19,8 +19,8 @@
 package com.wire.kalium.logic.util
 
 import com.wire.kalium.common.error.CoreFailure
-import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import okio.BufferedSource
 import okio.Path
 import okio.Sink

--- a/logic/src/macosMain/kotlin/com/wire/kalium/logic/util/BackupUtils.kt
+++ b/logic/src/macosMain/kotlin/com/wire/kalium/logic/util/BackupUtils.kt
@@ -1,0 +1,220 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.util
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.logger.kaliumLogger
+import com.wire.kalium.logic.data.asset.KaliumFileSystem
+import com.wire.kalium.logic.data.web.KtxWebSerializer
+import kotlinx.serialization.decodeFromString
+import okio.BufferedSource
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+import okio.Sink
+import okio.Source
+import okio.buffer
+import okio.use
+import platform.Foundation.NSCachesDirectory
+import platform.Foundation.NSSearchPathForDirectoriesInDomains
+import platform.Foundation.NSUserDomainMask
+
+@Suppress("TooGenericExceptionCaught", "NestedBlockDepth")
+internal actual fun createCompressedFile(files: List<Pair<Source, String>>, outputSink: Sink): Either<CoreFailure, Long> = try {
+    val fileSystem = FileSystem.SYSTEM
+    val tempDir = appCacheTempDir("kalium-backup-zip-${kotlin.random.Random.nextInt().toUInt()}")
+    fileSystem.createDirectories(tempDir)
+
+    try {
+        val stagedFiles = stageSourceFiles(files, tempDir, fileSystem)
+
+        val zipPath = tempDir / "backup.zip"
+        val zipResult = execCommand(
+            args = listOf("/usr/bin/zip", "-q", "-j", zipPath.toString()) + stagedFiles.map { it.toString() },
+            workingDirectory = tempDir,
+        )
+        ensureSuccess(zipResult, "compress the provided files")
+
+        val compressedSize = fileSystem.metadata(zipPath).size ?: 0L
+        fileSystem.source(zipPath).buffer().use { zipSource ->
+            outputSink.buffer().use { bufferedSink ->
+                bufferedSink.writeAll(zipSource)
+            }
+        }
+        Either.Right(compressedSize)
+    } finally {
+        fileSystem.deleteRecursively(tempDir, false)
+    }
+} catch (e: Exception) {
+    Either.Left(StorageFailure.Generic(RuntimeException("There was an error trying to compress the provided files", e)))
+}
+
+private fun stageSourceFiles(files: List<Pair<Source, String>>, tempDir: Path, fileSystem: FileSystem): List<Path> =
+    files.map { (source, fileName) ->
+        val sanitizedFileName = sanitizeFileName(fileName)
+        val stagedPath = tempDir / sanitizedFileName
+        source.buffer().use { bufferedSource ->
+            fileSystem.sink(stagedPath).buffer().use { sink ->
+                sink.writeAll(bufferedSource)
+            }
+        }
+        stagedPath
+    }
+
+@Suppress("TooGenericExceptionCaught", "NestedBlockDepth")
+internal actual fun extractCompressedFile(
+    inputSource: Source,
+    outputRootPath: Path,
+    param: ExtractFilesParam,
+    fileSystem: KaliumFileSystem
+): Either<CoreFailure, Long> = try {
+    val systemFileSystem = FileSystem.SYSTEM
+    val tempDir = fileSystem.tempFilePath("backup-unzip-${kotlin.random.Random.nextInt().toUInt()}")
+    systemFileSystem.createDirectories(tempDir)
+
+    try {
+        val zipPath = writeSourceToFile(inputSource, tempDir / "archive.zip", systemFileSystem)
+        extractEntries(zipPath, outputRootPath, param, fileSystem)
+    } finally {
+        systemFileSystem.deleteRecursively(tempDir, false)
+    }
+} catch (e: Exception) {
+    kaliumLogger.e("Error extracting compressed backup file", e)
+    Either.Left(StorageFailure.Generic(RuntimeException("There was an error trying to extract the provided compressed file", e)))
+}
+
+private fun writeSourceToFile(source: Source, path: Path, fileSystem: FileSystem): Path {
+    source.buffer().use { bufferedSource ->
+        fileSystem.sink(path).buffer().use { sink ->
+            sink.writeAll(bufferedSource)
+        }
+    }
+    return path
+}
+
+private fun extractEntries(
+    zipPath: Path,
+    outputRootPath: Path,
+    param: ExtractFilesParam,
+    fileSystem: KaliumFileSystem
+): Either<CoreFailure, Long> {
+    val entries = listArchiveEntries(zipPath)
+    val targetEntries = when (param) {
+        ExtractFilesParam.All -> entries
+        is ExtractFilesParam.Only -> entries.filter { it in param.files }
+    }
+
+    if (targetEntries.any(::isInvalidEntryPathDestination)) {
+        throw IllegalArgumentException("Archive contains invalid entry path")
+    }
+
+    fileSystem.createDirectories(outputRootPath)
+    if (targetEntries.isNotEmpty()) {
+        val unzipArgs = buildUnzipArgs(zipPath, outputRootPath, param, targetEntries)
+        ensureSuccess(execCommand(args = unzipArgs), "extract the provided compressed file")
+    }
+
+    val totalExtractedSize = targetEntries.sumOf { entryName ->
+        val extractedPath = outputRootPath / entryName
+        if (fileSystem.exists(extractedPath)) {
+            FileSystem.SYSTEM.metadata(extractedPath).size ?: 0L
+        } else {
+            0L
+        }
+    }
+    return Either.Right(totalExtractedSize)
+}
+
+private fun buildUnzipArgs(
+    zipPath: Path,
+    outputRootPath: Path,
+    param: ExtractFilesParam,
+    targetEntries: List<String>
+): List<String> = buildList {
+    add("/usr/bin/unzip")
+    add("-qq")
+    add("-o")
+    add(zipPath.toString())
+    if (param is ExtractFilesParam.Only) addAll(targetEntries)
+    add("-d")
+    add(outputRootPath.toString())
+}
+
+@Suppress("TooGenericExceptionCaught")
+internal actual fun checkIfCompressedFileContainsFileTypes(
+    compressedFilePath: Path,
+    fileSystem: KaliumFileSystem,
+    expectedFileExtensions: List<String>
+): Either<CoreFailure, Map<String, Boolean>> =
+    try {
+        if (!fileSystem.exists(compressedFilePath)) {
+            return Either.Left(StorageFailure.DataNotFound)
+        }
+
+        val archiveEntries = listArchiveEntries(compressedFilePath)
+        val foundExtensions = archiveEntries.map { it.substringAfterLast('.', "") }.toSet()
+        Either.Right(expectedFileExtensions.associateWith { it in foundExtensions })
+    } catch (e: Exception) {
+        Either.Left(StorageFailure.Generic(RuntimeException("There was an error trying to validate the provided compressed file", e)))
+    }
+
+internal actual inline fun <reified T> decodeBufferSequence(bufferedSource: BufferedSource): Sequence<T> {
+    val jsonString = bufferedSource.readUtf8()
+    return KtxWebSerializer.json.decodeFromString<List<T>>(jsonString).asSequence()
+}
+
+private fun listArchiveEntries(zipPath: Path): List<String> {
+    val result = execCommand(
+        args = listOf("/usr/bin/unzip", "-Z1", zipPath.toString()),
+    )
+    ensureSuccess(result, "list compressed file entries")
+    return result.stdout
+        .lineSequence()
+        .map(String::trim)
+        .filter(String::isNotEmpty)
+        .toList()
+}
+
+private fun sanitizeFileName(fileName: String): String {
+    require(fileName.isNotBlank()) { "File name cannot be blank" }
+    require(!isInvalidEntryPathDestination(fileName)) { "Invalid file name: $fileName" }
+    return fileName.substringAfterLast('/')
+}
+
+@Suppress("TooGenericExceptionThrown")
+private fun ensureSuccess(result: ProcessResult, action: String) {
+    if (result.exitCode != 0) {
+        val detail = result.stderr.ifBlank { result.stdout.ifBlank { "exit code ${result.exitCode}" } }
+        throw RuntimeException("Failed to $action: ${detail.trim()}")
+    }
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun appCacheTempDir(name: String): Path {
+    val cacheDirs = NSSearchPathForDirectoriesInDomains(
+        NSCachesDirectory,
+        NSUserDomainMask,
+        true
+    ) as List<String>
+    val cacheRoot = cacheDirs.firstOrNull()?.toPath()
+        ?: FileSystem.SYSTEM_TEMPORARY_DIRECTORY
+    return cacheRoot / "com.wire.kalium" / name
+}

--- a/logic/src/macosMain/kotlin/com/wire/kalium/logic/util/ProcessResult.kt
+++ b/logic/src/macosMain/kotlin/com/wire/kalium/logic/util/ProcessResult.kt
@@ -1,0 +1,77 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+@file:OptIn(kotlinx.cinterop.BetaInteropApi::class)
+@file:Suppress("NoWildcardImports", "WildcardImport")
+
+package com.wire.kalium.logic.util
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import okio.Path
+import platform.Foundation.NSData
+import platform.Foundation.NSPipe
+import platform.Foundation.NSString
+import platform.Foundation.NSTask
+import platform.Foundation.NSURL
+import platform.Foundation.NSUTF8StringEncoding
+import platform.Foundation.create
+// Wildcard needed: fileHandleForReading, readDataToEndOfFile, waitUntilExit are ObjC
+// category extensions that cannot be imported individually in Kotlin/Native.
+import platform.Foundation.*
+
+internal data class ProcessResult(
+    val exitCode: Int,
+    val stdout: String,
+    val stderr: String,
+)
+
+@OptIn(ExperimentalForeignApi::class)
+internal fun execCommand(
+    args: List<String>,
+    workingDirectory: Path? = null,
+): ProcessResult {
+    require(args.isNotEmpty()) { "args must not be empty" }
+
+    val task = NSTask()
+    val stdoutPipe = NSPipe()
+    val stderrPipe = NSPipe()
+
+    task.executableURL = NSURL.fileURLWithPath(args.first())
+    task.arguments = args.drop(1)
+    task.standardOutput = stdoutPipe
+    task.standardError = stderrPipe
+
+    if (workingDirectory != null) {
+        task.currentDirectoryURL = NSURL.fileURLWithPath(workingDirectory.toString())
+    }
+
+    task.launchAndReturnError(null)
+    task.waitUntilExit()
+
+    val stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+    val stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+
+    return ProcessResult(
+        exitCode = task.terminationStatus,
+        stdout = stdoutData.toUtf8String(),
+        stderr = stderrData.toUtf8String(),
+    )
+}
+
+private fun NSData.toUtf8String(): String =
+    NSString.create(data = this, encoding = NSUTF8StringEncoding)?.toString() ?: ""

--- a/logic/src/macosTest/kotlin/com/wire/kalium/logic/util/BackupUtilsTest.kt
+++ b/logic/src/macosTest/kotlin/com/wire/kalium/logic/util/BackupUtilsTest.kt
@@ -1,0 +1,278 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.util
+
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.asset.KaliumFileSystem
+import okio.Buffer
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+import okio.Sink
+import okio.Source
+import okio.buffer
+import okio.use
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for macOS BackupUtils implementation.
+ * These tests exercise the real /usr/bin/zip and /usr/bin/unzip tools via NSTask.
+ */
+class BackupUtilsTest {
+
+    private val fileSystem = FileSystem.SYSTEM
+    private val testDir = FileSystem.SYSTEM_TEMPORARY_DIRECTORY / "kalium-backup-test-${kotlin.random.Random.nextInt().toUInt()}"
+    private val testKaliumFileSystem = RealKaliumFileSystem(testDir)
+
+    init {
+        fileSystem.createDirectories(testDir)
+    }
+
+    @AfterTest
+    fun cleanup() {
+        fileSystem.deleteRecursively(testDir, mustExist = false)
+    }
+
+    // region createCompressedFile
+
+    @Test
+    fun givenSingleFile_whenCreatingCompressedFile_thenReturnsRightWithSize() {
+        val content = "hello backup world"
+        val sources = listOf(content.toSource() to "test.txt")
+        val outputBuffer = Buffer()
+
+        val result = createCompressedFile(sources, outputBuffer)
+
+        assertIs<Either.Right<Long>>(result)
+        assertTrue(result.value > 0, "Compressed size should be positive")
+        assertTrue(outputBuffer.size > 0, "Output buffer should contain data")
+    }
+
+    @Test
+    fun givenMultipleFiles_whenCreatingCompressedFile_thenAllFilesAreIncluded() {
+        val files = listOf(
+            "content-a".toSource() to "file_a.txt",
+            "content-b".toSource() to "file_b.json",
+            "content-c".toSource() to "file_c.proto",
+        )
+        val zipPath = testDir / "multi.zip"
+
+        val createResult = createCompressedFile(files, fileSystem.sink(zipPath))
+        assertIs<Either.Right<Long>>(createResult)
+
+        val entries = listZipEntries(zipPath)
+        assertEquals(setOf("file_a.txt", "file_b.json", "file_c.proto"), entries.toSet())
+    }
+
+    @Test
+    fun givenEmptyFileList_whenCreatingCompressedFile_thenReturnsLeft() {
+        val outputBuffer = Buffer()
+
+        val result = createCompressedFile(emptyList(), outputBuffer)
+
+        assertIs<Either.Left<*>>(result)
+    }
+
+    // endregion
+
+    // region extractCompressedFile
+
+    @Test
+    fun givenCompressedFile_whenExtractingAll_thenFilesAreExtracted() {
+        val originalContent = "extract me please"
+        val zipPath = testDir / "extract-all.zip"
+        createCompressedFile(
+            listOf(originalContent.toSource() to "payload.txt"),
+            fileSystem.sink(zipPath)
+        )
+
+        val outputDir = testDir / "extracted-all"
+        val result = extractCompressedFile(
+            inputSource = fileSystem.source(zipPath),
+            outputRootPath = outputDir,
+            param = ExtractFilesParam.All,
+            fileSystem = testKaliumFileSystem,
+        )
+
+        assertIs<Either.Right<Long>>(result)
+        assertTrue(result.value > 0)
+
+        val extractedContent = fileSystem.source(outputDir / "payload.txt").buffer().use { it.readUtf8() }
+        assertEquals(originalContent, extractedContent)
+    }
+
+    @Test
+    fun givenCompressedFileWithMultipleEntries_whenExtractingOnly_thenOnlyMatchingFilesAreExtracted() {
+        val zipPath = testDir / "extract-only.zip"
+        createCompressedFile(
+            listOf(
+                "wanted".toSource() to "keep.txt",
+                "unwanted".toSource() to "skip.txt",
+            ),
+            fileSystem.sink(zipPath)
+        )
+
+        val outputDir = testDir / "extracted-only"
+        val result = extractCompressedFile(
+            inputSource = fileSystem.source(zipPath),
+            outputRootPath = outputDir,
+            param = ExtractFilesParam.Only("keep.txt"),
+            fileSystem = testKaliumFileSystem,
+        )
+
+        assertIs<Either.Right<Long>>(result)
+        assertTrue(fileSystem.exists(outputDir / "keep.txt"))
+        assertTrue(!fileSystem.exists(outputDir / "skip.txt"))
+    }
+
+    // endregion
+
+    // region round-trip
+
+    @Test
+    fun givenFilesCompressedThenExtracted_whenCompared_thenContentMatches() {
+        val files = mapOf(
+            "users.json" to """[{"id":"1","name":"Alice"}]""",
+            "conversations.json" to """[{"id":"c1","name":"General"}]""",
+            "messages.proto" to "binary-ish-content-here",
+        )
+
+        val zipPath = testDir / "roundtrip.zip"
+        val createResult = createCompressedFile(
+            files.map { (name, content) -> content.toSource() to name },
+            fileSystem.sink(zipPath)
+        )
+        assertIs<Either.Right<Long>>(createResult)
+
+        val outputDir = testDir / "roundtrip-extracted"
+        val extractResult = extractCompressedFile(
+            inputSource = fileSystem.source(zipPath),
+            outputRootPath = outputDir,
+            param = ExtractFilesParam.All,
+            fileSystem = testKaliumFileSystem,
+        )
+        assertIs<Either.Right<Long>>(extractResult)
+
+        files.forEach { (name, expectedContent) ->
+            val actual = fileSystem.source(outputDir / name).buffer().use { it.readUtf8() }
+            assertEquals(expectedContent, actual, "Content mismatch for $name")
+        }
+    }
+
+    // endregion
+
+    // region checkIfCompressedFileContainsFileTypes
+
+    @Test
+    fun givenZipWithMixedTypes_whenChecking_thenReturnsCorrectMap() {
+        val zipPath = testDir / "filetypes.zip"
+        createCompressedFile(
+            listOf(
+                "a".toSource() to "data.json",
+                "b".toSource() to "data.proto",
+            ),
+            fileSystem.sink(zipPath)
+        )
+
+        val result = checkIfCompressedFileContainsFileTypes(
+            compressedFilePath = zipPath,
+            fileSystem = testKaliumFileSystem,
+            expectedFileExtensions = listOf("json", "proto", "txt"),
+        )
+
+        assertIs<Either.Right<Map<String, Boolean>>>(result)
+        assertEquals(true, result.value["json"])
+        assertEquals(true, result.value["proto"])
+        assertEquals(false, result.value["txt"])
+    }
+
+    @Test
+    fun givenNonExistentFile_whenChecking_thenReturnsDataNotFound() {
+        val result = checkIfCompressedFileContainsFileTypes(
+            compressedFilePath = testDir / "does-not-exist.zip",
+            fileSystem = testKaliumFileSystem,
+            expectedFileExtensions = listOf("json"),
+        )
+
+        assertIs<Either.Left<StorageFailure.DataNotFound>>(result)
+    }
+
+    // endregion
+
+    // region helpers
+
+    private fun String.toSource(): Source {
+        val buffer = Buffer()
+        buffer.writeUtf8(this)
+        return buffer
+    }
+
+    private fun listZipEntries(zipPath: Path): List<String> {
+        val result = execCommand(args = listOf("/usr/bin/unzip", "-Z1", zipPath.toString()))
+        return result.stdout.lines().filter { it.isNotBlank() }
+    }
+
+    /**
+     * A KaliumFileSystem backed by the real filesystem for integration testing.
+     * Required because the macOS BackupUtils shells out to /usr/bin/zip and /usr/bin/unzip
+     * which operate on real files.
+     */
+    private class RealKaliumFileSystem(private val rootDir: Path) : KaliumFileSystem {
+        private val fs = FileSystem.SYSTEM
+
+        override val rootCachePath: Path = rootDir / "cache"
+        override val rootDBPath: Path = rootDir / "db"
+
+        init {
+            fs.createDirectories(rootCachePath)
+            fs.createDirectories(rootDBPath)
+        }
+
+        override fun sink(outputPath: Path, mustCreate: Boolean): Sink = fs.sink(outputPath, mustCreate)
+        override fun source(inputPath: Path): Source = fs.source(inputPath)
+        override fun createDirectories(dir: Path) = fs.createDirectories(dir)
+        override fun createDirectory(dir: Path, mustCreate: Boolean) = fs.createDirectory(dir, mustCreate)
+        override fun delete(path: Path, mustExist: Boolean) = fs.delete(path, mustExist)
+        override fun deleteContents(dir: Path, mustExist: Boolean) = fs.deleteRecursively(dir, mustExist)
+        override fun exists(path: Path): Boolean = fs.exists(path)
+        override fun copy(sourcePath: Path, targetPath: Path) = fs.copy(sourcePath, targetPath)
+
+        override fun tempFilePath(pathString: String?): Path {
+            val name = pathString ?: "temp_${kotlin.random.Random.nextInt().toUInt()}"
+            return rootCachePath / name
+        }
+
+        override fun providePersistentAssetPath(assetName: String): Path = rootDir / "assets" / assetName
+        override suspend fun readByteArray(inputPath: Path): ByteArray =
+            fs.source(inputPath).buffer().use { it.readByteArray() }
+
+        override suspend fun writeData(outputSink: Sink, dataSource: Source): Long =
+            outputSink.buffer().use { it.writeAll(dataSource) }
+
+        override fun selfUserAvatarPath(): Path = providePersistentAssetPath("self_avatar.jpg")
+        override suspend fun listDirectories(dir: Path): List<Path> = fs.list(dir)
+    }
+
+    // endregion
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24078
<!--jira-description-action-hidden-marker-end-->
## Summary

- Implement `BackupUtils.kt` actual functions for macOS (`macosMain` source set) using system `/usr/bin/zip` and `/usr/bin/unzip`
- Split `appleMain/BackupUtils.kt` into `macosMain` (real implementation) and `iosMain` (TODO stubs, unchanged — wire-ios bypasses these via ZIPFoundation injection)
- Move path traversal validation (`isInvalidEntryPathDestination`) to `commonMain` for reuse
- Add `ProcessExec.kt` using `NSTask`/`NSPipe` from Foundation for process execution (no temp files for I/O, no shell interpolation)
- `decodeBufferSequence` uses in-memory `Json.decodeFromString` (streaming not available on Native)

### Design decisions

- **NSTask over posix.system()**: Direct process execution via Foundation — stdout/stderr captured through `NSPipe` (in-memory), exit code from `terminationStatus`. No temp files for shell I/O, no shell quoting/injection surface.
- **App cache dir over /tmp**: `createCompressedFile` stages files in `~/Library/Caches/com.wire.kalium/` via `NSSearchPathForDirectoriesInDomains(NSCachesDirectory)`. `extractCompressedFile` uses `KaliumFileSystem.tempFilePath()` (app's data directory). Avoids writing sensitive backup data to world-readable system temp.
- **macOS-only**: iOS stubs remain as `TODO()` — wire-ios never calls `BackupUtils.kt`, it injects `ZIPFoundation` at the `domain/backup` layer via `FileZipper`/`BackupFileUnzipper` interfaces.

## Test plan

- [x] Build: `./gradlew :logic:compileKotlinMacosArm64 -PUSE_UNIFIED_CORE_CRYPTO=true`
- [x] Round-trip: create backup on JVM, restore on native macOS (and vice versa)
- [x] Encrypted backup round-trip cross-platform
- [x] Verify `checkIfCompressedFileContainsFileTypes` works without temp files
- [x] Verify cleanup: temp dirs removed after zip/unzip operations