### PR TITLE
feat(nomad devices): batched fetch messages per convo - add new endpoint and requests/response mapping - pt1 (WPB-24278)

### DIFF
--- a/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/nomaddevice/NomadBatchRestoreRequest.kt
+++ b/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/nomaddevice/NomadBatchRestoreRequest.kt
@@ -1,0 +1,34 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.authenticated.nomaddevice
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NomadBatchRestoreRequest(
+    @SerialName("conversation_ids")
+    val conversationIds: List<String>? = null,
+    @SerialName("limit")
+    val limit: Int? = null,
+    @SerialName("before_timestamp")
+    val beforeTimestamp: Long? = null,
+    @SerialName("next_cursor")
+    val nextCursor: Long? = null
+)

--- a/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/nomaddevice/NomadBatchRestoreResponse.kt
+++ b/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/nomaddevice/NomadBatchRestoreResponse.kt
@@ -1,0 +1,42 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.authenticated.nomaddevice
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NomadBatchRestoreResponse(
+    @SerialName("conversations")
+    val conversations: List<NomadConversationBatchRestore>
+)
+
+@Serializable
+data class NomadConversationBatchRestore(
+    @SerialName("conversation")
+    val conversation: Conversation,
+    @SerialName("messages")
+    val messages: List<NomadStoredMessage>,
+    @SerialName("has_more")
+    val hasMore: Boolean,
+    @SerialName("next_cursor")
+    val nextCursor: Long,
+    @SerialName("next_timestamp")
+    val nextTimestamp: Long
+)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/nomaddevice/NomadDeviceSyncApi.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/nomaddevice/NomadDeviceSyncApi.kt
@@ -19,6 +19,8 @@
 package com.wire.kalium.network.api.base.authenticated.nomaddevice
 
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadAllMessagesResponse
+import com.wire.kalium.network.api.authenticated.nomaddevice.NomadBatchRestoreRequest
+import com.wire.kalium.network.api.authenticated.nomaddevice.NomadBatchRestoreResponse
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadConversationMetadataResponse
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadMessageEventsRequest
 import com.wire.kalium.network.utils.NetworkResponse
