### PR TITLE
feat(nomad devices): estore Wire Cells multipart attachments and preserve last processed event id in crypto backup/restore

### DIFF
--- a/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/nomaddevice/NomadConversationMetadataResponse.kt
+++ b/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/nomaddevice/NomadConversationMetadataResponse.kt
@@ -38,7 +38,7 @@ data class NomadConversationMetadataItem(
 @Serializable
 data class NomadConversationMetadata(
     @SerialName("last_read")
-    val lastRead: Long,
+    val lastRead: Long? = null,
     @SerialName("last_modified")
     val lastModified: Long? = null,
 )

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/NomadDeviceSyncApiV0.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/NomadDeviceSyncApiV0.kt
@@ -277,7 +277,7 @@ internal open class NomadDeviceSyncApiV0 internal constructor(
         const val PATH_MESSAGES_SYNC = "sync"
         const val PATH_MESSAGES_BATCH = "batch"
         const val PATH_MESSAGES_RESTORE = "restore"
-        const val PATH_CONVERSATION_METADATA = "conversation/metadata"
+        const val PATH_CONVERSATION_METADATA = "conversations"
         const val PATH_CRYPTO_STATE = "crypto/state"
         const val PATH_CRYPTO_DEVICE = "crypto/device"
         const val QUERY_DEVICE_ID = "device_id"

--- a/data/network/src/commonTest/kotlin/com/wire/kalium/api/v0/nomaddevice/NomadDeviceSyncApiV0Test.kt
+++ b/data/network/src/commonTest/kotlin/com/wire/kalium/api/v0/nomaddevice/NomadDeviceSyncApiV0Test.kt
@@ -154,7 +154,7 @@ internal class NomadDeviceSyncApiV0Test : ApiTest() {
             statusCode = HttpStatusCode.OK,
             assertion = {
                 assertGet()
-                assertPathEqual("/event/conversation/metadata")
+                assertPathEqual("/event/conversations")
             }
         )
 
@@ -164,6 +164,26 @@ internal class NomadDeviceSyncApiV0Test : ApiTest() {
         assertTrue(response.isSuccessful())
         assertEquals(1, response.value.conversations.size)
         assertEquals(1707235100L, response.value.conversations.first().metadata.lastRead)
+        assertEquals(1707235200L, response.value.conversations.first().metadata.lastModified)
+    }
+
+    @Test
+    fun givenConversationMetadataWithoutLastRead_whenGettingConversationMetadata_thenResponseShouldAllowNullLastRead() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(
+            responseBody = CONVERSATION_METADATA_RESPONSE_WITH_NULL_LAST_READ_JSON,
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertGet()
+                assertPathEqual("/event/conversations")
+            }
+        )
+
+        val api: NomadDeviceSyncApi = NomadDeviceSyncApiV0(networkClient, nomadServiceUrl = "https://nomad.example.com")
+        val response = api.getConversationMetadata()
+
+        assertTrue(response.isSuccessful())
+        assertEquals(1, response.value.conversations.size)
+        assertEquals(null, response.value.conversations.first().metadata.lastRead)
         assertEquals(1707235200L, response.value.conversations.first().metadata.lastModified)
     }
 
@@ -277,7 +297,7 @@ internal class NomadDeviceSyncApiV0Test : ApiTest() {
                 assertGet()
                 assertEquals("nomad.example.com", url.host)
                 assertEquals(URLProtocol.HTTPS, url.protocol)
-                assertPathEqual("/service/event/conversation/metadata")
+                assertPathEqual("/service/event/conversations")
             }
         )
 
