### PR TITLE
fix(native): guard empty NSData.toByteArray on Apple targets [WPB-24206]

### DIFF
--- a/core/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/ProteusClientCoreCryptoImpl.kt
+++ b/core/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/ProteusClientCoreCryptoImpl.kt
@@ -198,7 +198,8 @@ class ProteusClientCoreCryptoImpl private constructor(
         } catch (e: Exception) {
             kaliumLogger.e(
                 "Unexpected non-Proteus exception in " +
-                        "ProteusClientCoreCrypto.wrapException: ${e::class.simpleName}: $e"
+                        "ProteusClientCoreCrypto.wrapException: ${e::class.simpleName}: $e\n" +
+                        "Stack trace: ${e.stackTraceToString()}"
             )
             throw ProteusException(e.message, ProteusException.Code.UNKNOWN_ERROR, null, e)
         }

--- a/core/util/src/appleMain/kotlin/com.wire.kalium.util/string/toUTF16BEByteArray.kt
+++ b/core/util/src/appleMain/kotlin/com.wire.kalium.util/string/toUTF16BEByteArray.kt
@@ -42,7 +42,10 @@ actual fun ByteArray.toStringFromUtf16BE(): String = memScoped {
 }
 
 fun NSData.toByteArray(): ByteArray {
-    val buffer = ByteArray(length.toInt())
+    val size = length.toInt()
+    // addressOf(0) on an empty ByteArray throws ArrayIndexOutOfBoundsException in K/N
+    if (size == 0) return ByteArray(0)
+    val buffer = ByteArray(size)
     buffer.usePinned {
         getBytes(it.addressOf(0))
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24206
<!--jira-description-action-hidden-marker-end-->
## Summary

- `NSData.toByteArray()` in the Apple `toUTF16BEByteArray` implementation crashes with `ArrayIndexOutOfBoundsException` when the `NSData` is empty, because `ByteArray(0).usePinned { addressOf(0) }` is invalid in Kotlin/Native
- This is triggered when `MessageContentEncoder.encodeMessageAsset` calls `toUTF16BEByteArray` on an empty `assetId` (observed with Wire Cells/Drive assets where `remoteData.assetId` is empty)
- The crash poisons the entire incremental sync batch — the event is never marked as processed, causing an infinite retry loop with exponential backoff
- Also improves `ProteusClientCoreCrypto.wrapException` error logging to include full stack traces for unexpected non-Proteus exceptions

## Test plan

- [x] Verify `"".toUTF16BEByteArray()` returns empty `ByteArray` on macOS native without crashing
- [x] Verify incremental sync processes events past messages that quote Cells/Drive assets
- [x] Existing `UTF16BEByteArrayTest` tests continue to pass on JVM