@@ -34,6 +36,11 @@ interface NomadDeviceSyncApi {
     suspend fun getAllMessages(): NetworkResponse<NomadAllMessagesResponse>
 
     suspend fun syncAllMessages(limit: Int = 100): NetworkResponse<NomadAllMessagesResponse>
+
+    suspend fun restoreMessagesBatch(
+        request: NomadBatchRestoreRequest,
+    ): NetworkResponse<NomadBatchRestoreResponse>
+
     suspend fun getConversationMetadata(): NetworkResponse<NomadConversationMetadataResponse>
     suspend fun uploadCryptoState(
         clientId: String,

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/NomadDeviceSyncApiV0.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/NomadDeviceSyncApiV0.kt
@@ -91,7 +91,7 @@ internal open class NomadDeviceSyncApiV0 internal constructor(
         requireNomadServiceUrl(apiName = "syncAllMessages") ?: wrapRequest {
             httpClient.get {
                 setNomadUrlIfAvailable(PATH_EVENT, "$PATH_MESSAGES/$PATH_MESSAGES_SYNC")
-                parameter("limit", limit)
+                parameter(QUERY_LIMIT, limit)
             }
         }
 

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/NomadDeviceSyncApiV0.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/NomadDeviceSyncApiV0.kt
@@ -20,6 +20,8 @@ package com.wire.kalium.network.api.v0.authenticated
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadAllMessagesResponse
+import com.wire.kalium.network.api.authenticated.nomaddevice.NomadBatchRestoreRequest
+import com.wire.kalium.network.api.authenticated.nomaddevice.NomadBatchRestoreResponse
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadConversationMetadataResponse
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadMessageEventsRequest
 import com.wire.kalium.network.api.authenticated.nomaddevice.SetLastDeviceIdRequest
@@ -90,6 +92,27 @@ internal open class NomadDeviceSyncApiV0 internal constructor(
             httpClient.get {
                 setNomadUrlIfAvailable(PATH_EVENT, "$PATH_MESSAGES/$PATH_MESSAGES_SYNC")
                 parameter("limit", limit)
+            }
+        }
+
+    override suspend fun restoreMessagesBatch(
+        request: NomadBatchRestoreRequest,
+    ): NetworkResponse<NomadBatchRestoreResponse> =
+        requireNomadServiceUrl(apiName = "restoreMessagesBatch") ?: wrapRequest {
+            httpClient.get {
+                setNomadUrlIfAvailable(PATH_EVENT, "$PATH_MESSAGES/$PATH_MESSAGES_BATCH", PATH_MESSAGES_RESTORE)
+                request.conversationIds?.let { conversationIds ->
+                    parameter(QUERY_CONVERSATION_IDS, conversationIds.joinToString(separator = ","))
+                }
+                request.limit?.let { limit ->
+                    parameter(QUERY_LIMIT, limit)
+                }
+                request.beforeTimestamp?.let { beforeTimestamp ->
+                    parameter(QUERY_BEFORE_TIMESTAMP, beforeTimestamp)
+                }
+                request.nextCursor?.let { nextCursor ->
+                    parameter(QUERY_NEXT_CURSOR, nextCursor)
+                }
             }
         }
 
@@ -252,10 +275,16 @@ internal open class NomadDeviceSyncApiV0 internal constructor(
         const val PATH_EVENT = "event"
         const val PATH_MESSAGES = "messages"
         const val PATH_MESSAGES_SYNC = "sync"
+        const val PATH_MESSAGES_BATCH = "batch"
+        const val PATH_MESSAGES_RESTORE = "restore"
         const val PATH_CONVERSATION_METADATA = "conversation/metadata"
         const val PATH_CRYPTO_STATE = "crypto/state"
         const val PATH_CRYPTO_DEVICE = "crypto/device"
         const val QUERY_DEVICE_ID = "device_id"
+        const val QUERY_CONVERSATION_IDS = "conversation_ids"
+        const val QUERY_LIMIT = "limit"
+        const val QUERY_BEFORE_TIMESTAMP = "before_timestamp"
+        const val QUERY_NEXT_CURSOR = "next_cursor"
         const val BUFFER_SIZE = 8L * 1024
         const val BOUNDARY = "frontier"
         const val CRYPTO_ZIP_FILENAME = "CHANGELOG.zip"

--- a/data/network/src/commonTest/kotlin/com/wire/kalium/api/v0/nomaddevice/NomadDeviceSyncApiV0Test.kt
+++ b/data/network/src/commonTest/kotlin/com/wire/kalium/api/v0/nomaddevice/NomadDeviceSyncApiV0Test.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.api.TEST_BACKEND_CONFIG
 import com.wire.kalium.api.json.model.testCredentials
 import com.wire.kalium.network.AuthenticatedNetworkClient
 import com.wire.kalium.network.api.authenticated.nomaddevice.LastRead
+import com.wire.kalium.network.api.authenticated.nomaddevice.NomadBatchRestoreRequest
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadMessageEvent
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadMessageEventsRequest
 import com.wire.kalium.network.api.base.authenticated.AccessTokenApi
@@ -117,6 +118,36 @@ internal class NomadDeviceSyncApiV0Test : ApiTest() {
     }
 
     @Test
+    fun givenNomadMessages_whenRestoringBatch_thenRequestMatchesContract() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(
+            responseBody = BATCH_RESTORE_RESPONSE_JSON,
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertGet()
+                assertPathEqual("/event/messages/batch/restore")
+                assertQueryParameter("conversation_ids", "conv123,conv456")
+                assertQueryParameter("limit", "50")
+                assertQueryParameter("before_timestamp", "1710936000")
+                assertQueryParameter("next_cursor", "0")
+            }
+        )
+
+        val api: NomadDeviceSyncApi = NomadDeviceSyncApiV0(networkClient, nomadServiceUrl = "https://nomad.example.com")
+        val response = api.restoreMessagesBatch(
+            NomadBatchRestoreRequest(
+                conversationIds = listOf("conv123", "conv456"),
+                limit = 50,
+                beforeTimestamp = 1_710_936_000,
+                nextCursor = 0
+            )
+        )
+
+        assertTrue(response.isSuccessful())
+        assertEquals(2, response.value.conversations.size)
+        assertTrue(response.value.conversations.first().hasMore)
+    }
+
+    @Test
     fun givenConversationMetadata_whenGettingConversationMetadata_thenRequestAndResponseShouldMatchContract() = runTest {
         val networkClient = mockAuthenticatedNetworkClient(
             responseBody = CONVERSATION_METADATA_RESPONSE_JSON,
@@ -176,6 +207,39 @@ internal class NomadDeviceSyncApiV0Test : ApiTest() {
             nomadServiceUrl = "https://nomad.example.com/service"
         )
         val response = api.syncAllMessages()
+
+        assertTrue(response.isSuccessful())
+    }
+
+    @Test
+    fun givenNomadServiceUrlWithBasePath_whenRestoringBatch_thenBasePathShouldBePreserved() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(
+            responseBody = BATCH_RESTORE_RESPONSE_JSON,
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertGet()
+                assertEquals("nomad.example.com", url.host)
+                assertEquals(URLProtocol.HTTPS, url.protocol)
+                assertPathEqual("/service/event/messages/batch/restore")
+                assertQueryParameter("conversation_ids", "conv123")
+                assertQueryParameter("limit", "10")
+                assertQueryParameter("before_timestamp", "1710936000")
+                assertQueryParameter("next_cursor", "123")
+            }
+        )
+
+        val api: NomadDeviceSyncApi = NomadDeviceSyncApiV0(
+            networkClient,
+            nomadServiceUrl = "https://nomad.example.com/service"
+        )
+        val response = api.restoreMessagesBatch(
+            NomadBatchRestoreRequest(
+                conversationIds = listOf("conv123"),
+                limit = 10,
+                beforeTimestamp = 1_710_936_000,
+                nextCursor = 123
+            )
+        )
 
         assertTrue(response.isSuccessful())
     }
@@ -351,6 +415,20 @@ internal class NomadDeviceSyncApiV0Test : ApiTest() {
     fun givenMissingNomadServiceUrl_whenSyncingAllMessages_thenItShouldShortCircuitWithoutNetworkCall() = runTest {
         assertShortCircuitedWithoutNetworkCall(expectedApiName = "syncAllMessages") { api ->
             api.syncAllMessages()
+        }
+    }
+
+    @Test
+    fun givenMissingNomadServiceUrl_whenRestoringBatch_thenItShouldShortCircuitWithoutNetworkCall() = runTest {
+        assertShortCircuitedWithoutNetworkCall(expectedApiName = "restoreMessagesBatch") { api ->
+            api.restoreMessagesBatch(
+                NomadBatchRestoreRequest(
+                    conversationIds = listOf("conv123"),
+                    limit = 10,
+                    beforeTimestamp = 1_710_936_000,
+                    nextCursor = 0
+                )
+            )
         }
     }
 
@@ -664,6 +742,42 @@ internal class NomadDeviceSyncApiV0Test : ApiTest() {
                   "metadata": {
                     "last_read": 1707235100
                   }
+                }
+              ]
+            }
+            """.trimIndent()
+
+        val BATCH_RESTORE_RESPONSE_JSON =
+            """
+            {
+              "conversations": [
+                {
+                  "conversation": {
+                    "id": "conv123",
+                    "domain": "example.com"
+                  },
+                  "messages": [
+                    {
+                      "message_id": "msg099",
+                      "timestamp": 1710935900,
+                      "payload": "T2xkZXIgbWVzc2FnZQ==",
+                      "reaction": "",
+                      "read_receipt": ""
+                    }
+                  ],
+                  "has_more": true,
+                  "next_cursor": 12345,
+                  "next_timestamp": 1710935700
+                },
+                {
+                  "conversation": {
+                    "id": "conv456",
+                    "domain": "example.com"
+                  },
+                  "messages": [],
+                  "has_more": false,
+                  "next_cursor": 0,
+                  "next_timestamp": 0
                 }
               ]
             }

