### PR TITLE
fix: sync MLS metadata from core-crypto in join and stale verification [WPB-24051]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationUseCase.kt
@@ -45,6 +45,7 @@ import com.wire.kalium.logic.featureFlags.FeatureSupport
 import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageFailureHandler
 import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageFailureResolution
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
+import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import io.mockative.Mockable
@@ -159,17 +160,7 @@ internal class JoinExistingMLSConversationUseCaseImpl(
                 logger.d(
                     "Skipping join/establish for ${conversation.id.toLogString()} because MLS group already exists locally"
                 )
-                if (protocol.groupState != Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED) {
-                    logger.d(
-                        "Updating local group state to ESTABLISHED for ${conversation.id.toLogString()} to sync DB with local MLS state"
-                    )
-                    conversationRepository.updateConversationGroupStateByConversationId(
-                        conversation.id,
-                        Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED
-                    )
-                } else {
-                    Either.Right(Unit)
-                }
+                syncEstablishedConversationMetadata(transactionContext, conversation)
             }
 
             protocol.epoch != 0UL -> {
@@ -275,5 +266,29 @@ internal class JoinExistingMLSConversationUseCaseImpl(
         put("protocol", CreateConversationParam.Protocol.MLS.name)
         put("protocolInfo", protocol.toLogMap())
         failure?.let { put("errorInfo", "$it") }
+    }
+
+    private suspend fun syncEstablishedConversationMetadata(
+        transactionContext: CryptoTransactionContext,
+        conversation: Conversation
+    ): Either<CoreFailure, Unit> {
+        val protocol = conversation.protocol as? Conversation.ProtocolInfo.MLSCapable ?: return Either.Right(Unit)
+        return transactionContext.wrapInMLSContext { mlsContext ->
+            mlsConversationRepository.getLocalGroupEpoch(mlsContext, protocol.groupId)
+        }.flatMap { localEpoch ->
+            if (protocol.groupState == Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED && protocol.epoch == localEpoch) {
+                Either.Right(Unit)
+            } else {
+                logger.d(
+                    "Updating local MLS metadata for ${conversation.id.toLogString()} to sync DB with local MLS state"
+                )
+                mlsConversationRepository.updateGroupIdAndState(
+                    conversation.id,
+                    protocol.groupId,
+                    localEpoch.toLong(),
+                    ConversationEntity.GroupState.ESTABLISHED
+                )
+            }
+        }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -160,6 +160,11 @@ internal interface MLSConversationRepository : MLSMemberAdder {
 
     suspend fun hasEstablishedMLSGroup(mlsContext: MlsCoreCryptoContext, groupID: GroupID): Either<MLSFailure, Boolean>
 
+    suspend fun getLocalGroupEpoch(
+        mlsContext: MlsCoreCryptoContext,
+        groupID: GroupID
+    ): Either<CoreFailure, ULong>
+
     suspend fun removeMembersFromMLSGroup(
         mlsContext: MlsCoreCryptoContext,
         groupID: GroupID,
@@ -355,6 +360,13 @@ internal class MLSConversationDataSource(
         groupID: GroupID
     ): Either<MLSFailure, Boolean> = wrapMLSRequest {
         mlsContext.conversationExists(idMapper.toCryptoModel(groupID))
+    }
+
+    override suspend fun getLocalGroupEpoch(
+        mlsContext: MlsCoreCryptoContext,
+        groupID: GroupID
+    ): Either<CoreFailure, ULong> = wrapMLSRequest {
+        mlsContext.conversationEpoch(idMapper.toCryptoModel(groupID))
     }
 
     override suspend fun joinGroupByExternalCommit(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ObservableMLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ObservableMLSConversationRepository.kt
@@ -78,6 +78,11 @@ internal class ObservableMLSConversationRepository(
         groupID: GroupID
     ): Either<MLSFailure, Boolean> = delegate.hasEstablishedMLSGroup(mlsContext, groupID)
 
+    override suspend fun getLocalGroupEpoch(
+        mlsContext: MlsCoreCryptoContext,
+        groupID: GroupID
+    ): Either<CoreFailure, ULong> = delegate.getLocalGroupEpoch(mlsContext, groupID)
+
     override suspend fun removeMembersFromMLSGroup(
         mlsContext: MlsCoreCryptoContext,
         groupID: GroupID,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1800,6 +1800,7 @@ public class UserSessionScope internal constructor(
     private val staleEpochVerifier: StaleEpochVerifier
         get() = StaleEpochVerifierImpl(
             systemMessageInserter = systemMessageInserter,
+            fetchConversationUseCase = fetchConversationUseCase,
             conversationRepository = conversationRepository,
             mlsConversationRepository = mlsConversationRepository,
             joinExistingMLSConversation = joinExistingMLSConversationUseCase,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1803,8 +1803,7 @@ public class UserSessionScope internal constructor(
             conversationRepository = conversationRepository,
             mlsConversationRepository = mlsConversationRepository,
             joinExistingMLSConversation = joinExistingMLSConversationUseCase,
-            subconversationRepository = subconversationRepository,
-            fetchConversation = fetchConversationUseCase
+            subconversationRepository = subconversationRepository
         )
 
     private val newMessageHandler: NewMessageEventHandler

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifier.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifier.kt
@@ -144,14 +144,21 @@ internal class StaleEpochVerifierImpl(
     }
 
     private fun ConversationResponse.toRemoteMLSConversationInfo(): Either<CoreFailure, RemoteMLSConversationInfo> {
-        if (protocol != ConvProtocol.MLS) {
-            return Either.Left(MLSFailure.ConversationDoesNotSupportMLS)
-        }
         val remoteGroupId = groupId?.takeIf { it.isNotBlank() }?.let(::GroupID)
-            ?: return Either.Left(CoreFailure.Unknown(IllegalStateException("Missing MLS group id in conversation response")))
         val remoteEpoch = epoch
-            ?: return Either.Left(CoreFailure.Unknown(IllegalStateException("Missing MLS epoch in conversation response")))
-        return Either.Right(RemoteMLSConversationInfo(remoteGroupId, remoteEpoch))
+        return when {
+            protocol != ConvProtocol.MLS ->
+                Either.Left(MLSFailure.ConversationDoesNotSupportMLS)
+
+            remoteGroupId == null ->
+                Either.Left(CoreFailure.Unknown(IllegalStateException("Missing MLS group id in conversation response")))
+
+            remoteEpoch == null ->
+                Either.Left(CoreFailure.Unknown(IllegalStateException("Missing MLS epoch in conversation response")))
+
+            else ->
+                Either.Right(RemoteMLSConversationInfo(remoteGroupId, remoteEpoch))
+        }
     }
 
     private data class RemoteMLSConversationInfo(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifier.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifier.kt
@@ -26,7 +26,10 @@ import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.cryptography.CryptoTransactionContext
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.data.client.wrapInMLSContext
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.ConversationSyncReason
+import com.wire.kalium.logic.data.conversation.FetchConversationUseCase
 import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCase
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.conversation.SubconversationRepository
@@ -34,8 +37,6 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.SubconversationId
 import com.wire.kalium.logic.data.message.SystemMessageInserter
-import com.wire.kalium.network.api.authenticated.conversation.ConvProtocol
-import com.wire.kalium.network.api.authenticated.conversation.ConversationResponse
 import com.wire.kalium.util.ConversationPersistenceApi
 import io.mockative.Mockable
 import kotlinx.datetime.Clock
@@ -53,6 +54,7 @@ internal interface StaleEpochVerifier {
 
 internal class StaleEpochVerifierImpl(
     private val systemMessageInserter: SystemMessageInserter,
+    private val fetchConversationUseCase: FetchConversationUseCase,
     private val conversationRepository: ConversationRepository,
     private val subconversationRepository: SubconversationRepository,
     private val mlsConversationRepository: MLSConversationRepository,
@@ -78,7 +80,7 @@ internal class StaleEpochVerifierImpl(
         conversationId: ConversationId
     ): Either<CoreFailure, Unit> {
         logger.i("Verifying stale epoch for conversation ${conversationId.toLogString()}")
-        return getUpdatedConversationProtocolInfo(conversationId).flatMap { remoteMlsInfo ->
+        return getUpdatedConversationProtocolInfo(transactionContext, conversationId).flatMap { remoteMlsInfo ->
             transactionContext.wrapInMLSContext {
                 mlsConversationRepository.isLocalGroupEpochStale(it, remoteMlsInfo.groupId, remoteMlsInfo.epoch)
             }
@@ -136,28 +138,27 @@ internal class StaleEpochVerifierImpl(
 
     @OptIn(ConversationPersistenceApi::class)
     private suspend fun getUpdatedConversationProtocolInfo(
+        transactionContext: CryptoTransactionContext,
         conversationId: ConversationId
     ): Either<CoreFailure, RemoteMLSConversationInfo> {
-        return conversationRepository.fetchConversation(conversationId).flatMap { response ->
-            response.toRemoteMLSConversationInfo()
+        return fetchConversationUseCase(
+            transactionContext,
+            conversationId,
+            ConversationSyncReason.Other
+        ).flatMap {
+            conversationRepository.getConversationProtocolInfo(conversationId)
+        }.flatMap { protocolInfo ->
+            protocolInfo.toRemoteMLSConversationInfo()
         }
     }
 
-    private fun ConversationResponse.toRemoteMLSConversationInfo(): Either<CoreFailure, RemoteMLSConversationInfo> {
-        val remoteGroupId = groupId?.takeIf { it.isNotBlank() }?.let(::GroupID)
-        val remoteEpoch = epoch
-        return when {
-            protocol != ConvProtocol.MLS ->
+    private fun Conversation.ProtocolInfo.toRemoteMLSConversationInfo(): Either<CoreFailure, RemoteMLSConversationInfo> {
+        return when (this) {
+            !is Conversation.ProtocolInfo.MLS ->
                 Either.Left(MLSFailure.ConversationDoesNotSupportMLS)
 
-            remoteGroupId == null ->
-                Either.Left(CoreFailure.Unknown(IllegalStateException("Missing MLS group id in conversation response")))
-
-            remoteEpoch == null ->
-                Either.Left(CoreFailure.Unknown(IllegalStateException("Missing MLS epoch in conversation response")))
-
             else ->
-                Either.Right(RemoteMLSConversationInfo(remoteGroupId, remoteEpoch))
+                Either.Right(RemoteMLSConversationInfo(groupId, epoch))
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifier.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifier.kt
@@ -26,15 +26,17 @@ import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.cryptography.CryptoTransactionContext
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.data.client.wrapInMLSContext
-import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
-import com.wire.kalium.logic.data.conversation.FetchConversationUseCase
 import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCase
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.conversation.SubconversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.SubconversationId
 import com.wire.kalium.logic.data.message.SystemMessageInserter
+import com.wire.kalium.network.api.authenticated.conversation.ConvProtocol
+import com.wire.kalium.network.api.authenticated.conversation.ConversationResponse
+import com.wire.kalium.util.ConversationPersistenceApi
 import io.mockative.Mockable
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
@@ -54,8 +56,7 @@ internal class StaleEpochVerifierImpl(
     private val conversationRepository: ConversationRepository,
     private val subconversationRepository: SubconversationRepository,
     private val mlsConversationRepository: MLSConversationRepository,
-    private val joinExistingMLSConversation: JoinExistingMLSConversationUseCase,
-    private val fetchConversation: FetchConversationUseCase
+    private val joinExistingMLSConversation: JoinExistingMLSConversationUseCase
 ) : StaleEpochVerifier {
 
     private val logger by lazy { kaliumLogger.withFeatureId(KaliumLogger.Companion.ApplicationFlow.MESSAGES) }
@@ -77,15 +78,9 @@ internal class StaleEpochVerifierImpl(
         conversationId: ConversationId
     ): Either<CoreFailure, Unit> {
         logger.i("Verifying stale epoch for conversation ${conversationId.toLogString()}")
-        return getUpdatedConversationProtocolInfo(transactionContext, conversationId).flatMap { protocol ->
-            if (protocol is Conversation.ProtocolInfo.MLS) {
-                Either.Right(protocol)
-            } else {
-                Either.Left(MLSFailure.ConversationDoesNotSupportMLS)
-            }
-        }.flatMap { protocolInfo ->
+        return getUpdatedConversationProtocolInfo(conversationId).flatMap { remoteMlsInfo ->
             transactionContext.wrapInMLSContext {
-                mlsConversationRepository.isLocalGroupEpochStale(it, protocolInfo.groupId, protocolInfo.epoch)
+                mlsConversationRepository.isLocalGroupEpochStale(it, remoteMlsInfo.groupId, remoteMlsInfo.epoch)
             }
                 .map { epochIsStale ->
                     epochIsStale
@@ -139,12 +134,28 @@ internal class StaleEpochVerifierImpl(
             }
     }
 
+    @OptIn(ConversationPersistenceApi::class)
     private suspend fun getUpdatedConversationProtocolInfo(
-        transactionContext: CryptoTransactionContext,
         conversationId: ConversationId
-    ): Either<CoreFailure, Conversation.ProtocolInfo> {
-        return fetchConversation(transactionContext, conversationId).flatMap {
-            conversationRepository.getConversationProtocolInfo(conversationId)
+    ): Either<CoreFailure, RemoteMLSConversationInfo> {
+        return conversationRepository.fetchConversation(conversationId).flatMap { response ->
+            response.toRemoteMLSConversationInfo()
         }
     }
+
+    private fun ConversationResponse.toRemoteMLSConversationInfo(): Either<CoreFailure, RemoteMLSConversationInfo> {
+        if (protocol != ConvProtocol.MLS) {
+            return Either.Left(MLSFailure.ConversationDoesNotSupportMLS)
+        }
+        val remoteGroupId = groupId?.takeIf { it.isNotBlank() }?.let(::GroupID)
+            ?: return Either.Left(CoreFailure.Unknown(IllegalStateException("Missing MLS group id in conversation response")))
+        val remoteEpoch = epoch
+            ?: return Either.Left(CoreFailure.Unknown(IllegalStateException("Missing MLS epoch in conversation response")))
+        return Either.Right(RemoteMLSConversationInfo(remoteGroupId, remoteEpoch))
+    }
+
+    private data class RemoteMLSConversationInfo(
+        val groupId: GroupID,
+        val epoch: ULong
+    )
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCaseTest.kt
@@ -49,6 +49,7 @@ import com.wire.kalium.network.api.base.authenticated.conversation.ConversationA
 import com.wire.kalium.network.api.model.ErrorResponse
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.KaliumDispatcher
 import io.mockative.any
@@ -186,9 +187,11 @@ class JoinExistingMLSConversationUseCaseTest {
             }.wasNotInvoked()
 
             coVerify {
-                arrangement.conversationRepository.updateConversationGroupStateByConversationId(
+                arrangement.mlsConversationRepository.updateGroupIdAndState(
                     eq(Arrangement.MLS_UNESTABLISHED_GROUP_CONVERSATION.id),
-                    eq(Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED)
+                    eq(Arrangement.GROUP_ID3),
+                    eq(Arrangement.LOCAL_GROUP_EPOCH.toLong()),
+                    eq(ConversationEntity.GroupState.ESTABLISHED)
                 )
             }.wasInvoked(once)
         }
@@ -201,6 +204,7 @@ class JoinExistingMLSConversationUseCaseTest {
                 .withHasRegisteredMLSClient(true)
                 .withGetConversationsByIdSuccessful(Arrangement.MLS_ESTABLISHED_GROUP_CONVERSATION)
                 .withLocalGroupExists(true)
+                .withLocalGroupEpoch(0UL)
                 .arrange()
 
             joinExistingMLSConversationsUseCase(
@@ -209,8 +213,34 @@ class JoinExistingMLSConversationUseCaseTest {
             ).shouldSucceed()
 
             coVerify {
-                arrangement.conversationRepository.updateConversationGroupStateByConversationId(any(), any())
+                arrangement.mlsConversationRepository.updateGroupIdAndState(any(), any(), any(), any())
             }.wasNotInvoked()
+        }
+
+    @Test
+    fun givenEstablishedConversationWithStaleDbEpochAndLocalGroupExists_whenInvokingUseCase_thenSyncEpochFromCoreCrypto() =
+        runTest {
+            val (arrangement, joinExistingMLSConversationsUseCase) = Arrangement(testKaliumDispatcher)
+                .withIsMLSSupported(true)
+                .withHasRegisteredMLSClient(true)
+                .withGetConversationsByIdSuccessful(Arrangement.MLS_ESTABLISHED_GROUP_CONVERSATION)
+                .withLocalGroupExists(true)
+                .withLocalGroupEpoch(Arrangement.LOCAL_GROUP_EPOCH)
+                .arrange()
+
+            joinExistingMLSConversationsUseCase(
+                arrangement.transactionContext,
+                Arrangement.MLS_ESTABLISHED_GROUP_CONVERSATION.id
+            ).shouldSucceed()
+
+            coVerify {
+                arrangement.mlsConversationRepository.updateGroupIdAndState(
+                    eq(Arrangement.MLS_ESTABLISHED_GROUP_CONVERSATION.id),
+                    eq(Arrangement.GROUP_ID3),
+                    eq(Arrangement.LOCAL_GROUP_EPOCH.toLong()),
+                    eq(ConversationEntity.GroupState.ESTABLISHED)
+                )
+            }.wasInvoked(once)
         }
 
     @Test
@@ -320,6 +350,7 @@ class JoinExistingMLSConversationUseCaseTest {
         val fetchConversation = mock(FetchConversationUseCase::class)
         val resetMlsConversation = mock(ResetMLSConversationUseCase::class)
         private var localGroupExists: Boolean = false
+        private var localGroupEpoch: ULong = LOCAL_GROUP_EPOCH
 
         val selfUserId = TestUser.USER_ID
 
@@ -342,7 +373,13 @@ class JoinExistingMLSConversationUseCaseTest {
                 Either.Right(localGroupExists)
             }
             coEvery {
-                conversationRepository.updateConversationGroupStateByConversationId(any(), any())
+                mlsConversationRepository.getLocalGroupEpoch(any(), any())
+            }.returns(Either.Right(localGroupEpoch))
+            coEvery {
+                conversationRepository.updateConversationGroupState(any(), any())
+            }.returns(Either.Right(Unit))
+            coEvery {
+                mlsConversationRepository.updateGroupIdAndState(any(), any(), any(), any())
             }.returns(Either.Right(Unit))
 
             coEvery {
@@ -384,6 +421,10 @@ class JoinExistingMLSConversationUseCaseTest {
 
         suspend fun withLocalGroupExists(exists: Boolean) = apply {
             localGroupExists = exists
+        }
+
+        suspend fun withLocalGroupEpoch(epoch: ULong) = apply {
+            localGroupEpoch = epoch
         }
 
         suspend fun withJoinByExternalCommitGroupFailing(failure: CoreFailure, times: Int = Int.MAX_VALUE) = apply {
@@ -436,6 +477,7 @@ class JoinExistingMLSConversationUseCaseTest {
             val GROUP_ID3 = GroupID("group3")
             val GROUP_ID_ONE_ON_ONE = GroupID("group-one-on-ne")
             val GROUP_ID_SELF = GroupID("group-self")
+            val LOCAL_GROUP_EPOCH = 7UL
 
             val MLS_CONVERSATION1 = TestConversation.GROUP(
                 Conversation.ProtocolInfo.MLS(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifierTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifierTest.kt
@@ -20,12 +20,13 @@ package com.wire.kalium.logic.feature.message
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.common.functional.Either
-import com.wire.kalium.logic.data.conversation.ConversationSyncReason
 import com.wire.kalium.logic.data.conversation.SubConversation
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.SubconversationId
+import com.wire.kalium.logic.data.id.toApi
 import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.util.arrangement.SystemMessageInserterArrangement
 import com.wire.kalium.logic.util.arrangement.SystemMessageInserterArrangementImpl
 import com.wire.kalium.logic.util.arrangement.mls.MLSConversationRepositoryArrangement
@@ -36,26 +37,33 @@ import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryA
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.repository.SubconversationRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.SubconversationRepositoryArrangementImpl
-import com.wire.kalium.logic.util.arrangement.usecase.FetchConversationUseCaseArrangement
-import com.wire.kalium.logic.util.arrangement.usecase.FetchConversationUseCaseArrangementImpl
 import com.wire.kalium.logic.util.arrangement.usecase.JoinExistingMLSConversationUseCaseArrangement
 import com.wire.kalium.logic.util.arrangement.usecase.JoinExistingMLSConversationUseCaseArrangementImpl
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
+import com.wire.kalium.network.api.authenticated.conversation.ConvProtocol
+import com.wire.kalium.network.api.authenticated.conversation.ConversationMemberDTO
+import com.wire.kalium.network.api.authenticated.conversation.ConversationMembersResponse
+import com.wire.kalium.network.api.authenticated.conversation.ConversationResponse
+import com.wire.kalium.network.api.authenticated.conversation.ReceiptMode
+import com.wire.kalium.network.api.model.ConversationAccessDTO
+import com.wire.kalium.network.api.model.ConversationAccessRoleDTO
+import com.wire.kalium.util.ConversationPersistenceApi
 import io.mockative.any
+import io.mockative.coEvery
 import io.mockative.coVerify
 import io.mockative.eq
 import io.mockative.once
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 
+@OptIn(ConversationPersistenceApi::class)
 class StaleEpochVerifierTest {
 
     @Test
     fun givenConversationIsNotMLS_whenHandlingStaleEpoch_thenShouldNotInsertWarning() = runTest {
         val (arrangement, staleEpochHandler) = arrange {
-            withFetchConversationSucceeding()
-            withGetConversationProtocolInfo(Either.Right(TestConversation.PROTEUS_PROTOCOL_INFO))
+            withFetchConversationResponse(Either.Right(PROTEUS_CONVERSATION_RESPONSE))
         }
 
         staleEpochHandler.verifyEpoch(arrangement.transactionContext, CONVERSATION_ID).shouldFail()
@@ -69,14 +77,13 @@ class StaleEpochVerifierTest {
     fun givenMLSConversation_whenHandlingStaleEpoch_thenShouldFetchConversationAgain() = runTest {
         val (arrangement, staleEpochHandler) = arrange {
             withIsGroupOutOfSync(Either.Right(false))
-            withFetchConversationSucceeding()
-            withGetConversationProtocolInfo(Either.Right(TestConversation.MLS_PROTOCOL_INFO))
+            withFetchConversationResponse(Either.Right(MLS_CONVERSATION_RESPONSE))
         }
 
         staleEpochHandler.verifyEpoch(arrangement.transactionContext, CONVERSATION_ID).shouldSucceed()
 
         coVerify {
-            arrangement.fetchConversation(any(), eq(CONVERSATION_ID), eq(ConversationSyncReason.Other))
+            arrangement.conversationRepository.fetchConversation(eq(CONVERSATION_ID))
         }.wasInvoked(once)
     }
 
@@ -84,8 +91,7 @@ class StaleEpochVerifierTest {
     fun givenEpochIsLatest_whenHandlingStaleEpoch_thenShouldNotRejoinTheConversation() = runTest {
         val (arrangement, staleEpochHandler) = arrange {
             withIsGroupOutOfSync(Either.Right(false))
-            withFetchConversationSucceeding()
-            withGetConversationProtocolInfo(Either.Right(TestConversation.MLS_PROTOCOL_INFO))
+            withFetchConversationResponse(Either.Right(MLS_CONVERSATION_RESPONSE))
         }
 
         staleEpochHandler.verifyEpoch(arrangement.transactionContext, CONVERSATION_ID).shouldSucceed()
@@ -99,8 +105,7 @@ class StaleEpochVerifierTest {
     fun givenStaleEpoch_whenHandlingStaleEpoch_thenShouldRejoinTheConversation() = runTest {
         val (arrangement, staleEpochHandler) = arrange {
             withIsGroupOutOfSync(Either.Right(true))
-            withFetchConversationSucceeding()
-            withGetConversationProtocolInfo(Either.Right(TestConversation.MLS_PROTOCOL_INFO))
+            withFetchConversationResponse(Either.Right(MLS_CONVERSATION_RESPONSE))
             withJoinExistingMLSConversationUseCaseReturning(Either.Right(Unit))
             withInsertLostCommitSystemMessage(Either.Right(Unit))
         }
@@ -120,8 +125,7 @@ class StaleEpochVerifierTest {
     fun givenRejoiningFails_whenHandlingStaleEpoch_thenShouldNotInsertLostCommitSystemMessage() = runTest {
         val (arrangement, staleEpochHandler) = arrange {
             withIsGroupOutOfSync(Either.Right(true))
-            withFetchConversationSucceeding()
-            withGetConversationProtocolInfo(Either.Right(TestConversation.MLS_PROTOCOL_INFO))
+            withFetchConversationResponse(Either.Right(MLS_CONVERSATION_RESPONSE))
             withJoinExistingMLSConversationUseCaseReturning(Either.Left(NetworkFailure.NoNetworkConnection(null)))
         }
 
@@ -136,8 +140,7 @@ class StaleEpochVerifierTest {
     fun givenConversationIsRejoined_whenHandlingStaleEpoch_thenShouldInsertLostCommitSystemMessage() = runTest {
         val (arrangement, staleEpochHandler) = arrange {
             withIsGroupOutOfSync(Either.Right(true))
-            withFetchConversationSucceeding()
-            withGetConversationProtocolInfo(Either.Right(TestConversation.MLS_PROTOCOL_INFO))
+            withFetchConversationResponse(Either.Right(MLS_CONVERSATION_RESPONSE))
             withJoinExistingMLSConversationUseCaseReturning(Either.Right(Unit))
             withInsertLostCommitSystemMessage(Either.Right(Unit))
         }
@@ -267,7 +270,7 @@ class StaleEpochVerifierTest {
         }.wasInvoked(once)
 
         coVerify {
-            arrangement.fetchConversation(any(), any(), any())
+            arrangement.conversationRepository.fetchConversation(any())
         }.wasNotInvoked()
     }
 
@@ -277,9 +280,14 @@ class StaleEpochVerifierTest {
         ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
         MLSConversationRepositoryArrangement by MLSConversationRepositoryArrangementImpl(),
         SubconversationRepositoryArrangement by SubconversationRepositoryArrangementImpl(),
-        FetchConversationUseCaseArrangement by FetchConversationUseCaseArrangementImpl(),
         CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl(),
         JoinExistingMLSConversationUseCaseArrangement by JoinExistingMLSConversationUseCaseArrangementImpl() {
+        suspend fun withFetchConversationResponse(result: Either<CoreFailure, ConversationResponse>) {
+            coEvery {
+                conversationRepository.fetchConversation(any())
+            }.returns(result)
+        }
+
         suspend fun arrange() = run {
             block()
             this@Arrangement to StaleEpochVerifierImpl(
@@ -287,8 +295,7 @@ class StaleEpochVerifierTest {
                 conversationRepository = conversationRepository,
                 subconversationRepository = subconversationRepository,
                 mlsConversationRepository = mlsConversationRepository,
-                joinExistingMLSConversation = joinExistingMLSConversationUseCase,
-                fetchConversation = fetchConversation
+                joinExistingMLSConversation = joinExistingMLSConversationUseCase
             )
         }
     }
@@ -297,6 +304,33 @@ class StaleEpochVerifierTest {
         suspend fun arrange(configuration: suspend Arrangement.() -> Unit) = Arrangement(configuration).arrange()
 
         val CONVERSATION_ID = ConversationId("conversation-value", "conversation-domain")
+
+        val MLS_CONVERSATION_RESPONSE = ConversationResponse(
+            creator = TestUser.USER_ID.value,
+            members = ConversationMembersResponse(
+                self = ConversationMemberDTO.Self(TestUser.SELF.id.toApi(), "wire_admin"),
+                otherMembers = listOf(ConversationMemberDTO.Other(TestUser.OTHER.id.toApi(), "wire_member"))
+            ),
+            name = "mls-conversation",
+            id = CONVERSATION_ID.toApi(),
+            groupId = TestConversation.MLS_PROTOCOL_INFO.groupId.value,
+            epoch = TestConversation.MLS_PROTOCOL_INFO.epoch,
+            type = ConversationResponse.Type.GROUP,
+            messageTimer = 0,
+            teamId = null,
+            protocol = ConvProtocol.MLS,
+            lastEventTime = "2022-03-30T15:36:00.000Z",
+            mlsCipherSuiteTag = null,
+            access = setOf(ConversationAccessDTO.INVITE),
+            accessRole = setOf(ConversationAccessRoleDTO.TEAM_MEMBER),
+            receiptMode = ReceiptMode.DISABLED
+        )
+
+        val PROTEUS_CONVERSATION_RESPONSE = MLS_CONVERSATION_RESPONSE.copy(
+            groupId = null,
+            epoch = null,
+            protocol = ConvProtocol.PROTEUS
+        )
 
         val TestSubConversationDetails = SubConversation(
             id = SubconversationId("subconversation-value"),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifierTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifierTest.kt
@@ -19,7 +19,11 @@ package com.wire.kalium.logic.feature.message
 
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.NetworkFailure
+import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationSyncReason
+import com.wire.kalium.logic.data.conversation.FetchConversationUseCase
 import com.wire.kalium.logic.data.conversation.SubConversation
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.GroupID
@@ -53,6 +57,7 @@ import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.coVerify
 import io.mockative.eq
+import io.mockative.mock
 import io.mockative.once
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -83,7 +88,11 @@ class StaleEpochVerifierTest {
         staleEpochHandler.verifyEpoch(arrangement.transactionContext, CONVERSATION_ID).shouldSucceed()
 
         coVerify {
-            arrangement.conversationRepository.fetchConversation(eq(CONVERSATION_ID))
+            arrangement.fetchConversationUseCase.invoke(
+                eq(arrangement.transactionContext),
+                eq(CONVERSATION_ID),
+                eq(ConversationSyncReason.Other)
+            )
         }.wasInvoked(once)
     }
 
@@ -270,7 +279,7 @@ class StaleEpochVerifierTest {
         }.wasInvoked(once)
 
         coVerify {
-            arrangement.conversationRepository.fetchConversation(any())
+            arrangement.fetchConversationUseCase.invoke(any(), any(), any())
         }.wasNotInvoked()
     }
 
@@ -282,16 +291,36 @@ class StaleEpochVerifierTest {
         SubconversationRepositoryArrangement by SubconversationRepositoryArrangementImpl(),
         CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl(),
         JoinExistingMLSConversationUseCaseArrangement by JoinExistingMLSConversationUseCaseArrangementImpl() {
+        val fetchConversationUseCase = mock(FetchConversationUseCase::class)
+
         suspend fun withFetchConversationResponse(result: Either<CoreFailure, ConversationResponse>) {
             coEvery {
-                conversationRepository.fetchConversation(any())
-            }.returns(result)
+                fetchConversationUseCase.invoke(any(), any(), any())
+            }.returns(
+                when (result) {
+                    is Either.Left -> Either.Left(result.value)
+                    is Either.Right -> Either.Right(Unit)
+                }
+            )
+
+            val localProtocolInfo: Either<StorageFailure, Conversation.ProtocolInfo> = when (result) {
+                is Either.Left -> Either.Left(StorageFailure.Generic(IllegalStateException(result.value.toString())))
+                is Either.Right -> when (result.value.protocol) {
+                    ConvProtocol.MLS -> Either.Right(TestConversation.MLS_PROTOCOL_INFO)
+                    else -> Either.Right(Conversation.ProtocolInfo.Proteus)
+                }
+            }
+
+            coEvery {
+                conversationRepository.getConversationProtocolInfo(any())
+            }.returns(localProtocolInfo)
         }
 
         suspend fun arrange() = run {
             block()
             this@Arrangement to StaleEpochVerifierImpl(
                 systemMessageInserter = systemMessageInserter,
+                fetchConversationUseCase = fetchConversationUseCase,
                 conversationRepository = conversationRepository,
                 subconversationRepository = subconversationRepository,
                 mlsConversationRepository = mlsConversationRepository,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24051
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

### Issues

- MLS recovery could still rely on stale local conversation metadata even when the MLS group already existed in core-crypto.
- `JoinExistingMLSConversationUseCase` only synced local DB state partially in that case, which left room for `groupState` / `epoch` drift.
- `StaleEpochVerifier` did not consistently use the freshest MLS metadata source when deciding whether a local group was actually stale.

### Causes (Optional)

- Local persistence, backend metadata, and core-crypto state are not updated atomically and can temporarily drift apart.
- When a conversation already existed locally in core-crypto, Android previously updated only part of the local metadata, instead of fully synchronizing it from the actual local MLS state.
- Some recovery decisions were therefore made from stale or incomplete local metadata rather than from the most reliable available source.

### Solutions

- Updated `JoinExistingMLSConversationUseCase` so that when the MLS group already exists locally, Android synchronizes conversation metadata from core-crypto instead of only forcing `ESTABLISHED`.
- Added retrieval of the local MLS epoch from `MLSConversationRepository` and used it to update persisted metadata consistently.
- Updated `StaleEpochVerifier` integration and related wiring/tests so stale verification and join/recovery logic use the synchronized metadata model.
- Added/adjusted tests covering:
  - syncing established MLS metadata from local core-crypto state,
  - avoiding unnecessary metadata updates when local and persisted state already match,
  - stale verification behavior after the metadata synchronization changes.