### PR TITLE
perf(native): increase sqlite reader concurrency WPB-8645

### DIFF
--- a/data/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/db/PlatformDatabaseData.kt
+++ b/data/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/db/PlatformDatabaseData.kt
@@ -74,7 +74,7 @@ fun databaseDriver(
             foreignKeyConstraints = driverConfiguration.areForeignKeyConstraintsEnforced
         )
     )
-    return NativeSqliteDriver(configuration)
+    return NativeSqliteDriver(configuration, maxReaderConnections = NATIVE_MAX_READER_CONNECTIONS)
 }
 
 private object GradleSafeSqliterLogger : Logger {
@@ -98,6 +98,7 @@ private object GradleSafeSqliterLogger : Logger {
 
 private const val SQLITER_FULL_TRACES_ENV = "KALIUM_SQLITER_FULL_TRACES"
 private const val SQLITER_TRACE_FILE_ENV = "KALIUM_SQLITER_TRACE_FILE"
+private const val NATIVE_MAX_READER_CONNECTIONS = 32
 
 private fun isSqliterFullTracesEnabled(): Boolean {
     val value = getenv(SQLITER_FULL_TRACES_ENV)?.toKString()?.lowercase() ?: return false


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8645
<!--jira-description-action-hidden-marker-end-->
## Summary
- raise Apple `NativeSqliteDriver` reader concurrency to 32 instead of using the single-reader default
- align the native reader pool more closely with Kalium's 32-lane read dispatcher to reduce rerun-wave serialization during sync