### PR TITLE
fix: remote muting not working [WPB-3185]

### DIFF
--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -49,7 +49,6 @@ import com.wire.kalium.logic.data.call.mapper.CallMapper
 import com.wire.kalium.logic.data.call.mapper.ParticipantMapperImpl
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Conversation
-import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.id.FederatedIdMapper
@@ -93,12 +92,10 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Instant
-import kotlinx.serialization.json.Json
 import java.util.Collections
 
 @Suppress("LongParameterList", "TooManyFunctions")
@@ -107,7 +104,6 @@ internal class CallManagerImpl internal constructor(
     private val callRepository: CallRepository,
     private val currentClientIdProvider: CurrentClientIdProvider,
     selfConversationIdProvider: SelfConversationIdProvider,
-    private val conversationRepository: ConversationRepository,
     messageSender: MessageSender,
     private val callMapper: CallMapper,
     private val federatedIdMapper: FederatedIdMapper,
@@ -123,8 +119,6 @@ internal class CallManagerImpl internal constructor(
     private val flowManagerService: FlowManagerService,
     private val createAndPersistRecentlyEndedCallMetadata: CreateAndPersistRecentlyEndedCallMetadataUseCase,
     private val selfUserId: UserId,
-    private val json: Json = Json { ignoreUnknownKeys = true },
-    private val shouldRemoteMuteChecker: ShouldRemoteMuteChecker = ShouldRemoteMuteCheckerImpl(),
     private val serverTimeHandler: ServerTimeHandler = ServerTimeHandlerImpl(),
     kaliumDispatchers: KaliumDispatcher = KaliumDispatcherImpl
 ) : CallManager {
@@ -263,40 +257,27 @@ internal class CallManagerImpl internal constructor(
         callingLogger.i("$tagWithUserId: onCallingMessageReceived called: { \"message\" : ${message.toLogString()}}")
         val msg = content.value.toByteArray()
 
-        val callingValue = json.decodeFromString<MessageContent.Calling.CallingValue>(content.value)
-        val conversationMembers = conversationRepository.observeConversationMembers(message.conversationId).first()
-        val shouldRemoteMute = shouldRemoteMuteChecker.check(
-            senderUserId = message.senderUserId,
-            selfUserId = selfUserId,
-            selfClientId = clientId.await().value,
-            targets = callingValue.targets,
-            conversationMembers = conversationMembers
-        )
-
-        if (callingValue.type != REMOTE_MUTE_TYPE || shouldRemoteMute) {
-            val targetConversationId = if (message.isSelfMessage) {
-                content.conversationId ?: message.conversationId
-            } else {
-                message.conversationId
-            }
-
-            val callConversationType = getCallConversationType(targetConversationId)
-            val type = callMapper.toConversationType(callConversationType)
-
-            wcall_recv_msg(
-                inst = deferredHandle.await(),
-                msg = msg,
-                len = msg.size,
-                curr_time = Uint32_t(value = serverTimeHandler.toServerTimestamp()),
-                msg_time = Uint32_t(value = message.date.epochSeconds),
-                convId = federatedIdMapper.parseToFederatedId(targetConversationId),
-                userId = federatedIdMapper.parseToFederatedId(message.senderUserId),
-                clientId = message.senderClientId.value,
-                convType = callMapper.toConversationTypeCalling(type).avsValue,
-                meeting = false.toInt()
-            )
-            callingLogger.i("$tagWithUserId: wcall_recv_msg() called")
+        val targetConversationId = if (message.isSelfMessage) {
+            content.conversationId ?: message.conversationId
+        } else {
+            message.conversationId
         }
+        val callConversationType = getCallConversationType(targetConversationId)
+        val type = callMapper.toConversationType(callConversationType)
+
+        wcall_recv_msg(
+            inst = deferredHandle.await(),
+            msg = msg,
+            len = msg.size,
+            curr_time = Uint32_t(value = serverTimeHandler.toServerTimestamp()),
+            msg_time = Uint32_t(value = message.date.epochSeconds),
+            convId = federatedIdMapper.parseToFederatedId(targetConversationId),
+            userId = federatedIdMapper.parseToFederatedId(message.senderUserId),
+            clientId = message.senderClientId.value,
+            convType = callMapper.toConversationTypeCalling(type).avsValue,
+            meeting = false.toInt()
+        )
+        callingLogger.i("$tagWithUserId: wcall_recv_msg() called")
     }
 
     override suspend fun startCall(
@@ -733,6 +714,5 @@ internal class CallManagerImpl internal constructor(
         internal const val TAG = "CallManager"
         internal const val DEFAULT_NETWORK_QUALITY_INTERVAL_SECONDS = 5
         internal const val UTF8_ENCODING = "UTF-8"
-        internal const val REMOTE_MUTE_TYPE = "REMOTEMUTE"
     }
 }

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -109,7 +109,6 @@ internal actual class GlobalCallManager(
                     selfConversationIdProvider = selfConversationIdProvider,
                     callMapper = callMapper,
                     messageSender = messageSender,
-                    conversationRepository = conversationRepository,
                     federatedIdMapper = federatedIdMapper,
                     qualifiedIdMapper = qualifiedIdMapper,
                     videoStateChecker = videoStateChecker,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -497,6 +497,8 @@ import com.wire.kalium.logic.sync.receiver.handler.ButtonActionConfirmationHandl
 import com.wire.kalium.logic.sync.receiver.handler.ButtonActionConfirmationHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.ButtonActionHandler
 import com.wire.kalium.logic.sync.receiver.handler.ButtonActionHandlerImpl
+import com.wire.kalium.logic.sync.receiver.handler.CallingMessageHandler
+import com.wire.kalium.logic.sync.receiver.handler.CallingMessageHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.CellsConfigHandler
 import com.wire.kalium.logic.sync.receiver.handler.ClearConversationContentHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.CodeDeletedHandler
@@ -1758,12 +1760,21 @@ public class UserSessionScope internal constructor(
         ButtonActionHandlerImpl(userId, compositeMessageRepository, userScopedLogger)
     }
 
+    private val callingMessageHandler: CallingMessageHandler by lazy {
+        CallingMessageHandlerImpl(
+            selfUserId = userId,
+            currentClientIdProvider = clientIdProvider,
+            callManager = callManager,
+            conversationRepository = conversationRepository,
+            muteCall = calls.muteCall,
+        )
+    }
+
     private val applicationMessageHandler: ApplicationMessageHandler
         get() = ApplicationMessageHandlerImpl(
             userRepository,
             messageRepository,
             assetMessageHandler,
-            callManager,
             persistMessage,
             persistReaction,
             MessageTextEditHandlerImpl(messageRepository, NotificationEventsManagerImpl),
@@ -1797,6 +1808,7 @@ public class UserSessionScope internal constructor(
             inCallReactionsRepository,
             buttonActionHandler,
             MessageCompositeEditHandlerImpl(messageRepository),
+            callingMessageHandler,
             userId
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/ShouldRemoteMuteChecker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/ShouldRemoteMuteChecker.kt
@@ -43,26 +43,20 @@ internal class ShouldRemoteMuteCheckerImpl : ShouldRemoteMuteChecker {
         selfClientId: String,
         targets: MessageContent.Calling.Targets?,
         conversationMembers: List<Conversation.Member>
-    ): Boolean {
-        val isAdmin = conversationMembers.any { member ->
+    ): Boolean = isSenderAnAdmin(senderUserId, conversationMembers) && isCurrentClientTargeted(selfUserId, selfClientId, targets)
+
+    // Only admins can remotely mute other participants, so we need to check if the sender is an admin or not.
+    private fun isSenderAnAdmin(senderUserId: UserId, conversationMembers: List<Conversation.Member>): Boolean =
+        conversationMembers.any { member ->
             member.id == senderUserId && member.role == Conversation.Member.Role.Admin
         }
-        return if (isAdmin) {
-            targets?.let {
-                // Having targets means that we are in an MLS call.
-                it.domainToUserIdToClients.values.any { userClientsMap ->
-                    userClientsMap[selfUserId.value]?.any { client ->
-                        client == selfClientId
-                    } ?: run {
-                        false
-                    }
-                }
-            } ?: run {
-                // If there are no targets, we should mute. It's a proteus message with no targets.
-                true
+
+    // Because of the nature of MLS (where all the MLS group members always receive a message),
+    // we need to check if the current client is a target of the remote mute or not.
+    private fun isCurrentClientTargeted(selfUserId: UserId, selfClientId: String, targets: MessageContent.Calling.Targets?): Boolean =
+        targets?.domainToUserIdToClients?.values.orEmpty().any { userClientsMap ->
+            userClientsMap[selfUserId.value].orEmpty().any { client ->
+                client == selfClientId
             }
-        } else {
-            false
         }
-    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandler.kt
@@ -38,10 +38,10 @@ import com.wire.kalium.logic.data.message.hasValidData
 import com.wire.kalium.logic.data.message.hasValidRemoteData
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
-import com.wire.kalium.logic.feature.call.CallManager
 import com.wire.kalium.logic.sync.receiver.asset.AssetMessageHandler
 import com.wire.kalium.logic.sync.receiver.handler.ButtonActionConfirmationHandler
 import com.wire.kalium.logic.sync.receiver.handler.ButtonActionHandler
+import com.wire.kalium.logic.sync.receiver.handler.CallingMessageHandler
 import com.wire.kalium.logic.sync.receiver.handler.ClearConversationContentHandler
 import com.wire.kalium.logic.sync.receiver.handler.DataTransferEventHandler
 import com.wire.kalium.logic.sync.receiver.handler.DeleteForMeHandler
@@ -89,7 +89,6 @@ internal class ApplicationMessageHandlerImpl(
     private val userRepository: UserRepository,
     private val messageRepository: MessageRepository,
     private val assetMessageHandler: AssetMessageHandler,
-    private val callManagerImpl: Lazy<CallManager>,
     private val persistMessage: PersistMessageUseCase,
     private val persistReaction: PersistReactionUseCase,
     private val editTextHandler: MessageTextEditHandler,
@@ -105,6 +104,7 @@ internal class ApplicationMessageHandlerImpl(
     private val inCallReactionsRepository: InCallReactionsRepository,
     private val buttonActionHandler: ButtonActionHandler,
     private val messageCompositeEditHandler: MessageCompositeEditHandler,
+    private val callingMessageHandler: CallingMessageHandler,
     private val selfUserId: UserId,
 ) : ApplicationMessageHandler {
 
@@ -195,12 +195,8 @@ internal class ApplicationMessageHandlerImpl(
             is MessageContent.DeleteForMe -> deleteForMeHandler.handle(signaling, content)
             is MessageContent.Calling -> {
                 logger.d("MessageContent.Calling")
-                callManagerImpl.value.onCallingMessageReceived(
-                    message = signaling,
-                    content = content,
-                )
+                callingMessageHandler.handle(message = signaling, content = content)
             }
-
             is MessageContent.TextEdited -> editTextHandler.handle(signaling, content)
             is MessageContent.LastRead -> lastReadContentHandler.handle(signaling, content)
             is MessageContent.Cleared -> clearConversationContentHandler.handle(transactionContext, signaling, content)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/CallingMessageHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/CallingMessageHandler.kt
@@ -1,0 +1,99 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.sync.receiver.handler
+
+import com.wire.kalium.common.functional.getOrNull
+import com.wire.kalium.common.logger.callingLogger
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.CurrentClientIdProvider
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.call.CallManager
+import com.wire.kalium.logic.feature.call.ShouldRemoteMuteChecker
+import com.wire.kalium.logic.feature.call.ShouldRemoteMuteCheckerImpl
+import com.wire.kalium.logic.feature.call.usecase.MuteCallUseCase
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.json.Json
+
+internal interface CallingMessageHandler {
+    suspend fun handle(message: Message.Signaling, content: MessageContent.Calling)
+}
+
+@Suppress("LongParameterList")
+internal class CallingMessageHandlerImpl internal constructor(
+    private val selfUserId: UserId,
+    private val currentClientIdProvider: CurrentClientIdProvider,
+    private val callManager: Lazy<CallManager>,
+    private val conversationRepository: ConversationRepository,
+    private val muteCall: MuteCallUseCase,
+    private val shouldRemoteMuteChecker: ShouldRemoteMuteChecker = ShouldRemoteMuteCheckerImpl(),
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) : CallingMessageHandler {
+    private val tagWithUserId = "$TAG(${selfUserId.toLogString()})"
+
+    override suspend fun handle(message: Message.Signaling, content: MessageContent.Calling) {
+        val targetConversationId = if (message.isSelfMessage) {
+            content.conversationId ?: message.conversationId
+        } else {
+            message.conversationId
+        }
+        val callingValue = json.decodeFromString<MessageContent.Calling.CallingValue>(content.value)
+        when (callingValue.type) {
+            REMOTE_MUTE_TYPE -> handleRemoteMuteMessage(
+                message = message,
+                targetConversationId = targetConversationId,
+                callingValue = callingValue
+            )
+
+            else -> callManager.value.onCallingMessageReceived(message = message, content = content)
+        }
+    }
+
+    private suspend fun handleRemoteMuteMessage(
+        message: Message.Signaling,
+        targetConversationId: ConversationId,
+        callingValue: MessageContent.Calling.CallingValue
+    ) {
+        val clientId = currentClientIdProvider().getOrNull()
+        if (clientId == null) {
+            callingLogger.e("$tagWithUserId: Current client ID is not available. Cannot process calling $REMOTE_MUTE_TYPE message.")
+            return
+        }
+
+        val conversationMembers = conversationRepository.observeConversationMembers(targetConversationId).first()
+        val shouldRemoteMute = shouldRemoteMuteChecker.check(
+            senderUserId = message.senderUserId,
+            selfUserId = selfUserId,
+            selfClientId = clientId.value,
+            targets = callingValue.targets,
+            conversationMembers = conversationMembers
+        )
+        callingLogger.i("$tagWithUserId: Calling $REMOTE_MUTE_TYPE message received for conversationId: $targetConversationId.")
+        if (shouldRemoteMute) {
+            muteCall(targetConversationId, true)
+        }
+    }
+
+    internal companion object {
+        internal const val TAG = "CallingMessageHandler"
+        internal const val REMOTE_MUTE_TYPE = "REMOTEMUTE"
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/ShouldRemoteMuteCheckerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/ShouldRemoteMuteCheckerTest.kt
@@ -42,7 +42,7 @@ class ShouldRemoteMuteCheckerTest {
     }
 
     @Test
-    fun givenNullTargets_whenChecking_thenReturnTrue() {
+    fun givenNullTargets_whenChecking_thenReturnFalse() {
         val (_, checker) = Arrangement()
             .arrange()
 
@@ -54,11 +54,11 @@ class ShouldRemoteMuteCheckerTest {
             conversationMembers = listOf(conversationMember)
         )
 
-        assertEquals(true, shouldRemoteMute)
+        assertEquals(false, shouldRemoteMute)
     }
 
     @Test
-    fun givenTargetContainsCurrentUser_whenChecking_thenReturnFalse() {
+    fun givenTargetsDoNotContainCurrentUserId_whenChecking_thenReturnFalse() {
         val (_, checker) = Arrangement()
             .arrange()
 
@@ -74,7 +74,7 @@ class ShouldRemoteMuteCheckerTest {
     }
 
     @Test
-    fun givenTargetDoesNotContainCurrentUser_whenChecking_thenReturnTrue() {
+    fun givenTargetsContainCurrentUserIdButDoNotContainCurrentClientId_whenChecking_thenReturnFalse() {
         val (_, checker) = Arrangement()
             .arrange()
 
@@ -82,27 +82,27 @@ class ShouldRemoteMuteCheckerTest {
             senderUserId = OTHER_USER_ID,
             selfUserId = SELF_USER_ID,
             selfClientId = SELF_CLIENT_ID,
-            targets = targetsWithCurrentUser,
-            conversationMembers = listOf(conversationMember)
-        )
-
-        assertEquals(true, shouldRemoteMute)
-    }
-
-    @Test
-    fun givenTargetThatDoesNotContainCurrentClientId_whenChecking_thenReturnFalse() {
-        val (_, checker) = Arrangement()
-            .arrange()
-
-        val shouldRemoteMute = checker.check(
-            senderUserId = OTHER_USER_ID,
-            selfUserId = SELF_USER_ID,
-            selfClientId = SELF_CLIENT_ID,
-            targets = targetsWithDifferentClientId,
+            targets = targetsWithCurrentUserButDifferentClient,
             conversationMembers = listOf(conversationMember)
         )
 
         assertEquals(false, shouldRemoteMute)
+    }
+
+    @Test
+    fun givenTargetsContainCurrentUserIdAndCurrentClientId_whenChecking_thenReturnTrue() {
+        val (_, checker) = Arrangement()
+            .arrange()
+
+        val shouldRemoteMute = checker.check(
+            senderUserId = OTHER_USER_ID,
+            selfUserId = SELF_USER_ID,
+            selfClientId = SELF_CLIENT_ID,
+            targets = targetsWithCurrentUserAndCurrentClient,
+            conversationMembers = listOf(conversationMember)
+        )
+
+        assertEquals(true, shouldRemoteMute)
     }
 
     internal class Arrangement {
@@ -115,7 +115,7 @@ class ShouldRemoteMuteCheckerTest {
         private val OTHER_USER_ID = UserId("otherUserId", "domain")
         private const val SELF_CLIENT_ID = "selfClientId"
         private const val OTHER_CLIENT_ID = "otherClientId"
-        val targetsWithCurrentUser = MessageContent.Calling.Targets(
+        val targetsWithCurrentUserAndCurrentClient = MessageContent.Calling.Targets(
             domainToUserIdToClients = mapOf(
                 "anta-env" to mapOf(
                     OTHER_USER_ID.value to listOf(OTHER_CLIENT_ID, OTHER_CLIENT_ID)
@@ -137,7 +137,7 @@ class ShouldRemoteMuteCheckerTest {
             )
         )
 
-        val targetsWithDifferentClientId = MessageContent.Calling.Targets(
+        val targetsWithCurrentUserButDifferentClient = MessageContent.Calling.Targets(
             domainToUserIdToClients = mapOf(
                 "diya-env" to mapOf(
                     SELF_USER_ID.value to listOf(OTHER_CLIENT_ID, OTHER_CLIENT_ID),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandlerTest.kt
@@ -32,12 +32,12 @@ import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.data.message.PersistReactionUseCase
 import com.wire.kalium.logic.data.message.ProtoContent
 import com.wire.kalium.logic.data.user.UserRepository
-import com.wire.kalium.logic.feature.call.CallManager
 import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.sync.receiver.asset.AssetMessageHandler
 import com.wire.kalium.logic.sync.receiver.handler.ButtonActionConfirmationHandler
 import com.wire.kalium.logic.sync.receiver.handler.ButtonActionHandler
+import com.wire.kalium.logic.sync.receiver.handler.CallingMessageHandler
 import com.wire.kalium.logic.sync.receiver.handler.ClearConversationContentHandler
 import com.wire.kalium.logic.sync.receiver.handler.DataTransferEventHandler
 import com.wire.kalium.logic.sync.receiver.handler.DeleteForMeHandler
@@ -50,13 +50,14 @@ import com.wire.kalium.logic.sync.receiver.handler.ReceiptMessageHandler
 import com.wire.kalium.logic.util.MessageContentEncoder
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
-import io.mockative.any
-import io.mockative.coEvery
-import io.mockative.coVerify
-import io.mockative.every
-import io.mockative.matches
-import io.mockative.mock
-import io.mockative.once
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.matcher.matches
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
 import kotlinx.coroutines.test.runTest
 import kotlin.io.encoding.Base64
 import kotlin.test.Test
@@ -98,13 +99,13 @@ class ApplicationMessageHandlerTest {
             protoContent
         )
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.assetMessageHandler.handle(
                 matches {
                     it.content is MessageContent.Asset
                 }
             )
-        }.wasInvoked(exactly = once)
+        }
     }
 
     @Test
@@ -122,7 +123,6 @@ class ApplicationMessageHandlerTest {
         )
         val (arrangement, messageHandler) = Arrangement()
             .withPersistingMessageReturning(Either.Right(Unit))
-            .withButtonAction()
             .arrange()
 
         val encodedEncryptedContent = Base64.encode("Hello".encodeToByteArray())
@@ -136,9 +136,9 @@ class ApplicationMessageHandlerTest {
             protoContent
         )
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.buttonActionHandler.handle(any(), any(), any(), any())
-        }.wasInvoked(exactly = once)
+        }
     }
 
     @Test
@@ -174,9 +174,9 @@ class ApplicationMessageHandlerTest {
             protoContent
         )
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.messageCompositeEditHandler.handle(any(), any())
-        }.wasInvoked(exactly = once)
+        }
     }
 
     @Test
@@ -208,9 +208,9 @@ class ApplicationMessageHandlerTest {
             protoContent
         )
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.messageMultipartEditHandler.handle(any(), any())
-        }.wasInvoked(exactly = once)
+        }
     }
 
     @Test
@@ -242,9 +242,9 @@ class ApplicationMessageHandlerTest {
             protoContent
         )
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.buttonActionConfirmationHandler.handle(any(), any(), any())
-        }.wasInvoked(exactly = once)
+        }
     }
 
     @Test
@@ -281,9 +281,9 @@ class ApplicationMessageHandlerTest {
         )
 
         // then
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.dataTransferEventHandler.handle(any(), any())
-        }.wasInvoked(exactly = once)
+        }
     }
 
     @Test
@@ -317,38 +317,69 @@ class ApplicationMessageHandlerTest {
         )
 
         // then
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.inCallReactionsRepository.addInCallReaction(messageEvent.conversationId, messageEvent.senderUserId, setOf("1"))
-        }.wasInvoked(exactly = once)
+        }
+    }
+
+    @Test
+    fun givenCallingMessageReceived_whenHandling_thenCorrectHandlerIsInvoked() = runTest {
+        // given
+        val messageId = "messageId"
+        val encodedEncryptedContent = Base64.encode("Hello".encodeToByteArray())
+        val messageEvent = TestEvent.newMessageEvent(encodedEncryptedContent)
+        val callingContent = MessageContent.Calling(value = "json content", conversationId = messageEvent.conversationId)
+        val protoContent = ProtoContent.Readable(
+            messageUid = messageId,
+            messageContent = callingContent,
+            expectsReadConfirmation = false,
+            legalHoldStatus = Conversation.LegalHoldStatus.DISABLED
+        )
+        val (arrangement, messageHandler) = Arrangement()
+            .arrange()
+
+        // when
+        messageHandler.handleContent(
+            arrangement.transactionContext,
+            messageEvent.conversationId,
+            messageEvent.messageInstant,
+            messageEvent.senderUserId,
+            messageEvent.senderClientId,
+            protoContent
+        )
+
+        // then
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.callingMessageHandler.handle(any(), callingContent)
+        }
     }
 
     private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
 
-        val persistMessage = mock(PersistMessageUseCase::class)
-        val messageRepository = mock(MessageRepository::class)
-        private val userRepository = mock(UserRepository::class)
-        val userConfigRepository = mock(UserConfigRepository::class)
-        private val callManager = mock(CallManager::class)
-        val persistReactionsUseCase = mock(PersistReactionUseCase::class)
-        val messageTextEditHandler = mock(MessageTextEditHandler::class)
-        val messageMultipartEditHandler = mock(MessageMultipartEditHandler::class)
-        val lastReadContentHandler = mock(LastReadContentHandler::class)
-        val clearConversationContentHandler = mock(ClearConversationContentHandler::class)
-        val deleteForMeHandler = mock(DeleteForMeHandler::class)
-        val deleteMessageHandler = mock(DeleteMessageHandler::class)
-        val receiptMessageHandler = mock(ReceiptMessageHandler::class)
-        val assetMessageHandler = mock(AssetMessageHandler::class)
-        val buttonActionConfirmationHandler = mock(ButtonActionConfirmationHandler::class)
-        val inCallReactionsRepository = mock(InCallReactionsRepository::class)
-        val dataTransferEventHandler = mock(DataTransferEventHandler::class)
-        val buttonActionHandler = mock(ButtonActionHandler::class)
-        val messageCompositeEditHandler = mock(MessageCompositeEditHandler::class)
+        val persistMessage = mock<PersistMessageUseCase>(MockMode.autoUnit)
+        val messageRepository = mock<MessageRepository>(MockMode.autoUnit)
+        private val userRepository = mock<UserRepository>(MockMode.autoUnit)
+        val userConfigRepository = mock<UserConfigRepository>(MockMode.autoUnit)
+        val persistReactionsUseCase = mock<PersistReactionUseCase>(MockMode.autoUnit)
+        val messageTextEditHandler = mock<MessageTextEditHandler>(MockMode.autoUnit)
+        val messageMultipartEditHandler = mock<MessageMultipartEditHandler>(MockMode.autoUnit)
+        val lastReadContentHandler = mock<LastReadContentHandler>(MockMode.autoUnit)
+        val clearConversationContentHandler = mock<ClearConversationContentHandler>(MockMode.autoUnit)
+        val deleteForMeHandler = mock<DeleteForMeHandler>(MockMode.autoUnit)
+        val deleteMessageHandler = mock<DeleteMessageHandler>(MockMode.autoUnit)
+        val receiptMessageHandler = mock<ReceiptMessageHandler>(MockMode.autoUnit)
+        val assetMessageHandler = mock<AssetMessageHandler>(MockMode.autoUnit)
+        val buttonActionConfirmationHandler = mock<ButtonActionConfirmationHandler>(MockMode.autoUnit)
+        val inCallReactionsRepository = mock<InCallReactionsRepository>(MockMode.autoUnit)
+        val dataTransferEventHandler = mock<DataTransferEventHandler>(MockMode.autoUnit)
+        val buttonActionHandler = mock<ButtonActionHandler>(MockMode.autoUnit)
+        val messageCompositeEditHandler = mock<MessageCompositeEditHandler>(MockMode.autoUnit)
+        val callingMessageHandler = mock<CallingMessageHandler>(MockMode.autoUnit)
 
         private val applicationMessageHandler = ApplicationMessageHandlerImpl(
             userRepository,
             messageRepository,
             assetMessageHandler,
-            lazyOf(callManager),
             persistMessage,
             persistReactionsUseCase,
             messageTextEditHandler,
@@ -364,17 +395,18 @@ class ApplicationMessageHandlerTest {
             inCallReactionsRepository,
             buttonActionHandler,
             messageCompositeEditHandler,
+            callingMessageHandler,
             TestUser.SELF.id
         )
 
-        suspend fun withPersistingMessageReturning(result: Either<CoreFailure, Unit>) = apply {
-            coEvery {
+        fun withPersistingMessageReturning(result: Either<CoreFailure, Unit>) = apply {
+            everySuspend {
                 persistMessage.invoke(any())
             }.returns(result)
         }
 
-        suspend fun withFileSharingEnabled() = apply {
-            coEvery {
+        fun withFileSharingEnabled() = apply {
+            everySuspend {
                 userConfigRepository.isFileSharingEnabled()
             }.returns(
                 Either.Right(
@@ -386,34 +418,28 @@ class ApplicationMessageHandlerTest {
             )
         }
 
-        suspend fun withErrorGetMessageById(storageFailure: StorageFailure) = apply {
-            coEvery {
+        fun withErrorGetMessageById(storageFailure: StorageFailure) = apply {
+            everySuspend {
                 messageRepository.getMessageById(any(), any())
             }.returns(Either.Left(storageFailure))
         }
 
-        suspend fun withButtonActionConfirmation(result: Either<StorageFailure, Unit>) = apply {
-            coEvery {
+        fun withButtonActionConfirmation(result: Either<StorageFailure, Unit>) = apply {
+            everySuspend {
                 buttonActionConfirmationHandler.handle(any(), any(), any())
             }.returns(result)
         }
 
-        suspend fun withMessageCompositeEditHandler() = apply {
-            coEvery {
+        fun withMessageCompositeEditHandler() = apply {
+            everySuspend {
                 messageCompositeEditHandler.handle(any(), any())
             }.returns(Either.Right(Unit))
         }
 
-        suspend fun withMessageMultipartEditHandler() = apply {
-            coEvery {
+        fun withMessageMultipartEditHandler() = apply {
+            everySuspend {
                 messageMultipartEditHandler.handle(any(), any())
             }.returns(Either.Right(Unit))
-        }
-
-        suspend fun withButtonAction() = apply {
-            coEvery {
-                buttonActionHandler.handle(any(), any(), any(), any())
-            }.returns(Unit)
         }
 
         fun arrange() = this to applicationMessageHandler

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/CallingMessageHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/CallingMessageHandlerTest.kt
@@ -81,7 +81,7 @@ class CallingMessageHandlerTest {
     }
 
     @Test
-    fun givenCallingMessage_whenHandling_andShouldRemoteMuteReturnsTrue_thenDoNotCallMute_andDoNotPassMessageToCallManager() = runTest {
+    fun givenCallingMessage_whenHandling_andShouldRemoteMuteReturnsFalse_thenDoNotCallMute_andDoNotPassMessageToCallManager() = runTest {
         // given
         val content = REMOTE_MUTE_CONTENT
         val message = CALLING_MESSAGE.copy(content = content)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/CallingMessageHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/CallingMessageHandlerTest.kt
@@ -1,0 +1,164 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.receiver.handler
+
+import com.wire.kalium.common.functional.right
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.id.CurrentClientIdProvider
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.feature.call.CallManager
+import com.wire.kalium.logic.feature.call.ShouldRemoteMuteChecker
+import com.wire.kalium.logic.feature.call.usecase.MuteCallUseCase
+import com.wire.kalium.logic.framework.TestCall
+import com.wire.kalium.logic.framework.TestClient
+import com.wire.kalium.logic.framework.TestUser
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlin.test.Test
+
+class CallingMessageHandlerTest {
+
+    @Test
+    fun givenCallingMessage_whenHandling_thenHandleInCallManager_andDoNotCallMute() = runTest {
+        // given
+        val content = CALLING_CONTENT
+        val message = CALLING_MESSAGE.copy(content = content)
+        val (arrangement, callingMessageHandler) = Arrangement().arrange()
+        // when
+        callingMessageHandler.handle(message, content)
+        // then
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.callManager.onCallingMessageReceived(message, content)
+        }
+        verifySuspend(VerifyMode.exactly(0)) {
+            arrangement.muteCallUseCase.invoke(message.conversationId, any())
+        }
+    }
+
+    @Test
+    fun givenCallingMessage_whenHandling_andShouldRemoteMuteReturnsTrue_thenCallMute_butDoNotPassMessageToCallManager() = runTest {
+        // given
+        val content = REMOTE_MUTE_CONTENT
+        val message = CALLING_MESSAGE.copy(content = content)
+        val (arrangement, callingMessageHandler) = Arrangement()
+            .withShouldRemoteMuteCheckerReturning(true)
+            .arrange()
+        // when
+        callingMessageHandler.handle(message, content)
+        // then
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.muteCallUseCase.invoke(message.conversationId, true)
+        }
+        verifySuspend(VerifyMode.exactly(0)) {
+            arrangement.callManager.onCallingMessageReceived(message, content)
+        }
+    }
+
+    @Test
+    fun givenCallingMessage_whenHandling_andShouldRemoteMuteReturnsTrue_thenDoNotCallMute_andDoNotPassMessageToCallManager() = runTest {
+        // given
+        val content = REMOTE_MUTE_CONTENT
+        val message = CALLING_MESSAGE.copy(content = content)
+        val (arrangement, callingMessageHandler) = Arrangement()
+            .withShouldRemoteMuteCheckerReturning(false)
+            .arrange()
+        // when
+        callingMessageHandler.handle(message, content)
+        // then
+        verifySuspend(VerifyMode.exactly(0)) {
+            arrangement.muteCallUseCase.invoke(message.conversationId, true)
+        }
+        verifySuspend(VerifyMode.exactly(0)) {
+            arrangement.callManager.onCallingMessageReceived(message, content)
+        }
+    }
+
+    private inner class Arrangement {
+
+        val currentClientIdProvider: CurrentClientIdProvider = mock(MockMode.autoUnit)
+        val callManager: CallManager = mock(MockMode.autoUnit)
+        val conversationRepository: ConversationRepository = mock(MockMode.autoUnit)
+        val muteCallUseCase: MuteCallUseCase = mock(MockMode.autoUnit)
+        val shouldRemoteMuteChecker: ShouldRemoteMuteChecker = mock(MockMode.autoUnit)
+
+        fun withShouldRemoteMuteCheckerReturning(shouldRemoteMute: Boolean) = apply {
+            everySuspend {
+                shouldRemoteMuteChecker.check(any(), any(), any(), any(), any())
+            } returns shouldRemoteMute
+        }
+
+        fun withCurrentClientIdProviderReturning(clientId: ClientId) = apply {
+            everySuspend {
+                currentClientIdProvider()
+            } returns clientId.right()
+        }
+
+        fun withObserveConversationMembersReturning(members: List<Conversation.Member>) = apply {
+            everySuspend {
+                conversationRepository.observeConversationMembers(any())
+            } returns flowOf(members)
+        }
+
+        init {
+            withCurrentClientIdProviderReturning(TestClient.CLIENT_ID)
+            withObserveConversationMembersReturning(emptyList())
+        }
+
+        fun arrange() = this to CallingMessageHandlerImpl(
+            selfUserId = TestUser.SELF.id,
+            currentClientIdProvider = currentClientIdProvider,
+            callManager = lazy { callManager },
+            conversationRepository = conversationRepository,
+            muteCall = muteCallUseCase,
+            shouldRemoteMuteChecker = shouldRemoteMuteChecker,
+        )
+    }
+
+    companion object {
+        val CALLING_CONTENT = MessageContent.Calling(
+            value = """{"type":"TYPE","conversationId":"${TestCall.CONVERSATION_ID}"}""",
+            conversationId = null
+        )
+        val REMOTE_MUTE_CONTENT = MessageContent.Calling(
+            value = """{"type":"REMOTEMUTE","conversationId":"${TestCall.CONVERSATION_ID}"}""",
+            conversationId = null
+        )
+        val CALLING_MESSAGE = Message.Signaling(
+            id = "message-id",
+            content = CALLING_CONTENT,
+            conversationId = TestCall.CONVERSATION_ID,
+            date = Clock.System.now(),
+            senderUserId = TestUser.USER_ID,
+            senderClientId = TestClient.CLIENT_ID,
+            status = Message.Status.Read(0),
+            isSelfMessage = false,
+            expirationData = null,
+        )
+    }
+}

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
@@ -31,8 +31,6 @@ import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.VideoStateChecker
 import com.wire.kalium.logic.data.call.mapper.CallMapperImpl
 import com.wire.kalium.logic.data.conversation.ClientId
-import com.wire.kalium.logic.data.conversation.Conversation
-import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.id.FederatedIdMapper
@@ -64,7 +62,6 @@ import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -103,14 +100,14 @@ internal class CallManagerTest {
 
         verify(VerifyMode.exactly(1)) {
             arrangement.calling.wcall_recv_msg(
-                eq(BASE_HANDLE),
+                BASE_HANDLE,
                 matches { it.contentEquals(CALL_CONTENT.value.toByteArray()) },
-                eq(CALL_CONTENT.value.toByteArray().size),
+                CALL_CONTENT.value.toByteArray().size,
                 any(),
                 any(),
-                eq(CALL_CONV_ID.toString()),
-                eq(USER_ID.toString()),
-                eq(CLIENT_ID.value),
+                CALL_CONV_ID.toString(),
+                USER_ID.toString(),
+                CLIENT_ID.value,
                 any(),
                 any()
             )
@@ -126,7 +123,6 @@ internal class CallManagerTest {
             .onParseToFederatedIdReturning(CALL_CONV_ID, CALL_CONV_ID.toString())
             .onWcallCreateReturning(BASE_HANDLE)
             .onWcallRecvMsgReturning(0)
-            .onObserveConversationMembersReturning(emptyList())
             .onGetCallConversationTypeReturning(ConversationTypeCalling.Conference)
             .withFetchServerTimeReturning()
             .arrange()
@@ -162,7 +158,6 @@ internal class CallManagerTest {
         internal val flowManagerService = mock<FlowManagerService>(MockMode.autoUnit)
         internal val selfConversationIdProvider = mock<SelfConversationIdProvider>()
         internal val userConfigRepository = mock<UserConfigRepository>()
-        internal val conversationRepository = mock<ConversationRepository>()
         internal val federatedIdMapper = mock<FederatedIdMapper>()
         internal val qualifiedIdMapper = mock<QualifiedIdMapper>()
         internal val conversationClientsInCallUpdater = mock<ConversationClientsInCallUpdater>()
@@ -198,10 +193,6 @@ internal class CallManagerTest {
             every { calling.wcall_recv_msg(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns result
         }
 
-        fun onObserveConversationMembersReturning(result: List<Conversation.Member>) = apply {
-            everySuspend { conversationRepository.observeConversationMembers(any()) } returns flowOf(result)
-        }
-
         fun onGetCallConversationTypeReturning(result: ConversationTypeCalling) = apply {
             everySuspend { getCallConversationType(any()) } returns result
         }
@@ -215,7 +206,6 @@ internal class CallManagerTest {
             callRepository = callRepository,
             currentClientIdProvider = currentClientIdProvider,
             selfConversationIdProvider = selfConversationIdProvider,
-            conversationRepository = conversationRepository,
             userConfigRepository = userConfigRepository,
             messageSender = messageSender,
             kaliumDispatchers = kaliumTestDispatcher,
@@ -239,7 +229,6 @@ internal class CallManagerTest {
             onParseToFederatedIdReturning(CALL_CONV_ID, CALL_CONV_ID.toString())
             onWcallCreateReturning(BASE_HANDLE)
             onWcallRecvMsgReturning(0)
-            onObserveConversationMembersReturning(emptyList())
             onGetCallConversationTypeReturning(ConversationTypeCalling.Conference)
             withFetchServerTimeReturning()
         }


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-3185
<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When an admin tries to remotely mute a participant, it doesn't work in Android app and the participant is not muted.

### Causes (Optional)

Android app, when it was implemented, was making use of the fact that AVS had the logic of handling such type of message, so this message was just passed to AVS, but after some time this logic was removed from AVS as it was not in accordance to the specs: https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/969605169/Use+case+conversation+admin+mutes+a+remote+participant#Step-3%3A-Targeted-client-receives-a-message-and-mutes-itself

### Solutions

App needs to call mute itself when receiving `REMOTEMUTE` message type. In specs there's also a part of passing this message to AVS, but it results in a failure and after discussing it with the AVS team, it turned out that this step isn't necessary, web doesn't do that and passing it to AVS results in a failure as it isn't actually a calling message, it just happens to have the same content type, maybe just so that it's grouped with calling messages as it's correlated.
In this PR, handling of messages with `Calling` content is extracted to a dedicated handler, just like we have for all other message content types. Inside this handler, it's determined whether it's actually a calling message - in that case pass it to AVS, or `REMOTEMUTE` - then execute the `MuteCallUseCase`.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Join a call, unmute yourself and let admin mute you remotely.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
