### PR TITLE
fix: failure message for adding user with no mls client (WPB-17105)

### DIFF
--- a/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
+++ b/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageContent.kt
@@ -300,7 +300,7 @@ sealed interface MessageContent {
          * Note: This is only valid for the creator of the conversation, local-only.
          */
         data class FailedToAdd(override val members: List<UserId>, val type: Type) : MemberChange(members) {
-            enum class Type { Federation, LegalHold, Unknown; }
+            enum class Type { Federation, LegalHold, Unknown, MissingKeyPackages; }
         }
 
         /**

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageEntity.kt
@@ -187,6 +187,12 @@ sealed interface MessageEntity {
         FAILED_TO_ADD_UNKNOWN,
 
         /**
+         * A member(s) was not added to the conversation due to missing MLS key packages.
+         * Note: This is only valid for the creator of the conversation, local-only.
+         */
+        FAILED_TO_ADD_MISSING_KEY_PACKAGES,
+
+        /**
          * Member(s) removed from the conversation, due to some backend stopped to federate between them, or us.
          */
         FEDERATION_REMOVED,

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageMapper.kt
@@ -175,7 +175,8 @@ object MessageMapper {
 
                     MessageEntity.MemberChangeType.FAILED_TO_ADD_FEDERATION,
                     MessageEntity.MemberChangeType.FAILED_TO_ADD_LEGAL_HOLD,
-                    MessageEntity.MemberChangeType.FAILED_TO_ADD_UNKNOWN -> {
+                    MessageEntity.MemberChangeType.FAILED_TO_ADD_UNKNOWN,
+                    MessageEntity.MemberChangeType.FAILED_TO_ADD_MISSING_KEY_PACKAGES -> {
                         MessagePreviewEntityContent.MembersFailedToAdded(
                             senderName = senderName,
                             isContainSelfUserId = userIdList.firstOrNull { it.value == selfUserId?.value }?.let { true } ?: false,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
@@ -351,7 +351,7 @@ internal class ConversationGroupRepositoryImpl(
                     userIdList = validUsers,
                     lastUsersAttempt = LastUsersAttempt.Failed(
                         failedUsers = lastUsersAttempt.failedUsers + failedUsers,
-                        failType = FailedToAdd.Type.Federation,
+                        failType = FailedToAdd.Type.MissingKeyPackages,
                     ),
                     remainingAttempts = remainingAttempts - 1,
                     cipherSuite = cipherSuite
@@ -398,6 +398,7 @@ internal class ConversationGroupRepositoryImpl(
                     userIdList = (lastUsersAttempt.failedUsers + userIdList),
                     type = when {
                         this.isMissingLegalHoldConsentError -> FailedToAdd.Type.LegalHold
+                        this is CoreFailure.MissingKeyPackages -> FailedToAdd.Type.MissingKeyPackages
                         else -> FailedToAdd.Type.Federation
                     }
                 ).flatMap {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageMapper.kt
@@ -467,6 +467,9 @@ internal fun MessageEntityContent.System.toMessageContent(): MessageContent.Syst
             MessageEntity.MemberChangeType.FAILED_TO_ADD_UNKNOWN ->
                 MessageContent.MemberChange.FailedToAdd(memberList, MessageContent.MemberChange.FailedToAdd.Type.Unknown)
 
+            MessageEntity.MemberChangeType.FAILED_TO_ADD_MISSING_KEY_PACKAGES ->
+                MessageContent.MemberChange.FailedToAdd(memberList, MessageContent.MemberChange.FailedToAdd.Type.MissingKeyPackages)
+
             MessageEntity.MemberChangeType.FEDERATION_REMOVED -> MessageContent.MemberChange.FederationRemoved(memberList)
             MessageEntity.MemberChangeType.REMOVED_FROM_TEAM -> MessageContent.MemberChange.RemovedFromTeam(memberList)
         }
@@ -765,6 +768,12 @@ internal fun MessageContent.System.toMessageEntityContent(): MessageEntityConten
 
                     MessageContent.MemberChange.FailedToAdd.Type.Unknown ->
                         MessageEntityContent.MemberChange(memberUserIdList, MessageEntity.MemberChangeType.FAILED_TO_ADD_UNKNOWN)
+
+                    MessageContent.MemberChange.FailedToAdd.Type.MissingKeyPackages ->
+                        MessageEntityContent.MemberChange(
+                            memberUserIdList,
+                            MessageEntity.MemberChangeType.FAILED_TO_ADD_MISSING_KEY_PACKAGES
+                        )
                 }
 
             is MessageContent.MemberChange.FederationRemoved -> MessageEntityContent.MemberChange(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-17105
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-17105
----

# What's new in this PR?

### Issues
When adding user with no MLS client application is showing Federation error and support page in conversation.

### Causes (Optional)
MissingKeyPackages error is always mapped to Federation error.

### Solutions
Adding new MissingKeyPackages so that we can detect it and show correct system message.