### PR TITLE
fix: harden one-on-one MLS resolve failure handling [WPB-24176]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -276,10 +276,14 @@ import com.wire.kalium.logic.feature.conversation.keyingmaterials.KeyingMaterial
 import com.wire.kalium.logic.feature.conversation.keyingmaterials.KeyingMaterialsManagerImpl
 import com.wire.kalium.logic.feature.conversation.mls.MLSOneOnOneConversationResolver
 import com.wire.kalium.logic.feature.conversation.mls.MLSOneOnOneConversationResolverImpl
+import com.wire.kalium.logic.feature.conversation.mls.InMemoryPendingOneOnOneResolutionsRepository
 import com.wire.kalium.logic.feature.conversation.mls.OneOnOneMigrator
 import com.wire.kalium.logic.feature.conversation.mls.OneOnOneMigratorImpl
 import com.wire.kalium.logic.feature.conversation.mls.OneOnOneResolver
 import com.wire.kalium.logic.feature.conversation.mls.OneOnOneResolverImpl
+import com.wire.kalium.logic.feature.conversation.mls.PendingOneOnOneResolutionsRepository
+import com.wire.kalium.logic.feature.conversation.mls.RecoverPendingOneOnOneResolutionsUseCase
+import com.wire.kalium.logic.feature.conversation.mls.RecoverPendingOneOnOneResolutionsUseCaseImpl
 import com.wire.kalium.logic.feature.debug.DebugScope
 import com.wire.kalium.logic.feature.e2ei.ACMECertificatesSyncUseCase
 import com.wire.kalium.logic.feature.e2ei.ACMECertificatesSyncUseCaseImpl
@@ -1289,12 +1293,24 @@ public class UserSessionScope internal constructor(
             userRepository,
             systemMessageInserter
         )
+    private val pendingOneOnOneResolutionsRepository: PendingOneOnOneResolutionsRepository by lazy {
+        InMemoryPendingOneOnOneResolutionsRepository()
+    }
     private val oneOnOneResolver: OneOnOneResolver
         get() = OneOnOneResolverImpl(
             userRepository,
             oneOnOneProtocolSelector,
             oneOnOneMigrator,
-            incrementalSyncRepository
+            incrementalSyncRepository,
+            pendingOneOnOneResolutionsRepository
+        )
+
+    private val recoverPendingOneOnOneResolutionsUseCase: RecoverPendingOneOnOneResolutionsUseCase
+        get() = RecoverPendingOneOnOneResolutionsUseCaseImpl(
+            pendingOneOnOneResolutionsRepository = pendingOneOnOneResolutionsRepository,
+            incrementalSyncRepository = incrementalSyncRepository,
+            transactionProvider = cryptoTransactionProvider,
+            oneOnOneResolver = oneOnOneResolver
         )
 
     private val updateSupportedProtocols: UpdateSelfUserSupportedProtocolsUseCase
