### PR TITLE
fix: restart slow sync after MLS client registration and E2EI finalize [WPB-20462]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -522,7 +522,7 @@ internal sealed class Event(open val id: String) {
             val model: MLSMigrationModel
         ) : FeatureConfig(id) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
-                typeKey to "FeatureConfig.MLSUpdated",
+                typeKey to "FeatureConfig.MLSMigrationUpdated",
                 idKey to id,
                 featureStatusKey to model.status.name,
                 "startTime" to model.startTime,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -2355,6 +2355,7 @@ public class UserSessionScope internal constructor(
             isE2EIEnabled,
             certificateRevocationListRepository,
             incrementalSyncRepository,
+            slowSyncRepository,
             sessionManager,
             selfTeamId,
             checkRevocationList,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
@@ -142,7 +142,8 @@ public class ClientScope @OptIn(DelicateKaliumApi::class) internal constructor(
             selfUserId,
             clientRepository,
             isAllowedToRegisterMLSClient,
-            registerMLSClientUseCase
+            registerMLSClientUseCase,
+            slowSyncRepository
         )
     internal val importClient: ImportClientUseCase
         get() = ImportClientUseCaseImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/FinalizeMLSClientAfterE2EIEnrollment.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/FinalizeMLSClientAfterE2EIEnrollment.kt
@@ -19,7 +19,9 @@ package com.wire.kalium.logic.feature.client
 
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationsUseCase
+import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.common.functional.map
+import com.wire.kalium.common.logger.kaliumLogger
 
 public interface FinalizeMLSClientAfterE2EIEnrollment {
     public suspend fun invoke()
@@ -27,11 +29,14 @@ public interface FinalizeMLSClientAfterE2EIEnrollment {
 
 internal class FinalizeMLSClientAfterE2EIEnrollmentImpl(
     private val clientRepository: ClientRepository,
-    private val joinExistingMLSConversationsUseCase: JoinExistingMLSConversationsUseCase
+    private val joinExistingMLSConversationsUseCase: JoinExistingMLSConversationsUseCase,
+    private val slowSyncRepository: SlowSyncRepository
 ) : FinalizeMLSClientAfterE2EIEnrollment {
     override suspend fun invoke() {
         joinExistingMLSConversationsUseCase().map {
             clientRepository.clearClientRegistrationBlockedByE2EI()
+            kaliumLogger.i("Clearing last slow sync completion instant after finalizing MLS client enrollment")
+            slowSyncRepository.clearLastSlowSyncCompletionInstant()
         }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/MLSClientManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/MLSClientManager.kt
@@ -68,8 +68,10 @@ internal class MLSClientManagerImpl internal constructor(
                         kaliumLogger.i("No existing MLS Client, registering..")
                         registerMLSClient.value(clientId).onSuccess { mlsClientRegistrationResult ->
                             kaliumLogger.i("Registering mls client result: $mlsClientRegistrationResult")
-                            kaliumLogger.i("Triggering slow sync after enabling MLS")
-                            slowSyncRepository.value.clearLastSlowSyncCompletionInstant()
+                            if (mlsClientRegistrationResult is RegisterMLSClientResult.Success) {
+                                kaliumLogger.i("Triggering slow sync after enabling MLS")
+                                slowSyncRepository.value.clearLastSlowSyncCompletionInstant()
+                            }
                         }
                     }
                 }.await()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/VerifyExistingClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/VerifyExistingClientUseCase.kt
@@ -22,8 +22,10 @@ import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.data.client.Client
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.common.functional.fold
+import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.util.DelicateKaliumApi
 import io.mockative.Mockable
 
@@ -45,6 +47,7 @@ internal class VerifyExistingClientUseCaseImpl @OptIn(DelicateKaliumApi::class) 
     private val clientRepository: ClientRepository,
     private val isAllowedToRegisterMLSClient: IsAllowedToRegisterMLSClientUseCase,
     private val registerMLSClientUseCase: RegisterMLSClientUseCase,
+    private val slowSyncRepository: SlowSyncRepository,
 ) : VerifyExistingClientUseCase {
 
     @OptIn(DelicateKaliumApi::class)
@@ -63,7 +66,12 @@ internal class VerifyExistingClientUseCaseImpl @OptIn(DelicateKaliumApi::class) 
                         }, {
                             if (it is RegisterMLSClientResult.E2EICertificateRequired)
                                 VerifyExistingClientResult.Failure.E2EICertificateRequired(registeredClient, selfUserId)
-                            else VerifyExistingClientResult.Success(registeredClient)
+                            else {
+                                kaliumLogger.i("Clearing last slow sync completion instant after verifying existing MLS client")
+                                slowSyncRepository.clearLastSlowSyncCompletionInstant()
+
+                                VerifyExistingClientResult.Success(registeredClient)
+                            }
                         })
                     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
@@ -37,6 +37,7 @@ import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.id.SelfTeamIdProvider
 import com.wire.kalium.logic.data.properties.UserPropertyRepository
 import com.wire.kalium.logic.data.session.SessionRepository
+import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.logic.data.user.AccountRepository
@@ -131,6 +132,7 @@ public class UserScope internal constructor(
     private val isE2EIEnabledUseCase: IsE2EIEnabledUseCase,
     private val certificateRevocationListRepository: CertificateRevocationListRepository,
     private val incrementalSyncRepository: IncrementalSyncRepository,
+    private val slowSyncRepository: SlowSyncRepository,
     private val sessionManager: SessionManager,
     private val selfTeamIdProvider: SelfTeamIdProvider,
     private val checkRevocationList: RevocationListChecker,
@@ -168,7 +170,8 @@ public class UserScope internal constructor(
     public val finalizeMLSClientAfterE2EIEnrollment: FinalizeMLSClientAfterE2EIEnrollment
         get() = FinalizeMLSClientAfterE2EIEnrollmentImpl(
             clientRepository,
-            joinExistingMLSConversationsUseCase
+            joinExistingMLSConversationsUseCase,
+            slowSyncRepository
         )
     public val getE2EICertificate: GetMLSClientIdentityUseCase
         get() = GetMLSClientIdentityUseCaseImpl(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/MLSClientManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/MLSClientManagerTest.kt
@@ -98,6 +98,25 @@ class MLSClientManagerTest {
         }
 
     @Test
+    fun givenE2EIIsRequired_whenObservingSyncFinishes_thenSlowSyncIsNotCleared() =
+        testScope.runTest {
+            val (arrangement, mlsClientManager) = Arrangement()
+                .withIsAllowedToRegisterMLSClient(true)
+                .withHasRegisteredMLSClient(Either.Right(false))
+                .withCurrentClientId(Either.Right(TestClient.CLIENT_ID))
+                .withRegisterMLSClientE2EIRequired()
+                .withSyncStates(Unit.right())
+                .arrange(testScope)
+
+            mlsClientManager.invoke()
+            advanceUntilIdle()
+
+            coVerify {
+                arrangement.slowSyncRepository.clearLastSlowSyncCompletionInstant()
+            }.wasNotInvoked()
+        }
+
+    @Test
     fun givenMLSClientIsRegistered_whenObservingSyncFinishes_thenMLSClientIsNotRegistered() =
         testScope.runTest {
             val (arrangement, mlsClientManager) = Arrangement()
@@ -155,7 +174,12 @@ class MLSClientManagerTest {
             coEvery {
                 registerMLSClient.invoke(any())
             }.returns(Either.Right(RegisterMLSClientResult.Success))
-            // todo: cover all cases
+        }
+
+        suspend fun withRegisterMLSClientE2EIRequired() = apply {
+            coEvery {
+                registerMLSClient.invoke(any())
+            }.returns(Either.Right(RegisterMLSClientResult.E2EICertificateRequired))
         }
 
         suspend fun withIsAllowedToRegisterMLSClient(enabled: Boolean) = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/VerifyExistingClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/VerifyExistingClientUseCaseTest.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.logic.feature.client
 
 import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestUser
@@ -31,7 +32,9 @@ import com.wire.kalium.logic.util.arrangement.usecase.RegisterMLSClientUseCaseAr
 import com.wire.kalium.logic.util.arrangement.usecase.RegisterMLSClientUseCaseArrangementImpl
 import com.wire.kalium.util.DelicateKaliumApi
 import io.mockative.any
+import io.mockative.coEvery
 import io.mockative.coVerify
+import io.mockative.mock
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -128,15 +131,22 @@ class VerifyExistingClientUseCaseTest {
         RegisterMLSClientUseCaseArrangement by RegisterMLSClientUseCaseArrangementImpl(),
         ClientRepositoryArrangement by ClientRepositoryArrangementImpl(),
         IsAllowedToRegisterMLSClientUseCaseArrangement by IsAllowedToRegisterMLSClientUseCaseArrangementImpl() {
+        val slowSyncRepository = mock(SlowSyncRepository::class)
 
         fun arrange() = run {
             runBlocking { block() }
+            runBlocking {
+                coEvery {
+                    slowSyncRepository.clearLastSlowSyncCompletionInstant()
+                }.returns(Unit)
+            }
 
             this@Arrangement to VerifyExistingClientUseCaseImpl(
                 TestUser.USER_ID,
                 clientRepository,
                 isAllowedToRegisterMLSClientUseCase,
-                registerMLSClientUseCase
+                registerMLSClientUseCase,
+                slowSyncRepository
             )
         }
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

During MLS migration testing on Android, a user who was logged out during migration could not properly recover access to an MLS group after logging back in.

- The user was not able to receive messages in the migrated group.
- The group started working only after the user sent a message from Android.
- In practice, the missing recovery after login left the local MLS state incomplete until another action forced it forward.

### Causes (Optional)

- After the client became MLS-capable again, Android did not reliably trigger the recovery path that depends on rerunning `SlowSync`.
- Because of that, the local MLS group state was not rebuilt early enough after login.
- In the E2EI path, the same missing `SlowSync` restart could happen after MLS client finalization.
- `MLSClientManager` could also restart `SlowSync` in the wrong moment, even when MLS registration was still blocked by `E2EICertificateRequired`.

### Solutions

- Restart `SlowSync` after successful MLS client verification/registration in the login flow by clearing `lastSlowSyncCompletionInstant`.
- Restart `SlowSync` after `FinalizeMLSClientAfterE2EIEnrollment`, so the E2EI path uses the same recovery trigger.
- Ensure `MLSClientManager` clears the slow sync timestamp only for real MLS registration success, not for `E2EICertificateRequired`.
- Add logs around the slow sync reset points to make this recovery trigger visible during debugging.