### PR TITLE
fix(nomad devices): cancellation exception while uploading crypto state (WPB-24404)

### DIFF
--- a/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadCryptoStateBackupCallback.kt
+++ b/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadCryptoStateBackupCallback.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -112,9 +113,16 @@ internal class UserScopedNomadCryptoStateChangeHookNotifier(
                     throw e
                 }
                 // Normal debounce path: protect the upload from late cancellations.
-                withContext(NonCancellable) {
-                    mutex.withLock { hasPendingChange = false }
-                    runBackup(this@launch)
+                // Acquire the lock before NonCancellable to avoid indefinite waits if a
+                // holder of the mutex is cancelled while we are in a non-cancellable context.
+                val currentJob = coroutineContext.job
+                val shouldBackup = mutex.withLock {
+                    hasPendingChange.also { hasPendingChange = false }
+                }
+                if (shouldBackup) {
+                    withContext(NonCancellable) {
+                        runBackup(currentJob)
+                    }
                 }
             }
         }
@@ -136,7 +144,7 @@ internal class UserScopedNomadCryptoStateChangeHookNotifier(
     }
 
     @Suppress("TooGenericExceptionCaught")
-    private suspend fun runBackup(currentJob: Any) {
+    private suspend fun runBackup(currentJob: Job) {
         try {
             backup()
         } catch (exception: Exception) {

--- a/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadCryptoStateBackupCallback.kt
+++ b/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadCryptoStateBackupCallback.kt
@@ -114,9 +114,7 @@ internal class UserScopedNomadCryptoStateChangeHookNotifier(
                 }
                 // Normal debounce path: protect the upload from late cancellations.
                 val currentJob = coroutineContext.job
-                val shouldBackup = mutex.withLock {
-                    hasPendingChange.also { hasPendingChange = false }
-                }
+                val shouldBackup = mutex.withLock { hasPendingChange }
                 if (shouldBackup) {
                     withContext(NonCancellable) {
                         runBackup(currentJob)
@@ -149,6 +147,7 @@ internal class UserScopedNomadCryptoStateChangeHookNotifier(
             kaliumLogger.w("User-scoped crypto state change hook execution failed", exception)
         } finally {
             mutex.withLock {
+                hasPendingChange = false
                 if (debounceJob == currentJob) {
                     debounceJob = null
                 }

--- a/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadCryptoStateBackupCallback.kt
+++ b/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadCryptoStateBackupCallback.kt
@@ -21,8 +21,8 @@ package com.wire.kalium.nomaddevice
 import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.messaging.hooks.CryptoStateChangeHookNotifier
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
@@ -120,12 +120,12 @@ internal class UserScopedNomadCryptoStateChangeHookNotifier(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private suspend fun flushIfPending() {
         val shouldBackup = mutex.withLock {
             hasPendingChange.also { hasPendingChange = false }
         }
         if (shouldBackup) {
-            @Suppress("TooGenericExceptionCaught")
             try {
                 backup()
             } catch (exception: Exception) {

--- a/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadCryptoStateBackupCallback.kt
+++ b/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadCryptoStateBackupCallback.kt
@@ -24,10 +24,13 @@ import com.wire.kalium.messaging.hooks.CryptoStateChangeHookNotifier
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 
 /**
  * Factory used with [NomadCryptoStateChangeHookNotifier]:
@@ -88,29 +91,60 @@ internal class UserScopedNomadCryptoStateChangeHookNotifier(
 
     private val mutex = Mutex()
     private var debounceJob: Job? = null
+    private var hasPendingChange = false
 
-    @Suppress("TooGenericExceptionCaught")
     override suspend fun onCryptoStateChanged(userId: UserId) {
         if (userId != selfUserId) {
             return
         }
 
         mutex.withLock {
+            hasPendingChange = true
             debounceJob?.cancel()
             debounceJob = scope.launch {
-                delay(debounceMs)
                 try {
-                    backup()
-                } catch (exception: CancellationException) {
-                    throw exception
-                } catch (exception: Exception) {
-                    kaliumLogger.w("User-scoped crypto state change hook execution failed", exception)
-                } finally {
-                    mutex.withLock {
-                        if (debounceJob == this) {
-                            debounceJob = null
-                        }
+                    delay(debounceMs)
+                } catch (e: CancellationException) {
+                    // Scope is shutting down (e.g. logout): flush any pending change before stopping.
+                    if (!scope.isActive) {
+                        withContext(NonCancellable) { flushIfPending() }
                     }
+                    throw e
+                }
+                // Normal debounce path: protect the upload from late cancellations.
+                withContext(NonCancellable) {
+                    mutex.withLock { hasPendingChange = false }
+                    runBackup(this@launch)
+                }
+            }
+        }
+    }
+
+    private suspend fun flushIfPending() {
+        val shouldBackup = mutex.withLock {
+            hasPendingChange.also { hasPendingChange = false }
+        }
+        if (shouldBackup) {
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                backup()
+            } catch (exception: Exception) {
+                kaliumLogger.w("User-scoped crypto state change hook execution failed", exception)
+            }
+        }
+        mutex.withLock { debounceJob = null }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun runBackup(currentJob: Any) {
+        try {
+            backup()
+        } catch (exception: Exception) {
+            kaliumLogger.w("User-scoped crypto state change hook execution failed", exception)
+        } finally {
+            mutex.withLock {
+                if (debounceJob == currentJob) {
+                    debounceJob = null
                 }
             }
         }

--- a/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadCryptoStateBackupCallback.kt
+++ b/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadCryptoStateBackupCallback.kt
@@ -113,8 +113,6 @@ internal class UserScopedNomadCryptoStateChangeHookNotifier(
                     throw e
                 }
                 // Normal debounce path: protect the upload from late cancellations.
-                // Acquire the lock before NonCancellable to avoid indefinite waits if a
-                // holder of the mutex is cancelled while we are in a non-cancellable context.
                 val currentJob = coroutineContext.job
                 val shouldBackup = mutex.withLock {
                     hasPendingChange.also { hasPendingChange = false }

--- a/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/NomadCryptoStateChangeHookNotifierTest.kt
+++ b/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/NomadCryptoStateChangeHookNotifierTest.kt
@@ -185,6 +185,37 @@ class NomadCryptoStateChangeHookNotifierTest {
         scheduler.runCurrent()
     }
 
+    @Test
+    fun givenUserScopedFactory_whenBackupFails_thenNextTriggerRetriesBackup() = runTest {
+        val scheduler = TestCoroutineScheduler()
+        val scope = TestScope(scheduler)
+        val calls = mutableListOf<String>()
+        var shouldFail = true
+        val notifier = createUserScopedNomadCryptoStateChangeHookNotifier(
+            selfUserId = USER_ID,
+            scope = scope,
+            backup = {
+                if (shouldFail) throw IllegalStateException("boom")
+                calls += "backup"
+            },
+            debounceMs = DEBOUNCE_MS
+        )
+
+        // First trigger — backup fails, flag should remain true
+        notifier.onCryptoStateChanged(USER_ID)
+        scheduler.advanceTimeBy(DEBOUNCE_MS + 1)
+        scheduler.runCurrent()
+        assertEquals(emptyList(), calls)
+
+        // Second trigger — backup succeeds this time
+        shouldFail = false
+        notifier.onCryptoStateChanged(USER_ID)
+        scheduler.advanceTimeBy(DEBOUNCE_MS + 1)
+        scheduler.runCurrent()
+
+        assertEquals(listOf("backup"), calls)
+    }
+
     private class FakeRepository(
         private val calls: MutableList<UserId>
     ) : NomadCryptoStateBackupRepository {

--- a/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/NomadCryptoStateChangeHookNotifierTest.kt
+++ b/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/NomadCryptoStateChangeHookNotifierTest.kt
@@ -20,6 +20,8 @@ package com.wire.kalium.nomaddevice
 
 import com.wire.kalium.logic.data.user.UserId
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -122,6 +124,49 @@ class NomadCryptoStateChangeHookNotifierTest {
         scheduler.runCurrent()
 
         assertEquals(emptyList(), calls)
+    }
+
+    @Test
+    fun givenUserScopedFactory_whenScopeCancelledDuringDebounce_thenPendingBackupIsFlushed() = runTest {
+        val scheduler = TestCoroutineScheduler()
+        val scope = TestScope(scheduler)
+        val calls = mutableListOf<String>()
+        val notifier = createUserScopedNomadCryptoStateChangeHookNotifier(
+            selfUserId = USER_ID,
+            scope = scope,
+            backup = { calls += "backup" },
+            debounceMs = DEBOUNCE_MS
+        )
+
+        notifier.onCryptoStateChanged(USER_ID)
+        scheduler.advanceTimeBy(DEBOUNCE_MS / 2) // mid-debounce
+        scope.cancel() // simulate logout
+        scheduler.runCurrent()
+
+        assertEquals(listOf("backup"), calls)
+    }
+
+    @Test
+    fun givenUserScopedFactory_whenScopeCancelledDuringBackup_thenBackupCompletes() = runTest {
+        val scheduler = TestCoroutineScheduler()
+        val scope = TestScope(scheduler)
+        val calls = mutableListOf<String>()
+        val notifier = createUserScopedNomadCryptoStateChangeHookNotifier(
+            selfUserId = USER_ID,
+            scope = scope,
+            backup = {
+                scope.cancel() // simulate logout mid-upload
+                delay(1) // suspension point that CancellationException would abort without NonCancellable
+                calls += "backup"
+            },
+            debounceMs = DEBOUNCE_MS
+        )
+
+        notifier.onCryptoStateChanged(USER_ID)
+        scheduler.advanceTimeBy(DEBOUNCE_MS + 1)
+        scheduler.runCurrent()
+
+        assertEquals(listOf("backup"), calls)
     }
 
     @Test


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24404
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

```
2026-03-26 16:31:59.268 21656-21693 featureId:...DataSource com.waz.zclient.dev.debug            D  Decrypting message for group AAEAAEohceZbCUobioYg4s0ivf0AZnVsdS53aXJlLmxpbms=
2026-03-26 16:31:59.278 21656-21861 CoreLogic[...7da2f0f29] com.waz.zclient.dev.debug            V  REQUEST FAILURE: {
                                                                                                    "endpoint":"nomad.fulu.wire.link/a/event/crypto/state?device_id=7cb***",
                                                                                                     "method":"POST",
                                                                                                      "cause":"java.util.concurrent.CancellationException: StandaloneCoroutine was cancelled"}
```

Cancellation exception while uploading crypto state

### Solutions

Add checks and guards with `NonCancellable` context and flush "do the upload" if the courutine is cancelled.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