@@ -2366,6 +2382,7 @@ public class UserSessionScope internal constructor(
             mlsClientManager,
             mlsMigrationManager,
             keyingMaterialsManager,
+            recoverPendingOneOnOneResolutionsUseCase,
             cryptoTransactionProvider,
             this,
         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolver.kt
@@ -98,6 +98,7 @@ internal class OneOnOneResolverImpl(
     private val oneOnOneProtocolSelector: OneOnOneProtocolSelector,
     private val oneOnOneMigrator: OneOnOneMigrator,
     private val incrementalSyncRepository: IncrementalSyncRepository,
+    private val pendingOneOnOneResolutionsRepository: PendingOneOnOneResolutionsRepository,
     kaliumDispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) : OneOnOneResolver {
 
@@ -121,7 +122,7 @@ internal class OneOnOneResolverImpl(
                         // Either it fetched all users on the previous step, or it's not needed
                         invalidateCurrentKnownProtocols = false
                     ).map { }.flatMapLeft {
-                        handleBatchEntryFailure(transactionContext, item, it)
+                        handleBatchEntryFailure(item, it)
                     }
                 }
             }.foldToEitherWhileRight(Unit) { item, _ ->
@@ -131,7 +132,6 @@ internal class OneOnOneResolverImpl(
     }
 
     private suspend fun handleBatchEntryFailure(
-        transactionContext: CryptoTransactionContext,
         user: OtherUser,
         failure: CoreFailure
     ) = when (failure) {
@@ -140,9 +140,9 @@ internal class OneOnOneResolverImpl(
             if (failure is CoreFailure.MissingKeyPackages) {
                 kaliumLogger.w(
                     "Resolving one-on-one failed $failure for ${user.id.toLogString()}, " +
-                        "scheduling retry after incremental sync is live"
+                        "adding retry for next foreground action"
                 )
-                scheduleResolveOneOnOneConversationWithUserId(transactionContext, user.id)
+                pendingOneOnOneResolutionsRepository.enqueue(user.id)
             } else {
                 kaliumLogger.e("Resolving one-on-one failed $failure, skipping")
             }
@@ -152,9 +152,9 @@ internal class OneOnOneResolverImpl(
         is NetworkFailure.FederatedBackendFailure.RetryableFailure -> {
             kaliumLogger.w(
                 "Resolving one-on-one failed $failure for ${user.id.toLogString()}, " +
-                    "scheduling retry after incremental sync is live"
+                    "adding retry for next foreground action"
             )
-            scheduleResolveOneOnOneConversationWithUserId(transactionContext, user.id)
+            pendingOneOnOneResolutionsRepository.enqueue(user.id)
             Either.Right(Unit)
         }
 
@@ -177,9 +177,9 @@ internal class OneOnOneResolverImpl(
             if (failure.cause == NetworkFailure.MlsMessageRejectedFailure.StaleMessage) {
                 kaliumLogger.w(
                     "Resolving one-on-one failed $failure for ${user.id.toLogString()}, " +
-                        "scheduling retry after incremental sync is live"
+                        "adding retry for next foreground action"
                 )
-                scheduleResolveOneOnOneConversationWithUserId(transactionContext, user.id)
+                pendingOneOnOneResolutionsRepository.enqueue(user.id)
             } else {
                 // MessageRejected can still leave the local active 1:1 pointer unresolved until
                 // another explicit resolve trigger happens. We currently prefer to keep the batch

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolver.kt
@@ -38,6 +38,7 @@ import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.protocol.OneOnOneProtocolSelector
+import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import io.mockative.Mockable
@@ -46,7 +47,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlin.time.Duration
@@ -121,7 +121,7 @@ internal class OneOnOneResolverImpl(
                         // Either it fetched all users on the previous step, or it's not needed
                         invalidateCurrentKnownProtocols = false
                     ).map { }.flatMapLeft {
-                        handleBatchEntryFailure(it)
+                        handleBatchEntryFailure(transactionContext, item, it)
                     }
                 }
             }.foldToEitherWhileRight(Unit) { item, _ ->
@@ -130,19 +130,70 @@ internal class OneOnOneResolverImpl(
         }
     }
 
-    private fun handleBatchEntryFailure(it: CoreFailure) = when (it) {
+    private suspend fun handleBatchEntryFailure(
+        transactionContext: CryptoTransactionContext,
+        user: OtherUser,
+        failure: CoreFailure
+    ) = when (failure) {
         is CoreFailure.MissingKeyPackages,
-        is NetworkFailure.ServerMiscommunication,
-        is NetworkFailure.FederatedBackendFailure,
-        is CoreFailure.NoCommonProtocolFound,
+        is CoreFailure.NoCommonProtocolFound -> {
+            if (failure is CoreFailure.MissingKeyPackages) {
+                kaliumLogger.w(
+                    "Resolving one-on-one failed $failure for ${user.id.toLogString()}, " +
+                        "scheduling retry after incremental sync is live"
+                )
+                scheduleResolveOneOnOneConversationWithUserId(transactionContext, user.id)
+            } else {
+                kaliumLogger.e("Resolving one-on-one failed $failure, skipping")
+            }
+            Either.Right(Unit)
+        }
+
+        is NetworkFailure.FederatedBackendFailure.RetryableFailure -> {
+            kaliumLogger.w(
+                "Resolving one-on-one failed $failure for ${user.id.toLogString()}, " +
+                    "scheduling retry after incremental sync is live"
+            )
+            scheduleResolveOneOnOneConversationWithUserId(transactionContext, user.id)
+            Either.Right(Unit)
+        }
+
+        is NetworkFailure.FederatedBackendFailure -> {
+            kaliumLogger.e("Resolving one-on-one failed $failure, skipping")
+            Either.Right(Unit)
+        }
+
+        is NetworkFailure.ServerMiscommunication -> {
+            if (failure.kaliumException is KaliumException.InvalidRequestError) {
+                kaliumLogger.e("Resolving one-on-one failed $failure, skipping")
+                Either.Right(Unit)
+            } else {
+                kaliumLogger.w("Resolving one-on-one failed $failure, retrying")
+                Either.Left(failure)
+            }
+        }
+
         is MLSFailure.MessageRejected -> {
-            kaliumLogger.e("Resolving one-on-one failed $it, skipping")
+            if (failure.cause == NetworkFailure.MlsMessageRejectedFailure.StaleMessage) {
+                kaliumLogger.w(
+                    "Resolving one-on-one failed $failure for ${user.id.toLogString()}, " +
+                        "scheduling retry after incremental sync is live"
+                )
+                scheduleResolveOneOnOneConversationWithUserId(transactionContext, user.id)
+            } else {
+                // MessageRejected can still leave the local active 1:1 pointer unresolved until
+                // another explicit resolve trigger happens. We currently prefer to keep the batch
+                // moving instead of retrying the entire one-on-one resolution here.
+                kaliumLogger.e("Resolving one-on-one failed $failure, skipping")
+            }
             Either.Right(Unit)
         }
 
         else -> {
-            kaliumLogger.e("Resolving one-on-one failed $it, retrying")
-            Either.Left(it)
+            kaliumLogger.w(
+                "Resolving one-on-one failed $failure, retrying"
+            )
+            Either.Left(failure)
         }
     }
 
@@ -159,7 +210,11 @@ internal class OneOnOneResolverImpl(
     ) =
         resolveActiveOneOnOneScope.launch {
             kaliumLogger.d("Schedule resolving active one-on-one")
-            incrementalSyncRepository.incrementalSyncState.first { it is IncrementalSyncStatus.Live }
+            val syncReachedLive = incrementalSyncRepository.incrementalSyncState.firstOrNull { it is IncrementalSyncStatus.Live }
+            if (syncReachedLive == null) {
+                kaliumLogger.w("Skipping scheduled active one-on-one resolve for ${userId.toLogString()} because sync state flow completed")
+                return@launch
+            }
             delay(delay)
             resolveOneOnOneConversationWithUserId(
                 transactionContext = transactionContext,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/PendingOneOnOneResolutionsRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/PendingOneOnOneResolutionsRepository.kt
@@ -1,0 +1,44 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.conversation.mls
+
+import com.wire.kalium.logic.data.user.UserId
+import io.mockative.Mockable
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+@Mockable
+internal interface PendingOneOnOneResolutionsRepository {
+    suspend fun enqueue(userId: UserId)
+    suspend fun dequeueAll(): Set<UserId>
+}
+
+internal class InMemoryPendingOneOnOneResolutionsRepository : PendingOneOnOneResolutionsRepository {
+    private val mutex = Mutex()
+    private val pendingUserIds = linkedSetOf<UserId>()
+
+    override suspend fun enqueue(userId: UserId) {
+        mutex.withLock {
+            pendingUserIds.add(userId)
+        }
+    }
+
+    override suspend fun dequeueAll(): Set<UserId> = mutex.withLock {
+        pendingUserIds.toSet().also { pendingUserIds.clear() }
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/RecoverPendingOneOnOneResolutionsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/RecoverPendingOneOnOneResolutionsUseCase.kt
@@ -1,0 +1,67 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.conversation.mls
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.logger.kaliumLogger
+import com.wire.kalium.common.functional.map
+import com.wire.kalium.common.functional.onFailure
+import com.wire.kalium.logic.data.client.CryptoTransactionProvider
+import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
+import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
+import io.mockative.Mockable
+import kotlinx.coroutines.flow.first
+
+@Mockable
+internal interface RecoverPendingOneOnOneResolutionsUseCase {
+    suspend operator fun invoke()
+}
+
+internal class RecoverPendingOneOnOneResolutionsUseCaseImpl(
+    private val pendingOneOnOneResolutionsRepository: PendingOneOnOneResolutionsRepository,
+    private val incrementalSyncRepository: IncrementalSyncRepository,
+    private val transactionProvider: CryptoTransactionProvider,
+    private val oneOnOneResolver: OneOnOneResolver,
+) : RecoverPendingOneOnOneResolutionsUseCase {
+
+    override suspend fun invoke() {
+        if (incrementalSyncRepository.incrementalSyncState.first() !is IncrementalSyncStatus.Live) {
+            return
+        }
+
+        val pendingUserIds = pendingOneOnOneResolutionsRepository.dequeueAll()
+        if (pendingUserIds.isEmpty()) return
+
+        transactionProvider.transaction("recoverPendingOneOnOneResolutions") { transactionContext ->
+            var result: Either<CoreFailure, Unit> = Either.Right(Unit)
+            pendingUserIds.forEach { userId ->
+                if (result is Either.Right) {
+                    result = oneOnOneResolver.resolveOneOnOneConversationWithUserId(
+                        transactionContext = transactionContext,
+                        userId = userId,
+                        invalidateCurrentKnownProtocols = true
+                    ).onFailure {
+                        kaliumLogger.w("Failed to recover pending one-on-one resolution for ${userId.toLogString()}: $it")
+                    }.map { Unit }
+                }
+            }
+            result
+        }
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
@@ -64,6 +64,7 @@ import com.wire.kalium.logic.feature.client.IsWireCellsEnabledUseCaseImpl
 import com.wire.kalium.logic.feature.client.MLSClientManager
 import com.wire.kalium.logic.feature.conversation.GetAllContactsNotInConversationUseCase
 import com.wire.kalium.logic.feature.conversation.keyingmaterials.KeyingMaterialsManager
+import com.wire.kalium.logic.feature.conversation.mls.RecoverPendingOneOnOneResolutionsUseCase
 import com.wire.kalium.logic.feature.e2ei.SyncCertificateRevocationListUseCase
 import com.wire.kalium.logic.feature.e2ei.SyncCertificateRevocationListUseCaseImpl
 import com.wire.kalium.logic.feature.e2ei.usecase.EnrollE2EIUseCase
@@ -142,6 +143,7 @@ public class UserScope internal constructor(
     private val mlsClientManager: MLSClientManager,
     private val mlsMigrationManager: MLSMigrationManager,
     private val keyingMaterialsManager: KeyingMaterialsManager,
+    private val recoverPendingOneOnOneResolutionsUseCase: RecoverPendingOneOnOneResolutionsUseCase,
     private val transactionProvider: CryptoTransactionProvider,
     private val userCoroutineScope: CoroutineScope,
 ) {
@@ -284,6 +286,7 @@ public class UserScope internal constructor(
             mlsClientManager = mlsClientManager,
             mlsMigrationManager = mlsMigrationManager,
             keyingMaterialsManager = keyingMaterialsManager,
+            recoverPendingOneOnOneResolutionsUseCase = recoverPendingOneOnOneResolutionsUseCase,
         )
 
     public val isWireCellsEnabled: IsWireCellsEnabledUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ForegroundActionsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/ForegroundActionsUseCase.kt
@@ -19,6 +19,7 @@ package com.wire.kalium.logic.sync
 
 import com.wire.kalium.logic.feature.client.MLSClientManager
 import com.wire.kalium.logic.feature.conversation.keyingmaterials.KeyingMaterialsManager
+import com.wire.kalium.logic.feature.conversation.mls.RecoverPendingOneOnOneResolutionsUseCase
 import com.wire.kalium.logic.feature.e2ei.SyncCertificateRevocationListUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.ObserveCertificateRevocationForSelfClientUseCase
 import com.wire.kalium.logic.feature.mlsmigration.MLSMigrationManager
@@ -49,6 +50,7 @@ internal class ForegroundActionsUseCaseImpl(
     private val mlsClientManager: MLSClientManager,
     private val mlsMigrationManager: MLSMigrationManager,
     private val keyingMaterialsManager: KeyingMaterialsManager,
+    private val recoverPendingOneOnOneResolutionsUseCase: RecoverPendingOneOnOneResolutionsUseCase,
     private val dispatchers: KaliumDispatcher = KaliumDispatcherImpl,
 ) : ForegroundActionsUseCase {
 
@@ -60,6 +62,7 @@ internal class ForegroundActionsUseCaseImpl(
         { mlsClientManager() },
         { mlsMigrationManager() },
         { keyingMaterialsManager() },
+        { recoverPendingOneOnOneResolutionsUseCase() },
     )
 
     override suspend operator fun invoke() = withContext(dispatchers.io) {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolverTest.kt
@@ -48,6 +48,7 @@ import io.mockative.coEvery
 import io.mockative.coVerify
 import io.mockative.eq
 import io.mockative.`in`
+import io.mockative.mock
 import io.mockative.once
 import io.mockative.twice
 import kotlinx.coroutines.flow.flowOf
@@ -385,13 +386,18 @@ class OneOnOneResolverTest {
         OneOnOneMigratorArrangement by OneOnOneMigratorArrangementImpl(),
         CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl(),
         IncrementalSyncRepositoryArrangement by IncrementalSyncRepositoryArrangementImpl() {
+        val pendingOneOnOneResolutionsRepository = mock(PendingOneOnOneResolutionsRepository::class)
         fun arrange() = run {
+            runBlocking {
+                coEvery { pendingOneOnOneResolutionsRepository.enqueue(any()) }.returns(Unit)
+            }
             runBlocking { block() }
             this@Arrangement to OneOnOneResolverImpl(
                 userRepository = userRepository,
                 oneOnOneProtocolSelector = oneOnOneProtocolSelector,
                 oneOnOneMigrator = oneOnOneMigrator,
                 incrementalSyncRepository = incrementalSyncRepository,
+                pendingOneOnOneResolutionsRepository = pendingOneOnOneResolutionsRepository,
                 kaliumDispatcher = dispatcher
             )
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolverTest.kt
@@ -37,10 +37,12 @@ import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProvider
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
 import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangementImpl
+import com.wire.kalium.logic.test_util.testKaliumDispatcher
 import com.wire.kalium.logic.test_util.TestNetworkException
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.util.KaliumDispatcher
 import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.coVerify
@@ -50,6 +52,8 @@ import io.mockative.once
 import io.mockative.twice
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 
@@ -372,7 +376,10 @@ class OneOnOneResolverTest {
         }.wasInvoked(exactly = once)
     }
 
-    private class Arrangement(private val block: suspend Arrangement.() -> Unit) :
+    private class Arrangement(
+        private val dispatcher: KaliumDispatcher,
+        private val block: suspend Arrangement.() -> Unit
+    ) :
         UserRepositoryArrangement by UserRepositoryArrangementImpl(),
         OneOnOneProtocolSelectorArrangement by OneOnOneProtocolSelectorArrangementImpl(),
         OneOnOneMigratorArrangement by OneOnOneMigratorArrangementImpl(),
@@ -384,13 +391,15 @@ class OneOnOneResolverTest {
                 userRepository = userRepository,
                 oneOnOneProtocolSelector = oneOnOneProtocolSelector,
                 oneOnOneMigrator = oneOnOneMigrator,
-                incrementalSyncRepository = incrementalSyncRepository
+                incrementalSyncRepository = incrementalSyncRepository,
+                kaliumDispatcher = dispatcher
             )
         }
     }
 
     private companion object {
-        fun arrange(configuration: suspend Arrangement.() -> Unit) = Arrangement(configuration).arrange()
+        fun TestScope.arrange(configuration: suspend Arrangement.() -> Unit) =
+            Arrangement(StandardTestDispatcher(testScheduler).testKaliumDispatcher(), configuration).arrange()
 
         val OTHER_USER = TestUser.OTHER
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolverTest.kt
@@ -18,7 +18,10 @@
 package com.wire.kalium.logic.feature.conversation.mls
 
 import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.MLSFailure
+import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.logic.data.user.SupportedProtocol
+import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.common.functional.Either
@@ -34,8 +37,10 @@ import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProvider
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
 import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangementImpl
+import com.wire.kalium.logic.test_util.TestNetworkException
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
+import com.wire.kalium.network.exceptions.KaliumException
 import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.coVerify
@@ -209,6 +214,108 @@ class OneOnOneResolverTest {
         coEvery {
             arrangement.oneOnOneMigrator.migrateToMLS(any(), eq(oneOnOneUsers.last()))
         }.returns(Either.Left(CoreFailure.Unknown(null)))
+
+        // when then
+        resolver.resolveAllOneOnOneConversations(arrangement.transactionContext).shouldFail()
+    }
+
+    @Test
+    fun givenStaleMessageDuringBatchResolve_whenResolveAllOneOnOneConversations_thenScheduleRetryAndContinue() = runTest {
+        // given
+        val staleFailure = MLSFailure.MessageRejected(NetworkFailure.MlsMessageRejectedFailure.StaleMessage)
+        val oneOnOneUsers = listOf(TestUser.OTHER.copy(id = TestUser.OTHER_USER_ID), TestUser.OTHER.copy(id = TestUser.OTHER_USER_ID_2))
+        val (arrangement, resolver) = arrange {
+            withIncrementalSyncState(flowOf(IncrementalSyncStatus.Pending))
+            withGetUsersWithOneOnOneConversationReturning(oneOnOneUsers)
+            withGetProtocolForUser(Either.Right(SupportedProtocol.MLS))
+            withMigrateToMLSReturns(Either.Right(TestConversation.ID))
+        }
+
+        coEvery {
+            arrangement.oneOnOneMigrator.migrateToMLS(any(), eq(oneOnOneUsers.last()))
+        }.returns(Either.Left(staleFailure))
+
+        // when
+        resolver.resolveAllOneOnOneConversations(arrangement.transactionContext).shouldSucceed()
+
+        // then
+        coVerify {
+            arrangement.oneOnOneMigrator.migrateToMLS(any(), eq(oneOnOneUsers.first()))
+        }.wasInvoked(exactly = once)
+        coVerify {
+            arrangement.oneOnOneMigrator.migrateToMLS(any(), eq(oneOnOneUsers.last()))
+        }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenRetryableFederatedFailureDuringBatchResolve_whenResolveAllOneOnOneConversations_thenScheduleRetryAndContinue() = runTest {
+        // given
+        val federatedFailure = NetworkFailure.FederatedBackendFailure.FailedDomains(listOf("wire.com"))
+        val oneOnOneUsers = listOf(TestUser.OTHER.copy(id = TestUser.OTHER_USER_ID), TestUser.OTHER.copy(id = TestUser.OTHER_USER_ID_2))
+        val (arrangement, resolver) = arrange {
+            withIncrementalSyncState(flowOf(IncrementalSyncStatus.Pending))
+            withGetUsersWithOneOnOneConversationReturning(oneOnOneUsers)
+            withGetProtocolForUser(Either.Right(SupportedProtocol.MLS))
+            withMigrateToMLSReturns(Either.Right(TestConversation.ID))
+        }
+
+        coEvery {
+            arrangement.oneOnOneMigrator.migrateToMLS(any(), eq(oneOnOneUsers.last()))
+        }.returns(Either.Left(federatedFailure))
+
+        // when
+        resolver.resolveAllOneOnOneConversations(arrangement.transactionContext).shouldSucceed()
+
+        // then
+        coVerify {
+            arrangement.oneOnOneMigrator.migrateToMLS(any(), eq(oneOnOneUsers.first()))
+        }.wasInvoked(exactly = once)
+        coVerify {
+            arrangement.oneOnOneMigrator.migrateToMLS(any(), eq(oneOnOneUsers.last()))
+        }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenInvalidRequestDuringBatchResolve_whenResolveAllOneOnOneConversations_thenSkipFailureAndContinue() = runTest {
+        // given
+        val invalidRequestFailure = NetworkFailure.ServerMiscommunication(TestNetworkException.badRequest)
+        val oneOnOneUsers = listOf(TestUser.OTHER.copy(id = TestUser.OTHER_USER_ID), TestUser.OTHER.copy(id = TestUser.OTHER_USER_ID_2))
+        val (arrangement, resolver) = arrange {
+            withGetUsersWithOneOnOneConversationReturning(oneOnOneUsers)
+            withGetProtocolForUser(Either.Right(SupportedProtocol.MLS))
+            withMigrateToMLSReturns(Either.Right(TestConversation.ID))
+        }
+
+        coEvery {
+            arrangement.oneOnOneMigrator.migrateToMLS(any(), eq(oneOnOneUsers.last()))
+        }.returns(Either.Left(invalidRequestFailure))
+
+        // when
+        resolver.resolveAllOneOnOneConversations(arrangement.transactionContext).shouldSucceed()
+
+        // then
+        coVerify {
+            arrangement.oneOnOneMigrator.migrateToMLS(any(), eq(oneOnOneUsers.first()))
+        }.wasInvoked(exactly = once)
+        coVerify {
+            arrangement.oneOnOneMigrator.migrateToMLS(any(), eq(oneOnOneUsers.last()))
+        }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenGenericServerMiscommunicationDuringBatchResolve_whenResolveAllOneOnOneConversations_thenFailTheBatch() = runTest {
+        // given
+        val serverFailure = NetworkFailure.ServerMiscommunication(KaliumException.GenericError(RuntimeException("boom")))
+        val oneOnOneUsers = listOf(TestUser.OTHER.copy(id = TestUser.OTHER_USER_ID), TestUser.OTHER.copy(id = TestUser.OTHER_USER_ID_2))
+        val (arrangement, resolver) = arrange {
+            withGetUsersWithOneOnOneConversationReturning(oneOnOneUsers)
+            withGetProtocolForUser(Either.Right(SupportedProtocol.MLS))
+            withMigrateToMLSReturns(Either.Right(TestConversation.ID))
+        }
+
+        coEvery {
+            arrangement.oneOnOneMigrator.migrateToMLS(any(), eq(oneOnOneUsers.last()))
+        }.returns(Either.Left(serverFailure))
 
         // when then
         resolver.resolveAllOneOnOneConversations(arrangement.transactionContext).shouldFail()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/RecoverPendingOneOnOneResolutionsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/RecoverPendingOneOnOneResolutionsUseCaseTest.kt
@@ -1,0 +1,181 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.conversation.mls
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.right
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.util.arrangement.IncrementalSyncRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.IncrementalSyncRepositoryArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import io.mockative.any
+import io.mockative.coEvery
+import io.mockative.coVerify
+import io.mockative.eq
+import io.mockative.mock
+import io.mockative.once
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+
+class RecoverPendingOneOnOneResolutionsUseCaseTest {
+
+    @Test
+    fun givenSyncNotLive_whenInvoked_thenDoesNothing() = runBlocking {
+        val (arrangement, useCase) = Arrangement {
+            withIncrementalSyncState(flowOf(com.wire.kalium.logic.data.sync.IncrementalSyncStatus.Pending))
+            withPendingUserIds(setOf(TestUser.OTHER_USER_ID))
+        }.arrange()
+
+        useCase()
+
+        coVerify {
+            arrangement.pendingOneOnOneResolutionsRepository.dequeueAll()
+        }.wasNotInvoked()
+        coVerify {
+            arrangement.cryptoTransactionProvider.transaction<Unit>(any(), any())
+        }.wasNotInvoked()
+    }
+
+    @Test
+    fun givenNoPendingUsers_whenInvoked_thenSkipsTransaction() = runBlocking {
+        val (arrangement, useCase) = Arrangement {
+            withIncrementalSyncState(flowOf(com.wire.kalium.logic.data.sync.IncrementalSyncStatus.Live))
+            withPendingUserIds(emptySet())
+        }.arrange()
+
+        useCase()
+
+        coVerify {
+            arrangement.pendingOneOnOneResolutionsRepository.dequeueAll()
+        }.wasInvoked(exactly = once)
+        coVerify {
+            arrangement.cryptoTransactionProvider.transaction<Unit>(any(), any())
+        }.wasNotInvoked()
+    }
+
+    @Test
+    fun givenPendingUsers_whenInvoked_thenUsesSingleTransactionForAllResolutions() = runBlocking {
+        val pendingUsers = setOf(TestUser.OTHER_USER_ID, TestUser.OTHER_USER_ID_2)
+        val (arrangement, useCase) = Arrangement {
+            withIncrementalSyncState(flowOf(com.wire.kalium.logic.data.sync.IncrementalSyncStatus.Live))
+            withPendingUserIds(pendingUsers)
+            withTransactionReturning(Either.Right(Unit))
+            withResolveOneOnOneConversationWithUserIdReturning(TestConversation.ID.right())
+        }.arrange()
+
+        useCase()
+
+        coVerify {
+            arrangement.cryptoTransactionProvider.transaction<Unit>(eq("recoverPendingOneOnOneResolutions"), any())
+        }.wasInvoked(exactly = once)
+        coVerify {
+            arrangement.oneOnOneResolver.resolveOneOnOneConversationWithUserId(
+                eq(arrangement.transactionContext),
+                eq(TestUser.OTHER_USER_ID),
+                eq(true)
+            )
+        }.wasInvoked(exactly = once)
+        coVerify {
+            arrangement.oneOnOneResolver.resolveOneOnOneConversationWithUserId(
+                eq(arrangement.transactionContext),
+                eq(TestUser.OTHER_USER_ID_2),
+                eq(true)
+            )
+        }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenFirstResolutionFails_whenInvoked_thenStopsProcessingRemainingUsers() = runBlocking {
+        val pendingUsers = linkedSetOf(TestUser.OTHER_USER_ID, TestUser.OTHER_USER_ID_2)
+        val failure = CoreFailure.Unknown(null)
+        val (arrangement, useCase) = Arrangement {
+            withIncrementalSyncState(flowOf(com.wire.kalium.logic.data.sync.IncrementalSyncStatus.Live))
+            withPendingUserIds(pendingUsers)
+            withTransactionReturning(Either.Right(Unit))
+        }.arrange()
+
+        coEvery {
+            arrangement.oneOnOneResolver.resolveOneOnOneConversationWithUserId(
+                eq(arrangement.transactionContext),
+                eq(TestUser.OTHER_USER_ID),
+                eq(true)
+            )
+        }.returns(Either.Left(failure))
+
+        coEvery {
+            arrangement.oneOnOneResolver.resolveOneOnOneConversationWithUserId(
+                eq(arrangement.transactionContext),
+                eq(TestUser.OTHER_USER_ID_2),
+                eq(true)
+            )
+        }.returns(TestConversation.ID.right())
+
+        useCase()
+
+        coVerify {
+            arrangement.oneOnOneResolver.resolveOneOnOneConversationWithUserId(
+                eq(arrangement.transactionContext),
+                eq(TestUser.OTHER_USER_ID),
+                eq(true)
+            )
+        }.wasInvoked(exactly = once)
+        coVerify {
+            arrangement.oneOnOneResolver.resolveOneOnOneConversationWithUserId(
+                eq(arrangement.transactionContext),
+                eq(TestUser.OTHER_USER_ID_2),
+                eq(true)
+            )
+        }.wasNotInvoked()
+    }
+
+    private class Arrangement(private val block: suspend Arrangement.() -> Unit) :
+        IncrementalSyncRepositoryArrangement by IncrementalSyncRepositoryArrangementImpl(),
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+
+        val pendingOneOnOneResolutionsRepository = mock(PendingOneOnOneResolutionsRepository::class)
+        val oneOnOneResolver = mock(OneOnOneResolver::class)
+
+        suspend fun arrange(): Pair<Arrangement, RecoverPendingOneOnOneResolutionsUseCase> = run {
+            withPendingUserIds(emptySet())
+            withResolveOneOnOneConversationWithUserIdReturning(TestConversation.ID.right())
+            block()
+            this@Arrangement to RecoverPendingOneOnOneResolutionsUseCaseImpl(
+                pendingOneOnOneResolutionsRepository = pendingOneOnOneResolutionsRepository,
+                incrementalSyncRepository = incrementalSyncRepository,
+                transactionProvider = cryptoTransactionProvider,
+                oneOnOneResolver = oneOnOneResolver
+            )
+        }
+
+        suspend fun withPendingUserIds(userIds: Set<com.wire.kalium.logic.data.user.UserId>) = apply {
+            coEvery { pendingOneOnOneResolutionsRepository.dequeueAll() }.returns(userIds)
+        }
+
+        suspend fun withResolveOneOnOneConversationWithUserIdReturning(
+            result: Either<CoreFailure, com.wire.kalium.logic.data.id.ConversationId>
+        ) = apply {
+            coEvery {
+                oneOnOneResolver.resolveOneOnOneConversationWithUserId(any(), any(), eq(true))
+            }.returns(result)
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/ForegroundActionsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/ForegroundActionsUseCaseTest.kt
@@ -19,6 +19,7 @@ package com.wire.kalium.logic.sync
 
 import com.wire.kalium.logic.feature.client.MLSClientManager
 import com.wire.kalium.logic.feature.conversation.keyingmaterials.KeyingMaterialsManager
+import com.wire.kalium.logic.feature.conversation.mls.RecoverPendingOneOnOneResolutionsUseCase
 import com.wire.kalium.logic.feature.e2ei.SyncCertificateRevocationListUseCase
 import com.wire.kalium.logic.feature.e2ei.usecase.ObserveCertificateRevocationForSelfClientUseCase
 import com.wire.kalium.logic.feature.mlsmigration.MLSMigrationManager
@@ -63,6 +64,7 @@ internal class ForegroundActionsUseCaseTest {
             mlsClientManager()
             mlsMigrationManager()
             keyingMaterialsManager()
+            recoverPendingOneOnOneResolutionsUseCase()
         }.wasInvoked(exactly = times)
     }
 
@@ -74,6 +76,7 @@ internal class ForegroundActionsUseCaseTest {
         val mlsClientManager = mock(MLSClientManager::class)
         val mlsMigrationManager = mock(MLSMigrationManager::class)
         val keyingMaterialsManager = mock(KeyingMaterialsManager::class)
+        val recoverPendingOneOnOneResolutionsUseCase = mock(RecoverPendingOneOnOneResolutionsUseCase::class)
 
         suspend fun arrange(): Pair<Arrangement, ForegroundActionsUseCase> = run {
             withActionResults(ActionResults())
@@ -86,6 +89,7 @@ internal class ForegroundActionsUseCaseTest {
                 mlsClientManager = mlsClientManager,
                 mlsMigrationManager = mlsMigrationManager,
                 keyingMaterialsManager = keyingMaterialsManager,
+                recoverPendingOneOnOneResolutionsUseCase = recoverPendingOneOnOneResolutionsUseCase,
                 dispatchers = dispatchers,
             )
         }
@@ -98,6 +102,7 @@ internal class ForegroundActionsUseCaseTest {
             coEvery { mlsClientManager() }.returns(Unit)
             coEvery { mlsMigrationManager() }.returns(Unit)
             coEvery { keyingMaterialsManager() }.returns(Unit)
+            coEvery { recoverPendingOneOnOneResolutionsUseCase() }.returns(Unit)
         }
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/mls/OneOnOneResolverArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/mls/OneOnOneResolverArrangement.kt
@@ -66,6 +66,3 @@ internal class OneOnOneResolverArrangementImpl : OneOnOneResolverArrangement {
     }
 
 }
-
-
-


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- Slow Sync could leave one-on-one MLS resolution in an inconsistent state when batch resolution hit recoverable failures.
- In particular, `MessageRejected(StaleMessage)` during `RESOLVE_ONE_ON_ONE_PROTOCOLS` could be skipped at batch level even though the conversation might still be recoverable.
- Batch handling for one-on-one resolution was also too broad for some failure types such as retryable federated errors and generic `ServerMiscommunication`.

### Causes (Optional)

- One-on-one resolution during Slow Sync is processed as a batch, and some failures were treated as “skip and continue” too early.
- This could allow Slow Sync to complete while a specific one-on-one conversation remained unresolved locally.
- Some error handling in this flow was less strict or less specific than in other MLS join/recovery paths.

### Solutions

- Added targeted retry scheduling for one-on-one resolution when batch processing hits `MessageRejected(StaleMessage)`.
- Added the same retry behavior for `MissingKeyPackages` and retryable federated failures.
- Tightened `ServerMiscommunication` handling:
  - invalid request errors are still skipped
  - other server miscommunication failures now fail the batch instead of being silently ignored
- Hardened the delayed retry path so it exits safely if incremental sync state completes before reaching `Live`.
- Added regression tests covering stale message, retryable federated failures, and server miscommunication handling.