### PR TITLE
feat(nomad devices): add use case to check if current session is a nomad account [WPB-24366]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/GlobalKaliumScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/GlobalKaliumScope.kt
@@ -26,6 +26,7 @@ import com.wire.kalium.logic.data.client.UserClientRepositoryProvider
 import com.wire.kalium.logic.data.client.UserClientRepositoryProviderImpl
 import com.wire.kalium.logic.data.session.SessionDataSource
 import com.wire.kalium.logic.data.session.SessionRepository
+import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.feature.UserSessionScopeProvider
 import com.wire.kalium.logic.feature.appVersioning.ObserveIfAppUpdateRequiredUseCase
 import com.wire.kalium.logic.feature.appVersioning.ObserveIfAppUpdateRequiredUseCaseImpl
@@ -40,6 +41,7 @@ import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCase
 import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCaseImpl
 import com.wire.kalium.logic.feature.auth.ValidateUserHandleUseCase
 import com.wire.kalium.logic.feature.auth.ValidateUserHandleUseCaseImpl
+import com.wire.kalium.logic.feature.auth.autoVersioningAuth.AuthenticationScopeForConfigIdUseCase
 import com.wire.kalium.logic.feature.auth.sso.ValidateSSOCodeUseCase
 import com.wire.kalium.logic.feature.auth.sso.ValidateSSOCodeUseCaseImpl
 import com.wire.kalium.logic.feature.client.ClearNewClientsForUserUseCase
@@ -50,18 +52,16 @@ import com.wire.kalium.logic.feature.featureConfig.ObserveIsAppLockEditableUseCa
 import com.wire.kalium.logic.feature.featureConfig.ObserveIsAppLockEditableUseCaseImpl
 import com.wire.kalium.logic.feature.notificationToken.SaveNotificationTokenUseCase
 import com.wire.kalium.logic.feature.notificationToken.SaveNotificationTokenUseCaseImpl
-import com.wire.kalium.logic.di.MapperProvider
-import com.wire.kalium.logic.feature.auth.autoVersioningAuth.AuthenticationScopeForConfigIdUseCase
 import com.wire.kalium.logic.feature.server.GetServerConfigUseCase
 import com.wire.kalium.logic.feature.server.ServerConfigForAccountUseCase
 import com.wire.kalium.logic.feature.server.UpdateApiVersionsUseCase
 import com.wire.kalium.logic.feature.server.UpdateApiVersionsUseCaseImpl
 import com.wire.kalium.logic.feature.session.DeleteSessionUseCase
 import com.wire.kalium.logic.feature.session.DoesValidNomadAccountExistUseCase
-import com.wire.kalium.logic.feature.session.IsCurrentSessionNomadAccountUseCase
 import com.wire.kalium.logic.feature.session.DoesValidSessionExistUseCase
 import com.wire.kalium.logic.feature.session.GetAllSessionsUseCase
 import com.wire.kalium.logic.feature.session.GetSessionsUseCase
+import com.wire.kalium.logic.feature.session.IsCurrentSessionNomadAccountUseCase
 import com.wire.kalium.logic.feature.session.ObserveSessionsUseCase
 import com.wire.kalium.logic.feature.session.SessionScope
 import com.wire.kalium.logic.feature.user.ObserveValidAccountsUseCase
