### PR TITLE
fix: E2EI key package rotation order for existing clients [WPB-24367]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -714,24 +714,21 @@ internal class MLSConversationDataSource(
             val existingGroupList =
                 groupIdList.filter { hasEstablishedMLSGroup(mlsContext, it).fold({ false }, { hasEstablished -> hasEstablished }) }
             wrapMLSRequest { mlsContext.e2eiRotateGroups(existingGroupList.map { it.toCrypto() }) }
-                .flatMap { wrapMLSRequest { mlsContext.generateKeyPackages(keyPackageLimitsProvider.refillAmount()) } }
-                .flatMap { newKeyPackages ->
+                .flatMap {
                     crlNewDistributionPoints?.let { checkRevocationList(mlsContext, it) }
                     if (!isNewClient) {
-                        logger.w("enrollment for existing client: upload new keypackages and drop old ones")
-                        keyPackageRepository
-                            .replaceKeyPackages(clientId, newKeyPackages, mlsContext.getDefaultCipherSuite().toModel())
-                            .flatMap {
-                                logger.w("removing stale key packages")
-                                wrapMLSRequest {
-                                    mlsContext.removeStaleKeyPackages()
-                                }
-                            }
-                            .fold({ failure ->
-                                E2EIFailure.RotationAndMigration(failure).left()
-                            }, {
-                                Either.Right(Unit)
-                            })
+                        logger.w("enrollment for existing client: drop stale key packages and upload new ones")
+                        wrapMLSRequest {
+                            mlsContext.removeStaleKeyPackages()
+                        }.flatMap {
+                            wrapMLSRequest { mlsContext.generateKeyPackages(keyPackageLimitsProvider.refillAmount()) }
+                        }.flatMap { newKeyPackages ->
+                            keyPackageRepository.replaceKeyPackages(clientId, newKeyPackages, mlsContext.getDefaultCipherSuite().toModel())
+                        }.fold({ failure ->
+                            E2EIFailure.RotationAndMigration(failure).left()
+                        }, {
+                            Either.Right(Unit)
+                        })
                     } else {
                         Either.Right(Unit)
                     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -1078,7 +1078,27 @@ class MLSConversationRepositoryTest {
             .withKeyPackageLimits(10)
             .withGenerateKeyPackageSuccessful(listOf())
             .withReplaceKeyPackagesReturning(Either.Right(Unit))
+            .withRemoveStaleKeyPackages()
             .arrange()
+        val invocationOrder = mutableListOf<String>()
+
+        coEvery { arrangement.mlsContext.removeStaleKeyPackages() }
+            .invokes {
+                invocationOrder += "removeStaleKeyPackages"
+                Unit
+            }
+
+        coEvery { arrangement.mlsContext.generateKeyPackages(any()) }
+            .invokes {
+                invocationOrder += "generateKeyPackages"
+                emptyList()
+            }
+
+        coEvery { arrangement.keyPackageRepository.replaceKeyPackages(any(), any(), any()) }
+            .invokes {
+                invocationOrder += "replaceKeyPackages"
+                Either.Right(Unit)
+            }
 
         assertEquals(
             Either.Right(Unit),
@@ -1106,6 +1126,11 @@ class MLSConversationRepositoryTest {
         coVerify {
             arrangement.mlsContext.removeStaleKeyPackages()
         }.wasInvoked(once)
+
+        assertEquals(
+            listOf("removeStaleKeyPackages", "generateKeyPackages", "replaceKeyPackages"),
+            invocationOrder
+        )
     }
 
     @Test


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24367
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Cherry-pick from https://github.com/wireapp/kalium/pull/3994