### PR TITLE
fix: read confirmation on reply from notification (WPB-8756)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
@@ -67,12 +67,27 @@ public class UpdateConversationReadDateUseCase internal constructor(
     /**
      * @param conversationId The conversation id to update the last read date.
      * @param time The last read date to update.
+     * @param invokeImmediately If true, executes the work directly in the calling coroutine instead of
+     *   enqueuing it to the debounced work queue. Use this when the read receipt must be sent within the
+     *   active sync session (e.g. when replying from a notification).
      */
-    public operator fun invoke(conversationId: QualifiedID, time: Instant) {
-        workQueue.enqueue(ConversationTimeEventInput(conversationId, time), worker)
+    public suspend operator fun invoke(
+        conversationId: QualifiedID,
+        time: Instant,
+        invokeImmediately: Boolean = false,
+    ) {
+        if (invokeImmediately) {
+            doWork(conversationId, time)
+        } else {
+            workQueue.enqueue(ConversationTimeEventInput(conversationId, time), worker)
+        }
     }
 
     private val worker = ConversationTimeEventWorker { (conversationId, time) ->
+        doWork(conversationId, time)
+    }
+
+    private suspend fun doWork(conversationId: QualifiedID, time: Instant) {
         coroutineScope {
             conversationRepository.observeConversationById(conversationId).first().onFailure {
                 logger.w("Failed to update conversation read date; StorageFailure $it")

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCaseTest.kt
@@ -142,6 +142,44 @@ class UpdateConversationReadDateUseCaseTest {
     }
 
     @Test
+    fun givenProvidedTimeIsNewer_whenInvokedImmediately_thenSendConfirmationIsCalled() = runTest {
+        val persistedLastRead = Clock.System.now()
+        val newLastRead = persistedLastRead + 1.seconds
+        val conversationId = TestConversation.CONVERSATION.id
+        val (arrangement, updateConversationReadDateUseCase) = arrange {
+            withObserveByIdReturning(
+                TestConversation.CONVERSATION.copy(lastReadDate = persistedLastRead)
+            )
+        }
+
+        updateConversationReadDateUseCase(conversationId, newLastRead, invokeImmediately = true)
+
+        coVerify {
+            arrangement.sendConfirmation(eq(conversationId), eq(persistedLastRead), eq(newLastRead))
+        }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenStoredLastReadDateIsNewer_whenInvokedImmediately_thenSendConfirmationIsNotCalled() = runTest {
+        val persistedLastRead = Clock.System.now()
+        val conversationId = TestConversation.CONVERSATION.id
+        val (arrangement, updateConversationReadDateUseCase) = arrange {
+            withObserveByIdReturning(
+                TestConversation.CONVERSATION.copy(lastReadDate = persistedLastRead)
+            )
+        }
+
+        updateConversationReadDateUseCase(conversationId, persistedLastRead - 1.seconds, invokeImmediately = true)
+
+        coVerify {
+            arrangement.sendConfirmation(any(), any(), any())
+        }.wasNotInvoked()
+        coVerify {
+            arrangement.conversationRepository.updateConversationReadDate(any(), any())
+        }.wasNotInvoked()
+    }
+
+    @Test
     fun givenAnyCall_whenInvoking_thenShouldEnqueueWork() = runTest {
         val expectedId = TestConversation.CONVERSATION.id.copy(value = "potato")
         val expectedTime = Clock.System.now()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8756
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-8756
----

# What's new in this PR?

### Issues
See issue description here: https://github.com/wireapp/wire-android/pull/4658

### Solutions
Adding new flag to bypass the 3 second delay for updating the last read date and sending read receipt.