### PR TITLE
fix: keep screen sharings on top when other videos are disabled [WPB-24273]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallingParticipantsOrder.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallingParticipantsOrder.kt
@@ -27,7 +27,7 @@ import io.mockative.Mockable
 internal interface CallingParticipantsOrder {
     suspend fun reorderItems(
         participants: List<Participant>,
-        orderType: CallingParticipantsOrderType = CallingParticipantsOrderType.VIDEOS_FIRST
+        orderType: CallingParticipantsOrderType = CallingParticipantsOrderType.ALL_MEDIA_FIRST
     ): List<Participant>
 }
 
@@ -54,7 +54,7 @@ internal class CallingParticipantsOrderImpl(
         )
 
         when (orderType) {
-            CallingParticipantsOrderType.VIDEOS_FIRST -> {
+            CallingParticipantsOrderType.ALL_MEDIA_FIRST -> {
                 val participantsSharingScreen = participantsFilter.participantsSharingScreen(otherParticipants, true)
                 val participantsNotSharingScreen = participantsFilter.participantsSharingScreen(otherParticipants, false)
 
@@ -76,6 +76,18 @@ internal class CallingParticipantsOrderImpl(
                 listOfNotNull(selfParticipant) + sortedParticipantsByName
             }
 
+            CallingParticipantsOrderType.PRESENTERS_FIRST -> {
+                val participantsSharingScreen = participantsFilter.participantsSharingScreen(otherParticipants, true)
+                val participantsNotSharingScreen = participantsFilter.participantsSharingScreen(otherParticipants, false)
+
+                val participantsSharingScreenSortedByName = participantsOrderByName.sortItems(participantsSharingScreen)
+                val participantsNotSharingScreenSortedByName = participantsOrderByName.sortItems(participantsNotSharingScreen)
+
+                val sortedParticipantsByName = participantsSharingScreenSortedByName + participantsNotSharingScreenSortedByName
+
+                listOfNotNull(selfParticipant) + sortedParticipantsByName
+            }
+
             CallingParticipantsOrderType.ALPHABETICALLY -> {
                 val sortedParticipants = participantsOrderByName.sortItems(otherParticipants)
                 listOfNotNull(selfParticipant) + sortedParticipants
@@ -86,15 +98,26 @@ internal class CallingParticipantsOrderImpl(
 
 public enum class CallingParticipantsOrderType {
     /**
-     * Self participant is always on top, no matter if sharing screen, has video on or off.
-     * Then, the rest of the participants are sorted in the following order: first the participants sharing screen, then the participants
-     * with video on, and finally the participants with video off. Inside each of these groups, participants are sorted alphabetically.
+     * Participants are sorted in the following order:
+     * - self participant, always on top, no matter if sharing screen, has video on or off
+     * - participants sharing screen alphabetically
+     * - participants with video on alphabetically
+     * - participants with video off alphabetically
      */
-    VIDEOS_FIRST,
+    ALL_MEDIA_FIRST,
 
     /**
-     * Self participant is always on top, no matter if sharing screen, has video on or off.
-     * Then, the rest of the participants are sorted alphabetically, regardless of their video or screen sharing status.
+     * Participants are sorted in the following order:
+     * - self participant, always on top, no matter if sharing screen, has video on or off
+     * - participants sharing screen alphabetically
+     * - all other participants alphabetically
+     */
+    PRESENTERS_FIRST,
+
+    /**
+     * Participants are sorted in the following order:
+     * - self participant, always on top, no matter if sharing screen, has video on or off
+     * - all other participants alphabetically
      */
     ALPHABETICALLY
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/ObserveLastActiveCallWithSortedParticipantsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/ObserveLastActiveCallWithSortedParticipantsUseCase.kt
@@ -34,7 +34,7 @@ import kotlinx.coroutines.flow.map
 public interface ObserveLastActiveCallWithSortedParticipantsUseCase {
     public suspend operator fun invoke(
         conversationId: ConversationId,
-        orderType: CallingParticipantsOrderType = CallingParticipantsOrderType.VIDEOS_FIRST
+        orderType: CallingParticipantsOrderType = CallingParticipantsOrderType.ALL_MEDIA_FIRST
     ): Flow<Call?>
 }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallingParticipantsOrderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallingParticipantsOrderTest.kt
@@ -47,25 +47,25 @@ class CallingParticipantsOrderTest {
     }
 
     @Test
-    fun givenAListOfParticipants_andNotKnownCurrentClient_whenOrderingByVideosFirst_thenOrderAllItemsProperly() = runTest {
+    fun givenAListOfParticipants_andNotKnownCurrentClient_whenOrderingByAllMediaFirst_thenOrderAllItemsProperly() = runTest {
         // given
         val (arrangement, callingParticipantsOrder) = Arrangement()
             .withCurrentClientIdProviderReturning(Either.Left(CoreFailure.MissingClientRegistration))
             .arrange()
         val expected = with(arrangement) {
             // no self participant at the beginning as it cannot be determined
-            allParticipants.sharingScreen().sortedByName() + // first all participants, including self, sharing screen sorted by name
+            allParticipants.sharingScreen().sortedByName() + // first all participants sharing screen sorted by name
                     allParticipants.notSharingScreen().withCameraOn().sortedByName() + // then others with camera on sorted by name
                     allParticipants.notSharingScreen().withCameraOff().sortedByName() // then the rest sorted by name
         }
         // when
-        val result = callingParticipantsOrder.reorderItems(arrangement.allParticipants, CallingParticipantsOrderType.VIDEOS_FIRST)
+        val result = callingParticipantsOrder.reorderItems(arrangement.allParticipants, CallingParticipantsOrderType.ALL_MEDIA_FIRST)
         // then
         assertEquals(expected, result)
     }
 
     @Test
-    fun givenAListOfParticipants_andKnownCurrentClientWithoutVideo_whenOrderingByVideosFirst_thenOrderItemsProperly() = runTest {
+    fun givenAListOfParticipants_andKnownCurrentClientWithoutVideo_whenOrderingByAllMediaFirst_thenOrderItemsProperly() = runTest {
         // given
         val (arrangement, callingParticipantsOrder) = Arrangement()
             .withCurrentClientIdProviderReturning(Either.Right(ClientId(selfClientId)))
@@ -77,13 +77,13 @@ class CallingParticipantsOrderTest {
                     otherParticipants.notSharingScreen().withCameraOff().sortedByName() // then the rest sorted by name
         }
         // when
-        val result = callingParticipantsOrder.reorderItems(arrangement.allParticipants, CallingParticipantsOrderType.VIDEOS_FIRST)
+        val result = callingParticipantsOrder.reorderItems(arrangement.allParticipants, CallingParticipantsOrderType.ALL_MEDIA_FIRST)
         // then
         assertEquals(expected, result)
     }
 
     @Test
-    fun givenAListOfParticipants_andKnownCurrentClientWithVideo_whenOrderingByVideosFirst_thenOrderItemsProperly() = runTest {
+    fun givenAListOfParticipants_andKnownCurrentClientWithVideo_whenOrderingByAllMediaFirst_thenOrderItemsProperly() = runTest {
         // given
         val (arrangement, callingParticipantsOrder) = Arrangement()
             .withCurrentClientIdProviderReturning(Either.Right(ClientId(selfClientId)))
@@ -95,7 +95,58 @@ class CallingParticipantsOrderTest {
                     otherParticipants.notSharingScreen().withCameraOff().sortedByName() // then the rest sorted by name
         }
         // when
-        val result = callingParticipantsOrder.reorderItems(arrangement.allParticipants, CallingParticipantsOrderType.VIDEOS_FIRST)
+        val result = callingParticipantsOrder.reorderItems(arrangement.allParticipants, CallingParticipantsOrderType.ALL_MEDIA_FIRST)
+        // then
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun givenAListOfParticipants_andNotKnownCurrentClient_whenOrderingByPresentersFirst_thenOrderAllItemsProperly() = runTest {
+        // given
+        val (arrangement, callingParticipantsOrder) = Arrangement()
+            .withCurrentClientIdProviderReturning(Either.Left(CoreFailure.MissingClientRegistration))
+            .arrange()
+        val expected = with(arrangement) {
+            // no self participant at the beginning as it cannot be determined
+            allParticipants.sharingScreen().sortedByName() + // first all participants sharing screen sorted by name
+                    allParticipants.notSharingScreen().sortedByName() // then all others not sharing screen sorted by name
+        }
+        // when
+        val result = callingParticipantsOrder.reorderItems(arrangement.allParticipants, CallingParticipantsOrderType.PRESENTERS_FIRST)
+        // then
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun givenAListOfParticipants_andKnownCurrentClientWithoutVideo_whenOrderingByPresentersFirst_thenOrderItemsProperly() = runTest {
+        // given
+        val (arrangement, callingParticipantsOrder) = Arrangement()
+            .withCurrentClientIdProviderReturning(Either.Right(ClientId(selfClientId)))
+            .arrange()
+        val expected = with(arrangement) {
+            listOf(selfParticipant) + // self participant first, even if not sharing screen and with camera off
+                    otherParticipants.sharingScreen().sortedByName() + // then other participants sharing screen sorted by name
+                    otherParticipants.notSharingScreen().sortedByName() // then all others not sharing screen sorted by name
+        }
+        // when
+        val result = callingParticipantsOrder.reorderItems(arrangement.allParticipants, CallingParticipantsOrderType.PRESENTERS_FIRST)
+        // then
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun givenAListOfParticipants_andKnownCurrentClientWithVideo_whenOrderingByPresentersFirst_thenOrderItemsProperly() = runTest {
+        // given
+        val (arrangement, callingParticipantsOrder) = Arrangement()
+            .withCurrentClientIdProviderReturning(Either.Right(ClientId(selfClientId)))
+            .arrange()
+        val expected = with(arrangement) {
+            listOf(selfParticipant) + // self participant first
+                    otherParticipants.sharingScreen().sortedByName() + // then other participants sharing screen sorted by name
+                    otherParticipants.notSharingScreen().sortedByName() // then all others not sharing screen sorted by name
+        }
+        // when
+        val result = callingParticipantsOrder.reorderItems(arrangement.allParticipants, CallingParticipantsOrderType.PRESENTERS_FIRST)
         // then
         assertEquals(expected, result)
     }
@@ -108,7 +159,7 @@ class CallingParticipantsOrderTest {
             .arrange()
         val expected = with(arrangement) {
             // no self participant at the beginning as it cannot be determined
-            allParticipants.sortedByName() // all participants, including self, sorted by name regardless of video or screen sharing
+            allParticipants.sortedByName() // all participants sorted by name regardless of video or screen sharing
         }
         // when
         val result = callingParticipantsOrder.reorderItems(arrangement.allParticipants, CallingParticipantsOrderType.ALPHABETICALLY)
@@ -152,7 +203,8 @@ class CallingParticipantsOrderTest {
 
         var selfParticipant = participant1
             private set
-        var otherParticipants: List<Participant> = listOf(participant5, participant2, participant4, participant3) // unordered list
+        var otherParticipants: List<Participant> =
+            listOf(participant5, participant2, participant6, participant4, participant3) // unordered list
             private set
         val allParticipants get() = listOf(selfParticipant) + otherParticipants
 
@@ -161,7 +213,8 @@ class CallingParticipantsOrderTest {
         }
 
         init {
-            every { participantsFilter.otherParticipants(any(), selfClientId)
+            every {
+                participantsFilter.otherParticipants(any(), selfClientId)
             } returns otherParticipants
             every {
                 participantsFilter.selfParticipant(any(), selfUserId, selfClientId)
@@ -209,7 +262,7 @@ class CallingParticipantsOrderTest {
             hasEstablishedAudio = true,
             accentId = 0
         )
-        private  val participant2 = Participant(
+        private val participant2 = Participant(
             id = QualifiedID("participant2", "domain"),
             clientId = "client2",
             isMuted = false,
@@ -243,6 +296,16 @@ class CallingParticipantsOrderTest {
             isMuted = false,
             isCameraOn = true,
             name = "Other user 5",
+            hasEstablishedAudio = true,
+            accentId = 0
+        )
+        private val participant6 = Participant(
+            id = QualifiedID("participant6", "domain"),
+            clientId = "client6",
+            isMuted = false,
+            isCameraOn = false,
+            isSharingScreen = true,
+            name = "Other user 6",
             hasEstablishedAudio = true,
             accentId = 0
         )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/ObserveLastActiveCallWithSortedParticipantsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/ObserveLastActiveCallWithSortedParticipantsUseCaseTest.kt
@@ -75,7 +75,7 @@ class ObserveLastActiveCallWithSortedParticipantsUseCaseTest {
             .withObserveLastActiveCallByConversationIdReturning(flowOf(call))
             .arrange()
         // when
-        useCase(call.conversationId, CallingParticipantsOrderType.VIDEOS_FIRST).test {
+        useCase(call.conversationId, CallingParticipantsOrderType.ALL_MEDIA_FIRST).test {
         // then
             assertEquals(call, awaitItem())
             awaitComplete()
@@ -84,7 +84,7 @@ class ObserveLastActiveCallWithSortedParticipantsUseCaseTest {
             arrangement.callRepository.observeLastActiveCallByConversationId(call.conversationId)
         }
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.callingParticipantsOrder.reorderItems(call.participants, CallingParticipantsOrderType.VIDEOS_FIRST)
+            arrangement.callingParticipantsOrder.reorderItems(call.participants, CallingParticipantsOrderType.ALL_MEDIA_FIRST)
         }
     }
 
@@ -166,7 +166,7 @@ class ObserveLastActiveCallWithSortedParticipantsUseCaseTest {
             callRepository,
             callingParticipantsOrder
         )
-        suspend fun withReorderItemsReturning(result: List<Participant>) = apply {
+        fun withReorderItemsReturning(result: List<Participant>) = apply {
             everySuspend {
                 callingParticipantsOrder.reorderItems(any(), any())
             }.returns(result)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24273
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When user disables other videos, screen sharing ones are also disabled.

### Solutions

Implement a new participant order type to keep screen sharing ones on top, right after self.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

- start/join a group call
- let others enable video and start screen sharing
- disable other videos

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
