### PR TITLE
feat: add GetConversationEpochFromCC use case and integrate into debug conversation screen [WPB-24877]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
@@ -158,6 +158,12 @@ public class DebugScope internal constructor(
             eventProcessor = eventProcessor
         )
 
+    public val getConversationEpochFromCC: GetConversationEpochFromCCUseCase
+        get() = GetConversationEpochFromCCUseCaseImpl(
+            conversationRepository = conversationRepository,
+            transactionProvider = transactionProvider
+        )
+
     public val synchronizeExternalData: SynchronizeExternalDataUseCase
         get() = SynchronizeExternalDataUseCaseImpl(
             eventRepository = eventRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/GetConversationEpochFromCCUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/GetConversationEpochFromCCUseCase.kt
@@ -1,0 +1,65 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.debug
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.fold
+import com.wire.kalium.common.functional.right
+import com.wire.kalium.logic.data.client.CryptoTransactionProvider
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.id.ConversationId
+import io.mockative.Mockable
+
+@Mockable
+public interface GetConversationEpochFromCCUseCase {
+    public suspend operator fun invoke(conversationId: ConversationId): GetConversationEpochFromCCResult
+}
+
+internal class GetConversationEpochFromCCUseCaseImpl(
+    private val conversationRepository: ConversationRepository,
+    private val transactionProvider: CryptoTransactionProvider,
+) : GetConversationEpochFromCCUseCase {
+
+    override suspend fun invoke(conversationId: ConversationId): GetConversationEpochFromCCResult =
+        conversationRepository.getConversationById(conversationId).fold(
+            fnL = { GetConversationEpochFromCCResult.Failure.Generic(it) },
+            fnR = { conversation ->
+                val protocol = conversation.protocol as? Conversation.ProtocolInfo.MLSCapable
+                if (protocol == null) {
+                    GetConversationEpochFromCCResult.Failure.NotMlsConversation
+                } else {
+                    transactionProvider.mlsTransaction("GetConversationEpochFromCC") { mlsContext ->
+                        mlsContext.conversationEpoch(protocol.groupId.value).right()
+                    }.fold(
+                        fnL = { GetConversationEpochFromCCResult.Failure.Generic(it) },
+                        fnR = { GetConversationEpochFromCCResult.Success(it) }
+                    )
+                }
+            }
+        )
+}
+
+public sealed class GetConversationEpochFromCCResult {
+    public data class Success(val epoch: ULong) : GetConversationEpochFromCCResult()
+
+    public sealed class Failure : GetConversationEpochFromCCResult() {
+        public data object NotMlsConversation : Failure()
+        public data class Generic(val coreFailure: CoreFailure) : Failure()
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/GetConversationEpochFromCCUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/GetConversationEpochFromCCUseCase.kt
@@ -25,6 +25,10 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
 
+/**
+ * Returns the current conv epoch from core-crypto
+ * see [MlsCoreCryptoContext.conversationEpoch]
+ */
 public interface GetConversationEpochFromCCUseCase {
     public suspend operator fun invoke(conversationId: ConversationId): GetConversationEpochFromCCResult
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/GetConversationEpochFromCCUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/GetConversationEpochFromCCUseCase.kt
@@ -24,9 +24,7 @@ import com.wire.kalium.logic.data.client.CryptoTransactionProvider
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
-import io.mockative.Mockable
 
-@Mockable
 public interface GetConversationEpochFromCCUseCase {
     public suspend operator fun invoke(conversationId: ConversationId): GetConversationEpochFromCCResult
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifier.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifier.kt
@@ -39,6 +39,8 @@ import com.wire.kalium.logic.data.id.SubconversationId
 import com.wire.kalium.logic.data.message.SystemMessageInserter
 import com.wire.kalium.util.ConversationPersistenceApi
 import io.mockative.Mockable
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifier.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifier.kt
@@ -39,8 +39,6 @@ import com.wire.kalium.logic.data.id.SubconversationId
 import com.wire.kalium.logic.data.message.SystemMessageInserter
 import com.wire.kalium.util.ConversationPersistenceApi
 import io.mockative.Mockable
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/debug/GetConversationEpochFromCCUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/debug/GetConversationEpochFromCCUseCaseTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.debug
+
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.right
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
+import io.mockative.any
+import io.mockative.coEvery
+import io.mockative.coVerify
+import io.mockative.eq
+import io.mockative.mock
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class GetConversationEpochFromCCUseCaseTest {
+
+    @Test
+    fun givenMLSConversation_whenInvoked_thenReturnEpochFromCC() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withConversation(TestConversation.GROUP(TestConversation.MLS_PROTOCOL_INFO).right())
+            .withCCEpoch(EXPECTED_EPOCH)
+            .arrange()
+
+        val result = useCase(TestConversation.ID)
+
+        coVerify {
+            arrangement.mlsContext.conversationEpoch(eq(TestConversation.GROUP_ID.value))
+        }.wasInvoked(exactly = 1)
+        assertEquals(GetConversationEpochFromCCResult.Success(EXPECTED_EPOCH), result)
+    }
+
+    @Test
+    fun givenProteusConversation_whenInvoked_thenReturnNotMlsConversationFailure() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withConversation(TestConversation.GROUP(Conversation.ProtocolInfo.Proteus).right())
+            .arrange()
+
+        val result = useCase(TestConversation.ID)
+
+        coVerify {
+            arrangement.cryptoTransactionProvider.mlsTransaction<ULong>(any(), any())
+        }.wasNotInvoked()
+        assertIs<GetConversationEpochFromCCResult.Failure.NotMlsConversation>(result)
+    }
+
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
+        val conversationRepository = mock(ConversationRepository::class)
+        private var ccEpoch = EXPECTED_EPOCH
+
+        suspend fun withConversation(result: Either<StorageFailure, Conversation>) = apply {
+            coEvery { conversationRepository.getConversationById(any()) } returns result
+        }
+
+        suspend fun withCCEpoch(epoch: ULong) = apply {
+            ccEpoch = epoch
+            coEvery { mlsContext.conversationEpoch(any()) } returns epoch
+        }
+
+        suspend fun arrange(): Pair<Arrangement, GetConversationEpochFromCCUseCaseImpl> {
+            withMLSTransactionReturning(ccEpoch.right())
+            return this to GetConversationEpochFromCCUseCaseImpl(
+                conversationRepository = conversationRepository,
+                transactionProvider = cryptoTransactionProvider,
+            )
+        }
+    }
+
+    private companion object {
+        val EXPECTED_EPOCH = 42UL
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/debug/GetConversationEpochFromCCUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/debug/GetConversationEpochFromCCUseCaseTest.kt
@@ -18,18 +18,20 @@
 package com.wire.kalium.logic.feature.debug
 
 import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.right
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
-import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
-import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
-import io.mockative.any
-import io.mockative.coEvery
-import io.mockative.coVerify
-import io.mockative.eq
-import io.mockative.mock
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMokkeryImpl
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.matcher.eq
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -46,9 +48,9 @@ class GetConversationEpochFromCCUseCaseTest {
 
         val result = useCase(TestConversation.ID)
 
-        coVerify {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsContext.conversationEpoch(eq(TestConversation.GROUP_ID.value))
-        }.wasInvoked(exactly = 1)
+        }
         assertEquals(GetConversationEpochFromCCResult.Success(EXPECTED_EPOCH), result)
     }
 
@@ -60,23 +62,23 @@ class GetConversationEpochFromCCUseCaseTest {
 
         val result = useCase(TestConversation.ID)
 
-        coVerify {
+        verifySuspend(VerifyMode.not) {
             arrangement.cryptoTransactionProvider.mlsTransaction<ULong>(any(), any())
-        }.wasNotInvoked()
+        }
         assertIs<GetConversationEpochFromCCResult.Failure.NotMlsConversation>(result)
     }
 
-    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl() {
-        val conversationRepository = mock(ConversationRepository::class)
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMokkeryImpl() {
+        val conversationRepository = mock<ConversationRepository>()
         private var ccEpoch = EXPECTED_EPOCH
 
         suspend fun withConversation(result: Either<StorageFailure, Conversation>) = apply {
-            coEvery { conversationRepository.getConversationById(any()) } returns result
+            everySuspend { conversationRepository.getConversationById(any()) } returns result
         }
 
         suspend fun withCCEpoch(epoch: ULong) = apply {
             ccEpoch = epoch
-            coEvery { mlsContext.conversationEpoch(any()) } returns epoch
+            everySuspend { mlsContext.conversationEpoch(any()) } returns epoch
         }
 
         suspend fun arrange(): Pair<Arrangement, GetConversationEpochFromCCUseCaseImpl> {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24877
<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

The debug inspect conversation screen showed the epoch from the local conversation object, which is not reliable enough for debugging.

### Solutions

- Kept the existing local epoch visible and marked it as deprecated.
- Added a new debug use case to fetch the conversation epoch from CC.
- Added a small refresh action because the CC epoch is fetched on demand and not exposed as a flow.
- Displayed the CC epoch as a separate line in the inspect conversation screen.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

#### How to Test

- Verified the new Kalium use case with unit tests.
- Verified the debug conversation ViewModel with unit tests.
- Ran static analysis successfully.

### Notes

The CC epoch is only available for MLS conversations.