@@ -752,6 +772,24 @@ internal class NomadDeviceSyncApiV0Test : ApiTest() {
                   },
                   "metadata": {
                     "last_read": 1707235100,
+                    "last_modified": 1707235200
+                  }
+                }
+              ]
+            }
+            """.trimIndent()
+
+        val CONVERSATION_METADATA_RESPONSE_WITH_NULL_LAST_READ_JSON =
+            """
+            {
+              "conversations": [
+                {
+                  "conversation": {
+                    "id": "conv-12345",
+                    "domain": "example.com"
+                  },
+                  "metadata": {
+                    "last_read": null,
                     "last_modified": 1707235200
                   }
                 }

--- a/data/persistence/src/jvmTest/kotlin/com/wire/kalium/persistence/dao/nomad/NomadMessagesDAOTest.kt
+++ b/data/persistence/src/jvmTest/kotlin/com/wire/kalium/persistence/dao/nomad/NomadMessagesDAOTest.kt
@@ -187,6 +187,47 @@ class NomadMessagesDAOTest {
         assertTrue(database.userDAO.getUsersDetailsByQualifiedIDList(listOf(invalidMessage.payload.senderUserId)).isEmpty())
     }
 
+    @Test
+    fun givenMultipartMessageWithAudioCellAttachment_whenStoring_thenAttachmentKeepsCellsRetrievalMetadata() = runTest {
+        val database = newDatabase()
+        val dao = newDao(database)
+        val message = NomadMessageToInsert(
+            id = "m-audio",
+            conversationId = qid("c1"),
+            date = Instant.fromEpochMilliseconds(1_500),
+            payload = SyncableMessagePayloadEntity.Multipart(
+                creationDate = Instant.fromEpochMilliseconds(1_500),
+                senderUserId = qid("u1"),
+                senderClientId = "sender-client",
+                lastEditDate = null,
+                text = null,
+                quotedMessageId = null,
+                mentions = emptyList(),
+                attachments = listOf(audioAttachment(assetId = "audio-1"))
+            ),
+        )
+
+        val result = dao.storeMessages(
+            messages = listOf(message),
+            batchSize = 20
+        )
+
+        assertEquals(1, result.storedMessages)
+
+        val storedMessage = assertNotNull(database.messageDAO.getMessageById("m-audio", qid("c1")))
+        val multipartContent = assertIs<MessageEntityContent.Multipart>(storedMessage.content)
+        assertEquals(1, multipartContent.attachments.size)
+        assertEquals("audio-1", multipartContent.attachments.single().assetId)
+
+        val storedAttachment = database.messageAttachments.getAttachment("audio-1")
+        assertTrue(storedAttachment.cellAsset)
+        assertEquals("audio/ogg", storedAttachment.mimeType)
+        assertEquals("cells/audio/audio-1.ogg", storedAttachment.assetPath)
+        assertEquals(2048L, storedAttachment.assetSize)
+        assertEquals(98_765L, storedAttachment.assetDuration)
+        assertEquals("NOT_DOWNLOADED", storedAttachment.assetTransferStatus)
+    }
+
     private fun newDatabase(): UserDatabaseBuilder = userDatabaseBuilder(
         platformDatabaseData = PlatformDatabaseData(StorageData.InMemory),
         userId = SELF_USER_ID_DAO,
@@ -312,6 +353,19 @@ class NomadMessagesDAOTest {
         assetWidth = null,
         assetHeight = null,
         assetDuration = null,
+        assetTransferStatus = "NOT_DOWNLOADED",
+        isEditSupported = false
+    )
+
+    private fun audioAttachment(assetId: String): MessageAttachmentEntity = MessageAttachmentEntity(
+        assetId = assetId,
+        cellAsset = true,
+        mimeType = "audio/ogg",
+        assetPath = "cells/audio/$assetId.ogg",
+        assetSize = 2048L,
+        assetWidth = null,
+        assetHeight = null,
+        assetDuration = 98_765L,
         assetTransferStatus = "NOT_DOWNLOADED",
         isEditSupported = false
     )

--- a/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadConversationMetadataSyncRepository.kt
+++ b/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadConversationMetadataSyncRepository.kt
@@ -80,7 +80,9 @@ internal class ConversationDAONomadConversationMetadataStore(
 
     override suspend fun applyMetadata(metadata: List<NomadConversationMetadataToSync>) =
         conversationDAO.updateConversationReadAndModifiedDates(
-            readDates = metadata.associate { it.conversationId to it.lastReadDate },
+            readDates = metadata.mapNotNull { entry ->
+                entry.lastReadDate?.let { entry.conversationId to it }
+            }.toMap(),
             modifiedDates = metadata.mapNotNull { entry ->
                 entry.lastModifiedDate?.let { entry.conversationId to it }
             }.toMap()

--- a/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadRemoteBackupChangeLogCallback.kt
+++ b/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadRemoteBackupChangeLogCallback.kt
@@ -26,6 +26,7 @@ import com.wire.kalium.common.functional.right
 import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.message.AssetContent
+import com.wire.kalium.logic.data.message.CellAssetContent
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.messaging.hooks.ConversationClearEventData
@@ -230,9 +231,7 @@ private fun PersistedMessageData.shouldLogMessageUpsert(): Boolean = when (val m
 private fun MessageContent.Multipart.hasSupportedPartForChangelog(): Boolean {
     // `value` is the textual part of a multipart message.
     val hasTextPart = value != null
-    // Only regular message assets are currently syncable in this changelog flow.
-    // Multipart payloads with only CellAssetContent attachments are intentionally skipped.
-    val hasSyncableAssetPart = attachments.any { it is AssetContent }
+    val hasSyncableAssetPart = attachments.any { it is AssetContent || it is CellAssetContent }
     return hasTextPart || hasSyncableAssetPart
 }
 

--- a/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadRemoteBackupChangeLogEventMapperConverters.kt
+++ b/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadRemoteBackupChangeLogEventMapperConverters.kt
@@ -80,7 +80,7 @@ internal fun List<MessageEntity.Mention>.toNomadDeviceMentions(): List<NomadDevi
 
 @Suppress("CyclomaticComplexMethod")
 internal fun List<MessageAttachmentEntity>.toNomadDeviceAttachments(): List<NomadDeviceAttachment> =
-    filter { !it.cellAsset }.map { attachment ->
+    map { attachment ->
         NomadDeviceAttachment(
             content = NomadDeviceAttachment.Content.Asset(
                 NomadDeviceAsset(

--- a/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/SyncNomadConversationMetadataUseCase.kt
+++ b/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/SyncNomadConversationMetadataUseCase.kt
@@ -72,7 +72,7 @@ public class SyncNomadConversationMetadataUseCase internal constructor(
                     value = it.conversation.id,
                     domain = it.conversation.domain
                 ),
-                lastReadDate = Instant.fromEpochMilliseconds(it.metadata.lastRead),
+                lastReadDate = it.metadata.lastRead?.let(Instant::fromEpochMilliseconds),
                 lastModifiedDate = it.metadata.lastModified?.let(Instant::fromEpochMilliseconds)
             )
         }
@@ -90,6 +90,6 @@ public class SyncNomadConversationMetadataUseCase internal constructor(
  */
 internal data class NomadConversationMetadataToSync(
     val conversationId: QualifiedIDEntity,
-    val lastReadDate: Instant,
+    val lastReadDate: Instant?,
     val lastModifiedDate: Instant?,
 )

--- a/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/NomadAllMessagesMapperTest.kt
+++ b/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/NomadAllMessagesMapperTest.kt
@@ -26,6 +26,7 @@ import com.wire.kalium.persistence.dao.backup.SyncableMessagePayloadEntity
 import com.wire.kalium.protobuf.encodeToByteArray
 import com.wire.kalium.protobuf.nomaddevice.NomadDeviceAsset
 import com.wire.kalium.protobuf.nomaddevice.NomadDeviceAttachment
+import com.wire.kalium.protobuf.nomaddevice.NomadDeviceAudioMetaData
 import com.wire.kalium.protobuf.nomaddevice.NomadDeviceImageMetaData
 import com.wire.kalium.protobuf.nomaddevice.NomadDeviceLocation
 import com.wire.kalium.protobuf.nomaddevice.NomadDeviceMessageContent
@@ -40,6 +41,7 @@ import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 class NomadAllMessagesMapperTest {
 
@@ -124,6 +126,30 @@ class NomadAllMessagesMapperTest {
         assertEquals(Instant.fromEpochMilliseconds(1_707_235_200_000L), message.date)
         assertEquals(Instant.fromEpochMilliseconds(1_707_235_201_000L), payload.creationDate)
         assertEquals(Instant.fromEpochMilliseconds(1_707_235_202_000L), payload.lastEditDate)
+    }
+
+    @Test
+    fun givenMultipartWithAudioAttachment_whenMapping_thenAttachmentKeepsCellsDownloadMetadata() {
+        val mapped = mapper.map(
+            responseWith(
+                storedMessage(
+                    messageId = "audio-message",
+                    timestamp = 1_707_235_500_000L,
+                    content = multipartContentWithAudioAttachment(attachmentAssetId = "audio-attachment")
+                )
+            )
+        )
+
+        val payload = assertIs<SyncableMessagePayloadEntity.Multipart>(mapped.messages.single().payload)
+        val attachment = payload.attachments.single()
+
+        assertTrue(attachment.cellAsset)
+        assertEquals("audio-attachment", attachment.assetId)
+        assertEquals("audio/ogg", attachment.mimeType)
+        assertEquals("cells/audio/audio-attachment.ogg", attachment.assetPath)
+        assertEquals(24L, attachment.assetSize)
+        assertEquals(7_654L, attachment.assetDuration)
+        assertEquals("NOT_DOWNLOADED", attachment.assetTransferStatus)
     }
 
     private fun responseWith(vararg messages: NomadStoredMessage): NomadAllMessagesResponse =
@@ -226,6 +252,32 @@ class NomadAllMessagesMapperTest {
                                             width = 128,
                                             height = 72
                                         )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+    private fun multipartContentWithAudioAttachment(attachmentAssetId: String): NomadDeviceMessageContent =
+        NomadDeviceMessageContent(
+            content = NomadDeviceMessageContent.Content.Multipart(
+                NomadDeviceMultipart(
+                    text = null,
+                    attachments = listOf(
+                        NomadDeviceAttachment(
+                            content = NomadDeviceAttachment.Content.Asset(
+                                NomadDeviceAsset(
+                                    mimeType = "audio/ogg",
+                                    size = 24L,
+                                    name = "cells/audio/$attachmentAssetId.ogg",
+                                    otrKey = ByteArr(byteArrayOf()),
+                                    sha256 = ByteArr(byteArrayOf()),
+                                    assetId = attachmentAssetId,
+                                    metaData = NomadDeviceAsset.MetaData.Audio(
+                                        NomadDeviceAudioMetaData(durationInMillis = 7_654L)
                                     )
                                 )
                             )

--- a/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/NomadRemoteBackupChangeLogHookNotifierTest.kt
+++ b/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/NomadRemoteBackupChangeLogHookNotifierTest.kt
@@ -69,7 +69,25 @@ class NomadRemoteBackupChangeLogHookNotifierTest {
             persistedMessage(
                 content = MessageContent.Multipart(
                     value = null,
-                    attachments = listOf(unsupportedAttachment(), assetContent("asset-multipart"))
+                    attachments = listOf(cellAttachment(), assetContent("asset-multipart"))
+                )
+            ),
+            SELF_USER_ID
+        )
+
+        assertEquals(1, dao.messageUpsertCalls.size)
+    }
+
+    @Test
+    fun givenMultipartWithOnlyCellAttachment_whenCallbackInvoked_thenMessageUpsertIsLogged() = runTest {
+        val dao = RecordingRemoteBackupChangeLogDAO()
+        val notifier = createNotifier(daoProvider = { dao })
+
+        notifier.onMessagePersisted(
+            persistedMessage(
+                content = MessageContent.Multipart(
+                    value = null,
+                    attachments = listOf(cellAttachment())
                 )
             ),
             SELF_USER_ID
@@ -97,7 +115,7 @@ class NomadRemoteBackupChangeLogHookNotifierTest {
     }
 
     @Test
-    fun givenMultipartWithOnlyUnsupportedParts_whenCallbackInvoked_thenEntryIsSkipped() = runTest {
+    fun givenMultipartWithoutTextOrAttachments_whenCallbackInvoked_thenEntryIsSkipped() = runTest {
         val dao = RecordingRemoteBackupChangeLogDAO()
         val notifier = createNotifier(daoProvider = { dao })
 
@@ -105,7 +123,7 @@ class NomadRemoteBackupChangeLogHookNotifierTest {
             persistedMessage(
                 content = MessageContent.Multipart(
                     value = null,
-                    attachments = listOf(unsupportedAttachment())
+                    attachments = emptyList()
                 )
             ),
             SELF_USER_ID
@@ -285,7 +303,7 @@ class NomadRemoteBackupChangeLogHookNotifierTest {
             )
         )
 
-    private fun unsupportedAttachment(): CellAssetContent =
+    private fun cellAttachment(): CellAssetContent =
         CellAssetContent(
             id = "cell-attachment-id",
             versionId = "v1",

--- a/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/SyncNomadConversationMetadataUseCaseTest.kt
+++ b/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/SyncNomadConversationMetadataUseCaseTest.kt
@@ -70,6 +70,24 @@ class SyncNomadConversationMetadataUseCaseTest {
     }
 
     @Test
+    fun givenMetadataResponseWithoutLastRead_whenInvoking_thenApplyNullLastReadDate() = runTest {
+        val repository = FakeNomadConversationMetadataSyncRepository(
+            metadataResponse = Either.Right(metadataResponse(lastRead = null)),
+        )
+        val useCase = SyncNomadConversationMetadataUseCase(
+            repository = repository
+        )
+
+        val result = useCase(SELF_USER_ID)
+
+        val success = assertIs<Either.Right<NomadConversationMetadataSyncResult>>(result).value
+        assertEquals(1, success.downloadedConversations)
+        assertEquals(1, repository.appliedMetadata.size)
+        assertEquals(null, repository.appliedMetadata.single().lastReadDate)
+        assertEquals(Instant.fromEpochMilliseconds(LAST_MODIFIED_TIMESTAMP), repository.appliedMetadata.single().lastModifiedDate)
+    }
+
+    @Test
     fun givenApiFailure_whenInvoking_thenDoNotTouchStorage() = runTest {
         val repository = FakeNomadConversationMetadataSyncRepository(
             metadataResponse = Either.Left(NetworkFailure.NoNetworkConnection(null)),
@@ -102,12 +120,12 @@ class SyncNomadConversationMetadataUseCaseTest {
         }
     }
 
-    private fun metadataResponse(): NomadConversationMetadataResponse =
+    private fun metadataResponse(lastRead: Long? = LAST_READ_TIMESTAMP): NomadConversationMetadataResponse =
         NomadConversationMetadataResponse(
             conversations = listOf(
                 NomadConversationMetadataItem(
                     conversation = Conversation(id = CONVERSATION_ID, domain = CONVERSATION_DOMAIN),
-                    metadata = NomadConversationMetadata(lastRead = LAST_READ_TIMESTAMP, lastModified = LAST_MODIFIED_TIMESTAMP)
+                    metadata = NomadConversationMetadata(lastRead = lastRead, lastModified = LAST_MODIFIED_TIMESTAMP)
                 )
             )
         )

--- a/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/SyncNomadRemoteBackupChangeLogUseCaseTest.kt
+++ b/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/SyncNomadRemoteBackupChangeLogUseCaseTest.kt
@@ -40,6 +40,9 @@ import com.wire.kalium.persistence.dao.backup.ConversationMetadataSyncEntity
 import com.wire.kalium.persistence.dao.backup.RemoteBackupChangeLogDAO
 import com.wire.kalium.persistence.dao.backup.SyncableMessagePayloadEntity
 import com.wire.kalium.persistence.dao.message.MessageEntity
+import com.wire.kalium.persistence.dao.message.attachment.MessageAttachmentEntity
+import com.wire.kalium.protobuf.nomaddevice.NomadDeviceAsset
+import com.wire.kalium.protobuf.nomaddevice.NomadDeviceAttachment
 import com.wire.kalium.protobuf.nomaddevice.NomadDeviceMessagePayload
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
@@ -195,6 +198,63 @@ class SyncNomadRemoteBackupChangeLogUseCaseTest {
         assertEquals(0, success.syncedEntries)
         assertEquals(0, success.postedEvents)
         assertTrue(api.requests.isEmpty())
+    }
+
+    @Test
+    fun givenMultipartWithCellAudioAttachment_whenSyncingPage_thenPayloadKeepsAttachmentMetadata() = runTest {
+        val dao = FakeRemoteBackupChangeLogDAO(
+            batch = ChangeLogSyncBatch(
+                events = listOf(
+                    ChangeLogSyncEvent.MessageUpsert(
+                        conversationId = CONVERSATION_ID,
+                        messageId = MESSAGE_ID,
+                        change = messageUpsertChange(),
+                        message = SyncableMessagePayloadEntity.Multipart(
+                            creationDate = Instant.fromEpochMilliseconds(1000L),
+                            senderUserId = SENDER_ID,
+                            senderClientId = "sender-client",
+                            lastEditDate = null,
+                            text = null,
+                            quotedMessageId = null,
+                            mentions = emptyList(),
+                            attachments = listOf(
+                                audioAttachment(assetId = "cell-audio", cellAsset = true),
+                                imageAttachment(assetId = "regular-image", cellAsset = false),
+                            )
+                        )
+                    )
+                ),
+                conversationMetadata = emptyList()
+            )
+        )
+        val api = FakeNomadDeviceSyncApi(NetworkResponse.Success(Unit, emptyMap(), 200))
+        val useCase = SyncNomadRemoteBackupChangeLogUseCase(
+            remoteBackupChangeLogDAOProvider = { dao },
+            nomadDeviceSyncApiProvider = { api },
+            pageSize = 10
+        )
+
+        useCase(SELF_USER_ID)
+
+        val upsertEvent = assertIs<NomadMessageEvent.UpsertMessageEvent>(api.requests.single().events.single())
+        val decodedPayload = NomadDeviceMessagePayload.decodeFromByteArray(Base64.Default.decode(upsertEvent.payload))
+        val attachments = decodedPayload.content.multipart?.attachments.orEmpty()
+
+        assertEquals(2, attachments.size)
+
+        val audioAttachment = attachments
+            .map { (it.content as NomadDeviceAttachment.Content.Asset).value }
+            .single { it.assetId == "cell-audio" }
+        assertEquals("audio/ogg", audioAttachment.mimeType)
+        assertEquals(1024L, audioAttachment.size)
+        assertEquals("cells/audio/cell-audio.ogg", audioAttachment.name)
+        assertEquals(12_345L, (audioAttachment.metaData as NomadDeviceAsset.MetaData.Audio).value.durationInMillis)
+
+        val imageAttachment = attachments
+            .map { (it.content as NomadDeviceAttachment.Content.Asset).value }
+            .single { it.assetId == "regular-image" }
+        assertEquals("image/png", imageAttachment.mimeType)
+        assertEquals("cells/image/regular-image.png", imageAttachment.name)
     }
 
     @Test
@@ -438,6 +498,34 @@ class SyncNomadRemoteBackupChangeLogUseCaseTest {
         timestampMs = 2000L,
         messageTimestampMs = 1500L
     )
+
+    private fun audioAttachment(assetId: String, cellAsset: Boolean): MessageAttachmentEntity =
+        MessageAttachmentEntity(
+            assetId = assetId,
+            cellAsset = cellAsset,
+            mimeType = "audio/ogg",
+            assetPath = "cells/audio/$assetId.ogg",
+            assetSize = 1024L,
+            assetWidth = null,
+            assetHeight = null,
+            assetDuration = 12_345L,
+            assetTransferStatus = "NOT_DOWNLOADED",
+            isEditSupported = false
+        )
+
+    private fun imageAttachment(assetId: String, cellAsset: Boolean): MessageAttachmentEntity =
+        MessageAttachmentEntity(
+            assetId = assetId,
+            cellAsset = cellAsset,
+            mimeType = "image/png",
+            assetPath = "cells/image/$assetId.png",
+            assetSize = 512L,
+            assetWidth = 320,
+            assetHeight = 180,
+            assetDuration = null,
+            assetTransferStatus = "NOT_DOWNLOADED",
+            isEditSupported = false
+        )
 
     private companion object {
         val SELF_USER_ID: UserId = UserId("self-user", "wire.test")

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1129,6 +1129,7 @@ public class UserSessionScope internal constructor(
             clientIdProvider = clientIdProvider,
             userRepository = userRepository,
             clientRepository = clientRepository,
+            eventRepository = eventRepository,
             kaliumFileSystem = kaliumFileSystem,
             userStorage = userStorage,
             cryptoTransactionProvider = cryptoTransactionProvider,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/ApplyCryptoStateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/ApplyCryptoStateUseCase.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.data.client.ClientRepository
+import com.wire.kalium.logic.data.event.EventRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.RootPathsProvider
 import com.wire.kalium.logic.util.SecurityHelper
@@ -49,12 +50,14 @@ internal interface ApplyCryptoStateUseCase {
     suspend operator fun invoke(extractResult: ExtractCryptoStateResult.Success): ApplyCryptoStateResult
 }
 
+@Suppress("LongParameterList")
 internal class ApplyCryptoStateUseCaseImpl(
     private val userId: UserId,
     private val rootPathsProvider: RootPathsProvider,
     private val kaliumFileSystem: KaliumFileSystem,
     private val securityHelper: SecurityHelper,
     private val clientRepository: ClientRepository,
+    private val eventRepository: EventRepository,
     private val dispatcher: KaliumDispatcher = KaliumDispatcherImpl,
 ) : ApplyCryptoStateUseCase {
 
@@ -84,6 +87,11 @@ internal class ApplyCryptoStateUseCaseImpl(
 
                 // Update database passphrases from backup metadata
                 updatePassphrases(extractResult.metadata)
+
+                when (val restoreEventIdResult = restoreLastProcessedEventId(extractResult.metadata)) {
+                    is ApplyCryptoStateResult.Failure -> return@withContext restoreEventIdResult
+                    ApplyCryptoStateResult.Success -> Unit
+                }
 
                 // Mark the client as having registered for MLS
                 clientRepository.setHasRegisteredMLSClient()
@@ -115,6 +123,20 @@ internal class ApplyCryptoStateUseCaseImpl(
         val proteusPassphraseKey = "${PROTEUS_DB_PASSPHRASE_PREFIX_V2}_$userId"
         securityHelper.setDBPassphrase(proteusPassphraseKey, metadata.proteusDbPassphrase)
         kaliumLogger.i("$TAG: Updated Proteus database passphrase")
+    }
+
+    private suspend fun restoreLastProcessedEventId(metadata: CryptoStateBackupMetadata): ApplyCryptoStateResult {
+        return when (val result = eventRepository.updateLastSavedEventId(metadata.lastProcessedEventId)) {
+            is com.wire.kalium.common.functional.Either.Right -> {
+                kaliumLogger.i("$TAG: Restored last processed event ID from crypto backup metadata")
+                ApplyCryptoStateResult.Success
+            }
+
+            is com.wire.kalium.common.functional.Either.Left -> {
+                kaliumLogger.e("$TAG: Failed to restore last processed event ID from crypto backup metadata")
+                ApplyCryptoStateResult.Failure(result.value)
+            }
+        }
     }
 
     private fun applyMLSKeystore(extractedMlsPath: Path, clientId: String): ApplyCryptoStateResult {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/BackupCryptoDBUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/BackupCryptoDBUseCase.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.data.client.CryptoBackupMetadata
 import com.wire.kalium.logic.data.client.CryptoTransactionProvider
+import com.wire.kalium.logic.data.event.EventRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.util.createCompressedFile
 import com.wire.kalium.util.DateTimeUtil
@@ -52,6 +53,7 @@ public interface BackupCryptoDBUseCase {
 internal class BackupCryptoDBUseCaseImpl(
     private val userId: UserId,
     private val cryptoTransactionProvider: CryptoTransactionProvider,
+    private val eventRepository: EventRepository,
     private val kaliumFileSystem: KaliumFileSystem,
     private val dispatchers: KaliumDispatcher = KaliumDispatcherImpl,
 ) : BackupCryptoDBUseCase {
@@ -84,7 +86,21 @@ internal class BackupCryptoDBUseCaseImpl(
             val tempBackupName = createTempBackupFileName(backupName)
             val tempBackupPath = cryptoBackupRootPath.resolve(tempBackupName)
             val backupFilePath = kaliumFileSystem.tempFilePath(backupName)
-            val metadataPath = createMetadataFile(mlsExportData, proteusExportData)
+            val lastProcessedEventId = when (val result = eventRepository.lastSavedEventId()) {
+                is Either.Right -> result.value
+                is Either.Left -> when (result.value) {
+                    is StorageFailure.DataNotFound -> when (val fetchResult = eventRepository.fetchMostRecentEventId()) {
+                        is Either.Right -> fetchResult.value
+                        is Either.Left -> return@withContext BackupCryptoDBResult.Failure(fetchResult.value)
+                    }
+                    else -> return@withContext BackupCryptoDBResult.Failure(result.value)
+                }
+            }
+            val metadataPath = createMetadataFile(
+                mlsExportData = mlsExportData,
+                proteusExportData = proteusExportData,
+                lastProcessedEventId = lastProcessedEventId
+            )
             createBackupZip(mlsDbBytes, proteusDbBytes, metadataPath, tempBackupPath).fold(
                 { error -> BackupCryptoDBResult.Failure(error) },
                 {
@@ -179,10 +195,12 @@ internal class BackupCryptoDBUseCaseImpl(
     private fun createMetadataFile(
         mlsExportData: CryptoBackupMetadata,
         proteusExportData: CryptoBackupMetadata,
+        lastProcessedEventId: String,
     ): Path {
         val metadata = CryptoStateBackupMetadata(
             version = CryptoStateBackupMetadata.CURRENT_VERSION,
             clientId = mlsExportData.clientId.value,
+            lastProcessedEventId = lastProcessedEventId,
             mlsDbPassphrase = Base64.encode(mlsExportData.passphrase),
             proteusDbPassphrase = Base64.encode(proteusExportData.passphrase)
         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/BackupScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/BackupScope.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.data.backup.CryptoStateBackupRemoteRepository
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.client.CryptoTransactionProvider
+import com.wire.kalium.logic.data.event.EventRepository
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
@@ -39,6 +40,7 @@ public class BackupScope internal constructor(
     private val clientIdProvider: CurrentClientIdProvider,
     private val userRepository: UserRepository,
     private val clientRepository: ClientRepository,
+    private val eventRepository: EventRepository,
     private val upgradeCurrentSession: UpgradeCurrentSessionUseCase,
     private val kaliumFileSystem: KaliumFileSystem,
     private val userStorage: UserStorage,
@@ -85,6 +87,7 @@ public class BackupScope internal constructor(
         BackupCryptoDBUseCaseImpl(
             userId,
             cryptoTransactionProvider,
+            eventRepository,
             kaliumFileSystem,
         )
     }
@@ -120,7 +123,8 @@ public class BackupScope internal constructor(
             rootPathsProvider = rootPathsProvider,
             kaliumFileSystem = kaliumFileSystem,
             securityHelper = securityHelper,
-            clientRepository = clientRepository
+            clientRepository = clientRepository,
+            eventRepository = eventRepository
         )
 
     public val restoreCryptoState: RestoreCryptoStateUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/CryptoStateBackupMetadata.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/CryptoStateBackupMetadata.kt
@@ -26,6 +26,8 @@ public data class CryptoStateBackupMetadata(
     val version: String,
     @SerialName("client_id")
     val clientId: String,
+    @SerialName("last_processed_event_id")
+    val lastProcessedEventId: String,
     @SerialName("mls_db_passphrase")
     val mlsDbPassphrase: String,
     @SerialName("proteus_db_passphrase")

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/ApplyCryptoStateUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/ApplyCryptoStateUseCaseTest.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.data.client.ClientRepository
+import com.wire.kalium.logic.data.event.EventRepository
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.di.RootPathsProvider
 import com.wire.kalium.logic.util.SecurityHelper
@@ -48,6 +49,7 @@ class ApplyCryptoStateUseCaseTest {
             .withSuccessfulFolderDeletion()
             .withSuccessfulFileCopy()
             .withSuccessfulDBPassphraseUpdate()
+            .withSuccessfulLastProcessedEventIdUpdate()
             .withSuccessfulMLSClientRegistration()
             .arrange()
 
@@ -56,6 +58,9 @@ class ApplyCryptoStateUseCaseTest {
         assertEquals(ApplyCryptoStateResult.Success, result)
         verifySuspend(VerifyMode.exactly(2)) {
             arrangement.securityHelper.setDBPassphrase(any(), any())
+        }
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.eventRepository.updateLastSavedEventId(LAST_PROCESSED_EVENT_ID)
         }
         verifySuspend(VerifyMode.exactly(1)) {
             arrangement.clientRepository.setHasRegisteredMLSClient()
@@ -120,11 +125,33 @@ class ApplyCryptoStateUseCaseTest {
         }
     }
 
+    @Test
+    fun givenStoringLastProcessedEventIdFails_whenInvoked_thenReturnFailure() = runTest {
+        val (_, useCase) = Arrangement()
+            .withFileExistingCheckReturning(true)
+            .withSuccessfulFileDeletion()
+            .withSuccessfulFolderDeletion()
+            .withSuccessfulFileCopy()
+            .withSuccessfulDBPassphraseUpdate()
+            .withLastProcessedEventIdUpdateFailure()
+            .arrange()
+
+        val result = useCase.invoke(extractResult)
+
+        assertTrue(result is ApplyCryptoStateResult.Failure)
+        assertTrue(result.error is StorageFailure.Generic)
+    }
+
     private inner class Arrangement {
 
         val kaliumFileSystem = mock<KaliumFileSystem>()
         val securityHelper = mock<SecurityHelper>()
         val clientRepository = mock<ClientRepository>()
+        val eventRepository = mock<EventRepository>()
+
+        init {
+            withSuccessfulLastProcessedEventIdUpdate()
+        }
 
         fun withExistingMLSKeystore(result: Boolean) = apply {
             everySuspend { kaliumFileSystem.exists(mlsKeystorePath) } returns result
@@ -154,6 +181,16 @@ class ApplyCryptoStateUseCaseTest {
             everySuspend { clientRepository.setHasRegisteredMLSClient() } returns Either.Right(Unit)
         }
 
+        fun withSuccessfulLastProcessedEventIdUpdate() = apply {
+            everySuspend { eventRepository.updateLastSavedEventId(any()) } returns Either.Right(Unit)
+        }
+
+        fun withLastProcessedEventIdUpdateFailure() = apply {
+            everySuspend { eventRepository.updateLastSavedEventId(any()) }.returns(
+                Either.Left(StorageFailure.Generic(Exception("db write failed")))
+            )
+        }
+
         fun withFileExistingCheckReturning(result: Boolean) = apply {
             everySuspend { kaliumFileSystem.exists(any()) } returns result
         }
@@ -168,7 +205,8 @@ class ApplyCryptoStateUseCaseTest {
                 rootPathsProvider = FakeRootPathsProvider(),
                 kaliumFileSystem = kaliumFileSystem,
                 securityHelper = securityHelper,
-                clientRepository = clientRepository
+                clientRepository = clientRepository,
+                eventRepository = eventRepository
             )
         }
     }
@@ -179,12 +217,14 @@ class ApplyCryptoStateUseCaseTest {
         private val proteusKeystorePath = "/tmp/proteus-keystore".toPath()
         private val extractedDir = "/tmp/extracted".toPath()
         private const val CLIENT_ID = "client-123"
+        private const val LAST_PROCESSED_EVENT_ID = "event-123"
         const val MLS_DB_PASSPHRASE = "mls-pass"
         const val PROTEUS_DB_PASSPHRASE = "proteus-pass"
 
         private val metadata = CryptoStateBackupMetadata(
             version = CryptoStateBackupMetadata.CURRENT_VERSION,
             clientId = CLIENT_ID,
+            lastProcessedEventId = LAST_PROCESSED_EVENT_ID,
             mlsDbPassphrase = MLS_DB_PASSPHRASE,
             proteusDbPassphrase = PROTEUS_DB_PASSPHRASE
         )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/BackupCryptoDBUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/BackupCryptoDBUseCaseTest.kt
@@ -32,6 +32,7 @@ import com.wire.kalium.logic.data.client.CryptoTransactionProviderImpl
 import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.data.client.ProteusClientProvider
 import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.event.EventRepository
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestUser
@@ -89,8 +90,10 @@ class BackupCryptoDBUseCaseTest {
         val proteusDbData: ByteArray = Base64.decode("cHJvdGV1cy1kYi1ieXRlcw==")
         val passphrase = ByteArray(32) { 0xAB.toByte() }
         val proteusPassphrase = ByteArray(32) { 0xBC.toByte() }
+        val lastProcessedEventId = "event-123"
         val (arrangement, useCase) = Arrangement()
             .withClientId(TestClient.CLIENT_ID)
+            .withLastProcessedEventId(lastProcessedEventId)
             .withMlsExportedCryptoDB("keystore_export", dbData, passphrase, TestClient.CLIENT_ID)
             .withProteusExportedCryptoDB("keystore_export_proteus", proteusDbData, proteusPassphrase, TestClient.CLIENT_ID)
             .withMlsTransactionSuccess()
@@ -122,6 +125,7 @@ class BackupCryptoDBUseCaseTest {
             val metadata = Json.decodeFromString<CryptoStateBackupMetadata>(metadataJson)
             assertEquals(metadata.version, CryptoStateBackupMetadata.CURRENT_VERSION)
             assertEquals(metadata.clientId, TestClient.CLIENT_ID.value)
+            assertEquals(metadata.lastProcessedEventId, lastProcessedEventId)
             assertEquals(metadata.mlsDbPassphrase, Base64.encode(passphrase))
             assertEquals(metadata.proteusDbPassphrase, Base64.encode(proteusPassphrase))
             val extractedMlsDB = listDirectories(extractedFilesPath).firstOrNull {
@@ -201,9 +205,11 @@ class BackupCryptoDBUseCaseTest {
     }
 
     private inner class Arrangement {
+        private val defaultLastProcessedEventId = "event-default"
         val clientIdProvider = mock<CurrentClientIdProvider>()
         val mlsClientProvider = mock<MLSClientProvider>()
         val proteusClientProvider = mock<ProteusClientProvider>()
+        val eventRepository = mock<EventRepository>()
         private val mlsClient = mock<MLSClient>()
         private val mlsContext = mock<MlsCoreCryptoContext>()
         private val proteusClient = mock<ProteusClient>()
@@ -214,8 +220,24 @@ class BackupCryptoDBUseCaseTest {
             proteusClientProvider = proteusClientProvider
         )
 
+        init {
+            withLastProcessedEventId(defaultLastProcessedEventId)
+        }
+
         fun withClientId(clientId: ClientId) = apply {
             everySuspend { clientIdProvider.invoke() }.returns(Either.Right(clientId))
+        }
+
+        fun withLastProcessedEventId(lastProcessedEventId: String) = apply {
+            everySuspend { eventRepository.lastSavedEventId() }.returns(Either.Right(lastProcessedEventId))
+        }
+
+        fun withMissingLastProcessedEventId() = apply {
+            everySuspend { eventRepository.lastSavedEventId() }.returns(Either.Left(StorageFailure.DataNotFound))
+        }
+
+        fun withMostRecentEventId(lastProcessedEventId: String) = apply {
+            everySuspend { eventRepository.fetchMostRecentEventId() }.returns(Either.Right(lastProcessedEventId))
         }
 
         fun withMlsExportedCryptoDB(path: String, dbData: ByteArray, passphrase: ByteArray, clientId: ClientId) = apply {
@@ -311,6 +333,7 @@ class BackupCryptoDBUseCaseTest {
         fun arrange(): Pair<Arrangement, BackupCryptoDBUseCase> = this to BackupCryptoDBUseCaseImpl(
             userId = TestUser.USER_ID,
             cryptoTransactionProvider = cryptoTransactionProvider,
+            eventRepository = eventRepository,
             kaliumFileSystem = fakeFileSystem,
             dispatchers = dispatcher
         )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/ExtractCryptoStateUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/ExtractCryptoStateUseCaseTest.kt
@@ -218,6 +218,7 @@ class ExtractCryptoStateUseCaseTest {
             val metadata = CryptoStateBackupMetadata(
                 version = CryptoStateBackupMetadata.CURRENT_VERSION,
                 clientId = "test-client-id",
+                lastProcessedEventId = "event-123",
                 mlsDbPassphrase = "mls-passphrase",
                 proteusDbPassphrase = "proteus-passphrase"
             )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/RestoreCryptoStateUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/RestoreCryptoStateUseCaseTest.kt
@@ -277,6 +277,7 @@ internal class RestoreCryptoStateUseCaseTest {
         private val metadata = CryptoStateBackupMetadata(
             version = CryptoStateBackupMetadata.CURRENT_VERSION,
             clientId = CLIENT_ID_VALUE,
+            lastProcessedEventId = "event-123",
             mlsDbPassphrase = "mls-passphrase",
             proteusDbPassphrase = "proteus-passphrase"
         )


### PR DESCRIPTION
# What's new in this PR?

### Issues

This PR fixes two restore/sync continuity issues:

1. Nomad restore on a second device did not preserve multipart attachments for Wire-Drive / Wire Cells conversations.
This was visible with same-user audio attachments: after sending from Device A and logging in on Device B, the restored message could appear without its audio attachment.

2. Crypto state backup/restore did not preserve the last processed event ID.
After restoring crypto state on another device/session, sync continuity could be lost because the restored session did not carry over the saved event position.

### Causes (Optional)

Nomad multipart attachments issue:
- multipart messages with only Cells attachments were considered not syncable for the nomad changelog
- `cellAsset = true` attachments were filtered out during nomad multipart attachment encoding
- restore reconstructs multipart attachments only from the nomad payload, so excluded attachments were missing on the second device

Crypto backup/restore event ID issue:
- crypto backup metadata did not include `last_processed_event_id`
- restore did not write any saved event ID back into local metadata storage
- if no local event ID was available during backup creation, there was no fallback to guarantee one in the exported metadata

### Solutions

Nomad fixes:
- Allowed multipart messages with Cells attachments to be included in the nomad changelog sync path
- Stopped filtering out `cellAsset` attachments when encoding nomad multipart attachments
- Kept the fix general for Cells multipart attachments, including audio, instead of special-casing audio only
- Made nomad conversation metadata handling tolerant to missing `last_read` values
- Updated the nomad conversation metadata endpoint path to the correct `conversations` route
- Added regression tests covering:
  - Cells-only multipart message changelog eligibility
  - nomad payload encoding for Cells audio attachments
  - restore mapping of Cells audio attachment metadata
  - DAO persistence of restored Cells audio attachment metadata used by the existing retrieval/download path

Crypto backup/restore fixes:
- Added `last_processed_event_id` to crypto state backup metadata
- Made `last_processed_event_id` mandatory in crypto backup metadata
- During crypto backup creation, used the locally stored event ID when present and fell back to `fetchMostRecentEventId()` when missing
- During crypto restore, persisted the restored `last_processed_event_id` back into local metadata storage
- Wired `EventRepository` through the crypto backup/restore flow
- Added regression tests covering:
  - crypto backup metadata containing `last_processed_event_id`
  - restore persisting the event ID back into storage
  - metadata parsing/restore coverage for the new required field

### Dependencies (Optional)

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Manual scenario:
1. In a Wire Cells enabled conversation, have User X send an audio attachment from Device A.
2. Log in as the same user on Device B with nomad restore enabled.
3. Verify the restored multipart message still contains the audio attachment metadata.
4. Verify the attachment can still be fetched through the existing Cells asset retrieval/download flow.
5. Perform crypto state backup/restore for the same account.
6. Verify the restored session keeps the saved event position via `last_processed_event_id` and can continue sync without losing continuity.

### Notes (Optional)

No nomad protobuf extension was required for the multipart attachment fix.
The existing nomad asset payload already carries enough metadata for restored Cells attachments to remain identifiable and downloadable.
Dynamic Cells fields such as version-specific or refreshed URL/hash state still depend on the normal Cells refresh/download flow after restore.

For the crypto backup/restore fix, the metadata format now includes a required `last_processed_event_id`.
Backup creation guarantees that this field is always populated before serialization by using the stored value or falling back to the most recent remote event ID.
