### PR TITLE
fix(apple): reorder CoreLogic property initializers to prevent EXC_BAD_ACCESS on iOS [WPB-8645]

### DIFF
--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
@@ -96,12 +96,11 @@ public actual class CoreLogic(
         userSessionScopeProvider.value.delete(userId)
     }
 
+    actual override val workSchedulerProvider: WorkSchedulerProvider = WorkSchedulerProviderImpl()
+    public actual override val audioNormalizedLoudnessBuilder: AudioNormalizedLoudnessBuilder = AudioNormalizedLoudnessBuilderImpl()
     actual override val globalCallManager: GlobalCallManager by lazy {
         GlobalCallManager(getGlobalScope(), networkStateObserver)
     }
-    actual override val workSchedulerProvider: WorkSchedulerProvider = WorkSchedulerProviderImpl()
-    public actual override val audioNormalizedLoudnessBuilder: AudioNormalizedLoudnessBuilder = AudioNormalizedLoudnessBuilderImpl()
-
 }
 
 @Suppress("MayBeConst")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8645
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

adaptation form https://github.com/wireapp/kalium/pull/3934

### Issues
Move `workSchedulerProvider` and `audioNormalizedLoudnessBuilder` before
`globalCallManager` to fix a crash on iOS startup.

Root cause:
Kotlin property initializers run strictly in declaration order. The previous
order was:

    globalCallManager    = GlobalCallManager(getGlobalScope(), ...)  // line 100
    workSchedulerProvider = WorkSchedulerProviderImpl()               // line 101

`GlobalCallManager(getGlobalScope(), ...)` triggers the lazy initialization
of `globalKaliumScope` in the parent class `CoreLogicCommon`. That lazy
block constructs `GlobalKaliumScope(...)`, which in its own initializer
immediately (non-lazily) calls:

    workSchedulerProvider.globalWorkScheduler(this)

At this point, `workSchedulerProvider`'s initializer on line 101 has not yet
run. In Kotlin/Native the backing field is therefore still zero-initialized
(null at the native memory level). Dispatching a method call on a null
pointer results in EXC_BAD_ACCESS (code=1, address=0x0).

Why this surprises people:
In Kotlin/JVM the same code would throw a NullPointerException at runtime,
making the bug obvious. In Kotlin/Native the call site is compiled to a
direct native function dispatch with no null check, so the crash manifests
as a hard memory fault rather than an exception -- and the stack trace points
into globalWorkScheduler, not to the uninitialized property, which obscures
the real cause.

The fix is a pure reorder: no logic changes, no new code.