@@ -154,7 +154,10 @@ public class GlobalKaliumScope internal constructor(
     public val getAllSessions: GetAllSessionsUseCase get() = GetAllSessionsUseCase(sessionRepository)
     public val doesValidSessionExist: DoesValidSessionExistUseCase get() = DoesValidSessionExistUseCase(sessionRepository)
     public val doesValidNomadAccountExist: DoesValidNomadAccountExistUseCase get() = DoesValidNomadAccountExistUseCase(sessionRepository)
-    public val isCurrentSessionNomadAccount: IsCurrentSessionNomadAccountUseCase get() = IsCurrentSessionNomadAccountUseCase(sessionRepository)
+    public val isCurrentSessionNomadAccount: IsCurrentSessionNomadAccountUseCase
+        get() = IsCurrentSessionNomadAccountUseCase(
+            sessionRepository
+        )
     public val observeValidAccounts: ObserveValidAccountsUseCase by lazy {
         ObserveValidAccountsUseCaseImpl(
             sessionRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/GlobalKaliumScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/GlobalKaliumScope.kt
@@ -58,6 +58,7 @@ import com.wire.kalium.logic.feature.server.UpdateApiVersionsUseCase
 import com.wire.kalium.logic.feature.server.UpdateApiVersionsUseCaseImpl
 import com.wire.kalium.logic.feature.session.DeleteSessionUseCase
 import com.wire.kalium.logic.feature.session.DoesValidNomadAccountExistUseCase
+import com.wire.kalium.logic.feature.session.IsCurrentSessionNomadAccountUseCase
 import com.wire.kalium.logic.feature.session.DoesValidSessionExistUseCase
 import com.wire.kalium.logic.feature.session.GetAllSessionsUseCase
 import com.wire.kalium.logic.feature.session.GetSessionsUseCase
@@ -153,6 +154,7 @@ public class GlobalKaliumScope internal constructor(
     public val getAllSessions: GetAllSessionsUseCase get() = GetAllSessionsUseCase(sessionRepository)
     public val doesValidSessionExist: DoesValidSessionExistUseCase get() = DoesValidSessionExistUseCase(sessionRepository)
     public val doesValidNomadAccountExist: DoesValidNomadAccountExistUseCase get() = DoesValidNomadAccountExistUseCase(sessionRepository)
+    public val isCurrentSessionNomadAccount: IsCurrentSessionNomadAccountUseCase get() = IsCurrentSessionNomadAccountUseCase(sessionRepository)
     public val observeValidAccounts: ObserveValidAccountsUseCase by lazy {
         ObserveValidAccountsUseCaseImpl(
             sessionRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/IsCurrentSessionNomadAccountUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/IsCurrentSessionNomadAccountUseCase.kt
@@ -1,0 +1,37 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.session
+
+import com.wire.kalium.common.functional.getOrElse
+import com.wire.kalium.logic.data.session.SessionRepository
+
+/**
+ * Checks whether the current session belongs to a valid nomad account
+ * (i.e., the current account is valid and has a non-null nomad_service_url).
+ */
+public class IsCurrentSessionNomadAccountUseCase internal constructor(
+    private val sessionRepository: SessionRepository
+) {
+    public suspend operator fun invoke(): Boolean {
+        val currentAccountInfo = sessionRepository.currentSession().getOrElse { return false }
+        if (!currentAccountInfo.isValid()) return false
+        val account = sessionRepository.fullAccountInfo(currentAccountInfo.userId).getOrElse { return false }
+        return !account.nomadServiceUrl.isNullOrBlank()
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/IsCurrentSessionNomadAccountUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/session/IsCurrentSessionNomadAccountUseCase.kt
@@ -18,7 +18,10 @@
 
 package com.wire.kalium.logic.feature.session
 
-import com.wire.kalium.common.functional.getOrElse
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.common.functional.fold
 import com.wire.kalium.logic.data.session.SessionRepository
 
 /**
@@ -28,10 +31,11 @@ import com.wire.kalium.logic.data.session.SessionRepository
 public class IsCurrentSessionNomadAccountUseCase internal constructor(
     private val sessionRepository: SessionRepository
 ) {
-    public suspend operator fun invoke(): Boolean {
-        val currentAccountInfo = sessionRepository.currentSession().getOrElse { return false }
-        if (!currentAccountInfo.isValid()) return false
-        val account = sessionRepository.fullAccountInfo(currentAccountInfo.userId).getOrElse { return false }
-        return !account.nomadServiceUrl.isNullOrBlank()
-    }
+    public suspend operator fun invoke(): Boolean =
+        sessionRepository.currentSession()
+            .flatMap { accountInfo ->
+                if (accountInfo.isValid()) sessionRepository.fullAccountInfo(accountInfo.userId)
+                else Either.Left(StorageFailure.DataNotFound)
+            }
+            .fold({ false }, { !it.nomadServiceUrl.isNullOrBlank() })
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/session/IsCurrentSessionNomadAccountUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/session/IsCurrentSessionNomadAccountUseCaseTest.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.logic.data.session.SessionRepository
 import com.wire.kalium.logic.data.user.UserId
 import io.mockative.coEvery
 import io.mockative.eq
+import io.mockative.every
 import io.mockative.mock
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -105,7 +106,7 @@ internal class IsCurrentSessionNomadAccountUseCaseTest {
         }
 
         suspend fun withFullAccountInfo(userId: UserId, result: Either<StorageFailure, Account>) = apply {
-            coEvery { sessionRepository.fullAccountInfo(eq(userId)) }.returns(result)
+            every { sessionRepository.fullAccountInfo(eq(userId)) }.returns(result)
         }
 
         fun arrange() = this to useCase

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/session/IsCurrentSessionNomadAccountUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/session/IsCurrentSessionNomadAccountUseCaseTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.session
+
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.configuration.server.CommonApiVersionType
+import com.wire.kalium.logic.configuration.server.ServerConfig
+import com.wire.kalium.logic.data.auth.Account
+import com.wire.kalium.logic.data.auth.AccountInfo
+import com.wire.kalium.logic.data.logout.LogoutReason
+import com.wire.kalium.logic.data.session.SessionRepository
+import com.wire.kalium.logic.data.user.UserId
+import io.mockative.coEvery
+import io.mockative.eq
+import io.mockative.mock
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class IsCurrentSessionNomadAccountUseCaseTest {
+
+    @Test
+    fun givenCurrentSessionIsValidWithNomadUrl_thenReturnTrue() = runTest {
+        val (_, useCase) = Arrangement()
+            .withCurrentSession(Either.Right(AccountInfo.Valid(TEST_USER_ID)))
+            .withFullAccountInfo(TEST_USER_ID, Either.Right(testAccount(nomadServiceUrl = "https://nomad.example.com")))
+            .arrange()
+
+        assertTrue(useCase())
+    }
+
+    @Test
+    fun givenCurrentSessionIsValidWithoutNomadUrl_thenReturnFalse() = runTest {
+        val (_, useCase) = Arrangement()
+            .withCurrentSession(Either.Right(AccountInfo.Valid(TEST_USER_ID)))
+            .withFullAccountInfo(TEST_USER_ID, Either.Right(testAccount(nomadServiceUrl = null)))
+            .arrange()
+
+        assertFalse(useCase())
+    }
+
+    @Test
+    fun givenCurrentSessionIsValidWithBlankNomadUrl_thenReturnFalse() = runTest {
+        val (_, useCase) = Arrangement()
+            .withCurrentSession(Either.Right(AccountInfo.Valid(TEST_USER_ID)))
+            .withFullAccountInfo(TEST_USER_ID, Either.Right(testAccount(nomadServiceUrl = "  ")))
+            .arrange()
+
+        assertFalse(useCase())
+    }
+
+    @Test
+    fun givenCurrentSessionIsInvalid_thenReturnFalse() = runTest {
+        val (_, useCase) = Arrangement()
+            .withCurrentSession(Either.Right(AccountInfo.Invalid(TEST_USER_ID, LogoutReason.SELF_HARD_LOGOUT)))
+            .arrange()
+
+        assertFalse(useCase())
+    }
+
+    @Test
+    fun givenNoCurrentSession_thenReturnFalse() = runTest {
+        val (_, useCase) = Arrangement()
+            .withCurrentSession(Either.Left(StorageFailure.DataNotFound))
+            .arrange()
+
+        assertFalse(useCase())
+    }
+
+    @Test
+    fun givenFullAccountInfoFails_thenReturnFalse() = runTest {
+        val (_, useCase) = Arrangement()
+            .withCurrentSession(Either.Right(AccountInfo.Valid(TEST_USER_ID)))
+            .withFullAccountInfo(TEST_USER_ID, Either.Left(StorageFailure.DataNotFound))
+            .arrange()
+
+        assertFalse(useCase())
+    }
+
+    private class Arrangement {
+
+        private val sessionRepository = mock(SessionRepository::class)
+        private val useCase by lazy { IsCurrentSessionNomadAccountUseCase(sessionRepository) }
+
+        suspend fun withCurrentSession(result: Either<StorageFailure, AccountInfo>) = apply {
+            coEvery { sessionRepository.currentSession() }.returns(result)
+        }
+
+        suspend fun withFullAccountInfo(userId: UserId, result: Either<StorageFailure, Account>) = apply {
+            coEvery { sessionRepository.fullAccountInfo(eq(userId)) }.returns(result)
+        }
+
+        fun arrange() = this to useCase
+    }
+
+    companion object {
+        private val TEST_USER_ID = UserId("test", "domain")
+
+        private val TEST_SERVER_CONFIG = ServerConfig(
+            id = "config-id",
+            links = ServerConfig.STAGING,
+            metaData = ServerConfig.MetaData(
+                federation = false,
+                commonApiVersion = CommonApiVersionType.Valid(version = 1),
+                domain = "domain"
+            )
+        )
+
+        private fun testAccount(nomadServiceUrl: String?) = Account(
+            info = AccountInfo.Valid(TEST_USER_ID),
+            serverConfig = TEST_SERVER_CONFIG,
+            ssoId = null,
+            nomadServiceUrl = nomadServiceUrl
+        )
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24366
<!--jira-description-action-hidden-marker-end-->
…
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
add use case to check if current session is a nomad account with tests