### PR TITLE
test: migrate crypto tests to mokkery part1 [WPB-8645]

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/client/E2EIClientProviderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/client/E2EIClientProviderTest.kt
@@ -28,7 +28,7 @@ import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.test_util.testKaliumDispatcher
 import com.wire.kalium.logic.util.arrangement.provider.E2EIClientProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.E2EIClientProviderArrangementMokkeryImpl
+import com.wire.kalium.logic.util.arrangement.provider.E2EIClientProviderArrangementImpl
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.messaging.hooks.NoOpCryptoStateChangeHookNotifier
@@ -178,7 +178,7 @@ class E2EIClientProviderTest {
 
     private class Arrangement(
         private val testDispatcher: KaliumDispatcher
-    ) : E2EIClientProviderArrangement by E2EIClientProviderArrangementMokkeryImpl() {
+    ) : E2EIClientProviderArrangement by E2EIClientProviderArrangementImpl() {
         private lateinit var e2eiClientProvider: E2EIClientProvider
 
         suspend fun arrange(block: suspend Arrangement.() -> Unit): Pair<Arrangement, E2EIClientProvider> {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
@@ -57,7 +57,7 @@ import com.wire.kalium.logic.framework.TestTeam
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.test_util.testKaliumDispatcher
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMokkeryImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.authenticated.time.ServerTimeDTO
 import com.wire.kalium.network.api.base.authenticated.CallApi
@@ -1954,7 +1954,7 @@ class CallRepositoryTest {
 
     private class Arrangement(
         private val kaliumTestDispatcher: KaliumDispatcher
-    ) : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMokkeryImpl() {
+    ) : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
 
         val callApi = mock<CallApi>()
         val conversationRepository = mock<ConversationRepository>()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/connection/ConnectionRepositoryTest.kt
@@ -36,7 +36,7 @@ import com.wire.kalium.logic.data.conversation.PersistConversationsUseCase
 import com.wire.kalium.logic.util.arrangement.dao.MemberDAOArrangement
 import com.wire.kalium.logic.util.arrangement.dao.MemberDAOArrangementImpl
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.base.authenticated.connection.ConnectionApi
@@ -510,7 +510,7 @@ class ConnectionRepositoryTest {
 
     private class Arrangement :
         MemberDAOArrangement by MemberDAOArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val conversationDAO = mock(ConversationDAO::class)
         val conversationRepository = mock(ConversationRepository::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
@@ -48,7 +48,7 @@ import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldHandler
 import com.wire.kalium.logic.util.arrangement.dao.MemberDAOArrangement
 import com.wire.kalium.logic.util.arrangement.dao.MemberDAOArrangementImpl
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.logic.util.thenReturnSequentially
@@ -1841,7 +1841,7 @@ class ConversationGroupRepositoryTest {
 
     private class Arrangement :
         MemberDAOArrangement by MemberDAOArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         val conversationMessageTimerEventHandler = mock(ConversationMessageTimerEventHandler::class)
         val userRepository: UserRepository = mock(UserRepository::class)
         val conversationRepository: ConversationRepository = mock(ConversationRepository::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/FetchConversationIfUnknownUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/FetchConversationIfUnknownUseCaseTest.kt
@@ -21,7 +21,7 @@ import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangementImpl
 import io.mockative.any
@@ -71,7 +71,7 @@ class FetchConversationIfUnknownUseCaseTest {
     private class Arrangement(
         private val block: suspend Arrangement.() -> Unit
     ) : ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val fetchConversation = mock(FetchConversationUseCase::class)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/FetchConversationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/FetchConversationsUseCaseTest.kt
@@ -23,7 +23,7 @@ import com.wire.kalium.common.functional.isRight
 import com.wire.kalium.logic.data.id.NetworkQualifiedId
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangementImpl
 import com.wire.kalium.network.api.authenticated.conversation.ConversationResponse
@@ -187,7 +187,7 @@ class FetchConversationsUseCaseTest {
     private class Arrangement(
         private val block: suspend Arrangement.() -> Unit
     ) : ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
-    CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl(){
+    CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl(){
 
         val persistConversations = mock(PersistConversationsUseCase::class)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -86,17 +86,19 @@ import com.wire.kalium.persistence.dao.conversation.ConversationDAO
 import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 import com.wire.kalium.persistence.dao.conversation.E2EIConversationClientInfoEntity
 import com.wire.kalium.util.time.UNIX_FIRST_DATE
+import dev.mokkery.MockMode
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.matcher.eq
+import dev.mokkery.matcher.matches
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
 import io.ktor.util.encodeBase64
-import io.mockative.any
-import io.mockative.coEvery
-import io.mockative.coVerify
-import io.mockative.eq
-import io.mockative.every
-import io.mockative.matches
-import io.mockative.mock
-import io.mockative.once
-import io.mockative.times
-import io.mockative.twice
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.sync.Mutex
@@ -124,13 +126,13 @@ class MLSConversationRepositoryTest {
 
             mlsConversationRepository.decryptMessage(arrangement.mlsContext, Arrangement.COMMIT, Arrangement.GROUP_ID)
 
-            coVerify {
+            verifySuspend(VerifyMode.exactly(1)) {
                 arrangement.checkRevocationList.check(any(), any())
-            }.wasInvoked(once)
+            }
 
-            coVerify {
+            verifySuspend(VerifyMode.exactly(1)) {
                 arrangement.certificateRevocationListRepository.addOrUpdateCRL(any(), any())
-            }.wasInvoked(once)
+            }
         }
 
     @Test
@@ -151,13 +153,13 @@ class MLSConversationRepositoryTest {
         )
         result.shouldSucceed()
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.createConversation(Arrangement.RAW_GROUP_ID, Arrangement.CRYPTO_MLS_PUBLIC_KEY)
-        }.wasInvoked(once)
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.addMember(eq(Arrangement.RAW_GROUP_ID), any())
-        }.wasInvoked(once)
+        }
     }
 
     @Test
@@ -182,17 +184,17 @@ class MLSConversationRepositoryTest {
             assertEquals(usersMissingKeyPackages, it.failedUserIds)
         }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.createConversation(eq(Arrangement.RAW_GROUP_ID), eq(Arrangement.CRYPTO_MLS_PUBLIC_KEY))
-        }.wasInvoked(once)
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.not) {
             arrangement.mlsContext.addMember(eq(Arrangement.RAW_GROUP_ID), any())
-        }.wasNotInvoked()
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.wipeConversation(eq(Arrangement.RAW_GROUP_ID))
-        }.wasInvoked(once)
+        }
     }
 
     @Test
@@ -221,17 +223,20 @@ class MLSConversationRepositoryTest {
             assertEquals(usersWithKeyPackages, it.successfullyAddedUsers)
         }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.createConversation(eq(Arrangement.RAW_GROUP_ID), eq(Arrangement.CRYPTO_MLS_PUBLIC_KEY))
-        }.wasInvoked(once)
+        }
 
-        coVerify {
-            arrangement.mlsContext.addMember(eq(Arrangement.RAW_GROUP_ID), matches { it.size == usersWithKeyPackages.size })
-        }.wasInvoked(exactly = once)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.mlsContext.addMember(
+                eq(Arrangement.RAW_GROUP_ID),
+                matches { it.size == usersWithKeyPackages.size }
+            )
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.not) {
             arrangement.mlsContext.wipeConversation(eq(Arrangement.RAW_GROUP_ID))
-        }.wasNotInvoked()
+        }
     }
 
     @Test
@@ -253,23 +258,23 @@ class MLSConversationRepositoryTest {
             )
         result.shouldSucceed()
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.createConversation(
                 groupId = eq(Arrangement.RAW_GROUP_ID),
                 externalSenders = any()
             )
-        }.wasInvoked(once)
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.addMember(
                 groupId = eq(Arrangement.RAW_GROUP_ID),
                 membersKeyPackages = any()
             )
-        }.wasInvoked(once)
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.not) {
             arrangement.mlsPublicKeysRepository.getKeyForCipherSuite(any())
-        }.wasNotInvoked()
+        }
     }
 
     @Test
@@ -291,17 +296,17 @@ class MLSConversationRepositoryTest {
             )
         result.shouldSucceed()
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.createConversation(eq(Arrangement.RAW_GROUP_ID), any())
-        }.wasInvoked(once)
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.addMember(eq(Arrangement.RAW_GROUP_ID), any())
-        }.wasInvoked(once)
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsPublicKeysRepository.getKeyForCipherSuite(any())
-        }.wasInvoked(once)
+        }
     }
 
     @Test
@@ -324,9 +329,9 @@ class MLSConversationRepositoryTest {
             )
         result.shouldSucceed()
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.checkRevocationList.check(any(), any())
-        }.wasInvoked(once)
+        }
     }
 
     @Test
@@ -346,13 +351,13 @@ class MLSConversationRepositoryTest {
             CIPHER_SUITE
         )
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.checkRevocationList.check(any(), any())
-        }.wasInvoked(exactly = once)
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.certificateRevocationListRepository.addOrUpdateCRL(any(), any())
-        }.wasInvoked(exactly = once)
+        }
     }
 
     @Test
@@ -373,9 +378,9 @@ class MLSConversationRepositoryTest {
         )
         result.shouldSucceed()
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(2)) {
             arrangement.mlsContext.addMember(any(), any())
-        }.wasInvoked(twice)
+        }
     }
 
     @Test
@@ -396,13 +401,13 @@ class MLSConversationRepositoryTest {
         )
         result.shouldFail()
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.addMember(any(), any())
-        }.wasInvoked(once)
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.wipeConversation(Arrangement.RAW_GROUP_ID)
-        }.wasInvoked(once)
+        }
     }
 
     @Test
@@ -423,14 +428,14 @@ class MLSConversationRepositoryTest {
         )
         result.shouldSucceed()
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.keyPackageRepository.claimKeyPackages(
                 matches {
                     it.containsAll(listOf(TestConversation.USER_1))
                 },
                 eq(CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519)
             )
-        }.wasInvoked(once)
+        }
     }
 
     @Test
@@ -447,9 +452,9 @@ class MLSConversationRepositoryTest {
             mlsConversationRepository.establishMLSGroup(arrangement.mlsContext, Arrangement.GROUP_ID, emptyList(), publicKeys = null)
         result.shouldSucceed()
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.updateKeyingMaterial(Arrangement.RAW_GROUP_ID)
-        }.wasInvoked(once)
+        }
     }
 
     @Test
@@ -468,9 +473,9 @@ class MLSConversationRepositoryTest {
         )
         result.shouldSucceed()
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.addMember(eq(Arrangement.RAW_GROUP_ID), any())
-        }.wasInvoked(once)
+        }
     }
 
     @Test
@@ -489,9 +494,9 @@ class MLSConversationRepositoryTest {
         )
         result.shouldSucceed()
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.commitPendingProposals(eq(Arrangement.RAW_GROUP_ID))
-        }.wasInvoked(once)
+        }
     }
 
     @Test
@@ -510,9 +515,9 @@ class MLSConversationRepositoryTest {
         )
         result.shouldSucceed()
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(2)) {
             arrangement.mlsContext.addMember(any(), any())
-        }.wasInvoked(twice)
+        }
     }
 
     @Test
@@ -540,13 +545,13 @@ class MLSConversationRepositoryTest {
         )
         result.shouldSucceed()
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(3)) {
             arrangement.mlsContext.addMember(any(), any())
             // 3 times:
             //      - The original attempt
             //      - The adding of missing users
             //      - The retry of the original attempt
-        }.wasInvoked(3.times)
+        }
     }
 
     @Test
@@ -575,9 +580,9 @@ class MLSConversationRepositoryTest {
         )
         result.shouldFail()
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(2)) {
             arrangement.mlsContext.addMember(any(), any())
-        }.wasInvoked(2.times)
+        }
     }
 
     @Test
@@ -626,26 +631,26 @@ class MLSConversationRepositoryTest {
 
         mlsConversationRepository.joinGroupByExternalCommit(arrangement.mlsContext, Arrangement.GROUP_ID, Arrangement.PUBLIC_GROUP_STATE)
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.joinByExternalCommit(any())
-        }.wasInvoked(once)
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.conversationDAO.updateMLSGroupIdAndState(
                 any(),
                 eq(Arrangement.RAW_GROUP_ID),
                 eq(2L),
                 eq(ConversationEntity.GroupState.ESTABLISHED),
             )
-        }.wasInvoked(once)
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.not) {
             arrangement.conversationDAO.updateConversationGroupState(any(), any())
-        }.wasNotInvoked()
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.not) {
             arrangement.checkRevocationList.check(any(), any())
-        }.wasNotInvoked()
+        }
     }
 
     @Test
@@ -654,20 +659,20 @@ class MLSConversationRepositoryTest {
             .withJoinByExternalCommitSuccessful()
             .withGetGroupEpochReturn(2UL)
             .arrange()
-        coEvery { arrangement.conversationDAO.getConversationByGroupID(any()) }.returns(null)
+        everySuspend { arrangement.conversationDAO.getConversationByGroupID(any()) } returns null
 
         mlsConversationRepository.joinGroupByExternalCommit(arrangement.mlsContext, Arrangement.GROUP_ID, Arrangement.PUBLIC_GROUP_STATE)
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.conversationDAO.updateConversationGroupState(
                 eq(ConversationEntity.GroupState.ESTABLISHED),
                 eq(Arrangement.RAW_GROUP_ID)
             )
-        }.wasInvoked(once)
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.not) {
             arrangement.conversationDAO.updateMLSGroupIdAndState(any(), any(), any(), any())
-        }.wasNotInvoked()
+        }
     }
 
     @Test
@@ -680,13 +685,13 @@ class MLSConversationRepositoryTest {
 
         mlsConversationRepository.joinGroupByExternalCommit(arrangement.mlsContext, Arrangement.GROUP_ID, Arrangement.PUBLIC_GROUP_STATE)
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.checkRevocationList.check(any(), any())
-        }.wasInvoked(exactly = once)
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.certificateRevocationListRepository.addOrUpdateCRL(any(), any())
-        }.wasInvoked(exactly = once)
+        }
     }
 
     @Test
@@ -713,9 +718,9 @@ class MLSConversationRepositoryTest {
         val result = mlsConversationRepository.commitPendingProposals(arrangement.mlsContext, Arrangement.GROUP_ID)
         result.shouldSucceed()
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.commitPendingProposals(eq(Arrangement.RAW_GROUP_ID))
-        }.wasInvoked(once)
+        }
     }
 
     @Test
@@ -728,9 +733,9 @@ class MLSConversationRepositoryTest {
         val result = mlsConversationRepository.commitPendingProposals(arrangement.mlsContext, Arrangement.GROUP_ID)
         result.shouldSucceed()
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.conversationDAO.clearProposalTimer(eq(Arrangement.RAW_GROUP_ID))
-        }.wasInvoked(once)
+        }
     }
 
     @Test
@@ -742,9 +747,9 @@ class MLSConversationRepositoryTest {
         val result = mlsConversationRepository.commitPendingProposals(arrangement.mlsContext, Arrangement.GROUP_ID)
         result.shouldFail()
 
-        coVerify {
+        verifySuspend(VerifyMode.not) {
             arrangement.conversationDAO.clearProposalTimer(Arrangement.GROUP_ID.value)
-        }.wasNotInvoked()
+        }
     }
 
     @Test
@@ -769,9 +774,9 @@ class MLSConversationRepositoryTest {
         val result = mlsConversationRepository.removeMembersFromMLSGroup(arrangement.mlsContext, Arrangement.GROUP_ID, users)
         result.shouldSucceed()
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.removeMember(eq(Arrangement.RAW_GROUP_ID), any())
-        }.wasInvoked(once)
+        }
     }
 
     @Test
@@ -786,9 +791,9 @@ class MLSConversationRepositoryTest {
         val result = mlsConversationRepository.removeMembersFromMLSGroup(arrangement.mlsContext, Arrangement.GROUP_ID, users)
         result.shouldSucceed()
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.commitPendingProposals(eq(Arrangement.RAW_GROUP_ID))
-        }.wasInvoked(once)
+        }
     }
 
     @Test
@@ -829,9 +834,9 @@ class MLSConversationRepositoryTest {
         val result = mlsConversationRepository.removeMembersFromMLSGroup(arrangement.mlsContext, Arrangement.GROUP_ID, users)
         result.shouldSucceed()
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(2)) {
             arrangement.mlsContext.removeMember(any(), any())
-        }.wasInvoked(twice)
+        }
     }
 
     @Test
@@ -847,9 +852,9 @@ class MLSConversationRepositoryTest {
         val result = mlsConversationRepository.removeMembersFromMLSGroup(arrangement.mlsContext, Arrangement.GROUP_ID, users)
         result.shouldSucceed()
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(2)) {
             arrangement.mlsContext.removeMember(any(), any())
-        }.wasInvoked(twice)
+        }
     }
 
     @Test
@@ -871,9 +876,9 @@ class MLSConversationRepositoryTest {
         val result = mlsConversationRepository.removeClientsFromMLSGroup(arrangement.mlsContext, Arrangement.GROUP_ID, clients)
         result.shouldSucceed()
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.removeMember(eq(Arrangement.RAW_GROUP_ID), any())
-        }.wasInvoked(once)
+        }
     }
 
     @Test
@@ -890,9 +895,9 @@ class MLSConversationRepositoryTest {
         val result = mlsConversationRepository.removeClientsFromMLSGroup(arrangement.mlsContext, Arrangement.GROUP_ID, clients)
         result.shouldSucceed()
 
-        coVerify {
+        verifySuspend(VerifyMode.not) {
             arrangement.mlsContext.removeMember(eq(Arrangement.RAW_GROUP_ID), any())
-        }.wasNotInvoked()
+        }
     }
 
     @Test
@@ -914,9 +919,9 @@ class MLSConversationRepositoryTest {
         val result = mlsConversationRepository.removeClientsFromMLSGroup(arrangement.mlsContext, Arrangement.GROUP_ID, clients)
         result.shouldSucceed()
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.commitPendingProposals(eq(Arrangement.RAW_GROUP_ID))
-        }.wasInvoked(once)
+        }
     }
 
     @Test
