### PR TITLE
docs: document MLS runtime, concurrency, and duplicate handling

### DIFF
--- a/docs/mls/README.md
+++ b/docs/mls/README.md
@@ -1,0 +1,84 @@
+# MLS Flow Documentation (Android / Kalium)
+
+This directory documents how Android currently handles MLS-related sync and recovery flows in `kalium/logic`.
+
+The goal of this documentation is to make the Android behavior understandable to:
+- other client teams,
+- core-crypto engineers,
+- backend engineers debugging notification / welcome / rejoin problems.
+
+## Scope
+
+This documentation covers:
+- how MLS-specific use cases and handlers are wired,
+- what each flow does on success,
+- what each flow does on error,
+- where Android relies on local DB state vs core-crypto vs fresh backend state,
+- how incremental sync, batching, cancellation, and duplicate processing can affect MLS flows.
+
+It does **not** try to document MLS protocol semantics in general. It documents the **Android implementation behavior**.
+
+## Documents
+
+- [Use Cases and Handlers](./use-cases.md)
+- [Incremental Sync and Failure Semantics](./incremental-sync.md)
+- [Runtime Timeline and Concurrency](./runtime-concurrency.md)
+- [Duplicate Handling](./duplicate-handling.md)
+
+## Main Entry Points
+
+- `ConversationEventReceiver` dispatches incoming conversation events to handlers:
+  - [`kalium/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt)
+- `IncrementalSyncWorker` processes gathered event batches inside a crypto transaction:
+  - [`kalium/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt)
+- `SyncExecutor` starts/stops sync depending on active requesters:
+  - [`kalium/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncExecutor.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncExecutor.kt)
+- Android app lifecycle requests temporary sync via:
+  - [`app/src/main/kotlin/com/wire/android/util/lifecycle/SyncLifecycleManager.kt`](../../../app/src/main/kotlin/com/wire/android/util/lifecycle/SyncLifecycleManager.kt)
+
+## High-Level Runtime Flow
+
+```mermaid
+flowchart LR
+    A["Push or foreground lifecycle"] --> B["SyncLifecycleManager"]
+    B --> C["SyncExecutor request"]
+    C --> D["Slow sync if needed"]
+    D --> E["IncrementalSyncManager"]
+    E --> F["EventGatherer"]
+    F --> G["EventRepository observeEvents"]
+    G --> H["IncrementalSyncWorker"]
+    H --> I["EventProcessor / ConversationEventReceiver"]
+    I --> J["MLS handlers and use cases"]
+```
+
+## Source of Truth Model
+
+Android MLS flows currently use three different sources of truth:
+
+1. **Core-crypto local state**
+   - `conversationExists(...)`
+   - `conversationEpoch(...)`
+   - welcome processing / join / establish state inside MLS engine
+
+2. **Backend current state**
+   - `fetchConversation(...)`
+   - `fetchGroupInfo(...)`
+   - reset endpoint
+
+3. **Persistence / DB state**
+   - `Conversation.protocol.groupId`
+   - `Conversation.protocol.epoch`
+   - `Conversation.protocol.groupState`
+
+A large part of MLS recovery complexity comes from these three sources becoming temporarily inconsistent.
+
+## Current Android-Specific Safety Guards
+
+The current branch includes these important guards:
+
+- `IncrementalSyncWorker` finishes processing + `setEventsAsProcessed(...)` inside `NonCancellable`, reducing duplicate re-processing during sync cancellation.
+- `JoinExistingMLSConversationUseCase` now syncs DB `epoch` from core-crypto when the MLS group already exists locally.
+- `StaleEpochVerifier` now uses fresh backend `ConversationResponse.epoch` instead of re-reading remote epoch from local DB after fetch.
+- `MLSWelcomeEventHandler` skips external-commit rejoin when `OrphanWelcome` happens but the group is already established locally.
+
+These changes are documented in detail in the linked files above.

--- a/docs/mls/duplicate-handling.md
+++ b/docs/mls/duplicate-handling.md
@@ -1,0 +1,169 @@
+# MLS Duplicate Handling
+
+This file documents how Android handles replay / duplicate processing for the three main MLS event types:
+
+1. `Conversation.MLSWelcome`
+2. `Conversation.NewMLSMessage`
+3. `Conversation.MLSReset`
+
+This is intentionally separate from sync/runtime documentation:
+- [Incremental Sync and Failure Semantics](./incremental-sync.md) explains why replay can happen at the queue/runtime level.
+- [Runtime Timeline and Concurrency](./runtime-concurrency.md) explains how replay can overlap with other MLS flows.
+
+## Why duplicates can happen at all
+
+Android does not have a formal exactly-once guarantee across:
+- process death,
+- app kill,
+- sync restart,
+- observer restart,
+- pending/live merge in the local event queue.
+
+The key reasons are:
+- `lastEmittedEventId` is in-memory only,
+- events are marked processed only after the batch completes,
+- live events can be replaced by pending copies with the same event id,
+- crash/cancel boundaries can replay an already-seen logical event.
+
+Current mitigation:
+- `IncrementalSyncWorker` finishes the current batch and `setEventsAsProcessed(...)` inside `NonCancellable`, reducing duplicate reprocessing during normal sync cancellation.
+
+Sources:
+- [`../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt)
+- [`../../logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt)
+
+## Duplicate `Conversation.MLSWelcome`
+
+Primary handler:
+- [`../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandler.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandler.kt)
+
+### Possible duplicate outcomes
+
+- `ConversationAlreadyExists`
+- `OrphanWelcome`
+- second establish attempt
+- external-commit recovery if the duplicate is not recognized as harmless
+
+### Current Android behavior
+
+#### `ConversationAlreadyExists`
+
+Android:
+- wipes the local conversation in core-crypto,
+- retries the same welcome once.
+
+This is not a pure no-op path. It is a destructive local repair plus retry.
+
+#### `OrphanWelcome`
+
+Android distinguishes two sub-cases:
+
+1. If local DB says `ESTABLISHED` and core-crypto confirms the local group exists:
+   - treat it as an already-handled welcome,
+   - skip external-commit rejoin.
+
+2. Otherwise:
+   - assume the welcome cannot be safely ignored,
+   - discard it,
+   - call `JoinExistingMLSConversationUseCase`.
+
+### Why duplicate welcome is the highest-risk duplicate
+
+If Android does not recognize the duplicate as harmless:
+- it can recover by external commit,
+- and messages sent between the original welcome timing and the rejoin point may be lost/decryption-failed for that client.
+
+## Duplicate `Conversation.NewMLSMessage`
+
+Primary handler:
+- [`../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt)
+
+Failure mapping:
+- [`../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageFailureHandler.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageFailureHandler.kt)
+
+### Possible duplicate outcomes
+
+- duplicate decrypt attempt,
+- `DuplicateMessage`,
+- buffered/future/stale classifications,
+- repeated downstream side effects if the crash boundary is bad.
+
+### Current Android behavior
+
+`NewMessageEventHandler` maps MLS failures into:
+- `Ignore`
+- `InformUser`
+- `OutOfSync`
+- `ResetConversation`
+
+The safest duplicate case is when replay resolves to a no-op/ignore-style failure.
+
+### Real duplicate risk is not just decryption
+
+Successful `NewMLSMessage` processing also triggers side effects:
+- persist application message content,
+- insert decryption/system state,
+- schedule delivery confirmations,
+- schedule self deletion,
+- legal hold handling.
+
+So duplicate safety depends on both:
+- crypto/message failure mapping,
+- idempotency of downstream side effects.
+
+### Practical Android position
+
+Android is relatively safe if replay resolves to:
+- `DuplicateMessage`
+- buffered/future/no-op style failures
+
+Android is less safe if replay happens after:
+- partial success,
+- side effects already happened,
+- process crashes before the event is marked processed.
+
+## Duplicate `Conversation.MLSReset`
+
+Primary handler:
+- [`../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSResetConversationEventHandler.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSResetConversationEventHandler.kt)
+
+### Possible duplicate outcomes
+
+- repeated leave/wipe of old group,
+- repeated metadata update to new group id/state/epoch,
+- second pass classifying the conversation as already-established vs pending-after-reset.
+
+### Current Android behavior
+
+This handler is more repair-oriented than welcome handling:
+- update local metadata to the new group information,
+- if new group already exists locally, mark it established,
+- otherwise leave it pending-after-reset.
+
+### Practical risk level
+
+Duplicate `MLSReset` is usually less dangerous than duplicate welcome because:
+- it already assumes local state may need repair,
+- repeated application often converges toward the same metadata outcome.
+
+It is still not guaranteed to be a strict no-op because:
+- the second processing attempt may observe a different local crypto state than the first,
+- especially if another recovery flow already ran in between.
+
+## Summary Matrix
+
+| Event type | Typical duplicate outcomes | Safest duplicate case | Highest-risk duplicate case |
+|---|---|---|---|
+| `MLSWelcome` | `ConversationAlreadyExists`, `OrphanWelcome`, second establish, external rejoin | `OrphanWelcome` recognized as already-handled welcome | false-negative duplicate causing external rejoin |
+| `NewMLSMessage` | `DuplicateMessage`, buffered/stale classifications, replayed side effects | failure maps to `Ignore` and no side effects repeat | partial success before crash, replay re-triggers side effects |
+| `MLSReset` | repeated metadata sync, second leave/wipe, state reclassification | second pass converges to same repaired state | second pass sees different local state and takes different branch |
+
+## Review Questions
+
+1. Which of these three event types are expected to be idempotent by design?
+2. Which duplicate cases are intentionally “recover by reset/rejoin” rather than strict no-op?
+3. For `NewMLSMessage`, which downstream side effects are guaranteed idempotent and which are only best-effort?
+4. Can core-crypto provide a stronger signal to distinguish:
+   - already-processed welcome
+   - genuinely orphaned welcome
+5. Should duplicate `MLSReset` be explicitly recognized/logged, or is the current repair-oriented behavior sufficient?

--- a/docs/mls/incremental-sync.md
+++ b/docs/mls/incremental-sync.md
@@ -1,0 +1,219 @@
+# Incremental Sync and Failure Semantics
+
+This file documents how Android incremental sync interacts with MLS event processing.
+
+It focuses on:
+- event gathering,
+- batching,
+- transaction boundaries,
+- cancellation,
+- duplicate processing scenarios at the queue/runtime level.
+
+Event-specific duplicate handling is documented separately in:
+- [Duplicate Handling](./duplicate-handling.md)
+
+## Main Components
+
+- `SyncLifecycleManager`
+  - Android lifecycle / notification-triggered sync requests.
+  - [`app/src/main/kotlin/com/wire/android/util/lifecycle/SyncLifecycleManager.kt`](../../../app/src/main/kotlin/com/wire/android/util/lifecycle/SyncLifecycleManager.kt)
+- `SyncExecutor`
+  - starts and cancels sync depending on active requesters.
+  - [`kalium/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncExecutor.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncExecutor.kt)
+- `EventRepository`
+  - websocket + pending notification ingestion and local event queue.
+  - [`kalium/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt)
+- `EventGatherer`
+  - turns remote/local event state into `EventStreamData` batches.
+  - [`kalium/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventGatherer.kt)
+- `IncrementalSyncWorker`
+  - processes batches in crypto transaction and marks them processed.
+  - [`kalium/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt)
+
+## High-Level Sequence
+
+```mermaid
+sequenceDiagram
+    participant App as App / Push
+    participant Lifecycle as SyncLifecycleManager
+    participant Executor as SyncExecutor
+    participant Repo as EventRepository
+    participant Gatherer as EventGatherer
+    participant Worker as IncrementalSyncWorker
+    participant Receiver as ConversationEventReceiver
+
+    App->>Lifecycle: foreground or push-triggered sync
+    Lifecycle->>Executor: request sync
+    Executor->>Gatherer: start incremental sync
+    Gatherer->>Repo: open WS / fetch pending / observe unprocessed events
+    Repo-->>Gatherer: EventStreamData.NewEvents
+    Gatherer-->>Worker: batch of EventEnvelope
+    Worker->>Receiver: process events in transaction
+    Worker->>Repo: setEventsAsProcessed(eventIds)
+```
+
+## Detailed Behavior
+
+### 1. Sync request lifecycle
+
+`SyncExecutor` keeps sync alive as long as at least one request is active.
+
+Important property:
+- sync start/stop is driven by `subscriptionCount` on internal sync state flow.
+
+This means sync can stop as soon as requesters disappear, including temporary push-triggered requesters.
+
+### 2. Temporary sync requests from push / background
+
+`SyncLifecycleManager.syncTemporarily(...)`:
+- opens a sync request,
+- waits until `Live` or failure,
+- optionally keeps request alive for a short grace period,
+- then releases request.
+
+If nothing else keeps sync alive, this can cause sync cancellation shortly after the app becomes live.
+
+### 3. WebSocket open behavior
+
+When WebSocket opens, `EventRepository`:
+1. sets all currently unprocessed events to `pending`,
+2. if on legacy notification flow, fetches pending events from server,
+3. emits `ReadyToProcess` immediately for legacy or waits for sentinel marker in async flow.
+
+This matters because it changes the local queue even before actual event processing begins.
+
+### 4. Event queue semantics
+
+`observeEvents()` emits local unprocessed events in batches.
+
+Important detail:
+- `lastEmittedEventId` is **in-memory only**.
+- If the observer restarts, it is reset to `null`.
+
+Consequence:
+- restart of gather/observe logic can re-emit already seen but not-yet-processed events.
+
+### 5. Pending/live merge behavior
+
+When pending notifications are fetched:
+- Android deletes unprocessed **live** events with the same event ids,
+- then inserts pending versions.
+
+Relevant code:
+- `deleteUnprocessedLiveEventsByIds(...)`
+- followed by `insertEvents(...)`
+
+Consequence:
+- the same `eventId` can appear again from a different source representation,
+- logs around the same logical event may show different `timestampIso` if payload mapping or timing differs.
+
+## Processing Transaction Semantics
+
+`IncrementalSyncWorker` currently does this per batch:
+
+1. collect a `NewEvents` batch from `EventGatherer`,
+2. enter `withContext(NonCancellable)`,
+3. open crypto transaction `processEvents`,
+4. process envelopes one by one,
+5. flush pending side effects,
+6. after transaction success, mark all returned event ids as processed.
+
+### Important current guarantee
+
+The worker now wraps the whole batch processing and `setEventsAsProcessed(...)` path in `NonCancellable`.
+
+Practical effect:
+- if sync cancellation happens because requesters disappear,
+- the current batch is still allowed to finish and mark events as processed.
+
+This directly reduces duplicate event handling during sync restart.
+
+## What can still go wrong
+
+Even with `NonCancellable`, duplicate or repeated handling is still possible in some scenarios.
+
+### Scenario A: process death / app kill
+
+If the process dies before the event is marked processed, local DB still contains an unprocessed event.
+
+Result:
+- after restart, the same event may be processed again.
+
+### Scenario B: crash after partial side effects
+
+If the handler performed side effects before the batch finishes and the process crashes before `setEventsAsProcessed(...)`, the event may be replayed.
+
+Result:
+- side effects may need to be idempotent.
+
+### Scenario C: observer restart + in-memory dedup reset
+
+`lastEmittedEventId` is not persisted.
+
+Result:
+- restarting `observeEvents()` can re-emit the same unprocessed event list.
+
+### Scenario D: pending/live merge reintroduces same event id
+
+If a live event was already inserted locally but still unprocessed, and then pending fetch returns the same event id:
+- unprocessed live event is deleted,
+- pending event is inserted.
+
+Result:
+- same logical event id may enter processing again from a different local row/source combination.
+
+## Why the same MLS event could be processed twice
+
+The observed Android MLS welcome issue is explained by this interaction:
+
+1. event inserted from WebSocket,
+2. batch processing starts,
+3. sync requester count drops to zero and sync is restarted,
+4. pending fetch inserts event list again,
+5. the same event id becomes visible again in a new batch.
+
+Historically, if cancellation hit before `setEventsAsProcessed(...)`, the event remained unprocessed and could be replayed.
+
+The current `NonCancellable` change reduces this specific window substantially.
+
+## MLS-Specific Consequences of Incremental Sync Issues
+
+Queue/runtime replay affects MLS handlers differently depending on event type.
+
+For handler-specific outcomes, see:
+- [Duplicate Handling](./duplicate-handling.md)
+
+## Batch Transaction Guarantees and Gaps
+
+### Guaranteed today
+
+- event batch processing runs in one crypto transaction,
+- pending side effects are flushed before marking processed,
+- current batch is shielded from coroutine cancellation by `NonCancellable`.
+
+### Not guaranteed today
+
+- exactly-once processing across process death,
+- exactly-once side effects across crash boundaries,
+- stable event queue ordering across WS/pending merge and sync restarts,
+- fully consistent DB state vs core-crypto state at every step.
+
+## Cross-Platform Review Questions
+
+These are the most useful questions for other client teams / core-crypto reviewers:
+
+1. Which handlers are truly idempotent if the same event id is processed twice?
+2. Which side effects happen before `setEventsAsProcessed(...)` and therefore can be replayed?
+3. Do other platforms persist an equivalent of `lastEmittedEventId`, or do they rely on pure DB processed flags?
+4. Should `setEventsAsProcessed(...)` eventually move inside the same durable unit as side effects, or is Android's current split acceptable?
+5. Which MLS/core-crypto failures are safe to treat as duplicate/no-op vs requiring rejoin/reset?
+
+## Current Android Position
+
+The current implementation is intentionally pragmatic:
+- reduce duplicate processing during normal coroutine cancellation,
+- prefer core-crypto over DB where local MLS state exists,
+- prefer fresh backend response over DB where remote epoch is needed,
+- still tolerate that some crash/restart scenarios can replay events.
+
+That is not a formal exactly-once guarantee. It is a best-effort model with MLS-specific guards on top.

--- a/docs/mls/runtime-concurrency.md
+++ b/docs/mls/runtime-concurrency.md
@@ -1,0 +1,501 @@
+# MLS Runtime Timeline and Concurrency
+
+This file documents when MLS-related Android use cases are started during normal app runtime, which ones run inside incremental sync, and where race conditions or state drift are still possible.
+
+It is intentionally implementation-focused. The goal is to answer:
+- when a given MLS use case starts,
+- whether it runs inside the incremental sync processing transaction,
+- whether another MLS use case can run at the same time,
+- what is protected by crypto transaction serialization,
+- what can still drift despite that serialization.
+
+Event-specific duplicate handling is documented separately in:
+- [Duplicate Handling](./duplicate-handling.md)
+
+## Runtime Overview
+
+### 1. Sync path
+
+```mermaid
+flowchart TD
+    A["App foreground or push"] --> B["SyncExecutor request"]
+    B --> C["Slow sync starts"]
+    C --> D{"any conversation\nin PENDING_JOIN?"}
+    D -->|"yes"| E["JoinExistingMLSConversationsUseCase"]
+    D -->|"no"| F["skip bulk join"]
+    E --> G["Incremental sync starts"]
+    F --> G
+    G --> H["IncrementalSyncWorker\nprocessEvents transaction"]
+    H --> I{"event type?"}
+    I -->|"MLSWelcome"| J["MLSWelcomeEventHandler"]
+    I -->|"NewMLSMessage"| K["NewMessageEventHandler"]
+    I -->|"MLSReset"| L["MLSResetConversationEventHandler"]
+    J --> M{"welcome failed\nwith OrphanWelcome?"}
+    M -->|"yes, local group missing"| N["JoinExistingMLSConversationUseCase"]
+    M -->|"yes, local group already established"| O["skip rejoin"]
+    M -->|"no"| P["mark ESTABLISHED\ncontinue"]
+    K --> Q{"decrypt failed?"}
+    Q -->|"out of sync"| R["StaleEpochVerifier"]
+    Q -->|"reset-worthy failure"| S["ResetMLSConversationUseCase"]
+    Q -->|"no"| T["persist message and side effects"]
+    R --> U{"backend epoch says\nlocal group is stale?"}
+    U -->|"yes"| N
+    U -->|"no"| V["assume unprocessed local events"]
+    G --> W{"sync reached Live?"}
+    W -->|"yes"| X{"needsToRecoverMLSGroups?"}
+    X -->|"yes"| Y["MLSConversationsRecoveryManager"]
+    Y --> Z["RecoverMLSConversationsUseCase"]
+    Z --> N
+    X -->|"no"| AA["no post-Live recovery"]
+    W -->|"no"| AB["continue catch-up"]
+```
+
+### 2. Send path
+
+```mermaid
+flowchart TD
+    A["User sends message"] --> B["MessageSenderImpl transaction"]
+    B --> C["MLSMessageCreator"]
+    C --> D{"local MLS group exists?"}
+    D -->|"no"| E["JoinExistingMLSConversationUseCase"]
+    D -->|"yes"| F["commit pending proposals if any"]
+    E --> G["encrypt and send"]
+    F --> G
+    G --> H{"send rejected as\nGroupOutOfSync?"}
+    H -->|"yes"| I["handle missing users\nand retry send"]
+    H -->|"no"| J{"send rejected as\nStaleMessage?"}
+    J -->|"yes"| K["StaleEpochVerifier"]
+    K --> L["waitUntilLiveOrFailure"]
+    L --> M["retry send"]
+    J -->|"no"| N["propagate send failure"]
+```
+
+### 3. Foreground recovery and mutation path
+
+```mermaid
+flowchart TD
+    A["FinalizeMLSClientAfterE2EIEnrollment"] --> B["JoinExistingMLSConversationsUseCase"]
+    C["AddMemberToConversationUseCase"] --> D["ConversationGroupRepository.addMembers"]
+    D --> E{"MLS rejection is\nInvalidLeafNodeIndex or Signature?"}
+    E -->|"yes"| F["ResetMLSConversationUseCase"]
+    G["Debug / repair UI"] --> F
+    H["RecoverMLSConversationsUseCase\n(after sync is Live)"] --> I{"local epoch stale?"}
+    I -->|"yes"| J["JoinExistingMLSConversationUseCase"]
+    I -->|"no"| K["do nothing"]
+```
+
+## Main Execution Contexts
+
+### 1. Slow sync phase
+
+Before incremental sync starts, slow sync can trigger MLS-related work:
+
+- `JoinExistingMLSConversationsUseCase`
+  - used for conversations in `PENDING_JOIN`
+  - source:
+    - [`../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorker.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorker.kt)
+    - [`../../logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationsUseCase.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationsUseCase.kt)
+
+- `OneOnOneResolver.resolveAllOneOnOneConversations(...)`
+  - may indirectly enter MLS establish / rejoin decisions
+  - same slow-sync step area as above
+
+Properties:
+- runs before incremental sync batch processing starts,
+- still uses `CryptoTransactionProvider`,
+- can mutate MLS state before event stream replay begins.
+
+### 2. Incremental sync event processing phase
+
+This is the most important MLS runtime path.
+
+`IncrementalSyncWorker`:
+- gathers unprocessed event batches from `EventGatherer`,
+- opens crypto transaction `processEvents`,
+- dispatches events through `ConversationEventReceiver`,
+- flushes pending side effects,
+- only then marks event ids as processed.
+
+Source:
+- [`../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt)
+- [`../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt)
+
+MLS-related handlers running inside this transaction:
+- `MLSWelcomeEventHandler`
+- `NewMessageEventHandler`
+- `MLSResetConversationEventHandler`
+- `ProtocolUpdateEventHandler` for protocol changes
+
+Important consequence:
+- if one of these handlers calls another MLS use case, that nested call happens in the same transaction context unless the nested use case opens a fresh top-level transaction on its own.
+
+### 3. Post-live recovery phase
+
+After incremental sync becomes `Live`, `MLSConversationsRecoveryManager` may trigger:
+- `RecoverMLSConversationsUseCase`
+
+Source:
+- [`../../logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationsRecoveryManager.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationsRecoveryManager.kt)
+- [`../../logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/RecoverMLSConversationsUseCase.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/RecoverMLSConversationsUseCase.kt)
+
+Properties:
+- intentionally delayed until incremental sync is `Live`,
+- reduces overlap with catch-up event processing,
+- still runs in its own crypto transaction,
+- can call `JoinExistingMLSConversationUseCase`.
+
+### 4. User / foreground / debug initiated phase
+
+These do not depend on incremental sync event processing and can be triggered by user behavior or explicit repair tools:
+
+- `MessageSenderImpl`
+  - sending MLS messages
+  - `MLSMessageCreator` may call `JoinExistingMLSConversationUseCase` if the local group does not exist yet
+  - on `StaleMessage` send rejection it calls `StaleEpochVerifier`, which may then rejoin
+  - source: [`../../logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSenderImpl.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSenderImpl.kt)
+  - source: [`../../logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MLSMessageCreator.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MLSMessageCreator.kt)
+- `AddMemberToConversationUseCase`
+  - add-member flow for existing conversation
+  - on selected MLS rejection failures it escalates to `ResetMLSConversationUseCase`
+  - source: [`../../logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCase.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/AddMemberToConversationUseCase.kt)
+- `FinalizeMLSClientAfterE2EIEnrollment`
+  - after enrollment completion, triggers `JoinExistingMLSConversationsUseCase`
+  - source: [`../../logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/FinalizeMLSClientAfterE2EIEnrollment.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/FinalizeMLSClientAfterE2EIEnrollment.kt)
+- `ResetMLSConversationUseCase`
+  - explicit repair/reset path
+  - source: [`../../logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt)
+- debug / repair helpers using their own transaction
+- enrollment/finalization flows that bulk-join MLS conversations
+
+Properties:
+- can happen while sync is active,
+- use the same `CryptoTransactionProvider`,
+- therefore crypto mutations serialize,
+- but they can still observe stale DB/backend state between transactions.
+
+## Send-Time Guarantees and Non-Guarantees
+
+This section is important because send behavior is easy to misunderstand.
+
+### What Android does guarantee today
+
+When an MLS send fails with `StaleMessage`:
+- Android runs `StaleEpochVerifier`,
+- then waits for `syncManager.waitUntilLiveOrFailure()`,
+- then retries the send.
+
+Source:
+- [`../../logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSenderImpl.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSenderImpl.kt)
+
+So Android does have a recovery step that says:
+- once we know the send was stale,
+- do not retry immediately,
+- wait until sync reports `Live`,
+- only then retry.
+
+### What Android does not guarantee today
+
+Android does **not** require `Live` before the **first** MLS send attempt.
+
+That means the first send can happen while:
+- incremental sync is still catching up,
+- local queued MLS commits have not all been processed yet,
+- local DB metadata may still lag behind core-crypto,
+- backend and local snapshots are still converging.
+
+### Practical interpretation
+
+The current send path is:
+
+1. try to send with current local state,
+2. if stale is detected, verify and recover,
+3. wait for `Live`,
+4. retry.
+
+This is a pragmatic model, not a strict “only send after full catch-up” model.
+
+### What this protects against
+
+- retrying too early after a known stale failure,
+- repeatedly sending while sync is obviously behind,
+- missing the chance to recover via stale-epoch verification before retry.
+
+### What this still leaves open
+
+- the first attempt may still use outdated MLS state,
+- the real cause may be:
+  - genuinely missing commits on the local client,
+  - or simply queued events/commits not yet processed,
+- `Live` is only a sync-state checkpoint, not a global guarantee that no further relevant MLS event can arrive immediately after.
+
+### Product implication
+
+If someone asks whether Android guarantees “we only send when fully caught up”, the answer is:
+
+- **No for the first attempt**
+- **Mostly yes for retry after stale detection**
+
+That distinction matters when reasoning about race conditions with incremental sync.
+
+## MLS Use Cases by Trigger
+
+| Use case / handler | Typical trigger | Inside incremental sync transaction | Can also run outside sync | Notes |
+|---|---|---|---|---|
+| `MLSWelcomeEventHandler` | `Conversation.MLSWelcome` event | Yes | No | event-driven only |
+| `NewMessageEventHandler` | `Conversation.NewMLSMessage` event | Yes | No | may trigger stale/recovery logic |
+| `StaleEpochVerifier` | MLS decrypt resolved as out-of-sync | Yes, when called from `NewMessageEventHandler` | Potentially yes if reused elsewhere later | compares local core-crypto vs fresh backend |
+| `JoinExistingMLSConversationUseCase` | orphan welcome recovery, stale recovery, explicit join, send flow, one-on-one resolver | Often yes | Yes | central decision point for join vs establish |
+| `JoinExistingMLSConversationsUseCase` | slow sync, enrollment finalization | No | Yes | opens its own top-level transaction |
+| `RecoverMLSConversationsUseCase` | post-sync `Live` recovery | No | Yes | delayed by `MLSConversationsRecoveryManager` |
+| `ResetMLSConversationUseCase` | reset-worthy MLS failure | Sometimes yes | Yes | can be nested inside sync event processing or used directly |
+| `MLSMessageCreator` | send path before encrypting MLS message | No | Yes | may call `JoinExistingMLSConversationUseCase` if local group does not exist |
+| `AddMemberToConversationUseCase` | user adds members to conversation | No | Yes | can trigger `ResetMLSConversationUseCase` after selected MLS message rejections |
+| `MLSResetConversationEventHandler` | `Conversation.MLSReset` event | Yes | No | updates local metadata after reset event |
+
+## What Transaction Serialization Actually Protects
+
+`CryptoTransactionProvider` serializes access through:
+- `proteus.transaction(...)`
+- `mls.transaction(...)`
+- combined `transaction(...)`
+
+Source:
+- [`../../logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/CryptoTransactionProvider.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/CryptoTransactionProvider.kt)
+
+This is strong protection for:
+- two MLS mutations trying to hit core-crypto at the same time,
+- nested MLS operations during one event batch,
+- send flow colliding with sync flow at the exact crypto mutation point.
+
+In practice, this means:
+- `MLSWelcomeEventHandler` and `MessageSenderImpl` should not mutate the same MLS client truly concurrently,
+- `JoinExistingMLSConversationUseCase` called from sync and `ResetMLSConversationUseCase` called from debug should serialize at transaction level,
+- one transaction will wait for the other rather than executing core-crypto mutations in parallel.
+
+## What Transaction Serialization Does Not Protect
+
+This is the important part. The transaction does **not** make the whole MLS flow globally race-free.
+
+It does **not** protect against:
+
+### 1. DB vs core-crypto drift
+
+Example:
+- transaction A establishes or joins locally,
+- DB metadata is only partially updated,
+- transaction B starts later and reads stale `groupState` / `epoch` from persistence.
+
+Current known examples:
+- `JoinExistingMLSConversationUseCase` still uses DB `epoch != 0` when local group does not exist.
+- `RecoverMLSConversationsUseCase` still compares local core-crypto state against epoch loaded from persistence.
+
+### 2. Backend vs local drift
+
+Example:
+- transaction A fetches remote conversation/group info,
+- before transaction B uses its own fetched metadata, remote state changes,
+- both transactions are locally serialized but reason over different snapshots.
+
+Current known examples:
+- stale join retry path,
+- reset flow after refetch,
+- stale epoch verification using fresh backend metadata while other local handlers may still process old queued events.
+
+### 3. Event queue replay
+
+The event queue lives outside the crypto transaction.
+
+`EventRepository.observeEvents()` keeps `lastEmittedEventId` only in memory.
+If event observation restarts, previously emitted but not yet processed events can be emitted again.
+
+Source:
+- [`../../logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt)
+
+This is exactly why the same logical MLS event can be handled more than once.
+
+### 4. Side effects outside core-crypto state
+
+Some side effects are logically downstream of decryption/processing but not part of the crypto transaction boundary:
+- system messages,
+- delivery confirmations,
+- self-deletion scheduling,
+- logging,
+- UI-observed DB state changes.
+
+If the process dies at the wrong moment, replay can happen even if crypto mutation serialization itself was correct.
+
+### 5. Sync cancellation / restart orchestration
+
+`SyncExecutor` starts and stops sync based on active requesters.
+Temporary requesters from lifecycle or push can disappear while current work is in progress.
+
+Source:
+- [`../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncExecutor.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncExecutor.kt)
+- [`../../../app/src/main/kotlin/com/wire/android/util/lifecycle/SyncLifecycleManager.kt`](../../../app/src/main/kotlin/com/wire/android/util/lifecycle/SyncLifecycleManager.kt)
+
+Current mitigation:
+- `IncrementalSyncWorker` finishes the current batch in `NonCancellable`.
+
+But this still does not guarantee:
+- exactly-once processing across process death,
+- exactly-once side effects,
+- no re-emission after observer restart.
+
+## Concrete Race / Drift Scenarios
+
+### Scenario A: same MLS event replay after sync restart
+
+Timeline:
+1. event inserted from WebSocket,
+2. incremental sync starts processing batch,
+3. sync requester disappears,
+4. sync restarts and pending/live merge rebuilds local event queue,
+5. same event id is observed again.
+
+Transaction result:
+- crypto mutations are serialized,
+- but duplicate logical processing can still happen if event replay occurs.
+
+### Scenario B: send flow vs stale recovery
+
+Timeline:
+1. user sends message,
+2. `MessageSenderImpl` opens transaction,
+3. `MLSMessageCreator` may first trigger `JoinExistingMLSConversationUseCase` if the local group does not exist,
+4. send can fail with `StaleMessage` and call `StaleEpochVerifier`,
+5. incremental sync may also process MLS events for the same conversation around the same time,
+6. verifier may rejoin or repair.
+
+Transaction result:
+- core-crypto mutation is serialized,
+- but the send flow may have already reasoned from metadata that becomes stale by the time recovery runs.
+
+Potential symptom:
+- send failure classified differently than expected,
+- message retry / reset path triggered after local state changed.
+
+Important nuance:
+- Android does **not** require the client to already be `Live` before the first MLS send attempt.
+- The send path waits for `Live` only after a `StaleMessage` rejection and only before the retry.
+- This means the first send attempt can still happen while incremental sync has not yet processed all queued commits/events.
+
+Code path:
+- [`../../logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSenderImpl.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSenderImpl.kt)
+
+Practical consequence:
+- if local MLS state is outdated because commits have not been processed yet, the first send can legitimately fail,
+- Android then tries to recover by:
+  - running `StaleEpochVerifier`,
+  - waiting until sync is `Live`,
+  - retrying the send once it believes catch-up is complete.
+
+What this protects against:
+- retrying immediately while sync is still clearly behind.
+
+What this does **not** guarantee:
+- that the first attempt always had the latest commits,
+- that `Live` means no further relevant MLS event can still arrive immediately after,
+- that the stale cause was definitely “remote missing commits” rather than “queued local events not yet applied”.
+
+### Scenario C: add-members flow vs sync-driven repair
+
+Timeline:
+1. user runs `AddMemberToConversationUseCase`,
+2. server rejects MLS message with `InvalidLeafNodeIndex` or `InvalidLeafNodeSignature`,
+3. add-members flow triggers `ResetMLSConversationUseCase`,
+4. incremental sync may also still process queued MLS events for the same conversation.
+
+Transaction result:
+- crypto mutation is serialized,
+- but queued event processing and add-members UI flow can still reason from different DB/backend snapshots.
+
+Potential symptom:
+- add-members appears to fail or partially recover,
+- conversation state flips through reset/re-establish while sync still catches up.
+
+### Scenario D: recovery manager vs newly processed events
+
+Timeline:
+1. incremental sync becomes `Live`,
+2. `MLSConversationsRecoveryManager` starts recovery transaction,
+3. new live MLS events arrive immediately after `Live`,
+4. recovery and subsequent event processing use different local/remote snapshots.
+
+Mitigation:
+- manager waits for `Live`, which is better than running during catch-up.
+
+Remaining issue:
+- `Live` is not a global quiescent point. It only means current queue caught up once.
+
+### Scenario E: reset fallback using stale DB epoch
+
+Timeline:
+1. local MLS group is missing,
+2. `ResetMLSConversationUseCase` cannot read epoch from core-crypto,
+3. it falls back to DB epoch,
+4. backend reset is executed with that fallback epoch.
+
+Transaction result:
+- transaction is serialized,
+- but correctness still depends on persistence freshness.
+
+### Scenario F: recover-established flow using stale DB epoch
+
+Timeline:
+1. conversation is marked `ESTABLISHED` in DB,
+2. local epoch changed earlier or DB update lagged,
+3. `RecoverMLSConversationsUseCase` compares core-crypto against persistence epoch,
+4. it may classify stale/non-stale incorrectly.
+
+This is not a transaction race.
+It is a source-of-truth problem.
+
+## Practical Conclusions
+
+### Safe assumptions
+
+- MLS crypto mutations are not expected to run in parallel against core-crypto if they all go through `CryptoTransactionProvider`.
+- Event handlers inside one incremental sync batch behave as one serialized crypto-processing unit.
+- post-live recovery is less likely to fight with catch-up processing because it starts only after `Live`.
+
+### Unsafe assumptions
+
+- `Live` does not mean no further MLS event can arrive while recovery runs.
+- DB `epoch` / `groupState` are not guaranteed to be perfectly synchronized with local core-crypto state.
+- event processing is not exactly-once across restart/crash boundaries.
+- transaction boundaries do not make backend snapshots and DB snapshots atomic with crypto state.
+
+## Where I Would Still Look for State Drift
+
+These are the highest-value areas to keep reviewing:
+
+1. `JoinExistingMLSConversationUseCase`
+   - branch on DB `epoch`
+   - source: [`../../logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationUseCase.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationUseCase.kt)
+
+2. `RecoverMLSConversationsUseCase`
+   - stale comparison against DB epoch
+   - source: [`../../logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/RecoverMLSConversationsUseCase.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/RecoverMLSConversationsUseCase.kt)
+
+3. `ResetMLSConversationUseCase`
+   - DB epoch fallback when local group is missing
+   - source: [`../../logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt)
+
+4. `EventRepository.observeEvents()`
+   - in-memory dedup only
+   - source: [`../../logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventRepository.kt)
+
+5. `IncrementalSyncWorker`
+   - batch processing vs side effects vs mark-processed boundary
+   - source: [`../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt)
+
+## Review Questions for Other Platforms and Core-Crypto
+
+1. Do other platforms have an equivalent of `post-Live recovery`, and if yes, do they treat `Live` as sufficient isolation from incremental event processing?
+2. Which MLS flows are expected to be idempotent if replayed after restart or crash?
+3. Do other platforms rely on DB `epoch` for `join vs establish` or only for diagnostics?
+4. If local MLS group is missing, what is the preferred source of truth for recovery:
+   - backend,
+   - DB,
+   - or “hard fail and refetch everything”?
+5. Should recovery flows that use backend snapshots be considered authoritative over local persistence even if sync is still active?

