### PR TITLE
fix: rejecting 1:1 call doesn't inform other clients [WPB-24617]

### DIFF
--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -550,14 +550,12 @@ internal class CallManagerImpl internal constructor(
         conversationId: ConversationId,
         clients: String
     ) {
-        if (callRepository.getCallMetadata(conversationId)?.protocol !is Conversation.ProtocolInfo.MLS) {
-            withCalling {
-                wcall_set_clients_for_conv(
-                    it,
-                    federatedIdMapper.parseToFederatedId(conversationId),
-                    clients
-                )
-            }
+        withCalling {
+            wcall_set_clients_for_conv(
+                it,
+                federatedIdMapper.parseToFederatedId(conversationId),
+                clients
+            )
         }
     }
 

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
@@ -35,9 +35,6 @@ import com.wire.kalium.logic.data.call.mapper.CallMapperImpl
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
-import com.wire.kalium.logic.data.conversation.ProtocolInfoMapperTest.Companion.CONVERSATION_MIXED_PROTOCOL_INFO
-import com.wire.kalium.logic.data.conversation.ProtocolInfoMapperTest.Companion.CONVERSATION_MLS_PROTOCOL_INFO
-import com.wire.kalium.logic.data.conversation.ProtocolInfoMapperTest.Companion.CONVERSATION_PROTEUS_PROTOCOL_INFO
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.id.FederatedIdMapper

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
@@ -132,29 +132,18 @@ internal class CallManagerTest {
 
     @Test
     @Suppress("FunctionNaming") // native function has that name
-    fun givenCallManager_whenUpdatingConversationClients_then_wcall_set_clients_for_conv_IsCalledForProteusAndMixedProtocol() = runTest {
-        val callProteus = ConversationId(value = "proteus", domain = "domain")
-        val callMixed = ConversationId(value = "mixed", domain = "domain")
-        val callMLS = ConversationId(value = "mls", domain = "domain")
+    fun givenCallManager_whenUpdatingConversationClients_then_wcall_set_clients_for_conv_IsCalled() = runTest {
+        val call = ConversationId(value = "call", domain = "domain")
+        val clients = "clients"
         val (arrangement, callManager) = Arrangement(testDispatcher.testKaliumDispatcher())
-            .onParseToFederatedIdReturning(callProteus, callProteus.toString())
-            .onParseToFederatedIdReturning(callMixed, callMixed.toString())
-            .onParseToFederatedIdReturning(callMLS, callMLS.toString())
-            .withCallMetadataReturning(callProteus, CALL_METADATA.copy(protocol = CONVERSATION_PROTEUS_PROTOCOL_INFO))
-            .withCallMetadataReturning(callMixed, CALL_METADATA.copy(protocol = CONVERSATION_MIXED_PROTOCOL_INFO))
-            .withCallMetadataReturning(callMLS, CALL_METADATA.copy(protocol = CONVERSATION_MLS_PROTOCOL_INFO))
+            .onParseToFederatedIdReturning(call, call.toString())
+            .withCallMetadataReturning(call, CALL_METADATA)
             .arrange()
 
-        callManager.updateConversationClients(callProteus, "clients")
-        callManager.updateConversationClients(callMixed, "clients")
-        callManager.updateConversationClients(callMLS, "clients")
+        callManager.updateConversationClients(call, clients)
 
-        verify(VerifyMode.exactly(1)) { // called for proteus and mixed protocol
-            arrangement.calling.wcall_set_clients_for_conv(inst = any(), convId = callProteus.toString(), clientsJson = "clients")
-            arrangement.calling.wcall_set_clients_for_conv(inst = any(), convId = callMixed.toString(), clientsJson = "clients")
-        }
-        verify(VerifyMode.not) { // not called for MLS protocol
-            arrangement.calling.wcall_set_clients_for_conv(inst = any(), convId = callMLS.toString(), clientsJson = "clients")
+        verify(VerifyMode.exactly(1)) {
+            arrangement.calling.wcall_set_clients_for_conv(inst = any(), convId = call.toString(), clientsJson = clients)
         }
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Rejecting a 1:1 call doesn't inform other clients and they keep ringing.

### Causes (Optional)

There was a check to only call `wcall_set_clients_for_conv` when the protocol is other than MLS.
For MLS 1:1 calls, AVS needs to get the clients list in order to be able to send a REJECT message as it doesn't know whether a call is a 1:1 MLS or not, it only knows `ConferenceMLS` or `Conference`, so for MLS group calls it can notice that and send a message to SELF, but for 1:1 calls it relies on the app to provide clients list.

### Solutions

Remove the check and call `wcall_set_clients_for_conv` for all protocols, whenever AVS needs it. 
Thanks to that it becomes aligned with other platforms, as on web and iOS it's already called for all protocols.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Receive a 1:1 MLS call, reject it, on your other clients it should stop ringing.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