@@ -965,9 +970,9 @@ class MLSConversationRepositoryTest {
         val result = mlsConversationRepository.removeClientsFromMLSGroup(arrangement.mlsContext, Arrangement.GROUP_ID, clients)
         result.shouldSucceed()
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(2)) {
             arrangement.mlsContext.removeMember(any(), any())
-        }.wasInvoked(twice)
+        }
     }
 
     @Test
@@ -979,9 +984,9 @@ class MLSConversationRepositoryTest {
         val result = mlsConversationRepository.updateKeyingMaterial(arrangement.mlsContext, Arrangement.GROUP_ID)
         result.shouldSucceed()
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.updateKeyingMaterial(any())
-        }.wasInvoked(once)
+        }
     }
 
     @Test
@@ -993,9 +998,9 @@ class MLSConversationRepositoryTest {
         val result = mlsConversationRepository.updateKeyingMaterial(arrangement.mlsContext, Arrangement.GROUP_ID)
         result.shouldSucceed()
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.conversationDAO.updateKeyingMaterial(eq(Arrangement.RAW_GROUP_ID), any<Instant>())
-        }.wasInvoked(once)
+        }
     }
 
     @Test
@@ -1031,9 +1036,9 @@ class MLSConversationRepositoryTest {
         val result = mlsConversationRepository.isLocalGroupEpochStale(arrangement.mlsContext, Arrangement.GROUP_ID, conversationEpoch)
         result.shouldSucceed()
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.conversationEpoch(any())
-        }.wasInvoked(once)
+        }
 
     }
 
@@ -1082,20 +1087,20 @@ class MLSConversationRepositoryTest {
             .arrange()
         val invocationOrder = mutableListOf<String>()
 
-        coEvery { arrangement.mlsContext.removeStaleKeyPackages() }
-            .invokes {
+        everySuspend { arrangement.mlsContext.removeStaleKeyPackages() }
+            .calls {
                 invocationOrder += "removeStaleKeyPackages"
                 Unit
             }
 
-        coEvery { arrangement.mlsContext.generateKeyPackages(any()) }
-            .invokes {
+        everySuspend { arrangement.mlsContext.generateKeyPackages(any()) }
+            .calls {
                 invocationOrder += "generateKeyPackages"
                 emptyList()
             }
 
-        coEvery { arrangement.keyPackageRepository.replaceKeyPackages(any(), any(), any()) }
-            .invokes {
+        everySuspend { arrangement.keyPackageRepository.replaceKeyPackages(any(), any(), any()) }
+            .calls {
                 invocationOrder += "replaceKeyPackages"
                 Either.Right(Unit)
             }
@@ -1111,21 +1116,21 @@ class MLSConversationRepositoryTest {
             )
         )
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.e2eiRotateGroups(any())
-        }.wasInvoked(once)
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.keyPackageRepository.replaceKeyPackages(any(), any(), any())
-        }.wasInvoked(once)
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.not) {
             arrangement.checkRevocationList.check(any(), any())
-        }.wasNotInvoked()
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.removeStaleKeyPackages()
-        }.wasInvoked(once)
+        }
 
         assertEquals(
             listOf("removeStaleKeyPackages", "generateKeyPackages", "replaceKeyPackages"),
@@ -1156,13 +1161,13 @@ class MLSConversationRepositoryTest {
 
         result.shouldSucceed()
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.checkRevocationList.check(any(), any())
-        }.wasInvoked(exactly = once)
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.certificateRevocationListRepository.addOrUpdateCRL(any(), any())
-        }.wasInvoked(exactly = once)
+        }
     }
 
     @Test
@@ -1187,13 +1192,13 @@ class MLSConversationRepositoryTest {
             )
         )
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.e2eiRotateGroups(any())
-        }.wasInvoked(once)
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.keyPackageRepository.replaceKeyPackages(any(), any(), any())
-        }.wasInvoked(once)
+        }
     }
 
     @Test
@@ -1216,13 +1221,13 @@ class MLSConversationRepositoryTest {
         )
         result.shouldFail()
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.e2eiRotateGroups(any())
-        }.wasInvoked(once)
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.not) {
             arrangement.keyPackageRepository.replaceKeyPackages(any(), any(), any())
-        }.wasNotInvoked()
+        }
     }
 
     @Test
@@ -1234,13 +1239,13 @@ class MLSConversationRepositoryTest {
 
         assertEquals(Either.Right(WIRE_IDENTITY), mlsConversationRepository.getClientIdentity(arrangement.mlsContext, TestClient.CLIENT_ID))
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.getDeviceIdentities(any(), any())
-        }.wasInvoked(once)
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.conversationDAO.getE2EIConversationClientInfoByClientId(any())
-        }.wasInvoked(once)
+        }
     }
 
     @Test
@@ -1255,13 +1260,13 @@ class MLSConversationRepositoryTest {
             mlsConversationRepository.getClientIdentity(arrangement.mlsContext, TestClient.CLIENT_ID)
         )
 
-        coVerify {
+        verifySuspend(VerifyMode.not) {
             arrangement.mlsContext.getDeviceIdentities(any(), any())
-        }.wasNotInvoked()
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.conversationDAO.getE2EIConversationClientInfoByClientId(any())
-        }.wasInvoked(once)
+        }
     }
 
     @Test
@@ -1273,13 +1278,13 @@ class MLSConversationRepositoryTest {
 
         assertEquals(Either.Right(null), mlsConversationRepository.getClientIdentity(arrangement.mlsContext, TestClient.CLIENT_ID))
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.getDeviceIdentities(any(), any())
-        }.wasInvoked(once)
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.conversationDAO.getE2EIConversationClientInfoByClientId(any())
-        }.wasInvoked(once)
+        }
     }
 
     @Test
@@ -1300,17 +1305,17 @@ class MLSConversationRepositoryTest {
             mlsConversationRepository.getUserIdentity(arrangement.mlsContext, TestUser.USER_ID)
         )
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.getUserIdentities(eq(groupId), any())
-        }.wasInvoked(once)
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.not) {
             arrangement.conversationDAO.getMLSGroupIdByUserId(any())
-        }.wasNotInvoked()
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.conversationDAO.getEstablishedSelfMLSGroupId()
-        }.wasInvoked(once)
+        }
     }
 
     @Test
@@ -1331,12 +1336,12 @@ class MLSConversationRepositoryTest {
             mlsConversationRepository.getUserIdentity(arrangement.mlsContext, TestUser.OTHER_USER_ID)
         )
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.getUserIdentities(eq(groupId), any())
-        }.wasInvoked(once)
-        coVerify {
+        }
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.conversationDAO.getMLSGroupIdByUserId(any())
-        }.wasInvoked(once)
+        }
     }
 
     @Test
@@ -1365,13 +1370,13 @@ class MLSConversationRepositoryTest {
             mlsConversationRepository.getMembersIdentities(arrangement.mlsClient, TestConversation.ID, listOf(member1, member2, member3))
         )
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.getUserIdentities(eq(groupId), any())
-        }.wasInvoked(once)
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.conversationDAO.getMLSGroupIdByConversationId(any())
-        }.wasInvoked(once)
+        }
     }
 
     @Test
@@ -1396,13 +1401,13 @@ class MLSConversationRepositoryTest {
             )
             result.shouldSucceed()
 
-            coVerify {
+            verifySuspend(VerifyMode.exactly(1)) {
                 arrangement.mlsContext.createConversation(eq(Arrangement.RAW_GROUP_ID), eq(Arrangement.EXTERNAL_SENDER_KEY.value))
-            }.wasInvoked(once)
+            }
 
-            coVerify {
+            verifySuspend(VerifyMode.exactly(1)) {
                 arrangement.mlsContext.updateKeyingMaterial(any())
-            }.wasInvoked(once)
+            }
         }
 
     @Test
@@ -1482,7 +1487,7 @@ class MLSConversationRepositoryTest {
 
         result.shouldSucceed()
 
-        coVerify { arrangement.mlsContext.updateKeyingMaterial(any()) }.wasInvoked(2) // Retry should occur
+        verifySuspend(VerifyMode.exactly(2)) { arrangement.mlsContext.updateKeyingMaterial(any()) } // Retry should occur
     }
 
     @Test
@@ -1501,7 +1506,7 @@ class MLSConversationRepositoryTest {
 
         result.shouldSucceed()
 
-        coVerify { arrangement.mlsContext.updateKeyingMaterial(any()) }.wasInvoked(2) // Retry should occur
+        verifySuspend(VerifyMode.exactly(2)) { arrangement.mlsContext.updateKeyingMaterial(any()) } // Retry should occur
     }
 
     @Test
@@ -1522,20 +1527,20 @@ class MLSConversationRepositoryTest {
 
         result.shouldFail()
 
-        coVerify { arrangement.mlsContext.updateKeyingMaterial(any()) }.wasInvoked(1) // No retry should happen
+        verifySuspend(VerifyMode.exactly(1)) { arrangement.mlsContext.updateKeyingMaterial(any()) } // No retry should happen
     }
 
     private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
 
-        val keyPackageRepository = mock(KeyPackageRepository::class)
-        val mlsPublicKeysRepository = mock(MLSPublicKeysRepository::class)
-        val conversationDAO = mock(ConversationDAO::class)
-        val clientApi = mock(ClientApi::class)
-        val e2eiClient = mock(E2EIClient::class)
-        val keyPackageLimitsProvider = mock(KeyPackageLimitsProvider::class)
-        val checkRevocationList = mock(RevocationListChecker::class)
-        val certificateRevocationListRepository = mock(CertificateRevocationListRepository::class)
-        val epochChangesObserver = mock(EpochChangesObserver::class)
+        val keyPackageRepository: KeyPackageRepository = mock(mode = MockMode.autoUnit)
+        val mlsPublicKeysRepository: MLSPublicKeysRepository = mock(mode = MockMode.autoUnit)
+        val conversationDAO: ConversationDAO = mock(mode = MockMode.autoUnit)
+        val clientApi: ClientApi = mock(mode = MockMode.autoUnit)
+        val e2eiClient: E2EIClient = mock(mode = MockMode.autoUnit)
+        val keyPackageLimitsProvider: KeyPackageLimitsProvider = mock(mode = MockMode.autoUnit)
+        val checkRevocationList: RevocationListChecker = mock(mode = MockMode.autoUnit)
+        val certificateRevocationListRepository: CertificateRevocationListRepository = mock(mode = MockMode.autoUnit)
+        val epochChangesObserver: EpochChangesObserver = mock(mode = MockMode.autoUnit)
         val mlsClient = DummyMLSClient(mlsContext)
         val epochsFlow = MutableSharedFlow<GroupID>()
 
@@ -1554,71 +1559,69 @@ class MLSConversationRepositoryTest {
             mutex = Mutex()
         )
 