--- a/docs/mls/use-cases.md
+++ b/docs/mls/use-cases.md
@@ -1,0 +1,340 @@
+# MLS Use Cases and Handlers
+
+This file documents the main MLS-related Android flows and their error behavior.
+
+## Overview Table
+
+| Flow | Trigger | Success path | Main error behavior |
+|---|---|---|---|
+| `MLSWelcomeEventHandler` | `Conversation.MLSWelcome` event | process welcome, mark conversation established, resolve 1:1, refill key packages | recover from `ConversationAlreadyExists`; on `OrphanWelcome` either skip rejoin or rejoin depending on local state |
+| `JoinExistingMLSConversationUseCase` | explicit rejoin / stale recovery / orphan welcome recovery | join by external commit or establish locally | stale join retries after refetch, reset on selected failures |
+| `JoinExistingMLSConversationsUseCase` | bulk recovery for `PENDING_JOIN` conversations | iterate all pending MLS conversations and join/establish them | network/keypackage failures are mostly skipped, not fatal |
+| `RecoverMLSConversationsUseCase` | post-sync MLS recovery for established groups | compare local MLS epoch with stored remote epoch and rejoin if stale | `ConversationNotFound` marks group as `PENDING_AFTER_RESET` |
+| `StaleEpochVerifier` | MLS message decryption reports out-of-sync | compare local core-crypto epoch with fresh backend epoch, then rejoin if stale | does not rejoin if issue was only unprocessed local events |
+| `ResetMLSConversationUseCase` | explicit recovery when conversation cannot be recovered otherwise | reset backend conversation, leave local group, refetch metadata, establish again | if local MLS group is missing, fallback uses DB epoch |
+| `MLSResetConversationEventHandler` | `Conversation.MLSReset` event | leave old group, update new group id/state/epoch | if new group already exists locally, marks established; otherwise pending-after-reset |
+| `NewMessageEventHandler` | incoming Proteus/MLS message event | decrypt, persist application message, run side effects | MLS errors are mapped to ignore / inform-user / out-of-sync / reset |
+
+---
+
+## `MLSWelcomeEventHandler`
+
+Source:
+- [`kalium/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandler.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandler.kt)
+
+Detailed duplicate/replay semantics for `MLSWelcome`, `NewMLSMessage`, and `MLSReset` are documented separately in:
+- [Duplicate Handling](./duplicate-handling.md)
+
+### Normal flow
+
+1. Ensure MLS is enabled in the transaction context.
+2. Call `fetchConversationIfUnknown(...)` so local metadata exists.
+3. Call `processWelcomeMessage(...)` in core-crypto.
+4. If welcome carries CRL distribution points, validate them.
+5. Mark conversation as `ESTABLISHED` in local persistence.
+6. If this is a 1:1, resolve the one-on-one protocol state.
+7. Attempt to refill key packages.
+8. Log structured success with timing data.
+
+### Error handling
+
+#### `MLSFailure.ConversationAlreadyExists`
+
+Behavior:
+- wipe local conversation in core-crypto,
+- retry processing the same welcome once.
+
+Why:
+- this handles the case where local crypto state still contains a previous group for the same conversation.
+
+#### `MLSFailure.OrphanWelcome`
+
+Behavior is split into two sub-cases:
+
+1. If local DB says the group is `ESTABLISHED` **and** core-crypto confirms the group exists:
+   - skip rejoin,
+   - do **not** rejoin by external commit.
+
+2. Otherwise:
+   - discard welcome,
+   - try `JoinExistingMLSConversationUseCase`.
+
+Why:
+- the same core-crypto error can mean either:
+  - the welcome was already processed before, or
+  - the referenced key package was genuinely no longer available locally.
+
+### Important limitation
+
+After successful welcome processing Android currently marks the conversation as `ESTABLISHED`, but welcome flow itself does not directly write the local core-crypto epoch back into DB. Later recovery flows may therefore still need to resynchronize state.
+
+---
+
+## `JoinExistingMLSConversationUseCase`
+
+Source:
+- [`kalium/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationUseCase.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationUseCase.kt)
+
+### Purpose
+
+Join or establish MLS for a conversation where the user is already a member but local MLS state may be missing or stale.
+
+### Decision tree
+
+1. If protocol is not MLS-capable: no-op.
+2. If core-crypto already has the local MLS group:
+   - skip join/establish,
+   - synchronize DB metadata with local MLS state (`groupState=ESTABLISHED`, `epoch=local core-crypto epoch`).
+3. Else if DB `epoch != 0`:
+   - fetch `groupInfo` from backend,
+   - join by external commit.
+4. Else:
+   - establish a new local group using members/public keys.
+
+### Why step 2 matters
+
+This is one of the main Android protections against **state drift**:
+- DB may say `epoch=0` or `PENDING_JOIN`,
+- while core-crypto already has an established group.
+
+The current implementation explicitly trusts core-crypto more than DB in this case.
+
+### Error handling for external commit join
+
+`MLSMessageFailureHandler` maps failures to:
+
+- `Ignore`
+  - log and stop.
+- `ResetConversation`
+  - call `ResetMLSConversationUseCase`.
+- anything else
+  - propagate failure.
+
+### Retry behavior
+
+If join/establish fails with `StaleMessage`:
+- refetch conversation state,
+- read updated conversation from repository,
+- retry join/establish once with fresher metadata.
+
+### Still using DB state
+
+When local MLS group does **not** exist, the use case still uses DB `epoch != 0` to choose between `join` and `establish`.
+
+This is an intentional compromise:
+- if core-crypto has no local group, it cannot provide the missing epoch,
+- replacing this branch safely would require a backend-first strategy instead of local DB fallback.
+
+---
+
+## `JoinExistingMLSConversationsUseCase`
+
+Source:
+- [`kalium/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationsUseCase.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationsUseCase.kt)
+
+### Purpose
+
+Bulk wrapper over `JoinExistingMLSConversationUseCase` for all conversations currently in `PENDING_JOIN`.
+
+### Flow
+
+1. Open one crypto transaction.
+2. Load conversations with `groupState = PENDING_JOIN`.
+3. Launch async join tasks per conversation.
+4. Await all tasks; fail if one async result returns a hard failure.
+
+### Error behavior
+
+This bulk use case is intentionally tolerant:
+
+- `NetworkFailure.ServerMiscommunication` with invalid request:
+  - skipped.
+- `CoreFailure.MissingKeyPackages`:
+  - skipped.
+- other non-network failures:
+  - skipped.
+- generic network failure:
+  - propagated.
+
+This means bulk join is not a strict “all or nothing” operation from a product point of view.
+
+---
+
+## `RecoverMLSConversationsUseCase`
+
+Source:
+- [`kalium/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/RecoverMLSConversationsUseCase.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/RecoverMLSConversationsUseCase.kt)
+
+### Purpose
+
+Post-sync recovery for conversations already marked `ESTABLISHED`.
+
+### Flow
+
+1. Load all conversations with group state `ESTABLISHED`.
+2. For each MLS conversation:
+   - compare local core-crypto epoch against stored conversation epoch using `isLocalGroupEpochStale(...)`.
+3. If stale:
+   - call `JoinExistingMLSConversationUseCase`.
+4. If local crypto group is missing:
+   - mark conversation `PENDING_AFTER_RESET`.
+
+### Important caveat
+
+This use case still uses the conversation epoch from **local persistence** as the “remote/current” epoch reference.
+
+That means it is still sensitive to DB drift.
+
+This was left unchanged on purpose for now because replacing it with a backend fetch per conversation changes recovery cost and behavior significantly.
+
+---
+
+## `MLSConversationsRecoveryManager`
+
+Source:
+- [`kalium/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationsRecoveryManager.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationsRecoveryManager.kt)
+
+### Purpose
+
+Coordinator that waits until incremental sync is `Live` and only then triggers `RecoverMLSConversationsUseCase` if the persistent flag `needsToRecoverMLSGroups` is set.
+
+This avoids running MLS recovery too early while sync is still catching up.
+
+---
+
+## `StaleEpochVerifier`
+
+Source:
+- [`kalium/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifier.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifier.kt)
+
+### Trigger
+
+Called from `NewMessageEventHandler` when MLS message decryption resolves to `OutOfSync`.
+
+### Current behavior
+
+For parent conversations:
+1. Fetch fresh conversation metadata from backend.
+2. Extract remote `groupId` + `epoch` from `ConversationResponse`.
+3. Ask core-crypto whether local epoch is stale relative to that fresh backend epoch.
+4. If stale:
+   - rejoin existing MLS conversation,
+   - insert “lost commit” system message.
+5. If not stale:
+   - assume local issue was likely unprocessed events rather than missing commits,
+   - do nothing else.
+
+For subconversations:
+- fetch fresh subconversation details directly from backend,
+- do the same stale comparison,
+- if stale, join by external commit using backend group info.
+
+### Why this matters
+
+Earlier Android logic read epoch back from local DB after fetch. Current code instead uses the **fresh backend response directly**, which reduces the chance that stale persistence causes a wrong recovery decision.
+
+---
+
+## `ResetMLSConversationUseCase`
+
+Source:
+- [`kalium/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt)
+
+### Purpose
+
+Last-resort repair when Android decides the conversation must be reset.
+
+### Flow
+
+1. Check feature flags / user config / federation constraints.
+2. In a crypto transaction:
+   - get MLS-capable protocol info from conversation repository,
+   - try to get current local epoch from core-crypto,
+   - if local group is missing, fallback to DB epoch,
+   - call backend reset endpoint,
+   - leave local group,
+   - refetch conversation,
+   - re-establish MLS group with updated group id and current members.
+
+### Why this is still risky
+
+This is one of the last places where Android still falls back to DB epoch when core-crypto returns `ConversationNotFound`.
+
+That fallback is still there because:
+- by definition local crypto state is missing,
+- so core-crypto cannot provide epoch,
+- and this flow has not yet been rewritten to be fully backend-first.
+
+For cross-platform discussions, this is one of the most important places to review.
+
+---
+
+## `MLSResetConversationEventHandler`
+
+Source:
+- [`kalium/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSResetConversationEventHandler.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSResetConversationEventHandler.kt)
+
+### Purpose
+
+React to an incoming `Conversation.MLSReset` event.
+
+### Flow
+
+1. Leave the old group locally.
+2. Check whether the new group already exists in core-crypto.
+3. If yes:
+   - read epoch from core-crypto,
+   - set new state to `ESTABLISHED`.
+4. If no:
+   - set epoch to `0`,
+   - set new state to `PENDING_AFTER_RESET`.
+5. Update DB with new group id, new epoch, and new state.
+
+This is a good example of trusting core-crypto over DB where possible.
+
+---
+
+## `NewMessageEventHandler`
+
+Source:
+- [`kalium/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt)
+
+### MLS path
+
+1. Unpack MLS message via `MLSMessageUnpacker`.
+2. On success:
+   - process each unpacked message in the batch,
+   - persist application messages,
+   - run legal hold handling / delivery confirmation / self deletion side effects.
+3. On failure:
+   - map error via `MLSMessageFailureHandler`.
+
+### Failure outcomes
+
+- `Ignore`
+  - log only.
+- `InformUser`
+  - optionally insert failed decryption placeholder.
+- `OutOfSync`
+  - call `StaleEpochVerifier`.
+- `ResetConversation`
+  - call `ResetMLSConversationUseCase`.
+
+---
+
+## `MLSMessageFailureHandler`
+
+Source:
+- [`kalium/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageFailureHandler.kt`](../../logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageFailureHandler.kt)
+
+### Resolution matrix summary
+
+| Failure family | Resolution |
+|---|---|
+| `WrongEpoch`, `InvalidGroupId` | `OutOfSync` |
+| rejected failures indicating broken group state (`GroupOutOfSync`, invalid leaf info) | `ResetConversation` |
+| stale/missing reference/client mismatch style rejected failures | `InformUser` |
+| duplicates / buffered futures / self commit / unmerged / stale proposal / old epoch / orphan welcome / conversation missing | `Ignore` |
+| generic MLS / network / storage / unknown failures | `InformUser` |
+
+This is the central mapping that decides whether Android tries to recover, resets, or only surfaces a failure placeholder.


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

### Issues

- Document MLS runtime behavior and recovery flows in a way that is easier to review across teams.

### Causes (Optional)

- MLS behavior is spread across sync, send, recovery, and repair paths, so understanding it from code alone is time-consuming.
- Replay and state-drift scenarios are especially hard to reason about without a dedicated write-up.

### Solutions

- Added MLS documentation under `docs/mls/`.
- Covered:
  - use cases and handlers,
  - incremental sync and replay semantics,
  - runtime/concurrency timelines,
  - duplicate handling for `MLSWelcome`, `NewMLSMessage`, and `MLSReset`.