### PR TITLE
fix: stale epoch recovery (WPB-24596)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationUseCase.kt
@@ -153,25 +153,6 @@ internal class JoinExistingMLSConversationUseCaseImpl(
         return when {
             protocol !is Conversation.ProtocolInfo.MLSCapable -> Either.Right(Unit)
 
-            transactionContext.wrapInMLSContext { mlsContext ->
-                mlsConversationRepository.hasEstablishedMLSGroup(mlsContext, protocol.groupId)
-            }.fold({ false }, { it }) -> {
-                logger.d(
-                    "Skipping join/establish for ${conversation.id.toLogString()} because MLS group already exists locally"
-                )
-                if (protocol.groupState != Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED) {
-                    logger.d(
-                        "Updating local group state to ESTABLISHED for ${conversation.id.toLogString()} to sync DB with local MLS state"
-                    )
-                    conversationRepository.updateConversationGroupStateByConversationId(
-                        conversation.id,
-                        Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED
-                    )
-                } else {
-                    Either.Right(Unit)
-                }
-            }
-
             protocol.epoch != 0UL -> {
                 // TODO(refactor): don't use conversationAPI directly
                 //                 we could use mlsConversationRepository to solve this

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCaseTest.kt
@@ -155,65 +155,6 @@ class JoinExistingMLSConversationUseCaseTest {
         }
 
     @Test
-    fun givenGroupConversationWithZeroEpochAndLocalGroupExists_whenInvokingUseCase_ThenSkipEstablish() =
-        runTest {
-            val members = listOf(TestUser.USER_ID, TestUser.OTHER_USER_ID)
-            val (arrangement, joinExistingMLSConversationsUseCase) = Arrangement(testKaliumDispatcher)
-                .withIsMLSSupported(true)
-                .withHasRegisteredMLSClient(true)
-                .withGetConversationsByIdSuccessful(Arrangement.MLS_UNESTABLISHED_GROUP_CONVERSATION)
-                .withGetConversationMembersSuccessful(members)
-                .withLocalGroupExists(true)
-                .arrange()
-
-            joinExistingMLSConversationsUseCase(
-                arrangement.transactionContext,
-                Arrangement.MLS_UNESTABLISHED_GROUP_CONVERSATION.id
-            ).shouldSucceed()
-
-            coVerify {
-                arrangement.mlsConversationRepository.establishMLSGroup(
-                    mlsContext = any(),
-                    groupID = eq(Arrangement.GROUP_ID3),
-                    members = eq(members),
-                    publicKeys = any(),
-                    allowSkippingUsersWithoutKeyPackages = eq(false)
-                )
-            }.wasNotInvoked()
-
-            coVerify {
-                arrangement.mlsConversationRepository.joinGroupByExternalCommit(any(), any(), any())
-            }.wasNotInvoked()
-
-            coVerify {
-                arrangement.conversationRepository.updateConversationGroupStateByConversationId(
-                    eq(Arrangement.MLS_UNESTABLISHED_GROUP_CONVERSATION.id),
-                    eq(Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED)
-                )
-            }.wasInvoked(once)
-        }
-
-    @Test
-    fun givenEstablishedConversationAndLocalGroupExists_whenInvokingUseCase_thenDoNotUpdateLocalGroupState() =
-        runTest {
-            val (arrangement, joinExistingMLSConversationsUseCase) = Arrangement(testKaliumDispatcher)
-                .withIsMLSSupported(true)
-                .withHasRegisteredMLSClient(true)
-                .withGetConversationsByIdSuccessful(Arrangement.MLS_ESTABLISHED_GROUP_CONVERSATION)
-                .withLocalGroupExists(true)
-                .arrange()
-
-            joinExistingMLSConversationsUseCase(
-                arrangement.transactionContext,
-                Arrangement.MLS_ESTABLISHED_GROUP_CONVERSATION.id
-            ).shouldSucceed()
-
-            coVerify {
-                arrangement.conversationRepository.updateConversationGroupStateByConversationId(any(), any())
-            }.wasNotInvoked()
-        }
-
-    @Test
     fun givenSelfConversationWithZeroEpoch_whenInvokingUseCase_ThenEstablishMlsGroup() = runTest {
         // GIVEN
         val (arrangement, joinExistingMLSConversationUseCase) = Arrangement(testKaliumDispatcher)


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-24596
----

# What's new in this PR?

### Issues
Stale epoch recovery not working.

### Solutions
Remove extra condition for checking if the MLS conversation already exists.
This condition is already checked in the MLSWelcomeHandler (to fix duplicate MLS Welcome handling) and is safe in other call paths.