--- a/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/NomadConversationMetadataSyncRepositoryTest.kt
+++ b/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/NomadConversationMetadataSyncRepositoryTest.kt
@@ -22,6 +22,8 @@ import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.network.api.authenticated.nomaddevice.Conversation
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadAllMessagesResponse
+import com.wire.kalium.network.api.authenticated.nomaddevice.NomadBatchRestoreRequest
+import com.wire.kalium.network.api.authenticated.nomaddevice.NomadBatchRestoreResponse
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadConversationMetadata
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadConversationMetadataItem
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadConversationMetadataResponse
@@ -105,6 +107,11 @@ class NomadConversationMetadataSyncRepositoryTest {
             error("Not needed in this test")
 
         override suspend fun syncAllMessages(limit: Int): NetworkResponse<NomadAllMessagesResponse> =
+            error("Not needed in this test")
+
+        override suspend fun restoreMessagesBatch(
+            request: NomadBatchRestoreRequest,
+        ): NetworkResponse<NomadBatchRestoreResponse> =
             error("Not needed in this test")
 
         override suspend fun getConversationMetadata(): NetworkResponse<NomadConversationMetadataResponse> = metadataResponse

--- a/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/SyncNomadAllMessagesUseCaseTest.kt
+++ b/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/SyncNomadAllMessagesUseCaseTest.kt
@@ -23,6 +23,8 @@ import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.network.api.authenticated.nomaddevice.Conversation
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadAllMessagesResponse
+import com.wire.kalium.network.api.authenticated.nomaddevice.NomadBatchRestoreRequest
+import com.wire.kalium.network.api.authenticated.nomaddevice.NomadBatchRestoreResponse
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadConversationMetadataResponse
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadConversationWithMessages
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadStoredMessage
@@ -203,6 +205,12 @@ class SyncNomadAllMessagesUseCaseTest {
         override suspend fun syncAllMessages(limit: Int): NetworkResponse<NomadAllMessagesResponse> {
             lastPageSize = limit
             return allMessagesResponse
+        }
+
+        override suspend fun restoreMessagesBatch(
+            request: NomadBatchRestoreRequest,
+        ): NetworkResponse<NomadBatchRestoreResponse> {
+            error("Not needed in this test")
         }
 
         override suspend fun getConversationMetadata(): NetworkResponse<NomadConversationMetadataResponse> {

--- a/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/SyncNomadRemoteBackupChangeLogUseCaseTest.kt
+++ b/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/SyncNomadRemoteBackupChangeLogUseCaseTest.kt
@@ -23,6 +23,8 @@ import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadAllMessagesResponse
+import com.wire.kalium.network.api.authenticated.nomaddevice.NomadBatchRestoreRequest
+import com.wire.kalium.network.api.authenticated.nomaddevice.NomadBatchRestoreResponse
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadConversationMetadataResponse
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadMessageEvent
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadMessageEventsRequest
@@ -351,6 +353,12 @@ class SyncNomadRemoteBackupChangeLogUseCaseTest {
         }
 
         override suspend fun syncAllMessages(limit: Int): NetworkResponse<NomadAllMessagesResponse> {
+            error("Not needed for test")
+        }
+
+        override suspend fun restoreMessagesBatch(
+            request: NomadBatchRestoreRequest,
+        ): NetworkResponse<NomadBatchRestoreResponse> {
             error("Not needed for test")
         }
 

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/sync/slow/SyncNomadMessagesDuringSlowSyncUseCaseTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/sync/slow/SyncNomadMessagesDuringSlowSyncUseCaseTest.kt
@@ -25,6 +25,8 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.test_util.TestNetworkException
 import com.wire.kalium.network.api.authenticated.nomaddevice.Conversation
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadAllMessagesResponse
+import com.wire.kalium.network.api.authenticated.nomaddevice.NomadBatchRestoreRequest
+import com.wire.kalium.network.api.authenticated.nomaddevice.NomadBatchRestoreResponse
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadConversationMetadata
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadConversationMetadataItem
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadConversationMetadataResponse
@@ -265,6 +267,11 @@ class SyncNomadMessagesDuringSlowSyncUseCaseTest {
             calls += "syncAllMessages"
             return allMessagesResponse
         }
+
+        override suspend fun restoreMessagesBatch(
+            request: NomadBatchRestoreRequest,
+        ): NetworkResponse<NomadBatchRestoreResponse> =
+            error("Not needed in this test")
 
         override suspend fun getConversationMetadata(): NetworkResponse<NomadConversationMetadataResponse> {
             calls += "getConversationMetadata"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24278
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This is phase 2 of batched nomad devices messages sync restore, per conversation restore.

- This adds the new endpoints for restoring the older messages (paginated) per conversation.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

### Notes (Optional)

This is only the api layer, not pagination done, will be addressed in a separated PR.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
