### PR TITLE
feat(nomad devices): add new endpoint for sync messages and replace it in syncing flow (WPB-24207)

### DIFF
--- a/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/nomaddevice/NomadAllMessagesResponse.kt
+++ b/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/nomaddevice/NomadAllMessagesResponse.kt
@@ -24,7 +24,13 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class NomadAllMessagesResponse(
     @SerialName("conversations")
-    val conversations: List<NomadConversationWithMessages>
+    val conversations: List<NomadConversationWithMessages>,
+    @SerialName("has_more")
+    val hasMore: Boolean = false,
+    @SerialName("next_cursor")
+    val nextCursor: Int?,
+    @SerialName("next_timestamp")
+    val nextTimestamp: Long?
 )
 
 @Serializable

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/nomaddevice/NomadDeviceSyncApi.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/nomaddevice/NomadDeviceSyncApi.kt
@@ -29,7 +29,11 @@ import okio.Source
 @Mockable
 interface NomadDeviceSyncApi {
     suspend fun postMessageEvents(request: NomadMessageEventsRequest): NetworkResponse<Unit>
+
+    @Deprecated("Replaced with batched version", ReplaceWith("syncAllMessages"))
     suspend fun getAllMessages(): NetworkResponse<NomadAllMessagesResponse>
+
+    suspend fun syncAllMessages(limit: Int = 100): NetworkResponse<NomadAllMessagesResponse>
     suspend fun getConversationMetadata(): NetworkResponse<NomadConversationMetadataResponse>
     suspend fun uploadCryptoState(
         clientId: String,

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/NomadDeviceSyncApiV0.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/NomadDeviceSyncApiV0.kt
@@ -249,7 +249,7 @@ internal open class NomadDeviceSyncApiV0 internal constructor(
         }
 
     private companion object {
-        const val PATH_EVENT = "a/event"
+        const val PATH_EVENT = "event"
         const val PATH_MESSAGES = "messages"
         const val PATH_MESSAGES_SYNC = "sync"
         const val PATH_CONVERSATION_METADATA = "conversation/metadata"

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/NomadDeviceSyncApiV0.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/NomadDeviceSyncApiV0.kt
@@ -77,10 +77,19 @@ internal open class NomadDeviceSyncApiV0 internal constructor(
             }
         }
 
+    @Deprecated("Replaced with batched version", replaceWith = ReplaceWith("syncAllMessages"))
     override suspend fun getAllMessages(): NetworkResponse<NomadAllMessagesResponse> =
         requireNomadServiceUrl(apiName = "getAllMessages") ?: wrapRequest {
             httpClient.get {
                 setNomadUrlIfAvailable(PATH_EVENT, PATH_MESSAGES)
+            }
+        }
+
+    override suspend fun syncAllMessages(limit: Int): NetworkResponse<NomadAllMessagesResponse> =
+        requireNomadServiceUrl(apiName = "syncAllMessages") ?: wrapRequest {
+            httpClient.get {
+                setNomadUrlIfAvailable(PATH_EVENT, "$PATH_MESSAGES/$PATH_MESSAGES_SYNC")
+                parameter("limit", limit)
             }
         }
 
@@ -240,8 +249,9 @@ internal open class NomadDeviceSyncApiV0 internal constructor(
         }
 
     private companion object {
-        const val PATH_EVENT = "event"
+        const val PATH_EVENT = "a/event"
         const val PATH_MESSAGES = "messages"
+        const val PATH_MESSAGES_SYNC = "sync"
         const val PATH_CONVERSATION_METADATA = "conversation/metadata"
         const val PATH_CRYPTO_STATE = "crypto/state"
         const val PATH_CRYPTO_DEVICE = "crypto/device"

--- a/data/network/src/commonTest/kotlin/com/wire/kalium/api/v0/nomaddevice/NomadDeviceSyncApiV0Test.kt
+++ b/data/network/src/commonTest/kotlin/com/wire/kalium/api/v0/nomaddevice/NomadDeviceSyncApiV0Test.kt
@@ -98,6 +98,25 @@ internal class NomadDeviceSyncApiV0Test : ApiTest() {
     }
 
     @Test
+    fun givenNomadMessages_whenSyncingAllMessages_thenRequestIncludesSyncPathAndLimit() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(
+            responseBody = ALL_MESSAGES_RESPONSE_JSON,
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertGet()
+                assertPathEqual("/event/messages/sync")
+                assertQueryParameter("limit", "250")
+            }
+        )
+
+        val api: NomadDeviceSyncApi = NomadDeviceSyncApiV0(networkClient, nomadServiceUrl = "https://nomad.example.com")
+        val response = api.syncAllMessages(limit = 250)
+
+        assertTrue(response.isSuccessful())
+        assertEquals(2, response.value.conversations.size)
+    }
+
+    @Test
     fun givenConversationMetadata_whenGettingConversationMetadata_thenRequestAndResponseShouldMatchContract() = runTest {
         val networkClient = mockAuthenticatedNetworkClient(
             responseBody = CONVERSATION_METADATA_RESPONSE_JSON,
@@ -134,6 +153,29 @@ internal class NomadDeviceSyncApiV0Test : ApiTest() {
             nomadServiceUrl = "https://nomad.example.com/service"
         )
         val response = api.getAllMessages()
+
+        assertTrue(response.isSuccessful())
+    }
+
+    @Test
+    fun givenCustomNomadServiceUrl_whenSyncingAllMessages_thenNomadBaseUrlShouldOverrideDefaultBackendUrl() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(
+            responseBody = ALL_MESSAGES_RESPONSE_JSON,
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertGet()
+                assertEquals("nomad.example.com", url.host)
+                assertEquals(URLProtocol.HTTPS, url.protocol)
+                assertPathEqual("/service/event/messages/sync")
+                assertQueryParameter("limit", "100")
+            }
+        )
+
+        val api: NomadDeviceSyncApi = NomadDeviceSyncApiV0(
+            networkClient,
+            nomadServiceUrl = "https://nomad.example.com/service"
+        )
+        val response = api.syncAllMessages()
 
         assertTrue(response.isSuccessful())
     }
