### PR TITLE
feat: support web auth transport cookies and versionless access [WPB-23964]

### DIFF
--- a/data/network/src/appleMain/kotlin/com/wire/kalium/network/auth/WebAuth.apple.kt
+++ b/data/network/src/appleMain/kotlin/com/wire/kalium/network/auth/WebAuth.apple.kt
@@ -1,0 +1,15 @@
+package com.wire.kalium.network.auth
+
+import com.wire.kalium.network.api.model.RefreshTokenProperties
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
+
+internal actual fun HttpRequestBuilder.withBrowserCredentials() = Unit
+
+internal actual fun HttpRequestBuilder.withManagedRefreshCookie(refreshToken: String) {
+    header(HttpHeaders.Cookie, RefreshTokenProperties.COOKIE_NAME + "=" + refreshToken)
+}
+
+internal actual fun extractManagedRefreshToken(cookies: Map<String, String>): String? =
+    cookies[RefreshTokenProperties.COOKIE_NAME]

--- a/data/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/auth/WebAuth.commonJvmAndroid.kt
+++ b/data/network/src/commonJvmAndroid/kotlin/com/wire/kalium/network/auth/WebAuth.commonJvmAndroid.kt
@@ -1,0 +1,15 @@
+package com.wire.kalium.network.auth
+
+import com.wire.kalium.network.api.model.RefreshTokenProperties
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
+
+internal actual fun HttpRequestBuilder.withBrowserCredentials() = Unit
+
+internal actual fun HttpRequestBuilder.withManagedRefreshCookie(refreshToken: String) {
+    header(HttpHeaders.Cookie, RefreshTokenProperties.COOKIE_NAME + "=" + refreshToken)
+}
+
+internal actual fun extractManagedRefreshToken(cookies: Map<String, String>): String? =
+    cookies[RefreshTokenProperties.COOKIE_NAME]

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/AccessTokenApiV0.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/AccessTokenApiV0.kt
@@ -33,7 +33,7 @@ import io.ktor.client.request.post
 internal open class AccessTokenApiV0(private val httpClient: HttpClient) : AccessTokenApi {
     override suspend fun getToken(refreshToken: String, clientId: String?): NetworkResponse<Pair<AccessTokenDTO, RefreshTokenDTO?>> =
         wrapKaliumResponse<AccessTokenDTO> {
-            httpClient.post(PATH_ACCESS) {
+            httpClient.post("/$PATH_ACCESS") {
                 skipApiVersion()
                 withManagedRefreshCookie(refreshToken)
             }
@@ -54,6 +54,6 @@ internal open class AccessTokenApiV0(private val httpClient: HttpClient) : Acces
         }
 
     private companion object {
-        const val PATH_ACCESS = "/access"
+        const val PATH_ACCESS = "access"
     }
 }

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/AccessTokenApiV0.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/AccessTokenApiV0.kt
@@ -19,25 +19,26 @@
 package com.wire.kalium.network.api.v0.authenticated
 
 import com.wire.kalium.network.api.base.authenticated.AccessTokenApi
+import com.wire.kalium.network.auth.extractManagedRefreshToken
+import com.wire.kalium.network.auth.withManagedRefreshCookie
 import com.wire.kalium.network.api.model.AccessTokenDTO
 import com.wire.kalium.network.api.model.RefreshTokenDTO
-import com.wire.kalium.network.api.model.RefreshTokenProperties
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.flatMap
+import com.wire.kalium.network.utils.skipApiVersion
 import com.wire.kalium.network.utils.wrapKaliumResponse
 import io.ktor.client.HttpClient
-import io.ktor.client.request.header
 import io.ktor.client.request.post
-import io.ktor.http.HttpHeaders
 
 internal open class AccessTokenApiV0(private val httpClient: HttpClient) : AccessTokenApi {
     override suspend fun getToken(refreshToken: String, clientId: String?): NetworkResponse<Pair<AccessTokenDTO, RefreshTokenDTO?>> =
         wrapKaliumResponse<AccessTokenDTO> {
             httpClient.post(PATH_ACCESS) {
-                header(HttpHeaders.Cookie, "${RefreshTokenProperties.COOKIE_NAME}=$refreshToken")
+                skipApiVersion()
+                withManagedRefreshCookie(refreshToken)
             }
         }.flatMap { accessTokenResponse ->
-            accessTokenResponse.cookies[RefreshTokenProperties.COOKIE_NAME].let { newRefreshToken ->
+            extractManagedRefreshToken(accessTokenResponse.cookies).let { newRefreshToken ->
                 newRefreshToken?.let {
                     NetworkResponse.Success(
                         Pair(accessTokenResponse.value, RefreshTokenDTO(newRefreshToken)),
@@ -53,6 +54,6 @@ internal open class AccessTokenApiV0(private val httpClient: HttpClient) : Acces
         }
 
     private companion object {
-        const val PATH_ACCESS = "access"
+        const val PATH_ACCESS = "/access"
     }
 }

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/LogoutApiV0.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/LogoutApiV0.kt
@@ -22,15 +22,14 @@ import com.wire.kalium.network.AuthenticatedNetworkClient
 import com.wire.kalium.network.api.base.authenticated.logout.LogoutApi
 import com.wire.kalium.network.api.authenticated.logout.RemoveCookiesByIdsRequest
 import com.wire.kalium.network.api.authenticated.logout.RemoveCookiesByLabels
-import com.wire.kalium.network.api.model.RefreshTokenProperties
+import com.wire.kalium.network.auth.withBrowserCredentials
+import com.wire.kalium.network.auth.withManagedRefreshCookie
 import com.wire.kalium.network.session.SessionManager
 import com.wire.kalium.network.utils.CustomErrors.MISSING_REFRESH_TOKEN
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.wrapKaliumResponse
-import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
-import io.ktor.http.HttpHeaders
 
 internal open class LogoutApiV0 internal constructor(
     private val authenticatedNetworkClient: AuthenticatedNetworkClient,
@@ -42,7 +41,7 @@ internal open class LogoutApiV0 internal constructor(
     override suspend fun logout(): NetworkResponse<Unit> = sessionManager.session()?.refreshToken?.let { refreshToken ->
         wrapKaliumResponse {
             httpClient.post("$PATH_ACCESS/$PATH_LOGOUT") {
-                header(HttpHeaders.Cookie, "${RefreshTokenProperties.COOKIE_NAME}=$refreshToken")
+                withManagedRefreshCookie(refreshToken)
             }
         }
     } ?: MISSING_REFRESH_TOKEN
@@ -50,6 +49,7 @@ internal open class LogoutApiV0 internal constructor(
     override suspend fun removeCookiesByIds(removeCookiesByIdsRequest: RemoveCookiesByIdsRequest): NetworkResponse<Unit> =
         wrapKaliumResponse {
             httpClient.post("$PATH_COOKIES/$PATH_REMOVE") {
+                withBrowserCredentials()
                 setBody(removeCookiesByIdsRequest)
             }
         }
@@ -57,6 +57,7 @@ internal open class LogoutApiV0 internal constructor(
     override suspend fun removeCookiesByLabels(removeCookiesByLabelsRequest: RemoveCookiesByLabels): NetworkResponse<Unit> =
         wrapKaliumResponse {
             httpClient.post("$PATH_COOKIES/$PATH_REMOVE") {
+                withBrowserCredentials()
                 setBody(removeCookiesByLabelsRequest)
             }
         }

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/SelfApiV0.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/SelfApiV0.kt
@@ -23,9 +23,9 @@ import com.wire.kalium.network.api.base.authenticated.self.ChangeHandleRequest
 import com.wire.kalium.network.api.base.authenticated.self.SelfApi
 import com.wire.kalium.network.api.authenticated.self.UserUpdateRequest
 import com.wire.kalium.network.api.model.DeleteAccountRequest
-import com.wire.kalium.network.api.model.RefreshTokenProperties
 import com.wire.kalium.network.api.model.SelfUserDTO
 import com.wire.kalium.network.api.model.SupportedProtocolDTO
+import com.wire.kalium.network.auth.withManagedRefreshCookie
 import com.wire.kalium.network.api.model.UpdateEmailRequest
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.session.SessionManager
@@ -34,10 +34,8 @@ import com.wire.kalium.network.utils.flatMap
 import com.wire.kalium.network.utils.wrapKaliumResponse
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
-import io.ktor.client.request.header
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
-import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 
 internal open class SelfApiV0 internal constructor(
@@ -67,7 +65,7 @@ internal open class SelfApiV0 internal constructor(
         sessionManager.session()?.refreshToken?.let { cookie ->
             wrapKaliumResponse<Unit> {
                 httpClient.put("$PATH_ACCESS/$PATH_SELF/$PATH_EMAIL") {
-                    header(HttpHeaders.Cookie, "${RefreshTokenProperties.COOKIE_NAME}=$cookie")
+                    withManagedRefreshCookie(cookie)
                     setBody(UpdateEmailRequest(email))
                 }
             }.flatMap { successResponse ->

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/LoginApiV0.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/LoginApiV0.kt
@@ -26,6 +26,8 @@ import com.wire.kalium.network.api.model.SelfUserDTO
 import com.wire.kalium.network.api.model.SessionDTO
 import com.wire.kalium.network.api.model.toSessionDto
 import com.wire.kalium.network.api.unauthenticated.login.LoginParam
+import com.wire.kalium.network.auth.extractManagedRefreshToken
+import com.wire.kalium.network.auth.withBrowserCredentials
 import com.wire.kalium.network.utils.CustomErrors
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.flatMap
@@ -76,12 +78,13 @@ internal open class LoginApiV0 internal constructor(
         persist: Boolean
     ): NetworkResponse<Pair<SessionDTO, SelfUserDTO>> = wrapKaliumResponse<AccessTokenDTO> {
         httpClient.post(PATH_LOGIN) {
+            withBrowserCredentials()
             parameter(QUERY_PERSIST, persist)
             setBody(param.toRequestBody())
         }
     }.flatMap { accessTokenDTOResponse ->
         with(accessTokenDTOResponse) {
-            cookies[RefreshTokenProperties.COOKIE_NAME]?.let { refreshToken ->
+            extractManagedRefreshToken(cookies)?.let { refreshToken ->
                 NetworkResponse.Success(refreshToken, headers, httpCode)
             } ?: CustomErrors.MISSING_REFRESH_TOKEN
         }.mapSuccess { Pair(accessTokenDTOResponse.value, it) }

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/LoginApiV0.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/LoginApiV0.kt
@@ -21,7 +21,6 @@ package com.wire.kalium.network.api.v0.unauthenticated
 import com.wire.kalium.network.UnauthenticatedNetworkClient
 import com.wire.kalium.network.api.base.unauthenticated.login.LoginApi
 import com.wire.kalium.network.api.model.AccessTokenDTO
-import com.wire.kalium.network.api.model.RefreshTokenProperties
 import com.wire.kalium.network.api.model.SelfUserDTO
 import com.wire.kalium.network.api.model.SessionDTO
 import com.wire.kalium.network.api.model.toSessionDto

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/RegisterApiV0.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/RegisterApiV0.kt
@@ -20,22 +20,22 @@ package com.wire.kalium.network.api.v0.unauthenticated
 
 import com.wire.kalium.network.UnauthenticatedNetworkClient
 import com.wire.kalium.network.api.model.AccessTokenDTO
-import com.wire.kalium.network.api.model.RefreshTokenProperties
 import com.wire.kalium.network.api.model.SelfUserDTO
 import com.wire.kalium.network.api.model.SessionDTO
 import com.wire.kalium.network.api.unauthenticated.register.ActivationParam
 import com.wire.kalium.network.api.base.unauthenticated.register.RegisterApi
 import com.wire.kalium.network.api.unauthenticated.register.RegisterParam
 import com.wire.kalium.network.api.unauthenticated.register.RequestActivationCodeParam
+import com.wire.kalium.network.auth.extractManagedRefreshToken
+import com.wire.kalium.network.auth.withBrowserCredentials
+import com.wire.kalium.network.auth.withManagedRefreshCookie
 import com.wire.kalium.network.utils.CustomErrors
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.flatMap
 import com.wire.kalium.network.utils.mapSuccess
 import com.wire.kalium.network.utils.wrapKaliumResponse
-import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
-import io.ktor.http.HttpHeaders
 
 internal open class RegisterApiV0 internal constructor(
     private val unauthenticatedNetworkClient: UnauthenticatedNetworkClient
@@ -45,7 +45,7 @@ internal open class RegisterApiV0 internal constructor(
 
     private suspend fun getToken(refreshToken: String): NetworkResponse<AccessTokenDTO> = wrapKaliumResponse {
         httpClient.post(PATH_ACCESS) {
-            header(HttpHeaders.Cookie, "${RefreshTokenProperties.COOKIE_NAME}=$refreshToken")
+            withManagedRefreshCookie(refreshToken)
         }
     }
 
@@ -53,10 +53,11 @@ internal open class RegisterApiV0 internal constructor(
         param: RegisterParam
     ): NetworkResponse<Pair<SelfUserDTO, SessionDTO>> = wrapKaliumResponse<SelfUserDTO> {
         httpClient.post(REGISTER_PATH) {
+            withBrowserCredentials()
             setBody(param.toBody())
         }
     }.flatMap { registerResponse ->
-        registerResponse.cookies[RefreshTokenProperties.COOKIE_NAME]?.let { refreshToken ->
+        extractManagedRefreshToken(registerResponse.cookies)?.let { refreshToken ->
             getToken(refreshToken).mapSuccess { accessTokenDTO ->
                 Pair(
                     registerResponse.value,

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/SSOLoginApiV0.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/SSOLoginApiV0.kt
@@ -26,6 +26,7 @@ import com.wire.kalium.network.api.model.SelfUserDTO
 import com.wire.kalium.network.api.model.toSessionDto
 import com.wire.kalium.network.api.unauthenticated.sso.InitiateParam
 import com.wire.kalium.network.api.base.unauthenticated.sso.SSOLoginApi
+import com.wire.kalium.network.auth.withManagedRefreshCookie
 import com.wire.kalium.network.api.unauthenticated.sso.SSOSettingsResponse
 import com.wire.kalium.network.exceptions.APINotSupported
 import com.wire.kalium.network.utils.CustomErrors.MISSING_REFRESH_TOKEN
@@ -39,11 +40,9 @@ import io.ktor.client.request.accept
 import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.get
 import io.ktor.client.request.head
-import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.client.request.post
 import io.ktor.http.ContentType
-import io.ktor.http.HttpHeaders
 import io.ktor.http.appendPathSegments
 import io.ktor.http.parseServerSetCookieHeader
 
@@ -78,14 +77,14 @@ internal open class SSOLoginApiV0 internal constructor(
 
     override suspend fun finalize(cookie: String): NetworkResponse<String> = wrapKaliumResponse {
         httpClient.post("$PATH_SSO/$PATH_FINALIZE") {
-            header(HttpHeaders.Cookie, "${RefreshTokenProperties.COOKIE_NAME}=$cookie")
+            withManagedRefreshCookie(cookie)
         }
     }
 
     override suspend fun provideLoginSession(cookie: String): NetworkResponse<AuthenticationResultDTO> =
         wrapKaliumResponse<AccessTokenDTO> {
             httpClient.post(PATH_ACCESS) {
-                header(HttpHeaders.Cookie, cookie)
+                withManagedRefreshCookie(cookie)
             }
         }.flatMap { accessTokenDTOResponse ->
             val refreshToken = cookie.splitSetCookieHeader().flatMap { it.splitSetCookieHeader() }

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/authenticated/AccessTokenApiV3.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/authenticated/AccessTokenApiV3.kt
@@ -20,16 +20,16 @@ package com.wire.kalium.network.api.v3.authenticated
 
 import com.wire.kalium.network.api.model.AccessTokenDTO
 import com.wire.kalium.network.api.model.RefreshTokenDTO
-import com.wire.kalium.network.api.model.RefreshTokenProperties
+import com.wire.kalium.network.auth.extractManagedRefreshToken
+import com.wire.kalium.network.auth.withManagedRefreshCookie
 import com.wire.kalium.network.api.v2.authenticated.AccessTokenApiV2
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.flatMap
+import com.wire.kalium.network.utils.skipApiVersion
 import com.wire.kalium.network.utils.wrapKaliumResponse
 import io.ktor.client.HttpClient
-import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.client.request.post
-import io.ktor.http.HttpHeaders
 
 internal open class AccessTokenApiV3 internal constructor(
     private val httpClient: HttpClient
@@ -37,11 +37,12 @@ internal open class AccessTokenApiV3 internal constructor(
     override suspend fun getToken(refreshToken: String, clientId: String?): NetworkResponse<Pair<AccessTokenDTO, RefreshTokenDTO?>> =
         wrapKaliumResponse<AccessTokenDTO> {
             httpClient.post(PATH_ACCESS) {
-                header(HttpHeaders.Cookie, "${RefreshTokenProperties.COOKIE_NAME}=$refreshToken")
+                skipApiVersion()
+                withManagedRefreshCookie(refreshToken)
                 parameter(CLIENT_ID_QUERY_KEY, clientId)
             }
         }.flatMap { accessTokenResponse ->
-            accessTokenResponse.cookies[RefreshTokenProperties.COOKIE_NAME].let { newRefreshToken ->
+            extractManagedRefreshToken(accessTokenResponse.cookies).let { newRefreshToken ->
                 newRefreshToken?.let {
                     NetworkResponse.Success(
                         Pair(accessTokenResponse.value, RefreshTokenDTO(newRefreshToken)),
@@ -57,7 +58,7 @@ internal open class AccessTokenApiV3 internal constructor(
         }
 
     private companion object {
-        const val PATH_ACCESS = "access"
+        const val PATH_ACCESS = "/access"
         const val CLIENT_ID_QUERY_KEY = "client_id"
     }
 }

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/authenticated/AccessTokenApiV3.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v3/authenticated/AccessTokenApiV3.kt
@@ -36,7 +36,7 @@ internal open class AccessTokenApiV3 internal constructor(
 ) : AccessTokenApiV2(httpClient) {
     override suspend fun getToken(refreshToken: String, clientId: String?): NetworkResponse<Pair<AccessTokenDTO, RefreshTokenDTO?>> =
         wrapKaliumResponse<AccessTokenDTO> {
-            httpClient.post(PATH_ACCESS) {
+            httpClient.post("/$PATH_ACCESS") {
                 skipApiVersion()
                 withManagedRefreshCookie(refreshToken)
                 parameter(CLIENT_ID_QUERY_KEY, clientId)
@@ -58,7 +58,7 @@ internal open class AccessTokenApiV3 internal constructor(
         }
 
     private companion object {
-        const val PATH_ACCESS = "/access"
+        const val PATH_ACCESS = "access"
         const val CLIENT_ID_QUERY_KEY = "client_id"
     }
 }

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v9/authenticated/NotificationApiV9.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v9/authenticated/NotificationApiV9.kt
@@ -35,6 +35,7 @@ import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.deleteSensitiveItemsFromJson
 import com.wire.kalium.network.utils.mapSuccess
 import com.wire.kalium.network.utils.setWSSUrl
+import com.wire.kalium.network.auth.withBrowserCredentials
 import com.wire.kalium.network.utils.wrapKaliumResponse
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
@@ -106,7 +107,9 @@ internal open class NotificationApiV9 internal constructor(
         }
 
     private suspend fun cookies(): NetworkResponse<Unit> = wrapKaliumResponse {
-        authenticatedNetworkClient.httpClient.get("/cookies")
+        authenticatedNetworkClient.httpClient.get("/cookies") {
+            withBrowserCredentials()
+        }
     }
 
     private suspend fun FlowCollector<WebSocketEvent<ConsumableNotificationResponse>>.emitWebSocketEvents(

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/auth/WebAuth.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/auth/WebAuth.kt
@@ -1,0 +1,9 @@
+package com.wire.kalium.network.auth
+
+import io.ktor.client.request.HttpRequestBuilder
+
+internal expect fun HttpRequestBuilder.withBrowserCredentials()
+
+internal expect fun HttpRequestBuilder.withManagedRefreshCookie(refreshToken: String)
+
+internal expect fun extractManagedRefreshToken(cookies: Map<String, String>): String?

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/utils/WireDefaultRequest.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/utils/WireDefaultRequest.kt
@@ -22,27 +22,38 @@ import com.wire.kalium.network.api.unbound.configuration.ServerConfigDTO
 import com.wire.kalium.network.shouldAddApiVersion
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.header
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.URLProtocol
 import io.ktor.http.Url
 import io.ktor.http.encodedPath
+import io.ktor.util.AttributeKey
 
 fun HttpClientConfig<*>.installWireDefaultRequest(serverConfigDTO: ServerConfigDTO) {
     defaultRequest {
         header(HttpHeaders.ContentType, ContentType.Application.Json)
         with(serverConfigDTO) {
             val apiBaseUrl = Url(links.api)
+            val requestPath = url.encodedPath.trim('/')
+            val shouldSkipVersion =
+                attributes.contains(SkipApiVersionKey) || requestPath == "access" || requestPath.startsWith("access/")
             // enforce https as url protocol
             url.protocol = URLProtocol.HTTPS
             // add the default host
             url.host = apiBaseUrl.host
             // for api version 0 no api version should be added to the request
             url.encodedPath =
-                if (shouldAddApiVersion(metaData.commonApiVersion.version))
+                if (!shouldSkipVersion && shouldAddApiVersion(metaData.commonApiVersion.version))
                     apiBaseUrl.encodedPath + "v${metaData.commonApiVersion.version}/"
                 else apiBaseUrl.encodedPath
         }
     }
+}
+
+private val SkipApiVersionKey = AttributeKey<Unit>("SkipApiVersionKey")
+
+fun HttpRequestBuilder.skipApiVersion() {
+    attributes.put(SkipApiVersionKey, Unit)
 }

--- a/data/network/src/jsMain/kotlin/com/wire/kalium/network/auth/WebAuth.js.kt
+++ b/data/network/src/jsMain/kotlin/com/wire/kalium/network/auth/WebAuth.js.kt
@@ -1,0 +1,26 @@
+package com.wire.kalium.network.auth
+
+import com.wire.kalium.network.api.model.RefreshTokenProperties
+import io.ktor.client.fetchOptions
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
+
+private const val BROWSER_MANAGED_REFRESH_TOKEN = "__browser_managed_refresh_cookie__"
+
+internal actual fun HttpRequestBuilder.withBrowserCredentials() {
+    fetchOptions {
+        credentials = "include"
+        mode = "cors"
+    }
+}
+
+internal actual fun HttpRequestBuilder.withManagedRefreshCookie(refreshToken: String) {
+    withBrowserCredentials()
+    if (refreshToken != BROWSER_MANAGED_REFRESH_TOKEN) {
+        header(HttpHeaders.Cookie, "${RefreshTokenProperties.COOKIE_NAME}=$refreshToken")
+    }
+}
+
+internal actual fun extractManagedRefreshToken(cookies: Map<String, String>): String? =
+    cookies.values.firstOrNull() ?: BROWSER_MANAGED_REFRESH_TOKEN


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-23964
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- Web auth transport was not fully aligned with browser cookie handling.
- The access-token refresh flow was going through the default API versioning path, even though the correct browser contract is the versionless `/access` endpoint.

### Causes (Optional)

- Kalium applies `/v{commonApiVersion}/` automatically to most REST requests.
- That is correct for regular API endpoints, but not for the browser refresh/access-token flow.
- Cookie handling also differs between browser and native clients, so the existing inline refresh-cookie logic was too rigid for web.

### Solutions

- Added a small platform-specific auth helper layer for browser credentials and refresh-cookie handling.
- Introduced a JS implementation for browser-managed cookie behavior, while keeping native platforms aligned with the previous manual cookie flow.
- Added an explicit way to skip API version prefixing for special-case endpoints.
- Updated the access-token refresh flow to use the correct versionless `/access` path.
- Switched the affected auth-related requests to the new helpers for more consistent web-compatible behavior.