-        suspend fun withClearProposalTimerSuccessful() = apply {
-            coEvery { conversationDAO.clearProposalTimer(any()) }
-                .returns(Unit)
+        fun withClearProposalTimerSuccessful() = apply {
+            everySuspend { conversationDAO.clearProposalTimer(any()) } returns Unit
         }
 
-        suspend fun withGetConversationByGroupID(conversationEntity: ConversationEntity) = apply {
-            coEvery { conversationDAO.getConversationByGroupID(any()) }
-                .returns(conversationEntity)
+        fun withGetConversationByGroupID(conversationEntity: ConversationEntity) = apply {
+            everySuspend { conversationDAO.getConversationByGroupID(any()) } returns conversationEntity
         }
 
-        suspend fun withClaimKeyPackagesSuccessful(
+        fun withClaimKeyPackagesSuccessful(
             keyPackages: List<KeyPackageDTO> = listOf(KEY_PACKAGE),
             usersWithoutKeyPackages: Set<UserId> = setOf()
         ) = apply {
-            coEvery {
+            everySuspend {
                 keyPackageRepository.claimKeyPackages(any(), any())
-            }.returns(Either.Right(KeyPackageClaimResult(keyPackages, usersWithoutKeyPackages)))
+            } returns Either.Right(KeyPackageClaimResult(keyPackages, usersWithoutKeyPackages))
         }
 
         fun withKeyPackageLimits(refillAmount: Int) = apply {
             every {
                 keyPackageLimitsProvider.refillAmount()
-            }.returns(refillAmount)
+            } returns refillAmount
         }
 
-        suspend fun withReplaceKeyPackagesReturning(result: Either<CoreFailure, Unit>) = apply {
-            coEvery {
+        fun withReplaceKeyPackagesReturning(result: Either<CoreFailure, Unit>) = apply {
+            everySuspend {
                 keyPackageRepository.replaceKeyPackages(any(), any(), any())
-            }.returns(result)
+            } returns result
         }
 
-        suspend fun withGetPublicKeysSuccessful() = apply {
-            coEvery {
+        fun withGetPublicKeysSuccessful() = apply {
+            everySuspend {
                 mlsPublicKeysRepository.getKeys()
-            }.returns(Either.Right(MLS_PUBLIC_KEY))
+            } returns Either.Right(MLS_PUBLIC_KEY)
         }
 
-        suspend fun withKeyForCipherSuite() = apply {
-            coEvery {
+        fun withKeyForCipherSuite() = apply {
+            everySuspend {
                 mlsPublicKeysRepository.getKeyForCipherSuite(any())
-            }.returns(Either.Right(CRYPTO_MLS_PUBLIC_KEY))
+            } returns Either.Right(CRYPTO_MLS_PUBLIC_KEY)
         }
 
         fun withGetDefaultCipherSuiteSuccessful() = apply {
             every {
                 mlsContext.getDefaultCipherSuite()
-            }.returns(CIPHER_SUITE.toCrypto())
+            } returns CIPHER_SUITE.toCrypto()
         }
 
-        suspend fun withGetExternalSenderKeySuccessful() = apply {
-            coEvery {
+        fun withGetExternalSenderKeySuccessful() = apply {
+            everySuspend {
                 mlsContext.getExternalSenders(any())
-            }.returns(EXTERNAL_SENDER_KEY)
+            } returns EXTERNAL_SENDER_KEY
         }
 
-        suspend fun withRotateGroupsSuccessful() = apply {
-            coEvery {
+        fun withRotateGroupsSuccessful() = apply {
+            everySuspend {
                 mlsContext.e2eiRotateGroups(any())
-            }.returns(Unit)
+            } returns Unit
         }
 
-        suspend fun withRotateGroupsThrowing(exception: Exception, times: Int = Int.MAX_VALUE) = apply {
+        fun withRotateGroupsThrowing(exception: Exception, times: Int = Int.MAX_VALUE) = apply {
             var invocationCounter = 0
-            coEvery { mlsContext.e2eiRotateGroups(any()) }
-                .invokes { _ ->
+            everySuspend { mlsContext.e2eiRotateGroups(any()) }
+                .calls {
                     if (invocationCounter < times) {
                         invocationCounter++
                         throw exception
@@ -1628,55 +1631,55 @@ class MLSConversationRepositoryTest {
                 }
         }
 
-        suspend fun withSaveX509CredentialsSuccessful(distributionPoints: List<String>?) = apply {
-            coEvery {
+        fun withSaveX509CredentialsSuccessful(distributionPoints: List<String>?) = apply {
+            everySuspend {
                 mlsContext.saveX509Credential(any(), any())
-            }.returns(distributionPoints)
+            } returns distributionPoints
         }
 
         suspend fun removeStaleKeyPackages() = apply {
-            coEvery {
+            everySuspend {
                 mlsContext.removeStaleKeyPackages()
-            }.returns(Unit)
+            } returns Unit
         }
 
-        suspend fun withGenerateKeyPackageSuccessful(keyPackages: List<ByteArray>) = apply {
-            coEvery {
+        fun withGenerateKeyPackageSuccessful(keyPackages: List<ByteArray>) = apply {
+            everySuspend {
                 mlsContext.generateKeyPackages(any())
-            }.returns(keyPackages)
+            } returns keyPackages
         }
 
-        suspend fun withGetDeviceIdentitiesReturn(identities: List<WireIdentity>) = apply {
-            coEvery {
+        fun withGetDeviceIdentitiesReturn(identities: List<WireIdentity>) = apply {
+            everySuspend {
                 mlsContext.getDeviceIdentities(any(), any())
-            }.returns(identities)
+            } returns identities
         }
 
-        suspend fun withGetE2EIConversationClientInfoByClientIdReturns(e2eiInfo: E2EIConversationClientInfoEntity?) = apply {
-            coEvery {
+        fun withGetE2EIConversationClientInfoByClientIdReturns(e2eiInfo: E2EIConversationClientInfoEntity?) = apply {
+            everySuspend {
                 conversationDAO.getE2EIConversationClientInfoByClientId(any())
-            }.returns(e2eiInfo)
+            } returns e2eiInfo
         }
 
-        suspend fun withGetEstablishedSelfMLSGroupIdReturns(id: String?) = apply {
-            coEvery {
+        fun withGetEstablishedSelfMLSGroupIdReturns(id: String?) = apply {
+            everySuspend {
                 conversationDAO.getEstablishedSelfMLSGroupId()
-            }.returns(id)
+            } returns id
         }
 
-        suspend fun withAddMLSMemberSuccessful(crlNewDistributionPoints: List<String>? = null) = apply {
-            coEvery {
+        fun withAddMLSMemberSuccessful(crlNewDistributionPoints: List<String>? = null) = apply {
+            everySuspend {
                 mlsContext.addMember(any(), any())
-            }.returns(crlNewDistributionPoints)
+            } returns crlNewDistributionPoints
         }
 
-        suspend fun withAddMLSMemberThrowing(
+        fun withAddMLSMemberThrowing(
             exception: Exception, times: Int = Int.MAX_VALUE,
             crlNewDistributionPoints: List<String>? = null
         ) = apply {
             var invocationCounter = 0
-            coEvery { mlsContext.addMember(any(), any()) }
-                .invokes { _ ->
+            everySuspend { mlsContext.addMember(any(), any()) }
+                .calls {
                     if (invocationCounter < times) {
                         invocationCounter++
                         throw exception
@@ -1686,26 +1689,26 @@ class MLSConversationRepositoryTest {
                 }
         }
 
-        suspend fun withGetGroupEpochReturn(epoch: ULong) = apply {
-            coEvery {
+        fun withGetGroupEpochReturn(epoch: ULong) = apply {
+            everySuspend {
                 mlsContext.conversationEpoch(any())
-            }.returns(epoch)
+            } returns epoch
         }
 
 
-        suspend fun withJoinByExternalCommitSuccessful(welcomeBundle: WelcomeBundle = WELCOME_BUNDLE) = apply {
-            coEvery {
+        fun withJoinByExternalCommitSuccessful(welcomeBundle: WelcomeBundle = WELCOME_BUNDLE) = apply {
+            everySuspend {
                 mlsContext.joinByExternalCommit(any())
-            }.returns(welcomeBundle)
+            } returns welcomeBundle
         }
 
-        suspend fun withJoinByExternalCommitThrowing(
+        fun withJoinByExternalCommitThrowing(
             exception: Exception, times: Int = Int.MAX_VALUE,
             welcomeBundle: WelcomeBundle = WELCOME_BUNDLE,
         ) = apply {
             var invocationCounter = 0
-            coEvery { mlsContext.joinByExternalCommit(any()) }
-                .invokes { _ ->
+            everySuspend { mlsContext.joinByExternalCommit(any()) }
+                .calls {
                     if (invocationCounter < times) {
                         invocationCounter++
                         throw exception
@@ -1715,16 +1718,16 @@ class MLSConversationRepositoryTest {
                 }
         }
 
-        suspend fun withCommitPendingProposalsSuccessful() = apply {
-            coEvery {
+        fun withCommitPendingProposalsSuccessful() = apply {
+            everySuspend {
                 mlsContext.commitPendingProposals(any())
-            }.returns(Unit)
+            } returns Unit
         }
 
-        suspend fun withCommitPendingProposalsThrowing(exception: Exception, times: Int = Int.MAX_VALUE) = apply {
+        fun withCommitPendingProposalsThrowing(exception: Exception, times: Int = Int.MAX_VALUE) = apply {
             var invocationCounter = 0
-            coEvery { mlsContext.commitPendingProposals(any()) }
-                .invokes { _ ->
+            everySuspend { mlsContext.commitPendingProposals(any()) }
+                .calls {
                     if (invocationCounter < times) {
                         invocationCounter++
                         throw exception
@@ -1734,24 +1737,24 @@ class MLSConversationRepositoryTest {
                 }
         }
 
-        suspend fun withCommitPendingProposalsReturningNothing(times: Int = Int.MAX_VALUE) = apply {
+        fun withCommitPendingProposalsReturningNothing(times: Int = Int.MAX_VALUE) = apply {
             withCommitPendingProposalsSuccessful()
             var invocationCounter = 0
-            coEvery {
+            everySuspend {
                 mlsContext.commitPendingProposals(matches { invocationCounter += 1; invocationCounter <= times })
-            }.returns(Unit)
+            } returns Unit
         }
 
-        suspend fun withUpdateKeyingMaterialSuccessful() = apply {
-            coEvery {
+        fun withUpdateKeyingMaterialSuccessful() = apply {
+            everySuspend {
                 mlsContext.updateKeyingMaterial(any())
-            }.returns(Unit)
+            } returns Unit
         }
 
-        suspend fun withUpdateKeyingMaterialThrowing(exception: Exception, times: Int = Int.MAX_VALUE) = apply {
+        fun withUpdateKeyingMaterialThrowing(exception: Exception, times: Int = Int.MAX_VALUE) = apply {
             var invocationCounter = 0
-            coEvery { mlsContext.updateKeyingMaterial(any()) }
-                .invokes { _ ->
+            everySuspend { mlsContext.updateKeyingMaterial(any()) }
+                .calls {
                     if (invocationCounter < times) {
                         invocationCounter++
                         throw exception
@@ -1761,34 +1764,34 @@ class MLSConversationRepositoryTest {
                 }
         }
 
-        suspend fun withCheckRevocationListResult() = apply {
-            coEvery {
+        fun withCheckRevocationListResult() = apply {
+            everySuspend {
                 checkRevocationList.check(any(), any())
-            }.returns(Either.Right(1uL))
+            } returns Either.Right(1uL)
         }
 
-        suspend fun withRemoveStaleKeyPackages() = apply {
-            coEvery {
+        fun withRemoveStaleKeyPackages() = apply {
+            everySuspend {
                 mlsContext.removeStaleKeyPackages()
-            }.returns(Unit)
+            } returns Unit
         }
 
-        suspend fun withDecryptMLSMessageSuccessful(decryptedMessage: com.wire.kalium.cryptography.DecryptedMessageBundle) = apply {
-            coEvery {
+        fun withDecryptMLSMessageSuccessful(decryptedMessage: com.wire.kalium.cryptography.DecryptedMessageBundle) = apply {
+            everySuspend {
                 mlsContext.decryptMessage(any(), any())
-            }.returns(listOf(decryptedMessage))
+            } returns listOf(decryptedMessage)
         }
 
-        suspend fun withRemoveMemberSuccessful() = apply {
-            coEvery {
+        fun withRemoveMemberSuccessful() = apply {
+            everySuspend {
                 mlsContext.removeMember(any(), any())
-            }.returns(Unit)
+            } returns Unit
         }
 
-        suspend fun withRemoveMemberThrowing(exception: Exception, times: Int = Int.MAX_VALUE) = apply {
+        fun withRemoveMemberThrowing(exception: Exception, times: Int = Int.MAX_VALUE) = apply {
             var invocationCounter = 0
-            coEvery { mlsContext.removeMember(any(), any()) }
-                .invokes { _ ->
+            everySuspend { mlsContext.removeMember(any(), any()) }
+                .calls {
                     if (invocationCounter < times) {
                         invocationCounter++
                         throw exception
@@ -1798,53 +1801,53 @@ class MLSConversationRepositoryTest {
                 }
         }
 
-        suspend fun withFetchClientsOfUsersSuccessful() = apply {
-            coEvery {
+        fun withFetchClientsOfUsersSuccessful() = apply {
+            everySuspend {
                 clientApi.listClientsOfUsers(any())
-            }.returns(NetworkResponse.Success(value = CLIENTS_OF_USERS_RESPONSE, headers = mapOf(), httpCode = 200))
+            } returns NetworkResponse.Success(value = CLIENTS_OF_USERS_RESPONSE, headers = mapOf(), httpCode = 200)
         }
 
 
-        suspend fun withGetMLSGroupIdByUserIdReturns(result: String?) = apply {
-            coEvery {
+        fun withGetMLSGroupIdByUserIdReturns(result: String?) = apply {
+            everySuspend {
                 conversationDAO.getMLSGroupIdByUserId(any())
-            }.returns(result)
+            } returns result
         }
 
-        suspend fun withGetMLSGroupIdByConversationIdReturns(result: String?) = apply {
-            coEvery {
+        fun withGetMLSGroupIdByConversationIdReturns(result: String?) = apply {
+            everySuspend {
                 conversationDAO.getMLSGroupIdByConversationId(any())
-            }.returns(result)
+            } returns result
         }
 
-        suspend fun withGetUserIdentitiesReturn(identitiesMap: Map<String, List<WireIdentity>>) = apply {
-            coEvery {
+        fun withGetUserIdentitiesReturn(identitiesMap: Map<String, List<WireIdentity>>) = apply {
+            everySuspend {
                 mlsContext.getUserIdentities(any(), any())
-            }.returns(identitiesMap)
+            } returns identitiesMap
         }
 
         fun withGetDefaultCipherSuite(cipherSuite: CipherSuite) = apply {
             every {
                 mlsContext.getDefaultCipherSuite()
-            }.returns(cipherSuite.toCrypto())
+            } returns cipherSuite.toCrypto()
         }
 
-        suspend fun withMembers(members: List<CryptoQualifiedClientId>) = apply {
-            coEvery {
+        fun withMembers(members: List<CryptoQualifiedClientId>) = apply {
+            everySuspend {
                 mlsContext.members(any())
-            }.returns(members)
+            } returns members
         }
 
-        suspend fun withUpdateMLSGroupIdAndStateSuccessful() = apply {
-            coEvery {
+        fun withUpdateMLSGroupIdAndStateSuccessful() = apply {
+            everySuspend {
                 conversationDAO.updateMLSGroupIdAndState(any(), any(), any(), any())
-            }.returns(Unit)
+            } returns Unit
         }
 
-        suspend fun withUpdateMLSGroupIdAndStateFailing(failure: StorageFailure.Generic) = apply {
-            coEvery {
+        fun withUpdateMLSGroupIdAndStateFailing(failure: StorageFailure.Generic) = apply {
+            everySuspend {
                 conversationDAO.updateMLSGroupIdAndState(any(), any(), any(), any())
-            }.throws(failure.rootCause)
+            } throws failure.rootCause
         }
 
         companion object {
@@ -1959,14 +1962,14 @@ class MLSConversationRepositoryTest {
         val result = mlsConversationRepository.updateGroupIdAndState(conversationId, newGroupId, 0L)
 
         result.shouldSucceed()
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.conversationDAO.updateMLSGroupIdAndState(
                 conversationId.toDao(),
                 newGroupId.toCrypto(),
                 0L,
                 ConversationEntity.GroupState.PENDING_JOIN
             )
-        }.wasInvoked(exactly = once)
+        }
     }
 
     @Test
@@ -1981,14 +1984,14 @@ class MLSConversationRepositoryTest {
         val result = mlsConversationRepository.updateGroupIdAndState(conversationId, newGroupId, 0L, customState)
 
         result.shouldSucceed()
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.conversationDAO.updateMLSGroupIdAndState(
                 conversationId.toDao(),
                 newGroupId.toCrypto(),
                 0L,
                 customState
             )
-        }.wasInvoked(exactly = once)
+        }
     }
 
     @Test
@@ -2026,14 +2029,14 @@ class MLSConversationRepositoryTest {
             val result = mlsConversationRepository.updateGroupIdAndState(conversationId, newGroupId, 0L, state)
 
             result.shouldSucceed()
-            coVerify {
+            verifySuspend(VerifyMode.exactly(1)) {
                 arrangement.conversationDAO.updateMLSGroupIdAndState(
                     conversationId.toDao(),
                     newGroupId.toCrypto(),
                     0L,
                     state
                 )
-            }.wasInvoked(exactly = once)
+            }
         }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/PersistConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/PersistConversationUseCaseTest.kt
@@ -26,7 +26,7 @@ import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestConversation.MLS_PROTOCOL_INFO
 import com.wire.kalium.logic.framework.TestConversation.NETWORK_ID
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangementImpl
 import io.mockative.any
@@ -117,7 +117,7 @@ class PersistConversationUseCaseTest {
     private class Arrangement(
         private val block: suspend Arrangement.() -> Unit
     ) : ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val persistConversations = mock(PersistConversationsUseCase::class)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCaseTest.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.common.functional.isRight
 import com.wire.kalium.common.functional.left
 import com.wire.kalium.common.functional.right
 import dev.mokkery.MockMode
+import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
@@ -34,12 +35,16 @@ import dev.mokkery.verifySuspend
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.conversation.mls.MLSAdditionResult
 import com.wire.kalium.logic.data.id.GroupID
-import com.wire.kalium.logic.feature.backup.UserId
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.framework.TestConversation
-import com.wire.kalium.logic.util.thenReturnSequentially
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.network.api.authenticated.conversation.ConvProtocol
+import com.wire.kalium.network.api.authenticated.conversation.ConversationResponse
+import com.wire.kalium.network.api.model.ErrorResponse
+import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.util.ConversationPersistenceApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertTrue
@@ -152,17 +157,17 @@ class ResetMLSConversationUseCaseTest {
 
         useCase(TEST_CONVERSATION_ID)
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.conversationRepository.resetMlsConversation(eq(TestConversation.GROUP_ID), eq(15UL))
-        }.wasInvoked(exactly = 1)
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.conversationRepository.fetchConversation(eq(TEST_CONVERSATION_ID))
-        }.wasInvoked(exactly = 1)
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.conversationRepository.resetMlsConversation(eq(TestConversation.GROUP_ID), eq(remoteEpoch))
-        }.wasInvoked(exactly = 1)
+        }
     }
 
     @OptIn(ConversationPersistenceApi::class)
@@ -213,33 +218,33 @@ class ResetMLSConversationUseCaseTest {
 
         useCase(TEST_CONVERSATION_ID)
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.conversationRepository.resetMlsConversation(eq(TestConversation.GROUP_ID), eq(15UL))
-        }.wasInvoked(exactly = 1)
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.conversationRepository.resetMlsConversation(eq(TestConversation.GROUP_ID), eq(refreshedEpoch))
-        }.wasInvoked(exactly = 1)
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(2)) {
             arrangement.conversationRepository.fetchConversation(eq(TEST_CONVERSATION_ID))
-        }.wasInvoked(exactly = 2)
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.not) {
             arrangement.conversationRepository.resetMlsConversation(eq(GroupID(updatedGroupId)), any())
-        }.wasNotInvoked()
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.fetchConversationUseCase(
                 transactionContext = any(),
                 conversationId = eq(TEST_CONVERSATION_ID),
                 reason = eq(ConversationSyncReason.ConversationReset)
             )
-        }.wasInvoked(exactly = 1)
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsConversationRepository.establishMLSGroup(any(), eq(GroupID(updatedGroupId)), any(), any(), any())
-        }.wasInvoked(exactly = 1)
+        }
     }
 
     @Test
@@ -400,32 +405,32 @@ class ResetMLSConversationUseCaseTest {
             kaliumConfigs = kaliumConfigs.copy(isMlsResetEnabled = true)
         }
 
-        suspend fun withRuntimeFlagDisabled() = apply {
+        fun withRuntimeFlagDisabled() = apply {
             everySuspend { userConfig.isMlsConversationsResetEnabled() } returns false
         }
 
-        suspend fun withRuntimeFlagEnabled() = apply {
+        fun withRuntimeFlagEnabled() = apply {
             everySuspend { userConfig.isMlsConversationsResetEnabled() } returns true
         }
 
-        suspend fun withFeatureDisabled() = apply {
+        fun withFeatureDisabled() = apply {
             withCompileTimeFlagEnabled()
             withRuntimeFlagDisabled()
         }
 
-        suspend fun withFeatureEnabled() = apply {
+        fun withFeatureEnabled() = apply {
             withCompileTimeFlagEnabled()
             withRuntimeFlagEnabled()
         }
 
-        suspend fun withConversation(conversation: Conversation) = apply {
+        fun withConversation(conversation: Conversation) = apply {
             everySuspend {
                 conversationRepository.getConversationById(any())
             } returns conversation.right()
             this.conversations = listOf(conversation)
         }
 
-        suspend fun withConversations(vararg conversations: Conversation) = apply {
+        fun withConversations(vararg conversations: Conversation) = apply {
             this.conversations = conversations.toList()
         }
 
@@ -441,7 +446,7 @@ class ResetMLSConversationUseCaseTest {
             resetConversationResults = results.toList()
         }
 
-        suspend fun withLeaveGroupFailing() = apply {
+        fun withLeaveGroupFailing() = apply {
             everySuspend {
                 mlsConversationRepository.leaveGroup(any(), any())
             } returns CoreFailure.Unknown(RuntimeException("Leave group failed")).left()
@@ -449,6 +454,9 @@ class ResetMLSConversationUseCaseTest {
 
         @OptIn(ConversationPersistenceApi::class)
         suspend fun arrange(): Pair<Arrangement, ResetMLSConversationUseCaseImpl> {
+            val conversationResults = conversations.map { it.right() }
+            val remoteConversationResults = remoteConversationResponses.map { it.right() }
+            var resetConversationResultIndex = 0
 
             withMLSTransactionReturning(Either.Right(Unit))
             withTransactionReturning(Either.Right(Unit))
@@ -460,24 +468,38 @@ class ResetMLSConversationUseCaseTest {
             everySuspend {
                 conversationRepository.getConversationById(any())
             }.also {
-                if (conversations.size == 1) {
-                    it returns conversations.single().right()
+                if (conversationResults.size == 1) {
+                    it returns conversationResults.single()
                 } else {
-                    it.thenReturnSequentially(*conversations.map { conversation -> conversation.right() }.toTypedArray())
+                    var conversationResultIndex = 0
+                    it calls {
+                        conversationResults.getOrElse(conversationResultIndex++) {
+                            error("getConversationById called more times than expected")
+                        }
+                    }
                 }
             }
 
             everySuspend {
                 conversationRepository.resetMlsConversation(any(), any())
-            }.thenReturnSequentially(*resetConversationResults.toTypedArray())
+            } calls {
+                resetConversationResults.getOrElse(resetConversationResultIndex++) {
+                    error("resetMlsConversation called more times than expected")
+                }
+            }
 
-            coEvery {
+            everySuspend {
                 conversationRepository.fetchConversation(any())
             }.also {
-                if (remoteConversationResponses.size == 1) {
-                    it returns remoteConversationResponses.single().right()
+                if (remoteConversationResults.size == 1) {
+                    it returns remoteConversationResults.single()
                 } else {
-                    it.thenReturnSequentially(*remoteConversationResponses.map { response -> response.right() }.toTypedArray())
+                    var remoteConversationResultIndex = 0
+                    it calls {
+                        remoteConversationResults.getOrElse(remoteConversationResultIndex++) {
+                            error("fetchConversation called more times than expected")
+                        }
+                    }
                 }
             }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCaseTest.kt
@@ -23,6 +23,14 @@ import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.isRight
 import com.wire.kalium.common.functional.left
 import com.wire.kalium.common.functional.right
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.matcher.eq
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.conversation.mls.MLSAdditionResult
 import com.wire.kalium.logic.data.id.GroupID
@@ -32,16 +40,6 @@ import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.util.thenReturnSequentially
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
-import com.wire.kalium.network.api.authenticated.conversation.ConvProtocol
-import com.wire.kalium.network.api.authenticated.conversation.ConversationResponse
-import com.wire.kalium.network.api.model.ErrorResponse
-import com.wire.kalium.network.exceptions.KaliumException
-import com.wire.kalium.util.ConversationPersistenceApi
-import io.mockative.any
-import io.mockative.coEvery
-import io.mockative.coVerify
-import io.mockative.eq
-import io.mockative.mock
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertTrue
@@ -61,9 +59,9 @@ class ResetMLSConversationUseCaseTest {
 
         assertTrue(result.isRight())
 
-        coVerify {
+        verifySuspend(VerifyMode.not) {
             arrangement.conversationRepository.resetMlsConversation(any(), any())
-        }.wasNotInvoked()
+        }
     }
 
     @Test
@@ -77,9 +75,9 @@ class ResetMLSConversationUseCaseTest {
 
         assertTrue(result.isRight())
 
-        coVerify {
+        verifySuspend(VerifyMode.not) {
             arrangement.conversationRepository.resetMlsConversation(any(), any())
-        }.wasNotInvoked()
+        }
     }
 
     @Test
@@ -93,9 +91,9 @@ class ResetMLSConversationUseCaseTest {
 
         assertTrue(result.isRight())
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.conversationRepository.resetMlsConversation(any(), any())
-        }.wasInvoked()
+        }
     }
 
     @Test
@@ -109,9 +107,9 @@ class ResetMLSConversationUseCaseTest {
 
         assertTrue(result.isRight())
 
-        coVerify {
+        verifySuspend(VerifyMode.not) {
             arrangement.conversationRepository.resetMlsConversation(any(), any())
-        }.wasNotInvoked()
+        }
     }
 
     @Test
@@ -123,9 +121,9 @@ class ResetMLSConversationUseCaseTest {
 
         useCase(TEST_CONVERSATION_ID)
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.conversationRepository.resetMlsConversation(any(), any())
-        }.wasInvoked()
+        }
     }
 
     @OptIn(ConversationPersistenceApi::class)
@@ -253,9 +251,9 @@ class ResetMLSConversationUseCaseTest {
 
         useCase(TEST_CONVERSATION_ID)
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsConversationRepository.leaveGroup(any(), any())
-        }.wasInvoked()
+        }
     }
 
     @Test
@@ -267,13 +265,13 @@ class ResetMLSConversationUseCaseTest {
 
         useCase(TEST_CONVERSATION_ID)
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.fetchConversationUseCase(
                 conversationId = any(),
                 transactionContext = any(),
                 reason = eq(ConversationSyncReason.ConversationReset)
             )
-        }.wasInvoked(exactly = 1)
+        }
     }
 
     @Test
@@ -285,9 +283,9 @@ class ResetMLSConversationUseCaseTest {
 
         useCase(TEST_CONVERSATION_ID)
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsConversationRepository.establishMLSGroup(any(), any(), any(), any(), any())
-        }.wasInvoked()
+        }
     }
 
     @Test
@@ -301,9 +299,9 @@ class ResetMLSConversationUseCaseTest {
 
         assertTrue(result.isRight())
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.conversationRepository.resetMlsConversation(any(), any())
-        }.wasInvoked()
+        }
     }
 
     @Test
@@ -317,9 +315,9 @@ class ResetMLSConversationUseCaseTest {
 
         assertTrue(result.isRight())
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.conversationRepository.resetMlsConversation(any(), any())
-        }.wasInvoked()
+        }
     }
 
     @Test
@@ -333,13 +331,13 @@ class ResetMLSConversationUseCaseTest {
 
         assertTrue(result.isRight())
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsConversationRepository.leaveGroup(any(), any())
-        }.wasInvoked()
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsConversationRepository.establishMLSGroup(any(), any(), any(), any(), any())
-        }.wasInvoked()
+        }
     }
 
     @Test
@@ -352,13 +350,13 @@ class ResetMLSConversationUseCaseTest {
 
         assertTrue(result.isRight())
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsConversationRepository.leaveGroup(any(), any())
-        }.wasInvoked()
+        }
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsConversationRepository.establishMLSGroup(any(), any(), any(), any(), any())
-        }.wasInvoked()
+        }
     }
 
     @Test
@@ -372,19 +370,19 @@ class ResetMLSConversationUseCaseTest {
 
         assertTrue(result.isRight())
 
-        coVerify {
+        verifySuspend(VerifyMode.not) {
             arrangement.conversationRepository.resetMlsConversation(any(), any())
-        }.wasNotInvoked()
+        }
     }
 
     private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
 
         private val TEST_USER_ID = UserId("testUser", "domain")
 
-        val userConfig = mock(UserConfigRepository::class)
-        val conversationRepository = mock(ConversationRepository::class)
-        val mlsConversationRepository = mock(MLSConversationRepository::class)
-        val fetchConversationUseCase = mock(FetchConversationUseCase::class)
+        val userConfig: UserConfigRepository = mock(mode = MockMode.autoUnit)
+        val conversationRepository: ConversationRepository = mock(mode = MockMode.autoUnit)
+        val mlsConversationRepository: MLSConversationRepository = mock(mode = MockMode.autoUnit)
+        val fetchConversationUseCase: FetchConversationUseCase = mock(mode = MockMode.autoUnit)
         var kaliumConfigs = KaliumConfigs(isMlsResetEnabled = true)
         private var remoteConversationResponses: List<ConversationResponse> = listOf(TestConversation.CONVERSATION_RESPONSE.copy(
             protocol = ConvProtocol.MLS,
@@ -403,11 +401,11 @@ class ResetMLSConversationUseCaseTest {
         }
 
         suspend fun withRuntimeFlagDisabled() = apply {
-            coEvery { userConfig.isMlsConversationsResetEnabled() } returns false
+            everySuspend { userConfig.isMlsConversationsResetEnabled() } returns false
         }
 
         suspend fun withRuntimeFlagEnabled() = apply {
-            coEvery { userConfig.isMlsConversationsResetEnabled() } returns true
+            everySuspend { userConfig.isMlsConversationsResetEnabled() } returns true
         }
 
         suspend fun withFeatureDisabled() = apply {
@@ -421,6 +419,9 @@ class ResetMLSConversationUseCaseTest {
         }
 
         suspend fun withConversation(conversation: Conversation) = apply {
+            everySuspend {
+                conversationRepository.getConversationById(any())
+            } returns conversation.right()
             this.conversations = listOf(conversation)
         }
 
@@ -441,7 +442,7 @@ class ResetMLSConversationUseCaseTest {
         }
 
         suspend fun withLeaveGroupFailing() = apply {
-            coEvery {
+            everySuspend {
                 mlsConversationRepository.leaveGroup(any(), any())
             } returns CoreFailure.Unknown(RuntimeException("Leave group failed")).left()
         }
@@ -452,12 +453,11 @@ class ResetMLSConversationUseCaseTest {
             withMLSTransactionReturning(Either.Right(Unit))
             withTransactionReturning(Either.Right(Unit))
 
-
-            coEvery {
+            everySuspend {
                 mlsContext.conversationEpoch(any())
             } returns 15UL
 
-            coEvery {
+            everySuspend {
                 conversationRepository.getConversationById(any())
             }.also {
                 if (conversations.size == 1) {
@@ -467,7 +467,7 @@ class ResetMLSConversationUseCaseTest {
                 }
             }
 
-            coEvery {
+            everySuspend {
                 conversationRepository.resetMlsConversation(any(), any())
             }.thenReturnSequentially(*resetConversationResults.toTypedArray())
 
@@ -481,19 +481,19 @@ class ResetMLSConversationUseCaseTest {
                 }
             }
 
-            coEvery {
+            everySuspend {
                 mlsConversationRepository.leaveGroup(any(), any())
             } returns Unit.right()
 
-            coEvery {
+            everySuspend {
                 mlsConversationRepository.establishMLSGroup(any(), any(), any(), any(), any())
             } returns MLSAdditionResult(emptySet(), emptySet()).right()
 
-            coEvery {
+            everySuspend {
                 fetchConversationUseCase(any(), any(), reason = eq(ConversationSyncReason.ConversationReset))
             } returns Unit.right()
 
-            coEvery {
+            everySuspend {
                 conversationRepository.getConversationMembers(any())
             } returns listOf(UserId("test", "test@user")).right()
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/UpdateConversationProtocolUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/UpdateConversationProtocolUseCaseTest.kt
@@ -72,7 +72,7 @@ internal class UpdateConversationProtocolUseCaseTest {
             .arrange()
 
         // When
-        val result = useCase(any(), eq(CONVERSATION_RESPONSE.id.toModel()), eq(Protocol.MLS),  eq(false))
+        val result = useCase(arrangement.transactionContext, CONVERSATION_RESPONSE.id.toModel(), Protocol.MLS, false)
 
         // Then
         assertEquals(Either.Right(true), result)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/UpdateConversationProtocolUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/UpdateConversationProtocolUseCaseTest.kt
@@ -22,7 +22,7 @@ import com.wire.kalium.logic.data.conversation.Conversation.Protocol
 import com.wire.kalium.logic.data.id.toModel
 import com.wire.kalium.logic.framework.TestConversation.CONVERSATION_RESPONSE
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.util.ConversationPersistenceApi
 import io.mockative.any
 import io.mockative.mock
@@ -78,7 +78,7 @@ internal class UpdateConversationProtocolUseCaseTest {
         assertEquals(Either.Right(true), result)
     }
 
-    class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         private val conversationRepository: ConversationRepository = mock(ConversationRepository::class)
         private val persistConversations: PersistConversationsUseCase = mock(PersistConversationsUseCase::class)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/e2ei/RevocationListCheckerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/e2ei/RevocationListCheckerTest.kt
@@ -25,7 +25,7 @@ import com.wire.kalium.logic.configuration.E2EISettings
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.featureFlags.FeatureSupport
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMokkeryImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.util.DateTimeUtil
@@ -103,7 +103,7 @@ class RevocationListCheckerTest {
         }
     }
 
-    internal class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMokkeryImpl() {
+    internal class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
         val certificateRevocationListRepository = mock<CertificateRevocationListRepository>()
         val featureSupport = mock<FeatureSupport>()
         val userConfigRepository = mock<UserConfigRepository>()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepositoryTest.kt
@@ -27,7 +27,7 @@ import com.wire.kalium.logic.data.keypackage.KeyPackageRepositoryTest.Arrangemen
 import com.wire.kalium.logic.data.mls.CipherSuite
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.authenticated.keypackage.ClaimedKeyPackageList
 import com.wire.kalium.network.api.authenticated.keypackage.KeyPackage
@@ -169,7 +169,7 @@ internal class KeyPackageRepositoryTest {
         }
     }
 
-    class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         val keyPackageApi = mock(KeyPackageApi::class)
         val currentClientIdProvider = mock(CurrentClientIdProvider::class)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/prekey/MessageSendFailureHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/prekey/MessageSendFailureHandlerTest.kt
@@ -38,7 +38,7 @@ import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.conversation.ConversationSyncReason
 import com.wire.kalium.logic.test_util.TestNetworkException
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.ClientRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.ClientRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.usecase.FetchConversationUseCaseArrangement
@@ -362,7 +362,7 @@ internal class MessageSendFailureHandlerTest {
 
     class Arrangement : ClientRepositoryArrangement by ClientRepositoryArrangementImpl(),
         FetchConversationUseCaseArrangement by FetchConversationUseCaseArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         internal val userRepository = mock(UserRepository::class)
         internal val messageRepository = mock(MessageRepository::class)
         val messageSendingScheduler = mock(MessageSendingScheduler::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/prekey/PreKeyRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/prekey/PreKeyRepositoryTest.kt
@@ -35,7 +35,7 @@ import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.test_util.TestNetworkException
 import com.wire.kalium.logic.util.arrangement.provider.ProteusCoreCryptoContextArrangement
-import com.wire.kalium.logic.util.arrangement.provider.ProteusCoreCryptoContextArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.ProteusCoreCryptoContextArrangementMockativeImpl
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.authenticated.prekey.PreKeyDTO
@@ -341,7 +341,7 @@ class PreKeyRepositoryTest {
         val NETWORK_ERROR = NetworkFailure.ServerMiscommunication(TestNetworkException.generic)
     }
 
-    private class Arrangement : ProteusCoreCryptoContextArrangement by ProteusCoreCryptoContextArrangementImpl() {
+    private class Arrangement : ProteusCoreCryptoContextArrangement by ProteusCoreCryptoContextArrangementMockativeImpl() {
         val preKeyApi: PreKeyApi = mock(PreKeyApi::class)
         val proteusClient: ProteusClient = mock(ProteusClient::class)
         val currentClientIdProvider: CurrentClientIdProvider = mock(CurrentClientIdProvider::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/ClientFingerprintUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/ClientFingerprintUseCaseTest.kt
@@ -26,7 +26,7 @@ import com.wire.kalium.logic.data.prekey.UsersWithoutSessions
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.coVerify
@@ -125,7 +125,7 @@ class ClientFingerprintUseCaseTest {
         }.wasNotInvoked()
     }
 
-    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val preKeyRepository = mock(PreKeyRepository::class)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/DeleteClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/DeleteClientUseCaseTest.kt
@@ -29,7 +29,7 @@ import com.wire.kalium.logic.test_util.TestNetworkException
 import com.wire.kalium.logic.util.arrangement.mls.OneOnOneResolverArrangement
 import com.wire.kalium.logic.util.arrangement.mls.OneOnOneResolverArrangementImpl
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangementImpl
 import com.wire.kalium.network.exceptions.KaliumException
@@ -129,7 +129,7 @@ class DeleteClientUseCaseTest {
     private class Arrangement(private val block: suspend Arrangement.() -> Unit) :
         UserRepositoryArrangement by UserRepositoryArrangementImpl(),
         OneOnOneResolverArrangement by OneOnOneResolverArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val clientRepository = mock(ClientRepository::class)
         val updateSupportedProtocolsAndResolveOneOnOnes = mock(UpdateSupportedProtocolsAndResolveOneOnOnesUseCase::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/NeedsToRegisterClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/NeedsToRegisterClientUseCaseTest.kt
@@ -28,7 +28,7 @@ import com.wire.kalium.logic.data.logout.LogoutReason
 import com.wire.kalium.logic.data.session.SessionRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.coVerify
@@ -128,7 +128,7 @@ class NeedsToRegisterClientUseCaseTest {
         val selfUserId = UserId("selfUserId", "selfUserDomain")
     }
 
-    private class Arrangement: CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement: CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         val currentClientIdProvider = mock(CurrentClientIdProvider::class)
         val sessionRepository = mock(SessionRepository::class)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/connection/AcceptConnectionRequestUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/connection/AcceptConnectionRequestUseCaseTest.kt
@@ -30,7 +30,7 @@ import com.wire.kalium.logic.util.arrangement.NewGroupConversationSystemMessageC
 import com.wire.kalium.logic.util.arrangement.mls.OneOnOneResolverArrangement
 import com.wire.kalium.logic.util.arrangement.mls.OneOnOneResolverArrangementImpl
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.ConnectionRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.ConnectionRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
@@ -147,7 +147,7 @@ class AcceptConnectionRequestUseCaseTest {
         OneOnOneResolverArrangement by OneOnOneResolverArrangementImpl(),
         FetchConversationUseCaseArrangement by FetchConversationUseCaseArrangementImpl(),
         NewGroupConversationSystemMessageCreatorArrangement by NewGroupConversationSystemMessageCreatorArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         suspend fun arrange() = run {
             block()
             withTransactionReturning(Either.Right(Unit))

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/connection/BlockUserUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/connection/BlockUserUseCaseTest.kt
@@ -26,7 +26,7 @@ import com.wire.kalium.logic.framework.TestConnection
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.mock
@@ -58,7 +58,7 @@ class BlockUserUseCaseTest {
         assertTrue(result is BlockUserResult.Success)
     }
 
-    private class Arrangement: CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement: CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val connectionRepository: ConnectionRepository = mock(ConnectionRepository::class)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/connection/CancelConnectionRequestUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/connection/CancelConnectionRequestUseCaseTest.kt
@@ -26,7 +26,7 @@ import com.wire.kalium.logic.data.user.Connection
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.coVerify
@@ -74,7 +74,7 @@ class CancelConnectionRequestUseCaseTest {
         }.wasInvoked(once)
     }
 
-    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val connectionRepository: ConnectionRepository = mock(ConnectionRepository::class)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/connection/IgnoreConnectionRequestUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/connection/IgnoreConnectionRequestUseCaseTest.kt
@@ -26,7 +26,7 @@ import com.wire.kalium.logic.data.user.Connection
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.coVerify
@@ -74,7 +74,7 @@ class IgnoreConnectionRequestUseCaseTest {
         }.wasInvoked(once)
     }
 
-    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val connectionRepository: ConnectionRepository = mock(ConnectionRepository::class)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/connection/SendConnectionRequestUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/connection/SendConnectionRequestUseCaseTest.kt
@@ -25,7 +25,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.network.api.model.ErrorResponse
 import com.wire.kalium.network.exceptions.KaliumException
 import io.mockative.any
@@ -142,7 +142,7 @@ class SendConnectionRequestUseCaseTest {
         }.wasInvoked(once)
     }
 
-    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         val connectionRepository = mock(ConnectionRepository::class)
         val userRepository = mock(UserRepository::class)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/connection/UnblockUserUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/connection/UnblockUserUseCaseTest.kt
@@ -27,7 +27,7 @@ import com.wire.kalium.logic.framework.TestConnection
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.coVerify
@@ -76,7 +76,7 @@ class UnblockUserUseCaseTest {
         }.wasInvoked(exactly = once)
     }
 
-    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val connectionRepository: ConnectionRepository = mock(ConnectionRepository::class)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
@@ -27,7 +27,7 @@ import com.wire.kalium.common.functional.right
 import com.wire.kalium.logic.util.arrangement.mls.OneOnOneResolverArrangement
 import com.wire.kalium.logic.util.arrangement.mls.OneOnOneResolverArrangementImpl
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangement
@@ -124,7 +124,7 @@ class GetOrCreateOneToOneConversationUseCaseTest {
     ) : ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
         UserRepositoryArrangement by UserRepositoryArrangementImpl(),
         OneOnOneResolverArrangement by OneOnOneResolverArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl()
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl()
     {
 
         suspend fun arrange() = run {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCaseTest.kt
@@ -43,7 +43,7 @@ import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import com.wire.kalium.logic.test_util.testKaliumDispatcher
 import com.wire.kalium.logic.util.thenReturnSequentially
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
@@ -381,7 +381,7 @@ class JoinExistingMLSConversationUseCaseTest {
     }
 
     private class Arrangement(var dispatcher: KaliumDispatcher = TestKaliumDispatcher) :
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         val featureSupport = mock(FeatureSupport::class)
         val conversationApi = mock(ConversationApi::class)
         val clientRepository = mock(ClientRepository::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCaseTest.kt
@@ -33,7 +33,7 @@ import com.wire.kalium.logic.featureFlags.FeatureSupport
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.model.ErrorResponse
@@ -196,7 +196,7 @@ class JoinExistingMLSConversationsUseCaseTest {
         private val maxConcurrentJoins: Int = 4,
         private val maxThrottleRetries: Int = 3,
         private val throttleRetryDelayMs: Long = 250L,
-    ) : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    ) : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         val featureSupport = mock(FeatureSupport::class)
         val clientRepository = mock(ClientRepository::class)
         val conversationRepository = mock(ConversationRepository::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinSubconversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinSubconversationUseCaseTest.kt
@@ -29,7 +29,7 @@ import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.SubconversationId
 import com.wire.kalium.logic.data.id.toApi
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.authenticated.conversation.SubconversationDeleteRequest
@@ -177,7 +177,7 @@ class JoinSubconversationUseCaseTest {
         joinSubconversationUseCase(Arrangement.CONVERSATION_ID, Arrangement.SUBCONVERSATION_ID).shouldFail()
     }
 
-    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         val conversationApi = mock(ConversationApi::class)
         val mlsConversationRepository = mock(MLSConversationRepository::class)
         val subconversationRepository = mock(SubconversationRepository::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/LeaveSubconversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/LeaveSubconversationUseCaseTest.kt
@@ -31,7 +31,7 @@ import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
 import com.wire.kalium.network.api.authenticated.conversation.SubconversationResponse
 import com.wire.kalium.network.api.model.QualifiedID
@@ -120,7 +120,7 @@ class LeaveSubconversationUseCaseTest {
         }.wasInvoked(exactly = once)
     }
 
-    private class Arrangement: CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement: CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         val conversationApi = mock(ConversationApi::class)
         val subconversationRepository = mock(SubconversationRepository::class)
         val selfClientIdProvider = mock(CurrentClientIdProvider::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationsRecoveryManagerTests.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationsRecoveryManagerTests.kt
@@ -27,7 +27,7 @@ import com.wire.kalium.logic.featureFlags.FeatureSupport
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.coVerify
@@ -133,7 +133,7 @@ class MLSConversationsRecoveryManagerTests {
             }.wasNotInvoked()
         }
 
-    private class Arrangement: CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement: CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val incrementalSyncRepository: IncrementalSyncRepository = mock(IncrementalSyncRepository::class)
         val clientRepository = mock(ClientRepository::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/NotifyConversationIsOpenUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/NotifyConversationIsOpenUseCaseTest.kt
@@ -26,7 +26,7 @@ import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.logic.util.arrangement.mls.OneOnOneResolverArrangement
 import com.wire.kalium.logic.util.arrangement.mls.OneOnOneResolverArrangementImpl
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangementImpl
 import io.mockative.any
@@ -102,7 +102,7 @@ class NotifyConversationIsOpenUseCaseTest {
         private val configure: suspend Arrangement.() -> Unit
     ) : OneOnOneResolverArrangement by OneOnOneResolverArrangementImpl(),
         ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         private val deleteEphemeralMessageEndDate = mock(DeleteEphemeralMessagesAfterEndDateUseCase::class)
         private val slowSyncRepository = mock(SlowSyncRepository::class)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/RecoverMLSConversationsUseCaseTests.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/RecoverMLSConversationsUseCaseTests.kt
@@ -33,7 +33,7 @@ import com.wire.kalium.logic.featureFlags.FeatureSupport
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.util.DateTimeUtil
 import io.mockative.any
 import io.mockative.coEvery
@@ -230,7 +230,7 @@ class RecoverMLSConversationsUseCaseTests {
         assertIs<RecoverMLSConversationsResult.Failure>(actual)
     }
 
-    private class Arrangement: CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement: CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         val mlsConversationRepository = mock(MLSConversationRepository::class)
         val featureSupport = mock(FeatureSupport::class)
         val joinExistingMLSConversationUseCase = mock(JoinExistingMLSConversationUseCase::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/RefreshConversationsWithoutMetadataUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/RefreshConversationsWithoutMetadataUseCaseTest.kt
@@ -26,7 +26,7 @@ import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestConversation.CONVERSATION_RESPONSE_DTO
 import com.wire.kalium.logic.test_util.testKaliumDispatcher
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.util.KaliumDispatcher
 import io.mockative.any
 import io.mockative.coEvery
@@ -82,7 +82,7 @@ class RefreshConversationsWithoutMetadataUseCaseTest {
     }
 
     private class Arrangement(private val dispatcher: KaliumDispatcher) :
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         val conversationRepository = mock(ConversationRepository::class)
         val persistConversations = mock(PersistConversationsUseCase::class)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/SyncConversationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/SyncConversationsUseCaseTest.kt
@@ -26,7 +26,7 @@ import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.conversation.FetchConversationsUseCase
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.coVerify
@@ -88,7 +88,7 @@ class SyncConversationsUseCaseTest {
         }.wasNotInvoked()
     }
 
-    private class Arrangement: CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement: CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val conversationRepository = mock(ConversationRepository::class)
         val systemMessageInserter = mock(SystemMessageInserter::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/delete/DeleteConversationLocallyUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/delete/DeleteConversationLocallyUseCaseTest.kt
@@ -22,7 +22,7 @@ import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.conversation.ClearConversationContentUseCase
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.usecase.DeleteConversationArrangement
 import com.wire.kalium.logic.util.arrangement.usecase.DeleteConversationArrangementImpl
 import io.mockative.any
@@ -76,7 +76,7 @@ class DeleteConversationLocallyUseCaseTest {
     }
 
     private class Arrangement : DeleteConversationArrangement by DeleteConversationArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val clearConversationContent = mock(ClearConversationContentUseCase::class)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/delete/DeleteConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/delete/DeleteConversationUseCaseTest.kt
@@ -25,7 +25,7 @@ import com.wire.kalium.messaging.hooks.PersistenceEventHookNotifier
 import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.mls.CipherSuite
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.repository.MLSConversationRepositoryArrangement
@@ -101,7 +101,7 @@ class DeleteConversationUseCaseTest {
     private class Arrangement :
         ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
         MLSConversationRepositoryArrangement by MLSConversationRepositoryArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val persistenceEventHookNotifier: PersistenceEventHookNotifier = object : PersistenceEventHookNotifier {}
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/keyingmaterials/UpdateKeyingMaterialsUseCaseTests.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/keyingmaterials/UpdateKeyingMaterialsUseCaseTests.kt
@@ -25,7 +25,7 @@ import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import kotlinx.io.IOException
 import io.mockative.any
 import io.mockative.coEvery
@@ -118,7 +118,7 @@ class UpdateKeyingMaterialsUseCaseTests {
         assertIs<UpdateKeyingMaterialsResult.Failure>(actual)
     }
 
-    private class Arrangement: CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement: CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val mlsConversationRepository = mock(MLSConversationRepository::class)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/MLSOneOnOneConversationResolverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/MLSOneOnOneConversationResolverTest.kt
@@ -25,7 +25,7 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.usecase.JoinExistingMLSConversationUseCaseArrangement
@@ -142,7 +142,7 @@ class MLSOneOnOneConversationResolverTest {
         private val block: suspend Arrangement.() -> Unit
     ) : ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
         JoinExistingMLSConversationUseCaseArrangement by JoinExistingMLSConversationUseCaseArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl()
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl()
     {
             val fetchMLSOneToOneConversation = mock(FetchMLSOneToOneConversationUseCase::class)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneMigratorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneMigratorTest.kt
@@ -28,7 +28,7 @@ import com.wire.kalium.logic.data.conversation.CreateConversationParam
 import com.wire.kalium.logic.util.arrangement.mls.MLSOneOnOneConversationResolverArrangement
 import com.wire.kalium.logic.util.arrangement.mls.MLSOneOnOneConversationResolverArrangementImpl
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.ConversationGroupRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.ConversationGroupRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
@@ -335,7 +335,7 @@ class OneOnOneMigratorTest {
         ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
         ConversationGroupRepositoryArrangement by ConversationGroupRepositoryArrangementImpl(),
         UserRepositoryArrangement by UserRepositoryArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         fun arrange() = run {
             runBlocking {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolverTest.kt
@@ -32,7 +32,7 @@ import com.wire.kalium.logic.util.arrangement.mls.OneOnOneMigratorArrangementImp
 import com.wire.kalium.logic.util.arrangement.protocol.OneOnOneProtocolSelectorArrangement
 import com.wire.kalium.logic.util.arrangement.protocol.OneOnOneProtocolSelectorArrangementImpl
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangementImpl
 import com.wire.kalium.logic.util.shouldFail
@@ -336,7 +336,7 @@ class OneOnOneResolverTest {
         UserRepositoryArrangement by UserRepositoryArrangementImpl(),
         OneOnOneProtocolSelectorArrangement by OneOnOneProtocolSelectorArrangementImpl(),
         OneOnOneMigratorArrangement by OneOnOneMigratorArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl(),
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl(),
         IncrementalSyncRepositoryArrangement by IncrementalSyncRepositoryArrangementImpl() {
         fun arrange() = run {
             runBlocking { block() }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/debug/RepairFaultyRemovalKeysUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/debug/RepairFaultyRemovalKeysUseCaseTest.kt
@@ -29,7 +29,7 @@ import com.wire.kalium.logic.feature.debug.RepairFaultyRemovalKeysUseCaseTest.Ar
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.coVerify
@@ -97,7 +97,7 @@ class RepairFaultyRemovalKeysUseCaseTest {
         assertEquals(1, result.failedRepairs.size)
     }
 
-    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         val conversationRepository = mock(ConversationRepository::class)
 
         val resetMLSConversationUseCase = mock(ResetMLSConversationUseCase::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/CheckCrlRevocationListUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/CheckCrlRevocationListUseCaseTest.kt
@@ -22,7 +22,7 @@ import com.wire.kalium.logic.data.e2ei.RevocationListChecker
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.persistence.config.CRLUrlExpirationList
 import com.wire.kalium.persistence.config.CRLWithExpiration
 import io.mockative.any
@@ -81,7 +81,7 @@ class CheckCrlRevocationListUseCaseTest {
         }.wasInvoked(exactly = once)
     }
 
-    private class Arrangement: CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement: CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val certificateRevocationListRepository = mock(CertificateRevocationListRepository::class)
         val checkRevocationList = mock(RevocationListChecker::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/EnrollE2EICertificateUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/EnrollE2EICertificateUseCaseTest.kt
@@ -38,7 +38,7 @@ import com.wire.kalium.logic.feature.e2ei.usecase.FinalizeEnrollmentResult
 import com.wire.kalium.logic.feature.e2ei.usecase.InitialEnrollmentResult
 import com.wire.kalium.logic.framework.TestConversation.MLS_CONVERSATION
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangementImpl
 import com.wire.kalium.network.api.authenticated.e2ei.AccessTokenResponse
@@ -1049,7 +1049,7 @@ internal class EnrollE2EICertificateUseCaseTest {
     }
 
     private class Arrangement : UserRepositoryArrangement by UserRepositoryArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val e2EIRepository = mock(E2EIRepository::class)
         val conversationRepository = mock(ConversationRepository::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/GetE2eiCertificateUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/GetE2eiCertificateUseCaseTest.kt
@@ -32,7 +32,7 @@ import com.wire.kalium.logic.feature.e2ei.usecase.GetMLSClientIdentityResult
 import com.wire.kalium.logic.feature.e2ei.usecase.GetMLSClientIdentityUseCaseImpl
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.coVerify
@@ -126,7 +126,7 @@ class GetE2eiCertificateUseCaseTest {
             }.wasInvoked(once)
         }
 
-    private class Arrangement: CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement: CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         val mlsConversationRepository = mock(MLSConversationRepository::class)
 
         suspend fun arrange() = this to GetMLSClientIdentityUseCaseImpl(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/GetUserE2eiCertificateStatusUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/GetUserE2eiCertificateStatusUseCaseTest.kt
@@ -33,7 +33,7 @@ import com.wire.kalium.logic.util.arrangement.mls.IsE2EIEnabledUseCaseArrangemen
 import com.wire.kalium.logic.util.arrangement.mls.MLSConversationRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.mls.MLSConversationRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangementImpl
 import io.mockative.any
@@ -216,7 +216,7 @@ class GetUserE2eiCertificateStatusUseCaseTest {
     private class Arrangement(private val block: suspend Arrangement.() -> Unit) :
         MLSConversationRepositoryArrangement by MLSConversationRepositoryArrangementImpl(),
         IsE2EIEnabledUseCaseArrangement by IsE2EIEnabledUseCaseArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl(),
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl(),
         UserRepositoryArrangement by UserRepositoryArrangementImpl() {
 
         suspend fun arrange() = run {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/GetUserMlsClientIdentitiesUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/GetUserMlsClientIdentitiesUseCaseTest.kt
@@ -31,7 +31,7 @@ import com.wire.kalium.logic.util.arrangement.mls.IsMlsEnabledUseCaseArrangement
 import com.wire.kalium.logic.util.arrangement.mls.MLSConversationRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.mls.MLSConversationRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import io.mockative.any
 import io.mockative.coVerify
 import kotlinx.coroutines.runBlocking
@@ -117,7 +117,7 @@ class GetUserMlsClientIdentitiesUseCaseTest {
 
     private class Arrangement(private val block: suspend Arrangement.() -> Unit) :
         MLSConversationRepositoryArrangement by MLSConversationRepositoryArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl(),
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl(),
         IsMlsEnabledUseCaseArrangement by IsMlsEnabledUseCaseArrangementImpl() {
 
         fun arrange() = run {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/SyncCertificateRevocationListUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/e2ei/SyncCertificateRevocationListUseCaseTest.kt
@@ -24,7 +24,7 @@ import com.wire.kalium.logic.data.e2ei.RevocationListChecker
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.persistence.config.CRLUrlExpirationList
 import com.wire.kalium.persistence.config.CRLWithExpiration
 import io.mockative.any
@@ -65,7 +65,7 @@ class SyncCertificateRevocationListUseCaseTest {
 
     }
 
-    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val certificateRevocationListRepository = mock(CertificateRevocationListRepository::class)
         val incrementalSyncRepository = mock(IncrementalSyncRepository::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCaseTest.kt
@@ -62,7 +62,7 @@ import com.wire.kalium.logic.sync.receiver.handler.CellsConfigHandler
 import com.wire.kalium.logic.sync.receiver.handler.EnableUserProfileQRCodeConfigHandler
 import com.wire.kalium.logic.test_util.TestNetworkException
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.persistence.TestUserDatabase
 import com.wire.kalium.persistence.config.inMemoryUserConfigStorage
@@ -857,7 +857,7 @@ class SyncFeatureConfigsUseCaseTest {
     private fun TestScope.arrangement() = Arrangement(coroutineContext[CoroutineDispatcher]!! as TestDispatcher)
 
     private class Arrangement(dispatcher: TestDispatcher) :
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         private val inMemoryStorage = inMemoryUserConfigStorage()
         private val userDatabase = TestUserDatabase(TestUser.ENTITY_ID, dispatcher)
         val channelsConfigurationStorage = ChannelsConfigurationStorage(userDatabase.builder.metadataDAO)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/handler/MLSConfigHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/handler/MLSConfigHandlerTest.kt
@@ -26,7 +26,7 @@ import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.right
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.UserConfigRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.UserConfigRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.usecase.UpdateSupportedProtocolsAndResolveOneOnOnesArrangement
@@ -260,7 +260,7 @@ class MLSConfigHandlerTest {
 
     private class Arrangement(private val block: suspend Arrangement.() -> Unit) :
         UserConfigRepositoryArrangement by UserConfigRepositoryArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl(),
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl(),
         UpdateSupportedProtocolsAndResolveOneOnOnesArrangement by UpdateSupportedProtocolsAndResolveOneOnOnesArrangementImpl() {
         suspend fun arrange() = run {
             withTransactionReturning(Either.Right(Unit))

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/handler/MLSMigrationConfigHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/handler/MLSMigrationConfigHandlerTest.kt
@@ -21,7 +21,7 @@ import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.featureConfig.MLSMigrationModel
 import com.wire.kalium.logic.data.featureConfig.Status
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.UserConfigRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.UserConfigRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.usecase.UpdateSupportedProtocolsAndResolveOneOnOnesArrangement
@@ -113,7 +113,7 @@ class MLSMigrationConfigHandlerTest {
 
     private class Arrangement(private val block: suspend Arrangement.() -> Unit) :
         UserConfigRepositoryArrangement by UserConfigRepositoryArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl(),
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl(),
         UpdateSupportedProtocolsAndResolveOneOnOnesArrangement by UpdateSupportedProtocolsAndResolveOneOnOnesArrangementImpl() {
         fun arrange() = run {
             runBlocking {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/keypackage/KeyPackageManagerTests.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/keypackage/KeyPackageManagerTests.kt
@@ -29,7 +29,7 @@ import com.wire.kalium.logic.featureFlags.FeatureSupport
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.coVerify
@@ -139,7 +139,7 @@ class KeyPackageManagerTests {
             }.wasInvoked(once)
         }
 
-    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val incrementalSyncRepository: IncrementalSyncRepository = InMemoryIncrementalSyncRepository()
         val clientRepository = mock(ClientRepository::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/keypackage/MLSKeyPackageCountUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/keypackage/MLSKeyPackageCountUseCaseTest.kt
@@ -34,7 +34,7 @@ import com.wire.kalium.logic.feature.keypackage.MLSKeyPackageCountUseCaseTest.Ar
 import com.wire.kalium.logic.feature.keypackage.MLSKeyPackageCountUseCaseTest.Arrangement.Companion.NETWORK_FAILURE
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.UserConfigRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.UserConfigRepositoryArrangementImpl
 import com.wire.kalium.network.api.authenticated.keypackage.KeyPackageCountDTO
@@ -141,7 +141,7 @@ class MLSKeyPackageCountUseCaseTest {
     }
 
     private class Arrangement : UserConfigRepositoryArrangement by UserConfigRepositoryArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val keyPackageRepository = mock(KeyPackageRepository::class)
         val currentClientIdProvider = mock(CurrentClientIdProvider::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/keypackage/RefillKeyPackageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/keypackage/RefillKeyPackageUseCaseTest.kt
@@ -29,7 +29,7 @@ import com.wire.kalium.logic.data.mls.CipherSuite
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.messaging.hooks.NoOpCryptoStateChangeHookNotifier
 import com.wire.kalium.network.api.authenticated.keypackage.KeyPackageCountDTO
 import io.mockative.any
@@ -107,7 +107,7 @@ class RefillKeyPackageUseCaseTest {
         assertEquals(actual.failure, networkFailure)
     }
 
-    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         val keyPackageRepository = mock(KeyPackageRepository::class)
         val keyPackageLimitsProvider = mock(KeyPackageLimitsProvider::class)
         val currentClientIdProvider = mock(CurrentClientIdProvider::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/legalhold/ObserveLegalHoldRequestUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/legalhold/ObserveLegalHoldRequestUseCaseTest.kt
@@ -25,7 +25,7 @@ import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.legalhold.LastPreKey
 import com.wire.kalium.logic.data.legalhold.LegalHoldRequest
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.every
@@ -88,7 +88,7 @@ class ObserveLegalHoldRequestUseCaseTest {
             assertTrue(result.first() is ObserveLegalHoldRequestUseCase.Result.LegalHoldRequestAvailable)
         }
 
-    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         val userConfigRepository = mock(UserConfigRepository::class)
 
         fun withUserConfigRepositorySuccess() = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MLSMessageCreatorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MLSMessageCreatorTest.kt
@@ -33,7 +33,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.framework.TestMessage
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.shouldSucceed
 import io.mockative.any
 import io.mockative.coEvery
@@ -117,7 +117,7 @@ class MLSMessageCreatorTest {
         }.wasInvoked(once)
     }
 
-    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         val protoContentMapper = mock(ProtoContentMapper::class)
         val conversationRepository = mock(ConversationRepository::class)
         val mlsConversationRepository = mock(MLSConversationRepository::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageEnvelopeCreatorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageEnvelopeCreatorTest.kt
@@ -36,7 +36,7 @@ import com.wire.kalium.logic.data.message.ProtoContentMapper
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.framework.TestMessage
 import com.wire.kalium.logic.util.arrangement.provider.ProteusCoreCryptoContextArrangement
-import com.wire.kalium.logic.util.arrangement.provider.ProteusCoreCryptoContextArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.ProteusCoreCryptoContextArrangementMockativeImpl
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import io.mockative.any
@@ -537,7 +537,7 @@ class MessageEnvelopeCreatorTest {
         }.wasInvoked(exactly = once)
     }
 
-    private class Arrangement : ProteusCoreCryptoContextArrangement by ProteusCoreCryptoContextArrangementImpl() {
+    private class Arrangement : ProteusCoreCryptoContextArrangement by ProteusCoreCryptoContextArrangementMockativeImpl() {
         private val selfUserId: UserId = UserId("user-id", "domain")
 
         val proteusClient: ProteusClient = mock(ProteusClient::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
@@ -58,7 +58,7 @@ import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldHandler
 import com.wire.kalium.logic.util.arrangement.mls.StaleEpochVerifierArrangement
 import com.wire.kalium.logic.util.arrangement.mls.StaleEpochVerifierArrangementImpl
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.logic.util.thenReturnSequentially
@@ -1072,7 +1072,7 @@ class MessageSenderTest {
 
     private class Arrangement(private val block: suspend Arrangement.() -> Unit) :
         StaleEpochVerifierArrangement by StaleEpochVerifierArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val messageRepository: MessageRepository = mock(MessageRepository::class)
         val messageSendFailureHandler: MessageSendFailureHandler = mock(MessageSendFailureHandler::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/PendingProposalSchedulerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/PendingProposalSchedulerTest.kt
@@ -31,7 +31,7 @@ import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.MLSFailure
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.util.DateTimeUtil
 import io.mockative.any
 import io.mockative.coEvery
@@ -226,7 +226,7 @@ class PendingProposalSchedulerTest {
         }.wasNotInvoked()
     }
 
-    private class Arrangement: CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement: CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val incrementalSyncRepository = InMemoryIncrementalSyncRepository()
         val mlsConversationRepository = mock(MLSConversationRepository::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SessionEstablisherTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SessionEstablisherTest.kt
@@ -33,7 +33,7 @@ import com.wire.kalium.logic.data.prekey.UsersWithoutSessions
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.authenticated.prekey.PreKeyDTO
@@ -129,7 +129,7 @@ class SessionEstablisherTest {
         val TEST_RECIPIENT_1 = Recipient(TestUser.USER_ID, listOf(TestClient.CLIENT_ID))
     }
 
-    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         val preKeyRepository = mock(PreKeyRepository::class)
 
         private val sessionEstablisher: SessionEstablisher =

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifierTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifierTest.kt
@@ -36,7 +36,7 @@ import com.wire.kalium.logic.util.arrangement.SystemMessageInserterArrangementIm
 import com.wire.kalium.logic.util.arrangement.mls.MLSConversationRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.mls.MLSConversationRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.repository.SubconversationRepositoryArrangement
@@ -289,7 +289,7 @@ class StaleEpochVerifierTest {
         ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
         MLSConversationRepositoryArrangement by MLSConversationRepositoryArrangementImpl(),
         SubconversationRepositoryArrangement by SubconversationRepositoryArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl(),
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl(),
         JoinExistingMLSConversationUseCaseArrangement by JoinExistingMLSConversationUseCaseArrangementImpl() {
         val fetchConversationUseCase = mock(FetchConversationUseCase::class)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationWorkerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigrationWorkerTest.kt
@@ -37,7 +37,7 @@ import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.left
 import com.wire.kalium.common.functional.right
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import io.mockative.any
@@ -216,7 +216,7 @@ class MLSMigrationWorkerTest {
             coVerify { arrangement.mlsMigrator.finaliseProteusConversations() }.wasNotInvoked()
         }
 
-    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         val userConfigRepository: UserConfigRepository = mock(of<UserConfigRepository>())
         val featureConfigRepository: FeatureConfigRepository = mock(of<FeatureConfigRepository>())
         val updateSupportedProtocolsAndResolveOneOnOnes = mock(of<UpdateSupportedProtocolsAndResolveOneOnOnesUseCase>())

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigratorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigratorTest.kt
@@ -42,7 +42,7 @@ import com.wire.kalium.common.functional.right
 import com.wire.kalium.logic.data.conversation.UpdateConversationProtocolUseCase
 import com.wire.kalium.logic.test_util.TestNetworkResponseError
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.CallRepositoryArrangementImpl
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.model.ErrorResponse
@@ -227,7 +227,7 @@ class MLSMigratorTest {
         result.shouldSucceed()
     }
 
-    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         val userRepository = mock(UserRepository::class)
         val conversationRepository = mock(ConversationRepository::class)
         val mlsConversationRepository = mock(MLSConversationRepository::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/sessionreset/ResetSessionUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/sessionreset/ResetSessionUseCaseTest.kt
@@ -27,7 +27,7 @@ import com.wire.kalium.logic.feature.message.SessionResetSender
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.coVerify
@@ -103,7 +103,7 @@ class ResetSessionUseCaseTest {
         val failure = CoreFailure.Unknown(null)
     }
 
-    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         val sessionResetSender = mock(SessionResetSender::class)
         val messageRepository = mock(MessageRepository::class)
         val idMapper = IdMapper()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/team/DeleteTeamConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/team/DeleteTeamConversationUseCaseTest.kt
@@ -27,7 +27,7 @@ import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestTeam
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.usecase.DeleteConversationArrangement
 import com.wire.kalium.logic.util.arrangement.usecase.DeleteConversationArrangementImpl
 import io.mockative.any
@@ -112,7 +112,7 @@ class DeleteTeamConversationUseCaseTest {
     }
 
     private class Arrangement : DeleteConversationArrangement by DeleteConversationArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val selfTeamIdProvider: SelfTeamIdProvider = mock(SelfTeamIdProvider::class)
         val teamRepository: TeamRepository = mock(TeamRepository::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessorTest.kt
@@ -30,7 +30,7 @@ import com.wire.kalium.logic.sync.receiver.UserPropertiesEventReceiver
 import com.wire.kalium.logic.util.arrangement.eventHandler.FeatureConfigEventReceiverArrangement
 import com.wire.kalium.logic.util.arrangement.eventHandler.FeatureConfigEventReceiverArrangementImpl
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.shouldFail
 import io.mockative.any
 import io.mockative.coEvery
@@ -234,7 +234,7 @@ class EventProcessorTest {
     private class Arrangement(
         val processingScope: CoroutineScope
     ) : FeatureConfigEventReceiverArrangement by FeatureConfigEventReceiverArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val conversationEventReceiver = mock(ConversationEventReceiver::class)
         val userEventReceiver = mock(UserEventReceiver::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorkerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorkerTest.kt
@@ -31,7 +31,7 @@ import com.wire.kalium.logic.framework.TestEvent.wrapInEnvelope
 import com.wire.kalium.logic.sync.KaliumSyncException
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.persistence.TestUserDatabase
 import io.mockative.any
 import io.mockative.coEvery
@@ -212,7 +212,7 @@ class IncrementalSyncWorkerTest {
         }.wasInvoked(exactly = once)
     }
 
-    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         val eventProcessor: EventProcessor = mock(EventProcessor::class)
         val eventGatherer: EventGatherer = mock(EventGatherer::class)
         val eventRepository: EventRepository = mock(EventRepository::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
@@ -43,7 +43,7 @@ import com.wire.kalium.logic.util.arrangement.eventHandler.CodeDeletedHandlerArr
 import com.wire.kalium.logic.util.arrangement.eventHandler.CodeUpdatedHandlerArrangement
 import com.wire.kalium.logic.util.arrangement.eventHandler.CodeUpdatedHandlerArrangementImpl
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import io.mockative.any
@@ -447,7 +447,7 @@ class ConversationEventReceiverTest {
     private class Arrangement :
         CodeUpdatedHandlerArrangement by CodeUpdatedHandlerArrangementImpl(),
         CodeDeletedHandlerArrangement by CodeDeletedHandlerArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val conversationMessageTimerEventHandler = mock(ConversationMessageTimerEventHandler::class)
         val receiptModeUpdateEventHandler = mock(ReceiptModeUpdateEventHandler::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
@@ -51,7 +51,7 @@ import com.wire.kalium.logic.sync.receiver.handler.AssetAuditLogConfigHandler
 import com.wire.kalium.logic.sync.receiver.handler.CellsConfigHandler
 import com.wire.kalium.logic.sync.receiver.handler.EnableUserProfileQRCodeConfigHandler
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.shouldSucceed
 import io.mockative.any
 import io.mockative.coEvery
@@ -391,7 +391,7 @@ class FeatureConfigEventReceiverTest {
         ).shouldSucceed()
     }
 
-    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         var kaliumConfigs = KaliumConfigs()
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FederationEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FederationEventReceiverTest.kt
@@ -31,7 +31,7 @@ import com.wire.kalium.logic.test_util.testKaliumDispatcher
 import com.wire.kalium.logic.util.arrangement.dao.MemberDAOArrangement
 import com.wire.kalium.logic.util.arrangement.dao.MemberDAOArrangementImpl
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.ConnectionRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.ConnectionRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
@@ -236,7 +236,7 @@ class FederationEventReceiverTest {
         UserRepositoryArrangement by UserRepositoryArrangementImpl(),
         MemberDAOArrangement by MemberDAOArrangementImpl(),
         PersistMessageUseCaseArrangement by PersistMessageUseCaseArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl()
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl()
     {
 
         var dispatcher: KaliumDispatcher = TestKaliumDispatcher

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ProtocolUpdateEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ProtocolUpdateEventHandlerTest.kt
@@ -27,7 +27,7 @@ import com.wire.kalium.logic.sync.receiver.conversation.ProtocolUpdateEventHandl
 import com.wire.kalium.logic.util.arrangement.SystemMessageInserterArrangement
 import com.wire.kalium.logic.util.arrangement.SystemMessageInserterArrangementImpl
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.CallRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.CallRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
@@ -152,7 +152,7 @@ class ProtocolUpdateEventHandlerTest {
     private class Arrangement(private val block: suspend Arrangement.() -> Unit) :
         ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
         SystemMessageInserterArrangement by SystemMessageInserterArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl(),
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl(),
         CallRepositoryArrangement by CallRepositoryArrangementImpl() {
         val updateConversationProtocol = mock(UpdateConversationProtocolUseCase::class)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/TeamEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/TeamEventReceiverTest.kt
@@ -24,7 +24,7 @@ import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangementImpl
 import io.mockative.any
@@ -62,7 +62,7 @@ class TeamEventReceiverTest {
     }
 
     private class Arrangement : UserRepositoryArrangement by UserRepositoryArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         val persistMessageUseCase = mock(PersistMessageUseCase::class)
 
         private val teamEventReceiver: TeamEventReceiver = TeamEventReceiverImpl(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiverTest.kt
@@ -41,7 +41,7 @@ import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import com.wire.kalium.logic.util.arrangement.mls.OneOnOneResolverArrangement
 import com.wire.kalium.logic.util.arrangement.mls.OneOnOneResolverArrangementImpl
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangementImpl
 import io.mockative.any
@@ -400,7 +400,7 @@ class UserEventReceiverTest {
     private class Arrangement(private val block: suspend Arrangement.() -> Unit) :
         UserRepositoryArrangement by UserRepositoryArrangementImpl(),
         OneOnOneResolverArrangement by OneOnOneResolverArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         val connectionRepository = mock(ConnectionRepository::class)
         val logoutUseCase = mock(LogoutUseCase::class)
         private val currentClientIdProvider = mock(CurrentClientIdProvider::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserPropertiesEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserPropertiesEventReceiverTest.kt
@@ -23,7 +23,7 @@ import com.wire.kalium.logic.data.conversation.folders.ConversationFolderReposit
 import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.coVerify
@@ -65,7 +65,7 @@ class UserPropertiesEventReceiverTest {
         }.wasInvoked(exactly = once)
     }
 
-    private class Arrangement: CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement: CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val userConfigRepository = mock(UserConfigRepository::class)
         val conversationFolderRepository = mock(ConversationFolderRepository::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ClearConversationContentHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ClearConversationContentHandlerTest.kt
@@ -29,7 +29,7 @@ import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.sync.receiver.handler.ClearConversationContentHandler
 import com.wire.kalium.logic.sync.receiver.handler.ClearConversationContentHandlerImpl
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.usecase.DeleteConversationArrangement
@@ -256,7 +256,7 @@ class ClearConversationContentHandlerTest {
         private val hookNotifier: PersistenceEventHookNotifier = NoOpPersistenceEventHookNotifier,
     ) :
         ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl(),
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl(),
         DeleteConversationArrangement by DeleteConversationArrangementImpl() {
 
         val isMessageSentInSelfConversationUseCase = mock(IsMessageSentInSelfConversationUseCase::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/DeletedConversationEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/DeletedConversationEventHandlerTest.kt
@@ -24,7 +24,7 @@ import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangement
@@ -190,7 +190,7 @@ class DeletedConversationEventHandlerTest {
     ) : ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
         UserRepositoryArrangement by UserRepositoryArrangementImpl(),
         DeleteConversationArrangement by DeleteConversationArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl(),
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl(),
         NotificationEventsManagerArrangement by EphemeralEventsNotificationManagerArrangementImpl() {
 
         fun arrange() = run {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSResetConversationEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSResetConversationEventHandlerTest.kt
@@ -27,7 +27,7 @@ import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 import io.mockative.any
 import io.mockative.coEvery
@@ -237,7 +237,7 @@ class MLSResetConversationEventHandlerTest {
     }
 
     private class Arrangement(private val block: suspend Arrangement.() -> Unit) :
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val mlsConversationRepository = mock(MLSConversationRepository::class)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandlerTest.kt
@@ -40,7 +40,7 @@ import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.util.arrangement.mls.OneOnOneResolverArrangement
 import com.wire.kalium.logic.util.arrangement.mls.OneOnOneResolverArrangementImpl
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.usecase.FetchConversationIfUnknownUseCaseArrangement
@@ -342,7 +342,7 @@ class MLSWelcomeEventHandlerTest {
     private class Arrangement(private val block: suspend Arrangement.() -> Unit) :
         ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
         FetchConversationIfUnknownUseCaseArrangement by FetchConversationIfUnknownUseCaseArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl(),
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl(),
         OneOnOneResolverArrangement by OneOnOneResolverArrangementImpl() {
         val refillKeyPackagesUseCase = mock(RefillKeyPackagesUseCase::class)
         val checkRevocationList = mock(RevocationListChecker::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandlerTest.kt
@@ -30,7 +30,7 @@ import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.coVerify
@@ -156,7 +156,7 @@ class MemberChangeEventHandlerTest {
         }.wasNotInvoked()
     }
 
-    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val conversationRepository = mock(ConversationRepository::class)
         private val userRepository = mock(UserRepository::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandlerTest.kt
@@ -33,7 +33,7 @@ import com.wire.kalium.logic.util.arrangement.NewGroupConversationSystemMessageC
 import com.wire.kalium.logic.util.arrangement.eventHandler.LegalHoldHandlerArrangement
 import com.wire.kalium.logic.util.arrangement.eventHandler.LegalHoldHandlerArrangementImpl
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.repository.UserRepositoryArrangement
@@ -302,7 +302,7 @@ class MemberJoinEventHandlerTest {
         LegalHoldHandlerArrangement by LegalHoldHandlerArrangementImpl(),
         FetchConversationIfUnknownUseCaseArrangement by FetchConversationIfUnknownUseCaseArrangementImpl(),
         FetchConversationUseCaseArrangement by FetchConversationUseCaseArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl(),
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl(),
         NewGroupConversationSystemMessageCreatorArrangement by NewGroupConversationSystemMessageCreatorArrangementImpl() {
 
         suspend fun arrange() = run {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberLeaveEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberLeaveEventHandlerTest.kt
@@ -32,7 +32,7 @@ import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldHandler
 import com.wire.kalium.logic.util.arrangement.dao.MemberDAOArrangement
 import com.wire.kalium.logic.util.arrangement.dao.MemberDAOArrangementImpl
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.provider.SelfTeamIdProviderArrangement
 import com.wire.kalium.logic.util.arrangement.provider.SelfTeamIdProviderArrangementImpl
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
@@ -362,7 +362,7 @@ internal class MemberLeaveEventHandlerTest {
         SelfTeamIdProviderArrangement by SelfTeamIdProviderArrangementImpl(),
         DeleteConversationArrangement by DeleteConversationArrangementImpl(),
         ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
 
         val updateConversationClientsForCurrentCall = mock(UpdateConversationClientsForCurrentCallUseCase::class)
         val legalHoldHandler = mock(LegalHoldHandler::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandlerTest.kt
@@ -42,7 +42,7 @@ import com.wire.kalium.logic.framework.TestTeam
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.test_util.wasInTheLastSecond
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.network.api.authenticated.conversation.ConversationResponse
 import com.wire.kalium.network.api.authenticated.conversation.ReceiptMode
 import com.wire.kalium.util.time.UNIX_FIRST_DATE
@@ -315,7 +315,7 @@ class NewConversationEventHandlerTest {
             }.wasInvoked(exactly = once)
         }
 
-    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         val conversationRepository = mock(ConversationRepository::class)
         val userRepository = mock(UserRepository::class)
         val selfTeamIdProvider = mock(SelfTeamIdProvider::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageUnpackerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageUnpackerTest.kt
@@ -31,7 +31,7 @@ import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.getOrNull
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.util.DateTimeUtil
@@ -139,7 +139,7 @@ internal class MLSMessageUnpackerTest {
         }.wasInvoked(once)
     }
 
-    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         val conversationRepository = mock(ConversationRepository::class)
         val mlsConversationRepository = mock(MLSConversationRepository::class)
         val pendingProposalScheduler = mock(PendingProposalScheduler::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
@@ -39,7 +39,7 @@ import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.conversation.ResetMLSConversationUseCase
 import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldHandler
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.util.DateTimeUtil
 import io.mockative.any
 import io.mockative.coEvery
@@ -537,7 +537,7 @@ class NewMessageEventHandlerTest {
         }.wasNotInvoked()
     }
 
-    private class Arrangement: CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement: CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         val proteusMessageUnpacker = mock(ProteusMessageUnpacker::class)
         val mlsMessageUnpacker = mock(MLSMessageUnpacker::class)
         val applicationMessageHandler = mock(ApplicationMessageHandler::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ProteusMessageUnpackerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ProteusMessageUnpackerTest.kt
@@ -33,7 +33,7 @@ import com.wire.kalium.logic.data.message.ProtoContentMapper
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.protobuf.encodeToByteArray
 import com.wire.kalium.protobuf.messages.GenericMessage
@@ -139,7 +139,7 @@ class ProteusMessageUnpackerTest {
         }
     }
 
-    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         val protoContentMapper = mock(ProtoContentMapper::class)
 
         suspend fun withProteusClientDecryptingByteArray(decryptedData: ByteArray) = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorkerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorkerTest.kt
@@ -39,7 +39,7 @@ import com.wire.kalium.logic.sync.KaliumSyncException
 import com.wire.kalium.logic.sync.slow.migration.steps.SyncMigrationStep
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.EventRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.EventRepositoryArrangementImpl
 import com.wire.kalium.logic.util.stubs.FailureSyncMigration
@@ -634,7 +634,7 @@ class SlowSyncWorkerTest {
     }
 
     private class Arrangement : EventRepositoryArrangement by EventRepositoryArrangementImpl(),
-        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
         val syncSelfUser: SyncSelfUserUseCase = mock(SyncSelfUserUseCase::class)
         val syncUserProperties: SyncUserPropertiesUseCase = mokkeryMock<SyncUserPropertiesUseCase>()
         val syncFeatureConfigs: SyncFeatureConfigsUseCase = mock(SyncFeatureConfigsUseCase::class)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/provider/CryptoTransactionProviderArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/provider/CryptoTransactionProviderArrangement.kt
@@ -23,16 +23,13 @@ import com.wire.kalium.cryptography.CryptoTransactionContext
 import com.wire.kalium.cryptography.MlsCoreCryptoContext
 import com.wire.kalium.cryptography.ProteusCoreCryptoContext
 import com.wire.kalium.logic.data.client.CryptoTransactionProvider
+import dev.mokkery.MockMode
 import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
-import dev.mokkery.every as mokkeryEvery
+import dev.mokkery.every
 import dev.mokkery.everySuspend
-import dev.mokkery.matcher.any as mokkeryAny
-import dev.mokkery.mock as mokkeryMock
-import io.mockative.any
-import io.mockative.coEvery
-import io.mockative.every
-import io.mockative.mock
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
 
 internal interface CryptoTransactionProviderArrangement {
     val cryptoTransactionProvider: CryptoTransactionProvider
@@ -49,75 +46,21 @@ internal interface CryptoTransactionProviderArrangement {
 
 internal class CryptoTransactionProviderArrangementImpl : CryptoTransactionProviderArrangement {
 
-    override val proteusContext: ProteusCoreCryptoContext = mock(ProteusCoreCryptoContext::class)
-    override val mlsContext: MlsCoreCryptoContext = mock(MlsCoreCryptoContext::class)
-    override val transactionContext = mock(CryptoTransactionContext::class)
+    override val proteusContext: ProteusCoreCryptoContext = mock(mode = MockMode.autoUnit)
+    override val mlsContext: MlsCoreCryptoContext = mock(mode = MockMode.autoUnit)
+    override val transactionContext: CryptoTransactionContext = mock(mode = MockMode.autoUnit)
 
-    override val cryptoTransactionProvider: CryptoTransactionProvider = mock(CryptoTransactionProvider::class)
+    override val cryptoTransactionProvider: CryptoTransactionProvider = mock()
 
     init {
         every { transactionContext.proteus } returns proteusContext
         every { transactionContext.mls } returns mlsContext
     }
 
-    override suspend fun <R> withTransactionReturning(result: Either<CoreFailure, R>): CryptoTransactionProviderArrangement = apply {
-        coEvery {
-            cryptoTransactionProvider.transaction<R>(any(), any())
-        }.invokes { args ->
-            @Suppress("UNCHECKED_CAST")
-            val block = args[1] as suspend (CryptoTransactionContext) -> Either<CoreFailure, R>
-            block(transactionContext)
-        }
-    }
-
-    override suspend fun <R> withProteusTransactionReturning(
-        result: Either<CoreFailure, R>
-    ): CryptoTransactionProviderArrangement = apply {
-        coEvery {
-            cryptoTransactionProvider.proteusTransaction<R>(any(), any())
-        }.invokes { args ->
-            @Suppress("UNCHECKED_CAST")
-            val block = args[1] as suspend (ProteusCoreCryptoContext) -> Either<CoreFailure, R>
-            block(proteusContext)
-        }
-    }
-
-    override suspend fun <R> withProteusTransactionResultOnly(
-        result: Either<CoreFailure, R>
-    ): CryptoTransactionProviderArrangement = apply {
-        coEvery {
-            cryptoTransactionProvider.proteusTransaction<R>(any(), any())
-        }.returns(result)
-    }
-
-    override suspend fun <R> withMLSTransactionReturning(result: Either<CoreFailure, R>): CryptoTransactionProviderArrangement = apply {
-        coEvery {
-            cryptoTransactionProvider.mlsTransaction<R>(any(), any())
-        }.invokes { args ->
-            @Suppress("UNCHECKED_CAST")
-            val block = args[1] as suspend (MlsCoreCryptoContext) -> Either<CoreFailure, R>
-            block(mlsContext)
-        }
-    }
-}
-
-internal class CryptoTransactionProviderArrangementMokkeryImpl : CryptoTransactionProviderArrangement {
-
-    override val proteusContext: ProteusCoreCryptoContext = mokkeryMock()
-    override val mlsContext: MlsCoreCryptoContext = mokkeryMock()
-    override val transactionContext: CryptoTransactionContext = mokkeryMock()
-
-    override val cryptoTransactionProvider: CryptoTransactionProvider = mokkeryMock()
-
-    init {
-        mokkeryEvery { transactionContext.proteus } returns proteusContext
-        mokkeryEvery { transactionContext.mls } returns mlsContext
-    }
-
     @Suppress("UNCHECKED_CAST")
     override suspend fun <R> withTransactionReturning(result: Either<CoreFailure, R>): CryptoTransactionProviderArrangement = apply {
         everySuspend {
-            cryptoTransactionProvider.transaction<R>(mokkeryAny(), mokkeryAny())
+            cryptoTransactionProvider.transaction<R>(any(), any())
         } calls {
             val block = it.args[1] as suspend (CryptoTransactionContext) -> Either<CoreFailure, R>
             block(transactionContext)
@@ -129,7 +72,7 @@ internal class CryptoTransactionProviderArrangementMokkeryImpl : CryptoTransacti
         result: Either<CoreFailure, R>
     ): CryptoTransactionProviderArrangement = apply {
         everySuspend {
-            cryptoTransactionProvider.proteusTransaction<R>(mokkeryAny(), mokkeryAny())
+            cryptoTransactionProvider.proteusTransaction<R>(any(), any())
         } calls {
             val block = it.args[1] as suspend (ProteusCoreCryptoContext) -> Either<CoreFailure, R>
             block(proteusContext)
@@ -140,14 +83,14 @@ internal class CryptoTransactionProviderArrangementMokkeryImpl : CryptoTransacti
         result: Either<CoreFailure, R>
     ): CryptoTransactionProviderArrangement = apply {
         everySuspend {
-            cryptoTransactionProvider.proteusTransaction<R>(mokkeryAny(), mokkeryAny())
+            cryptoTransactionProvider.proteusTransaction<R>(any(), any())
         } returns result
     }
 
     @Suppress("UNCHECKED_CAST")
     override suspend fun <R> withMLSTransactionReturning(result: Either<CoreFailure, R>): CryptoTransactionProviderArrangement = apply {
         everySuspend {
-            cryptoTransactionProvider.mlsTransaction<R>(mokkeryAny(), mokkeryAny())
+            cryptoTransactionProvider.mlsTransaction<R>(any(), any())
         } calls {
             val block = it.args[1] as suspend (MlsCoreCryptoContext) -> Either<CoreFailure, R>
             block(mlsContext)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/provider/CryptoTransactionProviderArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/provider/CryptoTransactionProviderArrangement.kt
@@ -26,10 +26,14 @@ import com.wire.kalium.logic.data.client.CryptoTransactionProvider
 import dev.mokkery.MockMode
 import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
-import dev.mokkery.every
+import dev.mokkery.every as mokkeryEvery
 import dev.mokkery.everySuspend
-import dev.mokkery.matcher.any
-import dev.mokkery.mock
+import dev.mokkery.matcher.any as mokkeryAny
+import dev.mokkery.mock as mokkeryMock
+import io.mockative.any
+import io.mockative.coEvery
+import io.mockative.every
+import io.mockative.mock
 
 internal interface CryptoTransactionProviderArrangement {
     val cryptoTransactionProvider: CryptoTransactionProvider
@@ -44,23 +48,23 @@ internal interface CryptoTransactionProviderArrangement {
 
 }
 
-internal class CryptoTransactionProviderArrangementImpl : CryptoTransactionProviderArrangement {
+internal open class CryptoTransactionProviderArrangementMokkeryImpl : CryptoTransactionProviderArrangement {
 
-    override val proteusContext: ProteusCoreCryptoContext = mock(mode = MockMode.autoUnit)
-    override val mlsContext: MlsCoreCryptoContext = mock(mode = MockMode.autoUnit)
-    override val transactionContext: CryptoTransactionContext = mock(mode = MockMode.autoUnit)
+    override val proteusContext: ProteusCoreCryptoContext = mokkeryMock(mode = MockMode.autoUnit)
+    override val mlsContext: MlsCoreCryptoContext = mokkeryMock(mode = MockMode.autoUnit)
+    override val transactionContext: CryptoTransactionContext = mokkeryMock(mode = MockMode.autoUnit)
 
-    override val cryptoTransactionProvider: CryptoTransactionProvider = mock()
+    override val cryptoTransactionProvider: CryptoTransactionProvider = mokkeryMock()
 
     init {
-        every { transactionContext.proteus } returns proteusContext
-        every { transactionContext.mls } returns mlsContext
+        mokkeryEvery { transactionContext.proteus } returns proteusContext
+        mokkeryEvery { transactionContext.mls } returns mlsContext
     }
 
     @Suppress("UNCHECKED_CAST")
     override suspend fun <R> withTransactionReturning(result: Either<CoreFailure, R>): CryptoTransactionProviderArrangement = apply {
         everySuspend {
-            cryptoTransactionProvider.transaction<R>(any(), any())
+            cryptoTransactionProvider.transaction<R>(mokkeryAny(), mokkeryAny())
         } calls {
             val block = it.args[1] as suspend (CryptoTransactionContext) -> Either<CoreFailure, R>
             block(transactionContext)
@@ -72,7 +76,7 @@ internal class CryptoTransactionProviderArrangementImpl : CryptoTransactionProvi
         result: Either<CoreFailure, R>
     ): CryptoTransactionProviderArrangement = apply {
         everySuspend {
-            cryptoTransactionProvider.proteusTransaction<R>(any(), any())
+            cryptoTransactionProvider.proteusTransaction<R>(mokkeryAny(), mokkeryAny())
         } calls {
             val block = it.args[1] as suspend (ProteusCoreCryptoContext) -> Either<CoreFailure, R>
             block(proteusContext)
@@ -83,16 +87,72 @@ internal class CryptoTransactionProviderArrangementImpl : CryptoTransactionProvi
         result: Either<CoreFailure, R>
     ): CryptoTransactionProviderArrangement = apply {
         everySuspend {
-            cryptoTransactionProvider.proteusTransaction<R>(any(), any())
+            cryptoTransactionProvider.proteusTransaction<R>(mokkeryAny(), mokkeryAny())
         } returns result
     }
 
     @Suppress("UNCHECKED_CAST")
     override suspend fun <R> withMLSTransactionReturning(result: Either<CoreFailure, R>): CryptoTransactionProviderArrangement = apply {
         everySuspend {
-            cryptoTransactionProvider.mlsTransaction<R>(any(), any())
+            cryptoTransactionProvider.mlsTransaction<R>(mokkeryAny(), mokkeryAny())
         } calls {
             val block = it.args[1] as suspend (MlsCoreCryptoContext) -> Either<CoreFailure, R>
+            block(mlsContext)
+        }
+    }
+}
+
+internal class CryptoTransactionProviderArrangementImpl : CryptoTransactionProviderArrangementMokkeryImpl()
+
+internal class CryptoTransactionProviderArrangementMockativeImpl : CryptoTransactionProviderArrangement {
+
+    override val proteusContext: ProteusCoreCryptoContext = mock(ProteusCoreCryptoContext::class)
+    override val mlsContext: MlsCoreCryptoContext = mock(MlsCoreCryptoContext::class)
+    override val transactionContext: CryptoTransactionContext = mock(CryptoTransactionContext::class)
+
+    override val cryptoTransactionProvider: CryptoTransactionProvider = mock(CryptoTransactionProvider::class)
+
+    init {
+        every { transactionContext.proteus } returns proteusContext
+        every { transactionContext.mls } returns mlsContext
+    }
+
+    override suspend fun <R> withTransactionReturning(result: Either<CoreFailure, R>): CryptoTransactionProviderArrangement = apply {
+        coEvery {
+            cryptoTransactionProvider.transaction<R>(any(), any())
+        }.invokes { args ->
+            @Suppress("UNCHECKED_CAST")
+            val block = args[1] as suspend (CryptoTransactionContext) -> Either<CoreFailure, R>
+            block(transactionContext)
+        }
+    }
+
+    override suspend fun <R> withProteusTransactionReturning(
+        result: Either<CoreFailure, R>
+    ): CryptoTransactionProviderArrangement = apply {
+        coEvery {
+            cryptoTransactionProvider.proteusTransaction<R>(any(), any())
+        }.invokes { args ->
+            @Suppress("UNCHECKED_CAST")
+            val block = args[1] as suspend (ProteusCoreCryptoContext) -> Either<CoreFailure, R>
+            block(proteusContext)
+        }
+    }
+
+    override suspend fun <R> withProteusTransactionResultOnly(
+        result: Either<CoreFailure, R>
+    ): CryptoTransactionProviderArrangement = apply {
+        coEvery {
+            cryptoTransactionProvider.proteusTransaction<R>(any(), any())
+        }.returns(result)
+    }
+
+    override suspend fun <R> withMLSTransactionReturning(result: Either<CoreFailure, R>): CryptoTransactionProviderArrangement = apply {
+        coEvery {
+            cryptoTransactionProvider.mlsTransaction<R>(any(), any())
+        }.invokes { args ->
+            @Suppress("UNCHECKED_CAST")
+            val block = args[1] as suspend (MlsCoreCryptoContext) -> Either<CoreFailure, R>
             block(mlsContext)
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/provider/E2EIClientProviderArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/provider/E2EIClientProviderArrangement.kt
@@ -35,8 +35,11 @@ import com.wire.kalium.cryptography.MlsCoreCryptoContext
 import com.wire.kalium.cryptography.WireIdentity
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
-import dev.mokkery.matcher.any
-import dev.mokkery.mock
+import dev.mokkery.matcher.any as mokkeryAny
+import dev.mokkery.mock as mokkeryMock
+import io.mockative.any
+import io.mockative.coEvery
+import io.mockative.mock
 
 internal interface E2EIClientProviderArrangement {
 
@@ -65,42 +68,42 @@ internal interface E2EIClientProviderArrangement {
     suspend fun withGetOrFetchMLSConfig(result: SupportedCipherSuite)
 }
 
-internal class E2EIClientProviderArrangementImpl : E2EIClientProviderArrangement {
-    override val mlsClientProvider: MLSClientProvider = mock<MLSClientProvider>()
-    override val e2eiClient: E2EIClient = mock<E2EIClient>()
-    override val userRepository: UserRepository = mock<UserRepository>()
-    override val currentClientIdProvider: CurrentClientIdProvider = mock<CurrentClientIdProvider>()
-    override val coreCryptoCentral: CoreCryptoCentral = mock<CoreCryptoCentral>()
-    override val mlsContext: MlsCoreCryptoContext = mock<MlsCoreCryptoContext>()
+internal open class E2EIClientProviderArrangementMokkeryImpl : E2EIClientProviderArrangement {
+    override val mlsClientProvider: MLSClientProvider = mokkeryMock<MLSClientProvider>()
+    override val e2eiClient: E2EIClient = mokkeryMock<E2EIClient>()
+    override val userRepository: UserRepository = mokkeryMock<UserRepository>()
+    override val currentClientIdProvider: CurrentClientIdProvider = mokkeryMock<CurrentClientIdProvider>()
+    override val coreCryptoCentral: CoreCryptoCentral = mokkeryMock<CoreCryptoCentral>()
+    override val mlsContext: MlsCoreCryptoContext = mokkeryMock<MlsCoreCryptoContext>()
     override val mlsClient: MLSClient = DummyMLSClient(mlsContext)
 
     override suspend fun withGettingCoreCryptoSuccessful() {
         everySuspend {
-            mlsClientProvider.getCoreCrypto(any())
+            mlsClientProvider.getCoreCrypto(mokkeryAny())
         } returns Either.Right(coreCryptoCentral)
     }
 
     override suspend fun withGetNewAcmeEnrollmentSuccessful() {
         everySuspend {
-            coreCryptoCentral.newAcmeEnrollment(any(), any(), any(), any(), any(), any())
+            coreCryptoCentral.newAcmeEnrollment(mokkeryAny(), mokkeryAny(), mokkeryAny(), mokkeryAny(), mokkeryAny(), mokkeryAny())
         } returns e2eiClient
     }
 
     override suspend fun withGetMLSClientSuccessful() {
         everySuspend {
-            mlsClientProvider.getMLSClient(any())
+            mlsClientProvider.getMLSClient(mokkeryAny())
         } returns Either.Right(mlsClient)
     }
 
     override suspend fun withE2EINewActivationEnrollmentSuccessful() {
         everySuspend {
-            mlsContext.e2eiNewActivationEnrollment(any(), any(), any(), any())
+            mlsContext.e2eiNewActivationEnrollment(mokkeryAny(), mokkeryAny(), mokkeryAny(), mokkeryAny())
         } returns e2eiClient
     }
 
     override suspend fun withE2EINewRotationEnrollmentSuccessful() {
         everySuspend {
-            mlsContext.e2eiNewRotateEnrollment(any(), any(), any(), any())
+            mlsContext.e2eiNewRotateEnrollment(mokkeryAny(), mokkeryAny(), mokkeryAny(), mokkeryAny())
         } returns e2eiClient
     }
 
@@ -120,6 +123,66 @@ internal class E2EIClientProviderArrangementImpl : E2EIClientProviderArrangement
         everySuspend {
             mlsClientProvider.getOrFetchMLSConfig()
         } returns result.right()
+    }
+}
+
+internal class E2EIClientProviderArrangementImpl : E2EIClientProviderArrangementMokkeryImpl()
+
+internal class E2EIClientProviderArrangementMockativeImpl : E2EIClientProviderArrangement {
+    override val mlsClientProvider: MLSClientProvider = mock(MLSClientProvider::class)
+    override val e2eiClient: E2EIClient = mock(E2EIClient::class)
+    override val userRepository: UserRepository = mock(UserRepository::class)
+    override val currentClientIdProvider = mock(CurrentClientIdProvider::class)
+    override val coreCryptoCentral = mock(CoreCryptoCentral::class)
+    override val mlsContext: MlsCoreCryptoContext = mock(MlsCoreCryptoContext::class)
+    override val mlsClient: MLSClient = DummyMLSClient(mlsContext)
+
+    override suspend fun withGettingCoreCryptoSuccessful() {
+        coEvery {
+            mlsClientProvider.getCoreCrypto(any())
+        }.returns(Either.Right(coreCryptoCentral))
+    }
+
+    override suspend fun withGetNewAcmeEnrollmentSuccessful() {
+        coEvery {
+            coreCryptoCentral.newAcmeEnrollment(any(), any(), any(), any(), any(), any())
+        }.returns(e2eiClient)
+    }
+
+    override suspend fun withGetMLSClientSuccessful() {
+        coEvery {
+            mlsClientProvider.getMLSClient(any())
+        }.returns(Either.Right(mlsClient))
+    }
+
+    override suspend fun withE2EINewActivationEnrollmentSuccessful() {
+        coEvery {
+            mlsContext.e2eiNewActivationEnrollment(any(), any(), any(), any())
+        }.returns(e2eiClient)
+    }
+
+    override suspend fun withE2EINewRotationEnrollmentSuccessful() {
+        coEvery {
+            mlsContext.e2eiNewRotateEnrollment(any(), any(), any(), any())
+        }.returns(e2eiClient)
+    }
+
+    override suspend fun withE2EIEnabled(isEnabled: Boolean) {
+        coEvery {
+            mlsContext.isE2EIEnabled()
+        }.returns(isEnabled)
+    }
+
+    override suspend fun withSelfUser(result: Either<StorageFailure, SelfUser>) {
+        coEvery {
+            userRepository.getSelfUser()
+        }.returns(result)
+    }
+
+    override suspend fun withGetOrFetchMLSConfig(result: SupportedCipherSuite) {
+        coEvery {
+            mlsClientProvider.getOrFetchMLSConfig()
+        }.returns(result.right())
     }
 }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/provider/E2EIClientProviderArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/provider/E2EIClientProviderArrangement.kt
@@ -35,11 +35,8 @@ import com.wire.kalium.cryptography.MlsCoreCryptoContext
 import com.wire.kalium.cryptography.WireIdentity
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
-import dev.mokkery.matcher.any as mokkeryAny
-import dev.mokkery.mock as mokkeryMock
-import io.mockative.any
-import io.mockative.coEvery
-import io.mockative.mock
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
 
 internal interface E2EIClientProviderArrangement {
 
@@ -69,99 +66,41 @@ internal interface E2EIClientProviderArrangement {
 }
 
 internal class E2EIClientProviderArrangementImpl : E2EIClientProviderArrangement {
-    override val mlsClientProvider: MLSClientProvider = mock(MLSClientProvider::class)
-    override val e2eiClient: E2EIClient = mock(E2EIClient::class)
-    override val userRepository: UserRepository = mock(UserRepository::class)
-    override val currentClientIdProvider = mock(CurrentClientIdProvider::class)
-    override val coreCryptoCentral = mock(CoreCryptoCentral::class)
-    override val mlsContext: MlsCoreCryptoContext = mock(MlsCoreCryptoContext::class)
-    override val mlsClient: MLSClient = DummyMLSClient(mlsContext)
-
-    override suspend fun withGettingCoreCryptoSuccessful() {
-        coEvery {
-            mlsClientProvider.getCoreCrypto(any())
-        }.returns(Either.Right(coreCryptoCentral))
-    }
-
-    override suspend fun withGetNewAcmeEnrollmentSuccessful() {
-        coEvery {
-            coreCryptoCentral.newAcmeEnrollment(any(), any(), any(), any(), any(), any())
-        }.returns(e2eiClient)
-    }
-
-    override suspend fun withGetMLSClientSuccessful() {
-        coEvery {
-            mlsClientProvider.getMLSClient(any())
-        }.returns(Either.Right(mlsClient))
-    }
-
-    override suspend fun withE2EINewActivationEnrollmentSuccessful() {
-        coEvery {
-            mlsContext.e2eiNewActivationEnrollment(any(), any(), any(), any())
-        }.returns(e2eiClient)
-    }
-    override suspend fun withE2EINewRotationEnrollmentSuccessful() {
-        coEvery {
-            mlsContext.e2eiNewRotateEnrollment(any(), any(), any(), any())
-        }.returns(e2eiClient)
-    }
-
-    override suspend fun withE2EIEnabled(isEnabled: Boolean) {
-        coEvery {
-            mlsContext.isE2EIEnabled()
-        }.returns(isEnabled)
-    }
-
-    override suspend fun withSelfUser(result: Either<StorageFailure, SelfUser>) {
-        coEvery {
-            userRepository.getSelfUser()
-        }.returns(result)
-    }
-
-    override suspend fun withGetOrFetchMLSConfig(result: SupportedCipherSuite) {
-        coEvery {
-            mlsClientProvider.getOrFetchMLSConfig()
-        }.returns(result.right())
-    }
-
-}
-
-internal class E2EIClientProviderArrangementMokkeryImpl : E2EIClientProviderArrangement {
-    override val mlsClientProvider: MLSClientProvider = mokkeryMock<MLSClientProvider>()
-    override val e2eiClient: E2EIClient = mokkeryMock<E2EIClient>()
-    override val userRepository: UserRepository = mokkeryMock<UserRepository>()
-    override val currentClientIdProvider: CurrentClientIdProvider = mokkeryMock<CurrentClientIdProvider>()
-    override val coreCryptoCentral: CoreCryptoCentral = mokkeryMock<CoreCryptoCentral>()
-    override val mlsContext: MlsCoreCryptoContext = mokkeryMock<MlsCoreCryptoContext>()
+    override val mlsClientProvider: MLSClientProvider = mock<MLSClientProvider>()
+    override val e2eiClient: E2EIClient = mock<E2EIClient>()
+    override val userRepository: UserRepository = mock<UserRepository>()
+    override val currentClientIdProvider: CurrentClientIdProvider = mock<CurrentClientIdProvider>()
+    override val coreCryptoCentral: CoreCryptoCentral = mock<CoreCryptoCentral>()
+    override val mlsContext: MlsCoreCryptoContext = mock<MlsCoreCryptoContext>()
     override val mlsClient: MLSClient = DummyMLSClient(mlsContext)
 
     override suspend fun withGettingCoreCryptoSuccessful() {
         everySuspend {
-            mlsClientProvider.getCoreCrypto(mokkeryAny())
+            mlsClientProvider.getCoreCrypto(any())
         } returns Either.Right(coreCryptoCentral)
     }
 
     override suspend fun withGetNewAcmeEnrollmentSuccessful() {
         everySuspend {
-            coreCryptoCentral.newAcmeEnrollment(mokkeryAny(), mokkeryAny(), mokkeryAny(), mokkeryAny(), mokkeryAny(), mokkeryAny())
+            coreCryptoCentral.newAcmeEnrollment(any(), any(), any(), any(), any(), any())
         } returns e2eiClient
     }
 
     override suspend fun withGetMLSClientSuccessful() {
         everySuspend {
-            mlsClientProvider.getMLSClient(mokkeryAny())
+            mlsClientProvider.getMLSClient(any())
         } returns Either.Right(mlsClient)
     }
 
     override suspend fun withE2EINewActivationEnrollmentSuccessful() {
         everySuspend {
-            mlsContext.e2eiNewActivationEnrollment(mokkeryAny(), mokkeryAny(), mokkeryAny(), mokkeryAny())
+            mlsContext.e2eiNewActivationEnrollment(any(), any(), any(), any())
         } returns e2eiClient
     }
 
     override suspend fun withE2EINewRotationEnrollmentSuccessful() {
         everySuspend {
-            mlsContext.e2eiNewRotateEnrollment(mokkeryAny(), mokkeryAny(), mokkeryAny(), mokkeryAny())
+            mlsContext.e2eiNewRotateEnrollment(any(), any(), any(), any())
         } returns e2eiClient
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/provider/ProteusCoreCryptoContextArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/provider/ProteusCoreCryptoContextArrangement.kt
@@ -19,9 +19,11 @@ package com.wire.kalium.logic.util.arrangement.provider
 
 import com.wire.kalium.cryptography.PreKeyCrypto
 import com.wire.kalium.cryptography.ProteusCoreCryptoContext
-import io.mockative.any
-import io.mockative.coEvery
-import io.mockative.mock
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
 
 internal interface ProteusCoreCryptoContextArrangement {
     val proteusContext: ProteusCoreCryptoContext
@@ -36,29 +38,29 @@ internal interface ProteusCoreCryptoContextArrangement {
 
 internal class ProteusCoreCryptoContextArrangementImpl : ProteusCoreCryptoContextArrangement {
 
-    override val proteusContext: ProteusCoreCryptoContext = mock(ProteusCoreCryptoContext::class)
+    override val proteusContext: ProteusCoreCryptoContext = mock()
 
     override suspend fun withNewLastResortPreKeyReturning(result: PreKeyCrypto) = apply {
-        coEvery { proteusContext.newLastResortPreKey() }.returns(result)
+        everySuspend { proteusContext.newLastResortPreKey() } returns  result
     }
 
     override suspend fun withCreateSessionSuccess() = apply {
-        coEvery { proteusContext.createSession(any(), any()) }.returns(Unit)
+        everySuspend { proteusContext.createSession(any(), any()) } returns Unit
     }
 
     override suspend fun withCreateSessionThrowing(exception: Throwable) = apply {
-        coEvery { proteusContext.createSession(any(), any()) }.throws(exception)
+        everySuspend { proteusContext.createSession(any(), any()) } throws exception
     }
 
     override suspend fun withDoesSessionExistReturning(result: Boolean) = apply {
-        coEvery { proteusContext.doesSessionExist(any()) }.returns(result)
+        everySuspend { proteusContext.doesSessionExist(any()) } returns result
     }
 
     override suspend fun withGetLocalFingerprintReturning(fingerprint: String) = apply {
-        coEvery { proteusContext.getLocalFingerprint() }.returns(fingerprint)
+        everySuspend { proteusContext.getLocalFingerprint() } returns fingerprint
     }
 
     override suspend fun withDeleteSessionSuccess() = apply {
-        coEvery { proteusContext.deleteSession(any()) }.returns(Unit)
+        everySuspend { proteusContext.deleteSession(any()) } returns Unit
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/provider/ProteusCoreCryptoContextArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/provider/ProteusCoreCryptoContextArrangement.kt
@@ -22,8 +22,11 @@ import com.wire.kalium.cryptography.ProteusCoreCryptoContext
 import dev.mokkery.answering.returns
 import dev.mokkery.answering.throws
 import dev.mokkery.everySuspend
-import dev.mokkery.matcher.any
-import dev.mokkery.mock
+import dev.mokkery.matcher.any as mokkeryAny
+import dev.mokkery.mock as mokkeryMock
+import io.mockative.any
+import io.mockative.coEvery
+import io.mockative.mock
 
 internal interface ProteusCoreCryptoContextArrangement {
     val proteusContext: ProteusCoreCryptoContext
@@ -36,24 +39,24 @@ internal interface ProteusCoreCryptoContextArrangement {
     suspend fun withDeleteSessionSuccess(): ProteusCoreCryptoContextArrangement
 }
 
-internal class ProteusCoreCryptoContextArrangementImpl : ProteusCoreCryptoContextArrangement {
+internal open class ProteusCoreCryptoContextArrangementMokkeryImpl : ProteusCoreCryptoContextArrangement {
 
-    override val proteusContext: ProteusCoreCryptoContext = mock()
+    override val proteusContext: ProteusCoreCryptoContext = mokkeryMock()
 
     override suspend fun withNewLastResortPreKeyReturning(result: PreKeyCrypto) = apply {
-        everySuspend { proteusContext.newLastResortPreKey() } returns  result
+        everySuspend { proteusContext.newLastResortPreKey() } returns result
     }
 
     override suspend fun withCreateSessionSuccess() = apply {
-        everySuspend { proteusContext.createSession(any(), any()) } returns Unit
+        everySuspend { proteusContext.createSession(mokkeryAny(), mokkeryAny()) } returns Unit
     }
 
     override suspend fun withCreateSessionThrowing(exception: Throwable) = apply {
-        everySuspend { proteusContext.createSession(any(), any()) } throws exception
+        everySuspend { proteusContext.createSession(mokkeryAny(), mokkeryAny()) } throws exception
     }
 
     override suspend fun withDoesSessionExistReturning(result: Boolean) = apply {
-        everySuspend { proteusContext.doesSessionExist(any()) } returns result
+        everySuspend { proteusContext.doesSessionExist(mokkeryAny()) } returns result
     }
 
     override suspend fun withGetLocalFingerprintReturning(fingerprint: String) = apply {
@@ -61,6 +64,37 @@ internal class ProteusCoreCryptoContextArrangementImpl : ProteusCoreCryptoContex
     }
 
     override suspend fun withDeleteSessionSuccess() = apply {
-        everySuspend { proteusContext.deleteSession(any()) } returns Unit
+        everySuspend { proteusContext.deleteSession(mokkeryAny()) } returns Unit
+    }
+}
+
+internal class ProteusCoreCryptoContextArrangementImpl : ProteusCoreCryptoContextArrangementMokkeryImpl()
+
+internal class ProteusCoreCryptoContextArrangementMockativeImpl : ProteusCoreCryptoContextArrangement {
+
+    override val proteusContext: ProteusCoreCryptoContext = mock(ProteusCoreCryptoContext::class)
+
+    override suspend fun withNewLastResortPreKeyReturning(result: PreKeyCrypto) = apply {
+        coEvery { proteusContext.newLastResortPreKey() }.returns(result)
+    }
+
+    override suspend fun withCreateSessionSuccess() = apply {
+        coEvery { proteusContext.createSession(any(), any()) }.returns(Unit)
+    }
+
+    override suspend fun withCreateSessionThrowing(exception: Throwable) = apply {
+        coEvery { proteusContext.createSession(any(), any()) }.throws(exception)
+    }
+
+    override suspend fun withDoesSessionExistReturning(result: Boolean) = apply {
+        coEvery { proteusContext.doesSessionExist(any()) }.returns(result)
+    }
+
+    override suspend fun withGetLocalFingerprintReturning(fingerprint: String) = apply {
+        coEvery { proteusContext.getLocalFingerprint() }.returns(fingerprint)
+    }
+
+    override suspend fun withDeleteSessionSuccess() = apply {
+        coEvery { proteusContext.deleteSession(any()) }.returns(Unit)
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8645
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

trying to remove mockative and ksp from the crypto module

### Solutions

for start migrate the arrangement classes to mokkery and few related tests