@@ -234,6 +276,29 @@ internal class NomadDeviceSyncApiV0Test : ApiTest() {
     }
 
     @Test
+    fun givenNomadServiceUrlWithDeepBasePath_whenSyncingAllMessages_thenFullBasePathShouldBePreserved() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(
+            responseBody = ALL_MESSAGES_RESPONSE_JSON,
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertGet()
+                assertEquals("nomad.example.com", url.host)
+                assertEquals(URLProtocol.HTTPS, url.protocol)
+                assertPathEqual("/api/v1/event/messages/sync")
+                assertQueryParameter("limit", "100")
+            }
+        )
+
+        val api: NomadDeviceSyncApi = NomadDeviceSyncApiV0(
+            networkClient,
+            nomadServiceUrl = "https://nomad.example.com/api/v1"
+        )
+        val response = api.syncAllMessages()
+
+        assertTrue(response.isSuccessful())
+    }
+
+    @Test
     fun givenEmptyLastReadEvent_whenConstructingMessageEvent_thenItShouldThrow() {
         val exception = assertFailsWith<IllegalArgumentException> {
             NomadMessageEvent.LastReadEvent(lastRead = emptyList())
@@ -283,10 +348,40 @@ internal class NomadDeviceSyncApiV0Test : ApiTest() {
     }
 
     @Test
+    fun givenMissingNomadServiceUrl_whenSyncingAllMessages_thenItShouldShortCircuitWithoutNetworkCall() = runTest {
+        assertShortCircuitedWithoutNetworkCall(expectedApiName = "syncAllMessages") { api ->
+            api.syncAllMessages()
+        }
+    }
+
+    @Test
     fun givenMissingNomadServiceUrl_whenGettingConversationMetadata_thenItShouldShortCircuitWithoutNetworkCall() = runTest {
         assertShortCircuitedWithoutNetworkCall(expectedApiName = "getConversationMetadata") { api ->
             api.getConversationMetadata()
         }
+    }
+
+    @Test
+    fun givenNomadServiceUrlWithBasePath_whenSyncingAllMessages_thenBasePathShouldBePreserved() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(
+            responseBody = ALL_MESSAGES_RESPONSE_JSON,
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertGet()
+                assertEquals("nomad.example.com", url.host)
+                assertEquals(URLProtocol.HTTPS, url.protocol)
+                assertPathEqual("/service/event/messages/sync")
+                assertQueryParameter("limit", "150")
+            }
+        )
+
+        val api: NomadDeviceSyncApi = NomadDeviceSyncApiV0(
+            networkClient,
+            nomadServiceUrl = "https://nomad.example.com/service"
+        )
+        val response = api.syncAllMessages(limit = 150)
+
+        assertTrue(response.isSuccessful())
     }
 
     @Test

