### PR TITLE
fix: calling in a conversation with mixed protocol [WPB-24529]

### DIFF
--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -550,7 +550,7 @@ internal class CallManagerImpl internal constructor(
         conversationId: ConversationId,
         clients: String
     ) {
-        if (callRepository.getCallMetadata(conversationId)?.protocol is Conversation.ProtocolInfo.Proteus) {
+        if (callRepository.getCallMetadata(conversationId)?.protocol !is Conversation.ProtocolInfo.MLS) {
             withCalling {
                 wcall_set_clients_for_conv(
                     it,

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
@@ -27,12 +27,17 @@ import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.right
 import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.data.call.CallMetadata
 import com.wire.kalium.logic.data.call.CallRepository
+import com.wire.kalium.logic.data.call.CallStatus
 import com.wire.kalium.logic.data.call.VideoStateChecker
 import com.wire.kalium.logic.data.call.mapper.CallMapperImpl
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.ProtocolInfoMapperTest.Companion.CONVERSATION_MIXED_PROTOCOL_INFO
+import com.wire.kalium.logic.data.conversation.ProtocolInfoMapperTest.Companion.CONVERSATION_MLS_PROTOCOL_INFO
+import com.wire.kalium.logic.data.conversation.ProtocolInfoMapperTest.Companion.CONVERSATION_PROTEUS_PROTOCOL_INFO
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.id.FederatedIdMapper
@@ -46,6 +51,7 @@ import com.wire.kalium.logic.feature.call.usecase.CreateAndPersistRecentlyEndedC
 import com.wire.kalium.logic.feature.call.usecase.EpochInfoUpdater
 import com.wire.kalium.logic.feature.call.usecase.GetCallConversationTypeProvider
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
+import com.wire.kalium.logic.framework.TestCall
 import com.wire.kalium.logic.test_util.testKaliumDispatcher
 import com.wire.kalium.messaging.sending.MessageSender
 import com.wire.kalium.network.NetworkStateObserver
@@ -124,6 +130,34 @@ internal class CallManagerTest {
         }
     }
 
+    @Test
+    @Suppress("FunctionNaming") // native function has that name
+    fun givenCallManager_whenUpdatingConversationClients_then_wcall_set_clients_for_conv_IsCalledForProteusAndMixedProtocol() = runTest {
+        val callProteus = ConversationId(value = "proteus", domain = "domain")
+        val callMixed = ConversationId(value = "mixed", domain = "domain")
+        val callMLS = ConversationId(value = "mls", domain = "domain")
+        val (arrangement, callManager) = Arrangement(testDispatcher.testKaliumDispatcher())
+            .onParseToFederatedIdReturning(callProteus, callProteus.toString())
+            .onParseToFederatedIdReturning(callMixed, callMixed.toString())
+            .onParseToFederatedIdReturning(callMLS, callMLS.toString())
+            .withCallMetadataReturning(callProteus, CALL_METADATA.copy(protocol = CONVERSATION_PROTEUS_PROTOCOL_INFO))
+            .withCallMetadataReturning(callMixed, CALL_METADATA.copy(protocol = CONVERSATION_MIXED_PROTOCOL_INFO))
+            .withCallMetadataReturning(callMLS, CALL_METADATA.copy(protocol = CONVERSATION_MLS_PROTOCOL_INFO))
+            .arrange()
+
+        callManager.updateConversationClients(callProteus, "clients")
+        callManager.updateConversationClients(callMixed, "clients")
+        callManager.updateConversationClients(callMLS, "clients")
+
+        verify(VerifyMode.exactly(1)) { // called for proteus and mixed protocol
+            arrangement.calling.wcall_set_clients_for_conv(inst = any(), convId = callProteus.toString(), clientsJson = "clients")
+            arrangement.calling.wcall_set_clients_for_conv(inst = any(), convId = callMixed.toString(), clientsJson = "clients")
+        }
+        verify(VerifyMode.not) { // not called for MLS protocol
+            arrangement.calling.wcall_set_clients_for_conv(inst = any(), convId = callMLS.toString(), clientsJson = "clients")
+        }
+    }
+
     inner class Arrangement(private val kaliumTestDispatcher: KaliumDispatcher) {
         internal val calling = mock<Calling>(MockMode.autoUnit)
         internal val callRepository = mock<CallRepository>()
@@ -181,6 +215,10 @@ internal class CallManagerTest {
             everySuspend { callRepository.fetchServerTime() } returns "2022-03-30T16:36:00.000Z"
         }
 
+        fun withCallMetadataReturning(conversationId: ConversationId, callMetadata: CallMetadata?) = apply {
+            everySuspend { callRepository.getCallMetadata(conversationId) } returns callMetadata
+        }
+
         suspend fun arrange() = this to CallManagerImpl(
             calling = calling,
             callRepository = callRepository,
@@ -204,7 +242,15 @@ internal class CallManagerTest {
             createAndPersistRecentlyEndedCallMetadata = createAndPersistRecentlyEndedCallMetadata,
             selfUserId = selfUserId
         ).also {
+            onCurrentClientIdReturning(CLIENT_ID.right())
             onParseToFederatedIdReturning(selfUserId, selfUserId.toString())
+            onParseToFederatedIdReturning(USER_ID, USER_ID.toString())
+            onParseToFederatedIdReturning(CALL_CONV_ID, CALL_CONV_ID.toString())
+            onWcallCreateReturning(BASE_HANDLE)
+            onWcallRecvMsgReturning(0)
+            onObserveConversationMembersReturning(emptyList())
+            onGetCallConversationTypeReturning(ConversationTypeCalling.Conference)
+            withFetchServerTimeReturning()
         }
     }
 
@@ -224,6 +270,19 @@ internal class CallManagerTest {
             status = Message.Status.Sent,
             isSelfMessage = false,
             expirationData = null
+        )
+        private val CALL_METADATA = CallMetadata(
+            callerId = TestCall.CALLER_ID,
+            isMuted = false,
+            isCameraOn = false,
+            isCbrEnabled = false,
+            conversationName = null,
+            conversationType = Conversation.Type.OneOnOne,
+            callerName = null,
+            callerTeamName = null,
+            establishedTime = null,
+            callStatus = CallStatus.INCOMING,
+            protocol = Conversation.ProtocolInfo.Proteus
         )
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In a conversation with mixed protocol, the android user is not able to connect to the other users.

### Causes (Optional)

`wcall_set_clients_for_conv` was being called only when protocol is of type `Proteus`, so it wasn't being called for `Mixed` type, when proteus is used as well.

### Solutions

Change the conditions to call it also for `Mixed` protocol.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Join a call on a conversation with `Mixed` protocol.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
