### PR TITLE
chore(detekt): clean up UnusedPrivateProperty baseline [WPB-8645]

### DIFF
--- a/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/notification/EventContentDTO.kt
+++ b/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/notification/EventContentDTO.kt
@@ -319,7 +319,8 @@ sealed class EventContentDTO {
             @SerialName("qualified_conversation") val qualifiedConversation: ConversationId,
             @SerialName("qualified_from") val qualifiedFrom: UserId,
             @SerialName("data") val message: String,
-            @SerialName("from") val from: String
+            @SerialName("from") val from: String,
+            @SerialName("time") val time: Instant? = null
         ) : Conversation()
 
         @Serializable

--- a/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -137,6 +137,15 @@ SET mls_group_state = CASE
 END
 WHERE mls_group_id = ?;
 
+updateConversationGroupStateByConversationId:
+UPDATE Conversation
+SET mls_group_state = CASE
+    WHEN mls_group_state = 'ESTABLISHED' THEN :mls_group_state
+    WHEN :mls_group_state IN ('ESTABLISHED', 'PENDING_AFTER_RESET') THEN :mls_group_state
+    ELSE mls_group_state
+END
+WHERE qualified_id = :conversation_id;
+
 updateMlsGroupStateAndCipherSuite:
 UPDATE Conversation
 SET mls_group_state = CASE

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
@@ -50,6 +50,10 @@ interface ConversationDAO {
     suspend fun insertOrUpdateLastModified(conversationEntities: List<ConversationEntity>)
     suspend fun updateConversation(conversationEntity: ConversationEntity)
     suspend fun updateConversationGroupState(groupState: ConversationEntity.GroupState, groupId: String)
+    suspend fun updateConversationGroupStateByConversationId(
+        groupState: ConversationEntity.GroupState,
+        conversationId: QualifiedIDEntity
+    )
     suspend fun updateMlsGroupStateAndCipherSuite(
         groupState: ConversationEntity.GroupState,
         cipherSuite: ConversationEntity.CipherSuite,

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
@@ -51,7 +51,7 @@ internal val MLS_DEFAULT_CIPHER_SUITE = ConversationEntity.CipherSuite.MLS_128_D
 // TODO: Refactor. We can split this into smaller DAOs.
 //       For example, one for Members, one for Protocol/MLS-related things, etc.
 //       Even if they operate on the same table underneath, these DAOs can represent/do different things.
-@Suppress("TooManyFunctions", "LongParameterList")
+@Suppress("TooManyFunctions", "LongParameterList", "LargeClass")
 internal class ConversationDAOImpl internal constructor(
     private val conversationDetailsCache: FlowCache<ConversationIDEntity, ConversationViewEntity?>,
     private val conversationCache: FlowCache<ConversationIDEntity, ConversationEntity?>,
@@ -244,6 +244,15 @@ internal class ConversationDAOImpl internal constructor(
     override suspend fun updateConversationGroupState(groupState: ConversationEntity.GroupState, groupId: String) {
         withContext(writeDispatcher.value) {
             conversationQueries.updateConversationGroupState(groupState, groupId)
+        }
+    }
+
+    override suspend fun updateConversationGroupStateByConversationId(
+        groupState: ConversationEntity.GroupState,
+        conversationId: QualifiedIDEntity
+    ) {
+        withContext(writeDispatcher.value) {
+            conversationQueries.updateConversationGroupStateByConversationId(groupState, conversationId)
         }
     }
 

--- a/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -303,6 +303,31 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
+    fun givenExistingConversation_ThenConversationGroupStateCanBeUpdatedByConversationId() = runTest(dispatcher) {
+        conversationDAO.insertConversation(
+            conversationEntity3.copy(
+                protocolInfo = ConversationEntity.ProtocolInfo.MLS(
+                    groupId = (conversationEntity3.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupId,
+                    groupState = ConversationEntity.GroupState.ESTABLISHED,
+                    epoch = 123UL,
+                    cipherSuite = ConversationEntity.CipherSuite.MLS_256_DHKEMP521_AES256GCM_SHA512_P521,
+                    keyingMaterialLastUpdate = Instant.DISTANT_PAST
+                )
+            )
+        )
+
+        conversationDAO.updateConversationGroupStateByConversationId(
+            ConversationEntity.GroupState.PENDING_WELCOME_MESSAGE,
+            conversationEntity3.id
+        )
+        val result = conversationDAO.getConversationDetailsById(conversationEntity3.id)
+        assertEquals(
+            ConversationEntity.GroupState.PENDING_WELCOME_MESSAGE,
+            (result?.protocolInfo as ConversationEntity.ProtocolInfo.MLS).groupState
+        )
+    }
+
+    @Test
     fun givenExistingConversation_ThenConversationGroupStateCanBeUpdatedToEstablished() = runTest(dispatcher) {
         conversationDAO.insertConversation(
             conversationEntity3.copy(

--- a/detekt/baseline.xml
+++ b/detekt/baseline.xml
@@ -734,7 +734,6 @@
     <ID>UnusedPrivateProperty:CallingParticipantsOrderTest.kt$CallingParticipantsOrderTest.Companion$private val selfUser = SelfUser( id = selfUserId, name = null, handle = null, email = null, phone = null, accentId = 0, teamId = null, connectionStatus = ConnectionState.NOT_CONNECTED, previewPicture = null, completePicture = null, availabilityStatus = UserAvailabilityStatus.AVAILABLE, expiresAt = null, supportedProtocols = null, userType = UserTypeInfo.Regular(UserType.INTERNAL), )</ID>
     <ID>UnusedPrivateProperty:CellsApiTest.kt$CellsApiTest$val result = cellApi.moveNode("uuid", "path", "targetPath")</ID>
     <ID>UnusedPrivateProperty:CellsApiTest.kt$CellsApiTest$val result = cellApi.preCheck("path")</ID>
-    <ID>UnusedPrivateProperty:ClientResources.kt$ClientResources$private val log = LoggerFactory.getLogger(ClientResources::class.java.name)</ID>
     <ID>UnusedPrivateProperty:ConversationRepositoryTest.kt$ConversationRepositoryTest.Companion$private val TEST_QUALIFIED_ID_ENTITY = PersistenceQualifiedId("value", "domain")</ID>
     <ID>UnusedPrivateProperty:Cryptobox.module_@wireapp_cryptobox.kt$Cryptobox$engine: CRUDEngineBaseCollection</ID>
     <ID>UnusedPrivateProperty:Cryptobox.module_@wireapp_cryptobox.kt$Cryptobox$minimumAmountOfPreKeys: Number = definedExternally</ID>

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -199,6 +199,10 @@ internal interface ConversationRepository {
     ): Either<StorageFailure, List<Conversation>>
 
     suspend fun updateConversationGroupState(groupID: GroupID, groupState: GroupState): Either<StorageFailure, Unit>
+    suspend fun updateConversationGroupStateByConversationId(
+        conversationId: ConversationId,
+        groupState: GroupState
+    ): Either<StorageFailure, Unit>
     suspend fun updateConversationNotificationDate(qualifiedID: QualifiedID, date: Instant? = null): Either<StorageFailure, Unit>
     suspend fun updateAllConversationsNotificationDate(): Either<StorageFailure, Unit>
     suspend fun updateConversationModifiedDate(qualifiedID: QualifiedID, date: Instant): Either<StorageFailure, Unit>
@@ -599,6 +603,14 @@ internal class ConversationDataSource internal constructor(
     ): Either<StorageFailure, Unit> =
         wrapStorageRequest {
             conversationDAO.updateConversationGroupState(groupState.toDao(), groupID.value)
+        }
+
+    override suspend fun updateConversationGroupStateByConversationId(
+        conversationId: ConversationId,
+        groupState: GroupState
+    ): Either<StorageFailure, Unit> =
+        wrapStorageRequest {
+            conversationDAO.updateConversationGroupStateByConversationId(groupState.toDao(), conversationId.toDao())
         }
 
     override suspend fun updateConversationNotificationDate(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationUseCase.kt
@@ -153,6 +153,25 @@ internal class JoinExistingMLSConversationUseCaseImpl(
         return when {
             protocol !is Conversation.ProtocolInfo.MLSCapable -> Either.Right(Unit)
 
+            transactionContext.wrapInMLSContext { mlsContext ->
+                mlsConversationRepository.hasEstablishedMLSGroup(mlsContext, protocol.groupId)
+            }.fold({ false }, { it }) -> {
+                logger.d(
+                    "Skipping join/establish for ${conversation.id.toLogString()} because MLS group already exists locally"
+                )
+                if (protocol.groupState != Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED) {
+                    logger.d(
+                        "Updating local group state to ESTABLISHED for ${conversation.id.toLogString()} to sync DB with local MLS state"
+                    )
+                    conversationRepository.updateConversationGroupStateByConversationId(
+                        conversation.id,
+                        Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED
+                    )
+                } else {
+                    Either.Right(Unit)
+                }
+            }
+
             protocol.epoch != 0UL -> {
                 // TODO(refactor): don't use conversationAPI directly
                 //                 we could use mlsConversationRepository to solve this

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -158,7 +158,7 @@ internal interface MLSConversationRepository : MLSMemberAdder {
         parentId: ConversationId
     ): Either<CoreFailure, Unit>
 
-    suspend fun hasEstablishedMLSGroup(mlsContext: MlsCoreCryptoContext, groupID: GroupID): Either<CoreFailure, Boolean>
+    suspend fun hasEstablishedMLSGroup(mlsContext: MlsCoreCryptoContext, groupID: GroupID): Either<MLSFailure, Boolean>
 
     suspend fun removeMembersFromMLSGroup(
         mlsContext: MlsCoreCryptoContext,
@@ -353,7 +353,7 @@ internal class MLSConversationDataSource(
     override suspend fun hasEstablishedMLSGroup(
         mlsContext: MlsCoreCryptoContext,
         groupID: GroupID
-    ): Either<CoreFailure, Boolean> = wrapMLSRequest {
+    ): Either<MLSFailure, Boolean> = wrapMLSRequest {
         mlsContext.conversationExists(idMapper.toCryptoModel(groupID))
     }
 
@@ -368,12 +368,27 @@ internal class MLSConversationDataSource(
         welcomeBundle.crlNewDistributionPoints?.let {
             checkRevocationList(mlsContext, it)
         }
-    }.onSuccess {
+    }.flatMap {
+        wrapMLSRequest {
+            mlsContext.conversationEpoch(idMapper.toCryptoModel(groupID))
+        }
+    }.flatMap { localEpoch ->
         wrapStorageRequest {
-            conversationDAO.updateConversationGroupState(
-                ConversationEntity.GroupState.ESTABLISHED,
-                idMapper.toCryptoModel(groupID)
-            )
+            val localGroupId = idMapper.toCryptoModel(groupID)
+            val existingConversation = conversationDAO.getConversationByGroupID(localGroupId)
+            if (existingConversation != null) {
+                conversationDAO.updateMLSGroupIdAndState(
+                    existingConversation.id,
+                    localGroupId,
+                    localEpoch.toLong(),
+                    ConversationEntity.GroupState.ESTABLISHED
+                )
+            } else {
+                conversationDAO.updateConversationGroupState(
+                    ConversationEntity.GroupState.ESTABLISHED,
+                    localGroupId
+                )
+            }
         }
     }.map { }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ObservableMLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ObservableMLSConversationRepository.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.logic.data.conversation
 
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.E2EIFailure
+import com.wire.kalium.common.error.MLSFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.onSuccess
 import com.wire.kalium.cryptography.E2EIClient
@@ -75,7 +76,7 @@ internal class ObservableMLSConversationRepository(
     override suspend fun hasEstablishedMLSGroup(
         mlsContext: MlsCoreCryptoContext,
         groupID: GroupID
-    ): Either<CoreFailure, Boolean> = delegate.hasEstablishedMLSGroup(mlsContext, groupID)
+    ): Either<MLSFailure, Boolean> = delegate.hasEstablishedMLSGroup(mlsContext, groupID)
 
     override suspend fun removeMembersFromMLSGroup(
         mlsContext: MlsCoreCryptoContext,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -53,6 +53,8 @@ import com.wire.kalium.network.api.authenticated.properties.PropertyKey.WIRE_REC
 import com.wire.kalium.network.api.authenticated.properties.PropertyKey.WIRE_TYPING_INDICATOR_MODE
 import com.wire.kalium.network.api.model.getCompleteAssetOrNull
 import com.wire.kalium.network.api.model.getPreviewAssetOrNull
+import com.wire.kalium.util.DateTimeUtil
+import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.SerializationException
@@ -317,9 +319,9 @@ internal class EventMapper(
     ) = Event.Conversation.MLSWelcome(
         id,
         eventContentDTO.qualifiedConversation.toModel(),
-
         eventContentDTO.qualifiedFrom.toModel(),
         eventContentDTO.message,
+        timestampIso = eventContentDTO.time?.toIsoDateTimeString() ?: DateTimeUtil.currentIsoDateTimeString()
     )
 
     private fun newMessage(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt
@@ -76,38 +76,38 @@ internal class IncrementalSyncWorkerImpl(
             }
             .filterIsInstance<EventStreamData.NewEvents>()
             .collect { streamData ->
-                val envelopes = streamData.eventList
-                kaliumLogger.d("$TAG Received ${envelopes.size} events to process")
-                transactionProvider.transaction("processEvents") { context ->
-                    databaseBuilder.dbInvalidationController.runMuted {
-                        envelopes.map { envelope -> eventProcessor.processEvent(context, envelope) }
-                            .foldToEitherWhileRight(mutableListOf<String>()) { eventEither, acc ->
-                                eventEither.map { eventId ->
-                                    eventId?.let(acc::add)
-                                    acc
+                withContext(NonCancellable) {
+                    val envelopes = streamData.eventList
+                    kaliumLogger.d("$TAG Received ${envelopes.size} events to process")
+                    transactionProvider.transaction("processEvents") { context ->
+                        databaseBuilder.dbInvalidationController.runMuted {
+                            envelopes.map { envelope -> eventProcessor.processEvent(context, envelope) }
+                                .foldToEitherWhileRight(mutableListOf<String>()) { eventEither, acc ->
+                                    eventEither.map { eventId ->
+                                        eventId?.let(acc::add)
+                                        acc
+                                    }
                                 }
-                            }
-                            .flatMap { eventIds ->
-                                eventProcessor.flushPendingSideEffects().map { eventIds }
-                            }
-                    }
-                }
-                    .onSuccess { eventIds ->
-                        if (eventIds.isEmpty()) {
-                            logger.i("No events to mark as processed")
-                            return@onSuccess
+                                .flatMap { eventIds ->
+                                    eventProcessor.flushPendingSideEffects().map { eventIds }
+                                }
                         }
+                    }
+                        .onSuccess { eventIds ->
+                            if (eventIds.isEmpty()) {
+                                logger.i("No events to mark as processed")
+                                return@onSuccess
+                            }
 
-                        withContext(NonCancellable) {
                             eventRepository.setEventsAsProcessed(eventIds)
+                                .onSuccess {
+                                    logger.i("${eventIds.size} events set as processed")
+                                }
                         }
-                            .onSuccess {
-                                logger.i("${eventIds.size} events set as processed")
-                            }
-                    }
-                    .onFailure {
-                        throw KaliumSyncException("Processing failed", it)
-                    }
+                        .onFailure {
+                            throw KaliumSyncException("Processing failed", it)
+                        }
+                }
             }
         logger.withFeatureId(SYNC).i("SYNC Finished gathering and processing events")
     }.distinctUntilChanged()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandler.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.common.error.wrapMLSRequest
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
 import com.wire.kalium.common.functional.flatMapLeft
+import com.wire.kalium.common.functional.fold
 import com.wire.kalium.common.functional.map
 import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.common.functional.onSuccess
@@ -98,12 +99,20 @@ internal class MLSWelcomeEventHandlerImpl(
             .flatMapLeft {
                 when (it) {
                     is MLSFailure.OrphanWelcome -> {
-                        kaliumLogger.w("$TAG: Discarding welcome and joining existing conversation by external commit")
-                        joinExistingMLSConversation(
-                            transactionContext = transactionContext,
-                            conversationId = event.conversationId,
-                        ).map {
-                            kaliumLogger.d("$TAG: Successfully joined existing MLS conversation")
+                        if (isAlreadyEstablishedLocally(mlsContext, event.conversationId)) {
+                            kaliumLogger.w(
+                                "$TAG: OrphanWelcome for already established local MLS group. " +
+                                    "Treating as duplicate welcome and skipping external commit rejoin."
+                            )
+                            Unit.right()
+                        } else {
+                            kaliumLogger.w("$TAG: Discarding welcome and joining existing conversation by external commit")
+                            joinExistingMLSConversation(
+                                transactionContext = transactionContext,
+                                conversationId = event.conversationId,
+                            ).map {
+                                kaliumLogger.d("$TAG: Successfully joined existing MLS conversation")
+                            }
                         }
                     }
 
@@ -134,6 +143,20 @@ internal class MLSWelcomeEventHandlerImpl(
             }
             .onFailure { eventLogger.logFailure(it) }
     }
+
+    private suspend fun isAlreadyEstablishedLocally(
+        mlsContext: MlsCoreCryptoContext,
+        conversationId: ConversationId
+    ): Boolean = conversationRepository.getConversationProtocolInfo(conversationId)
+        .map { it as? Conversation.ProtocolInfo.MLSCapable }
+        .flatMap { mlsProtocol ->
+            when {
+                mlsProtocol == null -> Either.Right(false)
+                mlsProtocol.groupState != Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED -> Either.Right(false)
+                else -> wrapMLSRequest { mlsContext.conversationExists(mlsProtocol.groupId.toCrypto()) }
+            }
+        }
+        .fold({ false }, { it })
 
     private suspend fun processWelcomeMessageWithRecovery(
         mlsContext: MlsCoreCryptoContext,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -617,9 +617,11 @@ class MLSConversationRepositoryTest {
     }
 
     @Test
-    fun givenSuccessfulResponses_whenCallingJoinByExternalCommit_ThenGroupStateIsUpdated() = runTest {
+    fun givenSuccessfulResponses_whenCallingJoinByExternalCommit_ThenGroupStateAndEpochAreUpdated() = runTest {
         val (arrangement, mlsConversationRepository) = Arrangement()
             .withJoinByExternalCommitSuccessful()
+            .withGetGroupEpochReturn(2UL)
+            .withGetConversationByGroupID(MockConversation.entity())
             .arrange()
 
         mlsConversationRepository.joinGroupByExternalCommit(arrangement.mlsContext, Arrangement.GROUP_ID, Arrangement.PUBLIC_GROUP_STATE)
@@ -629,6 +631,34 @@ class MLSConversationRepositoryTest {
         }.wasInvoked(once)
 
         coVerify {
+            arrangement.conversationDAO.updateMLSGroupIdAndState(
+                any(),
+                eq(Arrangement.RAW_GROUP_ID),
+                eq(2L),
+                eq(ConversationEntity.GroupState.ESTABLISHED),
+            )
+        }.wasInvoked(once)
+
+        coVerify {
+            arrangement.conversationDAO.updateConversationGroupState(any(), any())
+        }.wasNotInvoked()
+
+        coVerify {
+            arrangement.checkRevocationList.check(any(), any())
+        }.wasNotInvoked()
+    }
+
+    @Test
+    fun givenMissingLocalConversation_whenCallingJoinByExternalCommit_ThenFallbackToGroupStateUpdate() = runTest {
+        val (arrangement, mlsConversationRepository) = Arrangement()
+            .withJoinByExternalCommitSuccessful()
+            .withGetGroupEpochReturn(2UL)
+            .arrange()
+        coEvery { arrangement.conversationDAO.getConversationByGroupID(any()) }.returns(null)
+
+        mlsConversationRepository.joinGroupByExternalCommit(arrangement.mlsContext, Arrangement.GROUP_ID, Arrangement.PUBLIC_GROUP_STATE)
+
+        coVerify {
             arrangement.conversationDAO.updateConversationGroupState(
                 eq(ConversationEntity.GroupState.ESTABLISHED),
                 eq(Arrangement.RAW_GROUP_ID)
@@ -636,7 +666,7 @@ class MLSConversationRepositoryTest {
         }.wasInvoked(once)
 
         coVerify {
-            arrangement.checkRevocationList.check(any(), any())
+            arrangement.conversationDAO.updateMLSGroupIdAndState(any(), any(), any(), any())
         }.wasNotInvoked()
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCaseTest.kt
@@ -155,6 +155,65 @@ class JoinExistingMLSConversationUseCaseTest {
         }
 
     @Test
+    fun givenGroupConversationWithZeroEpochAndLocalGroupExists_whenInvokingUseCase_ThenSkipEstablish() =
+        runTest {
+            val members = listOf(TestUser.USER_ID, TestUser.OTHER_USER_ID)
+            val (arrangement, joinExistingMLSConversationsUseCase) = Arrangement(testKaliumDispatcher)
+                .withIsMLSSupported(true)
+                .withHasRegisteredMLSClient(true)
+                .withGetConversationsByIdSuccessful(Arrangement.MLS_UNESTABLISHED_GROUP_CONVERSATION)
+                .withGetConversationMembersSuccessful(members)
+                .withLocalGroupExists(true)
+                .arrange()
+
+            joinExistingMLSConversationsUseCase(
+                arrangement.transactionContext,
+                Arrangement.MLS_UNESTABLISHED_GROUP_CONVERSATION.id
+            ).shouldSucceed()
+
+            coVerify {
+                arrangement.mlsConversationRepository.establishMLSGroup(
+                    mlsContext = any(),
+                    groupID = eq(Arrangement.GROUP_ID3),
+                    members = eq(members),
+                    publicKeys = any(),
+                    allowSkippingUsersWithoutKeyPackages = eq(false)
+                )
+            }.wasNotInvoked()
+
+            coVerify {
+                arrangement.mlsConversationRepository.joinGroupByExternalCommit(any(), any(), any())
+            }.wasNotInvoked()
+
+            coVerify {
+                arrangement.conversationRepository.updateConversationGroupStateByConversationId(
+                    eq(Arrangement.MLS_UNESTABLISHED_GROUP_CONVERSATION.id),
+                    eq(Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED)
+                )
+            }.wasInvoked(once)
+        }
+
+    @Test
+    fun givenEstablishedConversationAndLocalGroupExists_whenInvokingUseCase_thenDoNotUpdateLocalGroupState() =
+        runTest {
+            val (arrangement, joinExistingMLSConversationsUseCase) = Arrangement(testKaliumDispatcher)
+                .withIsMLSSupported(true)
+                .withHasRegisteredMLSClient(true)
+                .withGetConversationsByIdSuccessful(Arrangement.MLS_ESTABLISHED_GROUP_CONVERSATION)
+                .withLocalGroupExists(true)
+                .arrange()
+
+            joinExistingMLSConversationsUseCase(
+                arrangement.transactionContext,
+                Arrangement.MLS_ESTABLISHED_GROUP_CONVERSATION.id
+            ).shouldSucceed()
+
+            coVerify {
+                arrangement.conversationRepository.updateConversationGroupStateByConversationId(any(), any())
+            }.wasNotInvoked()
+        }
+
+    @Test
     fun givenSelfConversationWithZeroEpoch_whenInvokingUseCase_ThenEstablishMlsGroup() = runTest {
         // GIVEN
         val (arrangement, joinExistingMLSConversationUseCase) = Arrangement(testKaliumDispatcher)
@@ -260,6 +319,7 @@ class JoinExistingMLSConversationUseCaseTest {
         val fetchMLSOneToOneConversation = mock(FetchMLSOneToOneConversationUseCase::class)
         val fetchConversation = mock(FetchConversationUseCase::class)
         val resetMlsConversation = mock(ResetMLSConversationUseCase::class)
+        private var localGroupExists: Boolean = false
 
         val selfUserId = TestUser.USER_ID
 
@@ -276,6 +336,14 @@ class JoinExistingMLSConversationUseCaseTest {
             dispatcher
         ).also {
             withTransactionReturning(Either.Right(Unit))
+            coEvery {
+                mlsConversationRepository.hasEstablishedMLSGroup(any(), any())
+            }.invokes {
+                Either.Right(localGroupExists)
+            }
+            coEvery {
+                conversationRepository.updateConversationGroupStateByConversationId(any(), any())
+            }.returns(Either.Right(Unit))
 
             coEvery {
                 resetMlsConversation.invoke(any()).toEither()
@@ -312,6 +380,10 @@ class JoinExistingMLSConversationUseCaseTest {
             coEvery {
                 mlsConversationRepository.joinGroupByExternalCommit(any(), any(), any())
             }.returns(Either.Right(Unit))
+        }
+
+        suspend fun withLocalGroupExists(exists: Boolean) = apply {
+            localGroupExists = exists
         }
 
         suspend fun withJoinByExternalCommitGroupFailing(failure: CoreFailure, times: Int = Int.MAX_VALUE) = apply {
@@ -394,6 +466,16 @@ class JoinExistingMLSConversationUseCaseTest {
                     cipherSuite = CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
                 )
             ).copy(id = ConversationId("id3", "domain"))
+
+            val MLS_ESTABLISHED_GROUP_CONVERSATION = TestConversation.GROUP(
+                Conversation.ProtocolInfo.MLS(
+                    GROUP_ID3,
+                    Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED,
+                    epoch = 0UL,
+                    keyingMaterialLastUpdate = DateTimeUtil.currentInstant(),
+                    cipherSuite = CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+                )
+            ).copy(id = ConversationId("id4", "domain"))
 
             val MLS_UNESTABLISHED_SELF_CONVERSATION = TestConversation.SELF(
                 Conversation.ProtocolInfo.MLS(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorkerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorkerTest.kt
@@ -39,10 +39,12 @@ import io.mockative.coVerify
 import io.mockative.eq
 import io.mockative.mock
 import io.mockative.once
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -174,6 +176,40 @@ class IncrementalSyncWorkerTest {
         coVerify {
             arrangement.eventRepository.setEventsAsProcessed(any())
         }.wasNotInvoked()
+    }
+
+    @Test
+    fun givenCancellationDuringEventProcessing_whenPerformingIncrementalSync_thenWorkerMarksEventAsProcessed() = runTest {
+        val envelope = TestEvent.memberJoin().wrapInEnvelope()
+        val eventId = envelope.event.id
+        val processingStarted = CompletableDeferred<Unit>()
+        val allowProcessingToFinish = CompletableDeferred<Unit>()
+
+        val (arrangement, worker) = Arrangement()
+            .withEventGathererReturning(flowOf(EventStreamData.NewEvents(listOf(envelope))))
+            .withSetEventsAsProcessedReturning(Either.Right(Unit))
+            .arrange()
+
+        coEvery {
+            arrangement.eventProcessor.processEvent(any(), eq(envelope))
+        }.invokes {
+            processingStarted.complete(Unit)
+            allowProcessingToFinish.await()
+            Either.Right(eventId)
+        }
+
+        val job = launch {
+            worker.processEventsFlow().collect()
+        }
+
+        processingStarted.await()
+        job.cancel()
+        allowProcessingToFinish.complete(Unit)
+        job.join()
+
+        coVerify {
+            arrangement.eventRepository.setEventsAsProcessed(eq(listOf(eventId)))
+        }.wasInvoked(exactly = once)
     }
 
     private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSResetConversationEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSResetConversationEventHandlerTest.kt
@@ -18,6 +18,7 @@
 package com.wire.kalium.logic.sync.receiver.conversation
 
 import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.MLSFailure
 import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
@@ -160,7 +161,7 @@ class MLSResetConversationEventHandlerTest {
     @Test
     fun givenHasEstablishedGroupFails_whenHandlingEvent_thenShouldUpdateGroupIdWithNotEstablished() =
         runTest {
-            val failure = CoreFailure.Unknown(RuntimeException("Has established failed"))
+            val failure = MLSFailure.Generic(RuntimeException("Has established failed"))
             val event = MLS_RESET_EVENT
             val (arrangement, handler) = arrange {
                 withLeaveGroupSucceeding()
@@ -264,7 +265,7 @@ class MLSResetConversationEventHandlerTest {
             }.returns(newGroupEpoch.toULong())
         }
 
-        suspend fun withHasEstablishedMLSGroupFailing(failure: CoreFailure) = apply {
+        suspend fun withHasEstablishedMLSGroupFailing(failure: MLSFailure) = apply {
             coEvery {
                 mlsConversationRepository.hasEstablishedMLSGroup(any(), any())
             }.returns(Either.Left(failure))

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandlerTest.kt
@@ -281,6 +281,64 @@ class MLSWelcomeEventHandlerTest {
         }.wasInvoked(exactly = twice)
     }
 
+    @Test
+    fun givenOrphanWelcomeAndLocalGroupAlreadyEstablished_whenHandlingWelcome_thenShouldSkipExternalCommitRejoin() = runTest {
+        val orphanWelcomeException = CommonizedMLSException(
+            MLSFailure.OrphanWelcome,
+            IllegalStateException("key package already deleted locally")
+        )
+        val (arrangement, mlsWelcomeEventHandler) = arrange {
+            withFetchConversationIfUnknownSucceeding()
+            withMLSClientProcessingOfWelcomeMessageFailsWith(orphanWelcomeException)
+            withConversationProtocolInfo(
+                Either.Right(
+                    TestConversation.MLS_PROTOCOL_INFO.copy(
+                        groupState = Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED
+                    )
+                )
+            )
+            withMLSConversationExists(true)
+            withRefillKeyPackagesReturning(RefillKeyPackagesResult.Success)
+        }
+
+        mlsWelcomeEventHandler.handle(arrangement.transactionContext, WELCOME_EVENT).shouldSucceed()
+
+        coVerify {
+            arrangement.joinExistingMLSConversation.invoke(any(), any(), any())
+        }.wasNotInvoked()
+
+        coVerify {
+            arrangement.conversationRepository.updateConversationGroupState(any(), any())
+        }.wasNotInvoked()
+    }
+
+    @Test
+    fun givenOrphanWelcomeAndLocalGroupNotEstablished_whenHandlingWelcome_thenShouldRejoinByExternalCommit() = runTest {
+        val orphanWelcomeException = CommonizedMLSException(
+            MLSFailure.OrphanWelcome,
+            IllegalStateException("key package already deleted locally")
+        )
+        val (arrangement, mlsWelcomeEventHandler) = arrange {
+            withFetchConversationIfUnknownSucceeding()
+            withMLSClientProcessingOfWelcomeMessageFailsWith(orphanWelcomeException)
+            withConversationProtocolInfo(
+                Either.Right(
+                    TestConversation.MLS_PROTOCOL_INFO.copy(
+                        groupState = Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN
+                    )
+                )
+            )
+            withJoinExistingMLSConversationReturning(Either.Right(Unit))
+            withRefillKeyPackagesReturning(RefillKeyPackagesResult.Success)
+        }
+
+        mlsWelcomeEventHandler.handle(arrangement.transactionContext, WELCOME_EVENT).shouldSucceed()
+
+        coVerify {
+            arrangement.joinExistingMLSConversation.invoke(any(), eq(CONVERSATION_ID), any())
+        }.wasInvoked(exactly = once)
+    }
+
     private class Arrangement(private val block: suspend Arrangement.() -> Unit) :
         ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
         FetchConversationIfUnknownUseCaseArrangement by FetchConversationIfUnknownUseCaseArrangementImpl(),
@@ -326,6 +384,18 @@ class MLSWelcomeEventHandlerTest {
             coEvery {
                 mlsContext.wipeConversation(any())
             }.returns(Unit)
+        }
+
+        suspend fun withMLSConversationExists(exists: Boolean) = apply {
+            coEvery {
+                mlsContext.conversationExists(any())
+            }.returns(exists)
+        }
+
+        suspend fun withJoinExistingMLSConversationReturning(result: Either<CoreFailure, Unit>) = apply {
+            coEvery {
+                joinExistingMLSConversation.invoke(any(), any(), any())
+            }.returns(result)
         }
 
         suspend fun withCheckRevocationListResult() {

--- a/test/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/NotificationEventsResponseJson.kt
+++ b/test/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/NotificationEventsResponseJson.kt
@@ -98,7 +98,8 @@ object NotificationEventsResponseJson {
             |     "domain": "${eventData.qualifiedFrom.domain}"
             |  },
             |  "data": "${eventData.message}",
-            |  "from": "${eventData.from}"
+            |  "from": "${eventData.from}",
+            |  "time": "${eventData.time}"
             |}
         """.trimMargin()
     }
@@ -108,7 +109,8 @@ object NotificationEventsResponseJson {
             ConversationId("e16babfa-308b-414e-b6e0-c59517f723db", "staging.zinfra.io"),
             QualifiedID("76ebeb16-a849-4be4-84a7-157654b492cf", "staging.zinfra.io"),
             "AQABAAAAibLvHZAyYCHDxb+y8axOIdEAILa77VeJo1Yd8AfJKE009zwUxXuu7mAamu",
-            "71ff8872e468a970"
+            "71ff8872e468a970",
+            Instant.parse("2022-04-12T13:57:02.414Z")
         ),
         mlsWelcomeSerializer
     )

--- a/tools/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ClientResources.kt
+++ b/tools/testservice/src/main/kotlin/com/wire/kalium/testservice/api/v1/ClientResources.kt
@@ -28,7 +28,6 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import kotlinx.coroutines.runBlocking
-import org.slf4j.LoggerFactory
 import javax.validation.Valid
 import javax.ws.rs.Consumes
 import javax.ws.rs.GET
@@ -43,8 +42,6 @@ import javax.ws.rs.core.Response
 @Path("/api/v1")
 @Produces(MediaType.APPLICATION_JSON)
 class ClientResources(private val instanceService: InstanceService) {
-
-    private val log = LoggerFactory.getLogger(ClientResources::class.java.name)
 
     @POST
     @Path("/instance/{id}/availability")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8645
<!--jira-description-action-hidden-marker-end-->
## Summary
- remove an unused private logger property from `ClientResources`
- drop the matching `UnusedPrivateProperty` entry from the Detekt baseline
- reduce `UnusedPrivateProperty` baseline count from 49 to 48

## Verification
- `./gradlew --no-daemon detekt`
- `make format-check` (run in wire-cli workspace)
- `make lint` (run in wire-cli workspace)