--- a/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/SyncNomadAllMessagesUseCase.kt
+++ b/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/SyncNomadAllMessagesUseCase.kt
@@ -28,6 +28,7 @@ import com.wire.kalium.common.functional.right
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadAllMessagesResponse
 import com.wire.kalium.network.api.base.authenticated.nomaddevice.NomadDeviceSyncApi
+import com.wire.kalium.nomaddevice.SyncNomadAllMessagesUseCase.Companion.DEFAULT_BATCH_SIZE
 import com.wire.kalium.persistence.dao.backup.NomadMessageStoreResult
 import com.wire.kalium.persistence.dao.backup.NomadMessagesDAO
 import com.wire.kalium.userstorage.di.UserStorageProvider
@@ -110,7 +111,7 @@ public class SyncNomadAllMessagesUseCase internal constructor(
      */
     public suspend operator fun invoke(selfUserId: UserId): Either<CoreFailure, NomadAllMessagesSyncResult> {
         val responseResult = wrapApiRequest {
-            nomadDeviceSyncApiProvider(selfUserId).getAllMessages()
+            nomadDeviceSyncApiProvider(selfUserId).syncAllMessages()
         }
 
         return when (responseResult) {

--- a/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/NomadAllMessagesMapperTest.kt
+++ b/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/NomadAllMessagesMapperTest.kt
@@ -133,7 +133,9 @@ class NomadAllMessagesMapperTest {
                     conversation = Conversation(id = CONVERSATION_ID, domain = TEST_DOMAIN),
                     messages = messages.toList()
                 )
-            )
+            ),
+            nextCursor = null,
+            nextTimestamp = null
         )
 
     private fun storedMessage(

--- a/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/NomadConversationMetadataSyncRepositoryTest.kt
+++ b/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/NomadConversationMetadataSyncRepositoryTest.kt
@@ -104,6 +104,9 @@ class NomadConversationMetadataSyncRepositoryTest {
         override suspend fun getAllMessages(): NetworkResponse<NomadAllMessagesResponse> =
             error("Not needed in this test")
 
+        override suspend fun syncAllMessages(limit: Int): NetworkResponse<NomadAllMessagesResponse> =
+            error("Not needed in this test")
+
         override suspend fun getConversationMetadata(): NetworkResponse<NomadConversationMetadataResponse> = metadataResponse
 
         override suspend fun uploadCryptoState(

--- a/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/SyncNomadAllMessagesUseCaseTest.kt
+++ b/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/SyncNomadAllMessagesUseCaseTest.kt
@@ -61,11 +61,14 @@ class SyncNomadAllMessagesUseCaseTest {
                         nomadStoredMessage(messageId = "msg-3", sender = SELF_USER_ID, text = "self"),
                     )
                 )
-            )
+            ),
+            nextCursor = null,
+            nextTimestamp = null
         )
         val fakeDao = FakeNomadMessagesDAO()
+        val fakeApi = FakeNomadDeviceSyncApi(NetworkResponse.Success(response, emptyMap(), 200))
         val useCase = SyncNomadAllMessagesUseCase(
-            nomadDeviceSyncApiProvider = { FakeNomadDeviceSyncApi(NetworkResponse.Success(response, emptyMap(), 200)) },
+            nomadDeviceSyncApiProvider = { fakeApi },
             nomadMessagesDAOProvider = { fakeDao },
             batchSize = 2
         )
