### PR TITLE
feat(nomad devices): migrate LAST_READ event to CONVERSATION_METADATA with last_modified support (part 27) [WPB-24198]

### DIFF
--- a/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/nomaddevice/NomadConversationMetadataResponse.kt
+++ b/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/nomaddevice/NomadConversationMetadataResponse.kt
@@ -38,5 +38,7 @@ data class NomadConversationMetadataItem(
 @Serializable
 data class NomadConversationMetadata(
     @SerialName("last_read")
-    val lastRead: Long
+    val lastRead: Long,
+    @SerialName("last_modified")
+    val lastModified: Long? = null,
 )

--- a/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/nomaddevice/NomadMessageEventsRequest.kt
+++ b/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/nomaddevice/NomadMessageEventsRequest.kt
@@ -82,23 +82,25 @@ sealed interface NomadMessageEvent {
     ) : NomadMessageEvent
 
     @Serializable
-    @SerialName("LAST_READ")
-    data class LastReadEvent(
-        @SerialName("last_read")
-        val lastRead: List<LastRead>
+    @SerialName("CONVERSATION_METADATA")
+    data class ConversationMetadataEvent(
+        @SerialName("conversation_metadata")
+        val conversationMetadata: List<ConversationMetadataEntry>
     ) : NomadMessageEvent {
         init {
-            require(lastRead.isNotEmpty()) { "last_read must not be empty." }
+            require(conversationMetadata.isNotEmpty()) { "conversation_metadata must not be empty." }
         }
     }
 }
 
 @Serializable
-data class LastRead(
+data class ConversationMetadataEntry(
     @SerialName("conversation_id")
     val conversationId: String,
     @SerialName("last_read")
-    val lastReadTimestamp: Long
+    val lastReadTimestamp: Long,
+    @SerialName("last_modified")
+    val lastModifiedTimestamp: Long,
 )
 
 @Serializable

--- a/data/network/src/commonTest/kotlin/com/wire/kalium/api/v0/nomaddevice/NomadDeviceSyncApiV0Test.kt
+++ b/data/network/src/commonTest/kotlin/com/wire/kalium/api/v0/nomaddevice/NomadDeviceSyncApiV0Test.kt
@@ -22,7 +22,7 @@ import com.wire.kalium.api.ApiTest
 import com.wire.kalium.api.TEST_BACKEND_CONFIG
 import com.wire.kalium.api.json.model.testCredentials
 import com.wire.kalium.network.AuthenticatedNetworkClient
-import com.wire.kalium.network.api.authenticated.nomaddevice.LastRead
+import com.wire.kalium.network.api.authenticated.nomaddevice.ConversationMetadataEntry
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadMessageEvent
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadMessageEventsRequest
 import com.wire.kalium.network.api.base.authenticated.AccessTokenApi
@@ -114,6 +114,7 @@ internal class NomadDeviceSyncApiV0Test : ApiTest() {
         assertTrue(response.isSuccessful())
         assertEquals(1, response.value.conversations.size)
         assertEquals(1707235100L, response.value.conversations.first().metadata.lastRead)
+        assertEquals(1707235200L, response.value.conversations.first().metadata.lastModified)
     }
 
     @Test
@@ -234,9 +235,9 @@ internal class NomadDeviceSyncApiV0Test : ApiTest() {
     }
 
     @Test
-    fun givenEmptyLastReadEvent_whenConstructingMessageEvent_thenItShouldThrow() {
+    fun givenEmptyConversationMetadataEvent_whenConstructingMessageEvent_thenItShouldThrow() {
         val exception = assertFailsWith<IllegalArgumentException> {
-            NomadMessageEvent.LastReadEvent(lastRead = emptyList())
+            NomadMessageEvent.ConversationMetadataEvent(conversationMetadata = emptyList())
         }
 
         assertFalse(exception.message.isNullOrBlank())
@@ -466,10 +467,18 @@ internal class NomadDeviceSyncApiV0Test : ApiTest() {
     private companion object {
         val REQUEST = NomadMessageEventsRequest(
             events = listOf(
-                NomadMessageEvent.LastReadEvent(
-                    lastRead = listOf(
-                        LastRead(conversationId = "conv_1", lastReadTimestamp = 1772014500000),
-                        LastRead(conversationId = "conv_2", lastReadTimestamp = 1772014800000)
+                NomadMessageEvent.ConversationMetadataEvent(
+                    conversationMetadata = listOf(
+                        ConversationMetadataEntry(
+                            conversationId = "conv_1",
+                            lastReadTimestamp = 1772014500000,
+                            lastModifiedTimestamp = 1772014600000
+                        ),
+                        ConversationMetadataEntry(
+                            conversationId = "conv_2",
+                            lastReadTimestamp = 1772014800000,
+                            lastModifiedTimestamp = 1772014900000
+                        )
                     )
                 )
             )
@@ -480,15 +489,17 @@ internal class NomadDeviceSyncApiV0Test : ApiTest() {
             {
               "events": [
                 {
-                  "type": "LAST_READ",
-                  "last_read": [
+                  "type": "CONVERSATION_METADATA",
+                  "conversation_metadata": [
                     {
                       "conversation_id": "conv_1",
-                      "last_read": 1772014500000
+                      "last_read": 1772014500000,
+                      "last_modified": 1772014600000
                     },
                     {
                       "conversation_id": "conv_2",
-                      "last_read": 1772014800000
+                      "last_read": 1772014800000,
+                      "last_modified": 1772014900000
                     }
                   ]
                 }
@@ -567,7 +578,8 @@ internal class NomadDeviceSyncApiV0Test : ApiTest() {
                     "domain": "example.com"
                   },
                   "metadata": {
-                    "last_read": 1707235100
+                    "last_read": 1707235100,
+                    "last_modified": 1707235200
                   }
                 }
               ]

--- a/data/network/src/commonTest/kotlin/com/wire/kalium/api/v0/nomaddevice/NomadDeviceSyncApiV0Test.kt
+++ b/data/network/src/commonTest/kotlin/com/wire/kalium/api/v0/nomaddevice/NomadDeviceSyncApiV0Test.kt
@@ -22,7 +22,6 @@ import com.wire.kalium.api.ApiTest
 import com.wire.kalium.api.TEST_BACKEND_CONFIG
 import com.wire.kalium.api.json.model.testCredentials
 import com.wire.kalium.network.AuthenticatedNetworkClient
-import com.wire.kalium.network.api.authenticated.nomaddevice.LastRead
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadBatchRestoreRequest
 import com.wire.kalium.network.api.authenticated.nomaddevice.ConversationMetadataEntry
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadMessageEvent

--- a/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/RemotebackupChangeLog.sq
+++ b/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/RemotebackupChangeLog.sq
@@ -167,7 +167,7 @@ LEFT JOIN MessageConversationLocationContent AS LocationContent
     AND Message.conversation_id = LocationContent.conversation_id
 ORDER BY latest.timestamp_ms ASC, latest.message_timestamp_ms ASC, latest.conversation_id ASC, latest.message_id ASC;
 
-getConversationLastReadForLastPendingChanges:
+getConversationMetadataForLastPendingChanges:
 WITH latest AS (
     SELECT *
     FROM RemotebackupChangeLog
@@ -176,7 +176,8 @@ WITH latest AS (
 )
 SELECT DISTINCT
     latest.conversation_id AS conversation_id,
-    Conversation.last_read_date AS last_read_date
+    Conversation.last_read_date AS last_read_date,
+    Conversation.last_modified_date AS last_modified_date
 FROM latest
 JOIN Conversation
     ON Conversation.qualified_id = latest.conversation_id

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/ChangeLogSyncBatch.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/ChangeLogSyncBatch.kt
@@ -20,5 +20,5 @@ package com.wire.kalium.persistence.dao.backup
 
 data class ChangeLogSyncBatch(
     val events: List<ChangeLogSyncEvent>,
-    val conversationLastReads: List<ConversationLastReadSyncEntity>,
+    val conversationMetadata: List<ConversationMetadataSyncEntity>,
 )

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/ConversationMetadataSyncEntity.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/ConversationMetadataSyncEntity.kt
@@ -21,7 +21,8 @@ package com.wire.kalium.persistence.dao.backup
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import kotlinx.datetime.Instant
 
-data class ConversationLastReadSyncEntity(
+data class ConversationMetadataSyncEntity(
     val conversationId: QualifiedIDEntity,
     val lastReadDate: Instant,
+    val lastModifiedDate: Instant,
 )

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/RemoteBackupChangeLogDAOImpl.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/RemoteBackupChangeLogDAOImpl.kt
@@ -123,13 +123,13 @@ internal class RemoteBackupChangeLogDAOImpl(
                     limit = limit,
                     mapper = mapper::toChangeLogSyncEvent
                 ).executeAsList()
-                val conversationLastReads = queries.getConversationLastReadForLastPendingChanges(
+                val conversationMetadata = queries.getConversationMetadataForLastPendingChanges(
                     limit = limit,
-                    mapper = mapper::toConversationLastReadSyncEntity
+                    mapper = mapper::toConversationMetadataSyncEntity
                 ).executeAsList()
                 ChangeLogSyncBatch(
                     events = events,
-                    conversationLastReads = conversationLastReads
+                    conversationMetadata = conversationMetadata
                 )
             }
         }

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/RemoteBackupChangeLogMapper.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/RemoteBackupChangeLogMapper.kt
@@ -52,13 +52,15 @@ internal object RemoteBackupChangeLogMapper {
         )
 
     @Suppress("FunctionParameterNaming")
-    fun toConversationLastReadSyncEntity(
+    fun toConversationMetadataSyncEntity(
         conversation_id: QualifiedIDEntity,
         last_read_date: Instant,
-    ): ConversationLastReadSyncEntity =
-        ConversationLastReadSyncEntity(
+        last_modified_date: Instant,
+    ): ConversationMetadataSyncEntity =
+        ConversationMetadataSyncEntity(
             conversationId = conversation_id,
-            lastReadDate = last_read_date
+            lastReadDate = last_read_date,
+            lastModifiedDate = last_modified_date
         )
 
     @Suppress("LongParameterList", "FunctionParameterNaming")

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
@@ -71,7 +71,7 @@ interface ConversationDAO {
     suspend fun updateConversationReadAndModifiedDates(
         readDates: Map<QualifiedIDEntity, Instant>,
         modifiedDates: Map<QualifiedIDEntity, Instant>,
-    ): Int
+    )
     suspend fun updateAllConversationsNotificationDate()
     suspend fun getAllConversations(): Flow<List<ConversationEntity>>
     suspend fun getAllConversationDetails(

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
@@ -68,6 +68,10 @@ interface ConversationDAO {
     suspend fun updateConversationNotificationDate(qualifiedID: QualifiedIDEntity, date: Instant? = null)
     suspend fun updateConversationReadDate(conversationID: QualifiedIDEntity, date: Instant)
     suspend fun updateConversationReadDates(conversationDates: Map<QualifiedIDEntity, Instant>): Int
+    suspend fun updateConversationReadAndModifiedDates(
+        readDates: Map<QualifiedIDEntity, Instant>,
+        modifiedDates: Map<QualifiedIDEntity, Instant>,
+    ): Int
     suspend fun updateAllConversationsNotificationDate()
     suspend fun getAllConversations(): Flow<List<ConversationEntity>>
     suspend fun getAllConversationDetails(

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
@@ -493,6 +493,31 @@ internal class ConversationDAOImpl internal constructor(
             }
         }
 
+    override suspend fun updateConversationReadAndModifiedDates(
+        readDates: Map<QualifiedIDEntity, Instant>,
+        modifiedDates: Map<QualifiedIDEntity, Instant>,
+    ): Int = withContext(writeDispatcher.value) {
+        if (readDates.isEmpty() && modifiedDates.isEmpty()) {
+            return@withContext 0
+        }
+
+        conversationQueries.transactionWithResult {
+            var updatedConversations = 0
+
+            readDates.forEach { (conversationId, date) ->
+                unreadEventsQueries.deleteUnreadEvents(date, conversationId)
+                conversationQueries.updateConversationReadDate(date, conversationId)
+                updatedConversations += conversationQueries.selectChanges().executeAsOne().toInt()
+            }
+
+            modifiedDates.forEach { (conversationId, date) ->
+                conversationQueries.updateConversationModifiedDate(date, conversationId)
+            }
+
+            updatedConversations
+        }
+    }
+
     override suspend fun updateKeyingMaterial(groupId: String, timestamp: Instant) {
         withContext(writeDispatcher.value) {
             conversationQueries.updateKeyingMaterialDate(timestamp, groupId)

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
@@ -496,25 +496,21 @@ internal class ConversationDAOImpl internal constructor(
     override suspend fun updateConversationReadAndModifiedDates(
         readDates: Map<QualifiedIDEntity, Instant>,
         modifiedDates: Map<QualifiedIDEntity, Instant>,
-    ): Int = withContext(writeDispatcher.value) {
+    ) = withContext(writeDispatcher.value) {
         if (readDates.isEmpty() && modifiedDates.isEmpty()) {
-            return@withContext 0
+            return@withContext
         }
 
-        conversationQueries.transactionWithResult {
-            var updatedConversations = 0
+        conversationQueries.transaction {
 
             readDates.forEach { (conversationId, date) ->
                 unreadEventsQueries.deleteUnreadEvents(date, conversationId)
                 conversationQueries.updateConversationReadDate(date, conversationId)
-                updatedConversations += conversationQueries.selectChanges().executeAsOne().toInt()
             }
 
             modifiedDates.forEach { (conversationId, date) ->
                 conversationQueries.updateConversationModifiedDate(date, conversationId)
             }
-
-            updatedConversations
         }
     }
 

--- a/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadConversationMetadataSyncRepository.kt
+++ b/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadConversationMetadataSyncRepository.kt
@@ -33,7 +33,7 @@ internal interface NomadConversationMetadataSyncRepository {
     suspend fun applyMetadata(
         selfUserId: UserId,
         metadata: List<NomadConversationMetadataToSync>,
-    ): Either<CoreFailure, Int>
+    ): Either<CoreFailure, Unit>
 }
 
 internal class NomadConversationMetadataSyncDataSource(
@@ -49,13 +49,13 @@ internal class NomadConversationMetadataSyncDataSource(
     override suspend fun applyMetadata(
         selfUserId: UserId,
         metadata: List<NomadConversationMetadataToSync>,
-    ): Either<CoreFailure, Int> {
+    ): Either<CoreFailure, Unit> {
         val metadataStore = metadataStoreProvider(selfUserId)
         if (metadataStore == null) {
             nomadLogger.w(
                 "Skipping Nomad conversation-metadata import: missing user storage for '${selfUserId.toLogString()}'."
             )
-            return 0.right()
+            return Unit.right()
         }
 
         return wrapStorageRequest {
@@ -68,7 +68,7 @@ internal class NomadConversationMetadataSyncDataSource(
  * Applies fetched Nomad conversation metadata to local storage.
  */
 internal interface NomadConversationMetadataStore {
-    suspend fun applyMetadata(metadata: List<NomadConversationMetadataToSync>): Int
+    suspend fun applyMetadata(metadata: List<NomadConversationMetadataToSync>)
 }
 
 /**
@@ -78,7 +78,7 @@ internal class ConversationDAONomadConversationMetadataStore(
     private val conversationDAO: ConversationDAO,
 ) : NomadConversationMetadataStore {
 
-    override suspend fun applyMetadata(metadata: List<NomadConversationMetadataToSync>): Int =
+    override suspend fun applyMetadata(metadata: List<NomadConversationMetadataToSync>) =
         conversationDAO.updateConversationReadAndModifiedDates(
             readDates = metadata.associate { it.conversationId to it.lastReadDate },
             modifiedDates = metadata.mapNotNull { entry ->

--- a/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadConversationMetadataSyncRepository.kt
+++ b/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadConversationMetadataSyncRepository.kt
@@ -30,7 +30,7 @@ import com.wire.kalium.persistence.dao.conversation.ConversationDAO
 
 internal interface NomadConversationMetadataSyncRepository {
     suspend fun getConversationMetadata(selfUserId: UserId): Either<CoreFailure, NomadConversationMetadataResponse>
-    suspend fun applyLastReadMetadata(
+    suspend fun applyMetadata(
         selfUserId: UserId,
         metadata: List<NomadConversationMetadataToSync>,
     ): Either<CoreFailure, Int>
@@ -46,7 +46,7 @@ internal class NomadConversationMetadataSyncDataSource(
             nomadDeviceSyncApiProvider(selfUserId).getConversationMetadata()
         }
 
-    override suspend fun applyLastReadMetadata(
+    override suspend fun applyMetadata(
         selfUserId: UserId,
         metadata: List<NomadConversationMetadataToSync>,
     ): Either<CoreFailure, Int> {
@@ -59,7 +59,7 @@ internal class NomadConversationMetadataSyncDataSource(
         }
 
         return wrapStorageRequest {
-            metadataStore.applyLastReadMetadata(metadata)
+            metadataStore.applyMetadata(metadata)
         }
     }
 }
@@ -68,7 +68,7 @@ internal class NomadConversationMetadataSyncDataSource(
  * Applies fetched Nomad conversation metadata to local storage.
  */
 internal interface NomadConversationMetadataStore {
-    suspend fun applyLastReadMetadata(metadata: List<NomadConversationMetadataToSync>): Int
+    suspend fun applyMetadata(metadata: List<NomadConversationMetadataToSync>): Int
 }
 
 /**
@@ -78,8 +78,11 @@ internal class ConversationDAONomadConversationMetadataStore(
     private val conversationDAO: ConversationDAO,
 ) : NomadConversationMetadataStore {
 
-    override suspend fun applyLastReadMetadata(metadata: List<NomadConversationMetadataToSync>): Int =
-        conversationDAO.updateConversationReadDates(
-            metadata.associate { it.conversationId to it.lastReadDate }
+    override suspend fun applyMetadata(metadata: List<NomadConversationMetadataToSync>): Int =
+        conversationDAO.updateConversationReadAndModifiedDates(
+            readDates = metadata.associate { it.conversationId to it.lastReadDate },
+            modifiedDates = metadata.mapNotNull { entry ->
+                entry.lastModifiedDate?.let { entry.conversationId to it }
+            }.toMap()
         )
 }

--- a/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadRemoteBackupChangeLogEventMapper.kt
+++ b/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadRemoteBackupChangeLogEventMapper.kt
@@ -18,7 +18,7 @@
 
 package com.wire.kalium.nomaddevice
 
-import com.wire.kalium.network.api.authenticated.nomaddevice.LastRead
+import com.wire.kalium.network.api.authenticated.nomaddevice.ConversationMetadataEntry
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadMessageEvent
 import com.wire.kalium.persistence.dao.backup.ChangeLogSyncBatch
 import com.wire.kalium.persistence.dao.backup.ChangeLogSyncEvent
@@ -40,14 +40,15 @@ import kotlin.io.encoding.Base64
 internal class NomadRemoteBackupChangeLogEventMapper {
     fun mapBatchToApiEvents(batch: ChangeLogSyncBatch): List<NomadMessageEvent> {
         val events = batch.events.mapNotNull { it.toApiEventOrNull() }.toMutableList()
-        val lastReads = batch.conversationLastReads.map {
-            LastRead(
+        val metadataEntries = batch.conversationMetadata.map {
+            ConversationMetadataEntry(
                 conversationId = it.conversationId.toString(),
-                lastReadTimestamp = it.lastReadDate.toEpochMilliseconds()
+                lastReadTimestamp = it.lastReadDate.toEpochMilliseconds(),
+                lastModifiedTimestamp = it.lastModifiedDate.toEpochMilliseconds()
             )
         }
-        if (lastReads.isNotEmpty()) {
-            events += NomadMessageEvent.LastReadEvent(lastRead = lastReads)
+        if (metadataEntries.isNotEmpty()) {
+            events += NomadMessageEvent.ConversationMetadataEvent(conversationMetadata = metadataEntries)
         }
         return events
     }

--- a/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadRemoteBackupChangeLogSyncRepository.kt
+++ b/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadRemoteBackupChangeLogSyncRepository.kt
@@ -46,7 +46,7 @@ internal class NomadRemoteBackupChangeLogSyncDataSource(
 
     override suspend fun getLastPendingChangesBatch(selfUserId: UserId, limit: Long): Either<CoreFailure, ChangeLogSyncBatch> {
         val dao = resolveDaoForUser(selfUserId, operation = "read")
-            ?: return ChangeLogSyncBatch(events = emptyList(), conversationLastReads = emptyList()).right()
+            ?: return ChangeLogSyncBatch(events = emptyList(), conversationMetadata = emptyList()).right()
         return wrapStorageRequest { dao.getLastPendingChangesBatch(limit) }
     }
 

--- a/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/SyncNomadConversationMetadataUseCase.kt
+++ b/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/SyncNomadConversationMetadataUseCase.kt
@@ -74,10 +74,11 @@ public class SyncNomadConversationMetadataUseCase internal constructor(
                     value = it.conversation.id,
                     domain = it.conversation.domain
                 ),
-                lastReadDate = Instant.fromEpochMilliseconds(it.metadata.lastRead)
+                lastReadDate = Instant.fromEpochMilliseconds(it.metadata.lastRead),
+                lastModifiedDate = it.metadata.lastModified?.let(Instant::fromEpochMilliseconds)
             )
         }
-        return when (val storeResult = repository.applyLastReadMetadata(selfUserId, metadata)) {
+        return when (val storeResult = repository.applyMetadata(selfUserId, metadata)) {
             is Either.Left -> storeResult.value.left()
             is Either.Right -> NomadConversationMetadataSyncResult(
                 downloadedConversations = metadata.size,
@@ -94,4 +95,5 @@ public class SyncNomadConversationMetadataUseCase internal constructor(
 internal data class NomadConversationMetadataToSync(
     val conversationId: QualifiedIDEntity,
     val lastReadDate: Instant,
+    val lastModifiedDate: Instant?,
 )

--- a/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/SyncNomadConversationMetadataUseCase.kt
+++ b/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/SyncNomadConversationMetadataUseCase.kt
@@ -30,8 +30,6 @@ import kotlinx.datetime.Instant
 
 public data class NomadConversationMetadataSyncResult(
     val downloadedConversations: Int,
-    val updatedConversations: Int,
-    val skippedConversations: Int,
 )
 
 /**
@@ -82,8 +80,6 @@ public class SyncNomadConversationMetadataUseCase internal constructor(
             is Either.Left -> storeResult.value.left()
             is Either.Right -> NomadConversationMetadataSyncResult(
                 downloadedConversations = metadata.size,
-                updatedConversations = storeResult.value,
-                skippedConversations = metadata.size - storeResult.value
             ).right()
         }
     }

--- a/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/NomadConversationMetadataSyncRepositoryTest.kt
+++ b/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/NomadConversationMetadataSyncRepositoryTest.kt
@@ -62,7 +62,7 @@ class NomadConversationMetadataSyncRepositoryTest {
             metadataStoreProvider = { null }
         )
 
-        val result = repository.applyLastReadMetadata(SELF_USER_ID, metadataToSync())
+        val result = repository.applyMetadata(SELF_USER_ID, metadataToSync())
 
         assertEquals(0, assertIs<Either.Right<Int>>(result).value)
     }
@@ -77,7 +77,7 @@ class NomadConversationMetadataSyncRepositoryTest {
             metadataStoreProvider = { store }
         )
 
-        val result = repository.applyLastReadMetadata(SELF_USER_ID, metadataToSync())
+        val result = repository.applyMetadata(SELF_USER_ID, metadataToSync())
 
         assertEquals(2, assertIs<Either.Right<Int>>(result).value)
         assertEquals(metadataToSync(), store.appliedMetadata)
@@ -88,7 +88,7 @@ class NomadConversationMetadataSyncRepositoryTest {
     ) : NomadConversationMetadataStore {
         var appliedMetadata: List<NomadConversationMetadataToSync> = emptyList()
 
-        override suspend fun applyLastReadMetadata(metadata: List<NomadConversationMetadataToSync>): Int {
+        override suspend fun applyMetadata(metadata: List<NomadConversationMetadataToSync>): Int {
             appliedMetadata = metadata
             return updatedConversations
         }
@@ -124,7 +124,7 @@ class NomadConversationMetadataSyncRepositoryTest {
             conversations = listOf(
                 NomadConversationMetadataItem(
                     conversation = Conversation(id = CONVERSATION_ID, domain = CONVERSATION_DOMAIN),
-                    metadata = NomadConversationMetadata(lastRead = LAST_READ_TIMESTAMP)
+                    metadata = NomadConversationMetadata(lastRead = LAST_READ_TIMESTAMP, lastModified = LAST_MODIFIED_TIMESTAMP)
                 )
             )
         )
@@ -133,11 +133,13 @@ class NomadConversationMetadataSyncRepositoryTest {
         listOf(
             NomadConversationMetadataToSync(
                 conversationId = QualifiedIDEntity(CONVERSATION_ID, CONVERSATION_DOMAIN),
-                lastReadDate = Instant.fromEpochMilliseconds(LAST_READ_TIMESTAMP)
+                lastReadDate = Instant.fromEpochMilliseconds(LAST_READ_TIMESTAMP),
+                lastModifiedDate = Instant.fromEpochMilliseconds(LAST_MODIFIED_TIMESTAMP)
             ),
             NomadConversationMetadataToSync(
                 conversationId = QualifiedIDEntity("conversation-id-2", CONVERSATION_DOMAIN),
-                lastReadDate = Instant.fromEpochMilliseconds(LAST_READ_TIMESTAMP + 1_000)
+                lastReadDate = Instant.fromEpochMilliseconds(LAST_READ_TIMESTAMP + 1_000),
+                lastModifiedDate = Instant.fromEpochMilliseconds(LAST_MODIFIED_TIMESTAMP + 1_000)
             )
         )
 
@@ -146,5 +148,6 @@ class NomadConversationMetadataSyncRepositoryTest {
         const val CONVERSATION_ID = "conversation-id"
         const val CONVERSATION_DOMAIN = "wire.test"
         const val LAST_READ_TIMESTAMP = 1_707_235_200_000L
+        const val LAST_MODIFIED_TIMESTAMP = 1_707_235_300_000L
     }
 }

--- a/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/NomadConversationMetadataSyncRepositoryTest.kt
+++ b/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/NomadConversationMetadataSyncRepositoryTest.kt
@@ -54,7 +54,7 @@ class NomadConversationMetadataSyncRepositoryTest {
     }
 
     @Test
-    fun givenMissingStore_whenApplyingMetadata_thenReturnZero() = runTest {
+    fun givenMissingStore_whenApplyingMetadata_thenReturnSuccess() = runTest {
         val repository = NomadConversationMetadataSyncDataSource(
             nomadDeviceSyncApiProvider = {
                 FakeNomadDeviceSyncApi(NetworkResponse.Success(metadataResponse(), emptyMap(), 200))
@@ -64,12 +64,12 @@ class NomadConversationMetadataSyncRepositoryTest {
 
         val result = repository.applyMetadata(SELF_USER_ID, metadataToSync())
 
-        assertEquals(0, assertIs<Either.Right<Int>>(result).value)
+        assertIs<Either.Right<Unit>>(result)
     }
 
     @Test
-    fun givenStore_whenApplyingMetadata_thenForwardAndReturnCount() = runTest {
-        val store = FakeNomadConversationMetadataStore(updatedConversations = 2)
+    fun givenStore_whenApplyingMetadata_thenForwardAndReturnSuccess() = runTest {
+        val store = FakeNomadConversationMetadataStore()
         val repository = NomadConversationMetadataSyncDataSource(
             nomadDeviceSyncApiProvider = {
                 FakeNomadDeviceSyncApi(NetworkResponse.Success(metadataResponse(), emptyMap(), 200))
@@ -79,18 +79,15 @@ class NomadConversationMetadataSyncRepositoryTest {
 
         val result = repository.applyMetadata(SELF_USER_ID, metadataToSync())
 
-        assertEquals(2, assertIs<Either.Right<Int>>(result).value)
+        assertIs<Either.Right<Unit>>(result)
         assertEquals(metadataToSync(), store.appliedMetadata)
     }
 
-    private class FakeNomadConversationMetadataStore(
-        private val updatedConversations: Int,
-    ) : NomadConversationMetadataStore {
+    private class FakeNomadConversationMetadataStore : NomadConversationMetadataStore {
         var appliedMetadata: List<NomadConversationMetadataToSync> = emptyList()
 
-        override suspend fun applyMetadata(metadata: List<NomadConversationMetadataToSync>): Int {
+        override suspend fun applyMetadata(metadata: List<NomadConversationMetadataToSync>) {
             appliedMetadata = metadata
-            return updatedConversations
         }
     }
 

--- a/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/SyncNomadConversationMetadataUseCaseTest.kt
+++ b/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/SyncNomadConversationMetadataUseCaseTest.kt
@@ -54,6 +54,7 @@ class SyncNomadConversationMetadataUseCaseTest {
         assertEquals(1, repository.appliedMetadata.size)
         assertEquals(qid(CONVERSATION_ID), repository.appliedMetadata.single().conversationId)
         assertEquals(Instant.fromEpochMilliseconds(LAST_READ_TIMESTAMP), repository.appliedMetadata.single().lastReadDate)
+        assertEquals(Instant.fromEpochMilliseconds(LAST_MODIFIED_TIMESTAMP), repository.appliedMetadata.single().lastModifiedDate)
     }
 
     @Test
@@ -100,7 +101,7 @@ class SyncNomadConversationMetadataUseCaseTest {
         override suspend fun getConversationMetadata(selfUserId: UserId): Either<CoreFailure, NomadConversationMetadataResponse> =
             metadataResponse
 
-        override suspend fun applyLastReadMetadata(
+        override suspend fun applyMetadata(
             selfUserId: UserId,
             metadata: List<NomadConversationMetadataToSync>,
         ): Either<CoreFailure, Int> {
@@ -114,7 +115,7 @@ class SyncNomadConversationMetadataUseCaseTest {
             conversations = listOf(
                 NomadConversationMetadataItem(
                     conversation = Conversation(id = CONVERSATION_ID, domain = CONVERSATION_DOMAIN),
-                    metadata = NomadConversationMetadata(lastRead = LAST_READ_TIMESTAMP)
+                    metadata = NomadConversationMetadata(lastRead = LAST_READ_TIMESTAMP, lastModified = LAST_MODIFIED_TIMESTAMP)
                 )
             )
         )
@@ -124,6 +125,7 @@ class SyncNomadConversationMetadataUseCaseTest {
         const val CONVERSATION_ID = "conversation-id"
         const val CONVERSATION_DOMAIN = "wire.test"
         const val LAST_READ_TIMESTAMP = 1_707_235_200_000L
+        const val LAST_MODIFIED_TIMESTAMP = 1_707_235_300_000L
     }
 }
 

--- a/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/SyncNomadConversationMetadataUseCaseTest.kt
+++ b/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/SyncNomadConversationMetadataUseCaseTest.kt
@@ -39,7 +39,6 @@ class SyncNomadConversationMetadataUseCaseTest {
     fun givenMetadataResponse_whenInvoking_thenApplyLastReadDates() = runTest {
         val repository = FakeNomadConversationMetadataSyncRepository(
             metadataResponse = Either.Right(metadataResponse()),
-            updatedConversations = 1
         )
         val useCase = SyncNomadConversationMetadataUseCase(
             repository = repository
@@ -49,8 +48,6 @@ class SyncNomadConversationMetadataUseCaseTest {
 
         val success = assertIs<Either.Right<NomadConversationMetadataSyncResult>>(result).value
         assertEquals(1, success.downloadedConversations)
-        assertEquals(1, success.updatedConversations)
-        assertEquals(0, success.skippedConversations)
         assertEquals(1, repository.appliedMetadata.size)
         assertEquals(qid(CONVERSATION_ID), repository.appliedMetadata.single().conversationId)
         assertEquals(Instant.fromEpochMilliseconds(LAST_READ_TIMESTAMP), repository.appliedMetadata.single().lastReadDate)
@@ -58,10 +55,9 @@ class SyncNomadConversationMetadataUseCaseTest {
     }
 
     @Test
-    fun givenMissingStorage_whenInvoking_thenSkipUpdates() = runTest {
+    fun givenMissingStorage_whenInvoking_thenStillReturnSuccess() = runTest {
         val repository = FakeNomadConversationMetadataSyncRepository(
             metadataResponse = Either.Right(metadataResponse()),
-            updatedConversations = 0
         )
         val useCase = SyncNomadConversationMetadataUseCase(
             repository = repository
@@ -71,15 +67,12 @@ class SyncNomadConversationMetadataUseCaseTest {
 
         val success = assertIs<Either.Right<NomadConversationMetadataSyncResult>>(result).value
         assertEquals(1, success.downloadedConversations)
-        assertEquals(0, success.updatedConversations)
-        assertEquals(1, success.skippedConversations)
     }
 
     @Test
     fun givenApiFailure_whenInvoking_thenDoNotTouchStorage() = runTest {
         val repository = FakeNomadConversationMetadataSyncRepository(
             metadataResponse = Either.Left(NetworkFailure.NoNetworkConnection(null)),
-            updatedConversations = 0
         )
         val useCase = SyncNomadConversationMetadataUseCase(
             repository = repository
@@ -94,7 +87,6 @@ class SyncNomadConversationMetadataUseCaseTest {
 
     private class FakeNomadConversationMetadataSyncRepository(
         private val metadataResponse: Either<CoreFailure, NomadConversationMetadataResponse>,
-        private val updatedConversations: Int,
     ) : NomadConversationMetadataSyncRepository {
         val appliedMetadata = mutableListOf<NomadConversationMetadataToSync>()
 
@@ -104,9 +96,9 @@ class SyncNomadConversationMetadataUseCaseTest {
         override suspend fun applyMetadata(
             selfUserId: UserId,
             metadata: List<NomadConversationMetadataToSync>,
-        ): Either<CoreFailure, Int> {
+        ): Either<CoreFailure, Unit> {
             appliedMetadata += metadata
-            return Either.Right(updatedConversations)
+            return Either.Right(Unit)
         }
     }
 

--- a/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/SyncNomadRemoteBackupChangeLogUseCaseTest.kt
+++ b/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/SyncNomadRemoteBackupChangeLogUseCaseTest.kt
@@ -34,7 +34,7 @@ import com.wire.kalium.persistence.dao.backup.ChangeLogEntry
 import com.wire.kalium.persistence.dao.backup.ChangeLogEventType
 import com.wire.kalium.persistence.dao.backup.ChangeLogSyncBatch
 import com.wire.kalium.persistence.dao.backup.ChangeLogSyncEvent
-import com.wire.kalium.persistence.dao.backup.ConversationLastReadSyncEntity
+import com.wire.kalium.persistence.dao.backup.ConversationMetadataSyncEntity
 import com.wire.kalium.persistence.dao.backup.RemoteBackupChangeLogDAO
 import com.wire.kalium.persistence.dao.backup.SyncableMessagePayloadEntity
 import com.wire.kalium.persistence.dao.message.MessageEntity
@@ -86,10 +86,11 @@ class SyncNomadRemoteBackupChangeLogUseCaseTest {
                         )
                     )
                 ),
-                conversationLastReads = listOf(
-                    ConversationLastReadSyncEntity(
+                conversationMetadata = listOf(
+                    ConversationMetadataSyncEntity(
                         conversationId = CONVERSATION_ID,
-                        lastReadDate = Instant.parse("2026-02-25T10:15:00Z")
+                        lastReadDate = Instant.parse("2026-02-25T10:15:00Z"),
+                        lastModifiedDate = Instant.parse("2026-02-25T10:16:00Z")
                     )
                 )
             )
@@ -123,10 +124,11 @@ class SyncNomadRemoteBackupChangeLogUseCaseTest {
         assertEquals("quoted-message", decodedPayload.content.text?.quotedMessageId)
         assertEquals(1, decodedPayload.content.text?.mentions?.size)
 
-        val lastReadEvent = assertIs<NomadMessageEvent.LastReadEvent>(request.events.last())
-        assertEquals(1, lastReadEvent.lastRead.size)
-        assertEquals(CONVERSATION_ID.toString(), lastReadEvent.lastRead.first().conversationId)
-        assertEquals(1772014500000, lastReadEvent.lastRead.first().lastReadTimestamp)
+        val metadataEvent = assertIs<NomadMessageEvent.ConversationMetadataEvent>(request.events.last())
+        assertEquals(1, metadataEvent.conversationMetadata.size)
+        assertEquals(CONVERSATION_ID.toString(), metadataEvent.conversationMetadata.first().conversationId)
+        assertEquals(1772014500000, metadataEvent.conversationMetadata.first().lastReadTimestamp)
+        assertEquals(1772014560000, metadataEvent.conversationMetadata.first().lastModifiedTimestamp)
     }
 
     @Test
@@ -134,7 +136,7 @@ class SyncNomadRemoteBackupChangeLogUseCaseTest {
         val dao = FakeRemoteBackupChangeLogDAO(
             batch = ChangeLogSyncBatch(
                 events = listOf(messageDeleteEvent()),
-                conversationLastReads = emptyList()
+                conversationMetadata = emptyList()
             )
         )
         val api = FakeNomadDeviceSyncApi(NetworkResponse.Error(KaliumException.NoNetwork()))
@@ -157,7 +159,7 @@ class SyncNomadRemoteBackupChangeLogUseCaseTest {
         val dao = FakeRemoteBackupChangeLogDAO(
             batch = ChangeLogSyncBatch(
                 events = emptyList(),
-                conversationLastReads = emptyList()
+                conversationMetadata = emptyList()
             )
         )
         val api = FakeNomadDeviceSyncApi(NetworkResponse.Success(Unit, emptyMap(), 200))
@@ -205,7 +207,7 @@ class SyncNomadRemoteBackupChangeLogUseCaseTest {
                         message = null
                     )
                 ),
-                conversationLastReads = emptyList()
+                conversationMetadata = emptyList()
             )
         )
         val api = FakeNomadDeviceSyncApi(NetworkResponse.Success(Unit, emptyMap(), 200))
@@ -236,10 +238,11 @@ class SyncNomadRemoteBackupChangeLogUseCaseTest {
                         message = null
                     )
                 ),
-                conversationLastReads = listOf(
-                    ConversationLastReadSyncEntity(
+                conversationMetadata = listOf(
+                    ConversationMetadataSyncEntity(
                         conversationId = CONVERSATION_ID,
-                        lastReadDate = Instant.parse("2026-02-25T10:15:00Z")
+                        lastReadDate = Instant.parse("2026-02-25T10:15:00Z"),
+                        lastModifiedDate = Instant.parse("2026-02-25T10:16:00Z")
                     )
                 )
             )
@@ -257,7 +260,7 @@ class SyncNomadRemoteBackupChangeLogUseCaseTest {
         assertEquals(1, success.syncedEntries)
         assertEquals(1, success.postedEvents)
         assertEquals(1, api.requests.size)
-        assertIs<NomadMessageEvent.LastReadEvent>(api.requests.single().events.single())
+        assertIs<NomadMessageEvent.ConversationMetadataEvent>(api.requests.single().events.single())
         assertEquals(1, dao.deletedChanges.size)
     }
 
@@ -287,7 +290,7 @@ class SyncNomadRemoteBackupChangeLogUseCaseTest {
             readResult = Either.Right(
                 ChangeLogSyncBatch(
                     events = listOf(messageDeleteEvent()),
-                    conversationLastReads = emptyList()
+                    conversationMetadata = emptyList()
                 )
             ),
             postResult = Either.Right(Unit),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SyncNomadMessagesDuringSlowSyncUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SyncNomadMessagesDuringSlowSyncUseCase.kt
@@ -63,9 +63,7 @@ internal class SyncNomadMessagesDuringSlowSyncUseCaseImpl(
             is Either.Right ->
                 logger.i(
                     "Nomad conversation-metadata slow sync finished for ${selfUserId.toLogString()}: " +
-                        "downloaded=${metadataResult.value.downloadedConversations}, " +
-                        "updated=${metadataResult.value.updatedConversations}, " +
-                        "skipped=${metadataResult.value.skippedConversations}"
+                        "downloaded=${metadataResult.value.downloadedConversations}"
                 )
         }
 

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/sync/slow/SyncNomadMessagesDuringSlowSyncUseCaseTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/sync/slow/SyncNomadMessagesDuringSlowSyncUseCaseTest.kt
@@ -339,7 +339,7 @@ private fun metadataResponse(): NetworkResponse<NomadConversationMetadataRespons
             conversations = listOf(
                 NomadConversationMetadataItem(
                     conversation = Conversation(id = TEST_CONVERSATION_ID, domain = CONVERSATION_DOMAIN),
-                    metadata = NomadConversationMetadata(lastRead = TEST_LAST_READ_TIMESTAMP)
+                    metadata = NomadConversationMetadata(lastRead = TEST_LAST_READ_TIMESTAMP, lastModified = TEST_LAST_MODIFIED_TIMESTAMP)
                 )
             )
         ),
@@ -378,4 +378,5 @@ private fun qid(value: String): QualifiedIDEntity = QualifiedIDEntity(value = va
 
 private const val TEST_CONVERSATION_ID = "conversation-id"
 private const val TEST_LAST_READ_TIMESTAMP = 1_707_235_200_000L
+private const val TEST_LAST_MODIFIED_TIMESTAMP = 1_707_235_300_000L
 private const val CONVERSATION_DOMAIN = "wire.test"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24198
<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

- Nomad sync used a `LAST_READ` event type that only carried `last_read` timestamps. This needed to be replaced with a richer `CONVERSATION_METADATA` event that also carries `last_modified` timestamps.

### Solutions

- Replaced the outbound `LAST_READ` / `LastReadEvent` with `CONVERSATION_METADATA` / `ConversationMetadataEvent` carrying both `last_read` and `last_modified`.
- Added nullable `last_modified` to the inbound `NomadConversationMetadata` response for backward compatibility.
- Extended the persistence query to also fetch `last_modified_date` from the `Conversation` table alongside `last_read_date`.
- Added `updateConversationReadAndModifiedDates` to `ConversationDAO` to update both fields in a single transaction.
- Renamed `ConversationLastReadSyncEntity` → `ConversationMetadataSyncEntity` and `applyLastReadMetadata` → `applyMetadata` throughout.