@@ -80,6 +83,7 @@ class SyncNomadAllMessagesUseCaseTest {
         assertEquals(2, fakeDao.batchSize)
         assertEquals(3, fakeDao.messages.size)
         assertEquals("hello", (fakeDao.messages.first().payload as SyncableMessagePayloadEntity.Text).text)
+        assertEquals(100, fakeApi.lastPageSize)
     }
 
     @Test
@@ -97,11 +101,14 @@ class SyncNomadAllMessagesUseCaseTest {
                         )
                     )
                 )
-            )
+            ),
+            nextCursor = null,
+            nextTimestamp = null
         )
         val fakeDao = FakeNomadMessagesDAO()
+        val fakeApi = FakeNomadDeviceSyncApi(NetworkResponse.Success(response, emptyMap(), 200))
         val useCase = SyncNomadAllMessagesUseCase(
-            nomadDeviceSyncApiProvider = { FakeNomadDeviceSyncApi(NetworkResponse.Success(response, emptyMap(), 200)) },
+            nomadDeviceSyncApiProvider = { fakeApi },
             nomadMessagesDAOProvider = { fakeDao },
             batchSize = 50
         )
@@ -114,6 +121,7 @@ class SyncNomadAllMessagesUseCaseTest {
         assertEquals(1, success.skippedMessages)
         assertEquals(1, success.batches)
         assertEquals(1, fakeDao.messages.size)
+        assertEquals(100, fakeApi.lastPageSize)
     }
 
     @Test
@@ -124,10 +132,13 @@ class SyncNomadAllMessagesUseCaseTest {
                     conversation = Conversation(id = CONVERSATION_ID, domain = CONVERSATION_DOMAIN),
                     messages = listOf(nomadStoredMessage(messageId = "msg-1", sender = SENDER_ID, text = "hello"))
                 )
-            )
+            ),
+            nextCursor = null,
+            nextTimestamp = null
         )
+        val fakeApi = FakeNomadDeviceSyncApi(NetworkResponse.Success(response, emptyMap(), 200))
         val useCase = SyncNomadAllMessagesUseCase(
-            nomadDeviceSyncApiProvider = { FakeNomadDeviceSyncApi(NetworkResponse.Success(response, emptyMap(), 200)) },
+            nomadDeviceSyncApiProvider = { fakeApi },
             nomadMessagesDAOProvider = { null },
             batchSize = 10
         )
@@ -139,13 +150,15 @@ class SyncNomadAllMessagesUseCaseTest {
         assertEquals(0, success.storedMessages)
         assertEquals(1, success.skippedMessages)
         assertEquals(0, success.batches)
+        assertEquals(100, fakeApi.lastPageSize)
     }
 
     @Test
     fun givenApiFailure_whenImporting_thenStorageIsNotCalled() = runTest {
         val fakeDao = FakeNomadMessagesDAO()
+        val fakeApi = FakeNomadDeviceSyncApi(NetworkResponse.Error(KaliumException.NoNetwork()))
         val useCase = SyncNomadAllMessagesUseCase(
-            nomadDeviceSyncApiProvider = { FakeNomadDeviceSyncApi(NetworkResponse.Error(KaliumException.NoNetwork())) },
+            nomadDeviceSyncApiProvider = { fakeApi },
             nomadMessagesDAOProvider = { fakeDao },
             batchSize = 10
         )
@@ -155,6 +168,7 @@ class SyncNomadAllMessagesUseCaseTest {
         assertIs<Either.Left<*>>(result)
         assertIs<NetworkFailure.NoNetworkConnection>((result as Either.Left).value)
         assertTrue(fakeDao.messages.isEmpty())
+        assertEquals(100, fakeApi.lastPageSize)
     }
 
     private class FakeNomadMessagesDAO : NomadMessagesDAO {
@@ -175,13 +189,21 @@ class SyncNomadAllMessagesUseCaseTest {
     private class FakeNomadDeviceSyncApi(
         private val allMessagesResponse: NetworkResponse<NomadAllMessagesResponse>
     ) : NomadDeviceSyncApi {
+        var lastPageSize: Int? = null
+
         override suspend fun postMessageEvents(
             request: com.wire.kalium.network.api.authenticated.nomaddevice.NomadMessageEventsRequest
         ): NetworkResponse<Unit> {
             error("Not needed in this test")
         }
 
-        override suspend fun getAllMessages(): NetworkResponse<NomadAllMessagesResponse> = allMessagesResponse
+        override suspend fun getAllMessages(): NetworkResponse<NomadAllMessagesResponse> =
+            error("Not needed in this test")
+
+        override suspend fun syncAllMessages(limit: Int): NetworkResponse<NomadAllMessagesResponse> {
+            lastPageSize = limit
+            return allMessagesResponse
+        }
 
         override suspend fun getConversationMetadata(): NetworkResponse<NomadConversationMetadataResponse> {
             error("Not needed in this test")

--- a/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/SyncNomadRemoteBackupChangeLogUseCaseTest.kt
+++ b/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/SyncNomadRemoteBackupChangeLogUseCaseTest.kt
@@ -350,6 +350,10 @@ class SyncNomadRemoteBackupChangeLogUseCaseTest {
             error("Not needed for test")
         }
 
+        override suspend fun syncAllMessages(limit: Int): NetworkResponse<NomadAllMessagesResponse> {
+            error("Not needed for test")
+        }
+
         override suspend fun getConversationMetadata(): NetworkResponse<NomadConversationMetadataResponse> {
             error("Not needed for test")
         }

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/sync/slow/SyncNomadMessagesDuringSlowSyncUseCaseTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/sync/slow/SyncNomadMessagesDuringSlowSyncUseCaseTest.kt
@@ -88,7 +88,9 @@ class SyncNomadMessagesDuringSlowSyncUseCaseTest {
                                 )
                             )
                         )
-                    )
+                    ),
+                    nextCursor = null,
+                    nextTimestamp = null
                 ),
                 emptyMap(),
                 200
@@ -102,7 +104,7 @@ class SyncNomadMessagesDuringSlowSyncUseCaseTest {
 
             assertIs<Either.Right<Unit>>(result)
             assertEquals(
-                listOf("getConversationMetadata", "getAllMessages"),
+                listOf("getConversationMetadata", "syncAllMessages"),
                 arrangement.nomadApi.calls
             )
 
@@ -157,7 +159,9 @@ class SyncNomadMessagesDuringSlowSyncUseCaseTest {
                                 )
                             )
                         )
-                    )
+                    ),
+                    nextCursor = null,
+                    nextTimestamp = null
                 ),
                 emptyMap(),
                 200
@@ -169,7 +173,7 @@ class SyncNomadMessagesDuringSlowSyncUseCaseTest {
 
             assertIs<Either.Right<Unit>>(result)
             assertEquals(
-                listOf("getConversationMetadata", "getAllMessages"),
+                listOf("getConversationMetadata", "syncAllMessages"),
                 arrangement.nomadApi.calls
             )
 
@@ -254,6 +258,11 @@ class SyncNomadMessagesDuringSlowSyncUseCaseTest {
 
         override suspend fun getAllMessages(): NetworkResponse<NomadAllMessagesResponse> {
             calls += "getAllMessages"
+            return allMessagesResponse
+        }
+
+        override suspend fun syncAllMessages(limit: Int): NetworkResponse<NomadAllMessagesResponse> {
+            calls += "syncAllMessages"
             return allMessagesResponse
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24207
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Implement phase 1 of batched messages by replacing it with a new endpoint that gets all conversations messages with a limit of 100 and configurable.
- Deprecates the old get all messages endpoint usage.

https://wearezeta.atlassian.net/wiki/x/CIAVo

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

### Notes (Optional)

This implements the calls to the new endpoint, mapping and replacement in the use case that does the call for getting the backed-up messages.

### Attachments (Optional)

<img width="1842" height="669" alt="Wire 2026-03-22 at 7_46 PM" src="https://github.com/user-attachments/assets/310f1ef9-defb-458c-8ec4-db7b3c0d56f5" />

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
