### PR TITLE
feat: Search for Apps - Part3 (Wiring Changes to UseCases) [WPB-20357]

### DIFF
--- a/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/service/ServiceDetails.kt
+++ b/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/service/ServiceDetails.kt
@@ -17,7 +17,6 @@
  */
 package com.wire.kalium.logic.data.service
 
-import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.UserAssetId
 
 data class ServiceDetails(
@@ -35,9 +34,3 @@ data class ServiceId(
     val id: String,
     val provider: String
 )
-
-fun ServiceId.toQualifiedID(): QualifiedID =
-    QualifiedID(
-        value = this.id,
-        domain = this.provider
-    )

--- a/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/service/ServiceDetails.kt
+++ b/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/service/ServiceDetails.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.kalium.logic.data.service
 
+import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.UserAssetId
 
 data class ServiceDetails(
@@ -34,3 +35,9 @@ data class ServiceId(
     val id: String,
     val provider: String
 )
+
+fun ServiceId.toQualifiedID(): QualifiedID =
+    QualifiedID(
+        value = this.id,
+        domain = this.provider
+    )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -41,6 +41,8 @@ import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.configuration.notification.NotificationTokenDataSource
 import com.wire.kalium.logic.data.analytics.AnalyticsDataSource
 import com.wire.kalium.logic.data.analytics.AnalyticsRepository
+import com.wire.kalium.logic.data.app.AppDataSource
+import com.wire.kalium.logic.data.app.AppRepository
 import com.wire.kalium.logic.data.asset.AssetDataSource
 import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.asset.DataStoragePaths
@@ -211,6 +213,7 @@ import com.wire.kalium.logic.feature.analytics.GetAnalyticsContactsDataUseCase
 import com.wire.kalium.logic.feature.analytics.GetCurrentAnalyticsTrackingIdentifierUseCase
 import com.wire.kalium.logic.feature.analytics.ObserveAnalyticsTrackingIdentifierStatusUseCase
 import com.wire.kalium.logic.feature.analytics.SetNewUserTrackingIdentifierUseCase
+import com.wire.kalium.logic.feature.app.AppScope
 import com.wire.kalium.logic.feature.applock.AppLockTeamFeatureConfigObserver
 import com.wire.kalium.logic.feature.applock.AppLockTeamFeatureConfigObserverImpl
 import com.wire.kalium.logic.feature.applock.MarkTeamAppLockStatusAsNotifiedUseCase
@@ -1022,6 +1025,7 @@ public class UserSessionScope internal constructor(
             userDAO = userStorage.database.userDAO,
             clientDAO = userStorage.database.clientDAO,
             memberDAO = userStorage.database.memberDAO,
+            appDAO = userStorage.database.appDAO,
             selfApi = authenticatedNetworkContainer.selfApi,
             userDetailsApi = authenticatedNetworkContainer.userDetailsApi,
             upgradePersonalToTeamApi = authenticatedNetworkContainer.upgradePersonalToTeamApi,
@@ -1029,8 +1033,7 @@ public class UserSessionScope internal constructor(
             sessionRepository = globalScope.sessionRepository,
             selfUserId = userId,
             selfTeamIdProvider = selfTeamId,
-            legalHoldHandler = legalHoldHandler,
-            appDAO = userStorage.database.appDAO
+            legalHoldHandler = legalHoldHandler
         )
 
     private val accountRepository: AccountRepository
@@ -1057,7 +1060,12 @@ public class UserSessionScope internal constructor(
 
     private val serviceRepository: ServiceRepository
         get() = ServiceDataSource(
-            serviceDAO = userStorage.database.serviceDAO
+            serviceDAO = userStorage.database.serviceDAO,
+        )
+
+    private val appRepository: AppRepository
+        get() = AppDataSource(
+            appDAO = userStorage.database.appDAO
         )
 
     private val persistConversationsUseCase: PersistConversationsUseCase
@@ -2641,6 +2649,11 @@ public class UserSessionScope internal constructor(
             teamRepository,
             userConfigRepository,
             selfTeamId
+        )
+
+    public val apps: AppScope
+        get() = AppScope(
+            appRepository = appRepository
         )
 
     public val calls: CallsScope

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/app/AppScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/app/AppScope.kt
@@ -1,0 +1,45 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.app
+
+import com.wire.kalium.logic.data.app.AppRepository
+
+public class AppScope internal constructor(
+    private val appRepository: AppRepository
+) {
+
+    public val getAppById: GetAppByIdUseCase
+        get() = GetAppByIdUseCaseImpl(
+            appRepository = appRepository
+        )
+
+    public val observeIsAppMember: ObserveIsAppMemberUseCase
+        get() = ObserveIsAppMemberUseCaseImpl(
+            appRepository = appRepository
+        )
+
+    public val observeAllApps: ObserveAllAppsUseCase
+        get() = ObserveAllAppsUseCaseImpl(
+            appRepository = appRepository
+        )
+
+    public val searchAppsByName: SearchAppsByNameUseCase
+        get() = SearchAppsByNameUseCaseImpl(
+            appRepository = appRepository
+        )
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/app/GetAppByIdUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/app/GetAppByIdUseCase.kt
@@ -1,0 +1,47 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.app
+
+import com.wire.kalium.common.functional.nullableFold
+import com.wire.kalium.logic.data.app.AppMapper
+import com.wire.kalium.logic.data.app.AppRepository
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.service.ServiceDetails
+import com.wire.kalium.logic.di.MapperProvider
+
+/**
+ * This use case is responsible for getting Service Details from given App ID.
+ * @param appId QualifiedID of the App
+ * @return ServiceDetails or NULL.
+ */
+public interface GetAppByIdUseCase {
+
+    public suspend operator fun invoke(appId: QualifiedID): ServiceDetails?
+}
+
+internal class GetAppByIdUseCaseImpl internal constructor(
+    private val appRepository: AppRepository,
+    private val appMapper: AppMapper = MapperProvider.appMapper()
+) : GetAppByIdUseCase {
+
+    override suspend fun invoke(appId: QualifiedID): ServiceDetails? =
+        appRepository.getAppById(appId = appId)
+            .nullableFold({ null }, {
+                it?.let { app -> appMapper.toServiceDetails(app) }
+            })
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/app/ObserveAllAppsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/app/ObserveAllAppsUseCase.kt
@@ -1,0 +1,49 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.app
+
+import com.wire.kalium.common.functional.fold
+import com.wire.kalium.logic.data.app.AppMapper
+import com.wire.kalium.logic.data.app.AppRepository
+import com.wire.kalium.logic.data.service.ServiceDetails
+import com.wire.kalium.logic.di.MapperProvider
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * This use case returns all Apps currently in the database.
+ *
+ * @return Flow<List<ServiceDetails>>
+ */
+public interface ObserveAllAppsUseCase {
+
+    public suspend operator fun invoke(): Flow<List<ServiceDetails>>
+}
+
+internal class ObserveAllAppsUseCaseImpl internal constructor(
+    private val appRepository: AppRepository,
+    private val appMapper: AppMapper = MapperProvider.appMapper()
+) : ObserveAllAppsUseCase {
+
+    override suspend fun invoke(): Flow<List<ServiceDetails>> =
+        appRepository.observeAllApps().map {
+            it.fold({ emptyList() }, { it })
+        }.map { apps ->
+            apps.map { app -> appMapper.toServiceDetails(app) }
+        }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/app/ObserveIsAppMemberUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/app/ObserveIsAppMemberUseCase.kt
@@ -18,7 +18,7 @@
 package com.wire.kalium.logic.feature.app
 
 import com.wire.kalium.common.error.StorageFailure
-import com.wire.kalium.common.functional.isRight
+import com.wire.kalium.common.functional.fold
 import com.wire.kalium.logic.data.app.AppRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
@@ -51,10 +51,11 @@ internal class ObserveIsAppMemberUseCaseImpl internal constructor(
             appId = appId,
             conversationId = conversationId
         ).map {
-            when (it.isRight()) {
-                true -> ObserveIsAppMemberResult.Success(it.value)
-                false -> ObserveIsAppMemberResult.Failure(it.value)
-            }
+            it.fold({ failure ->
+                ObserveIsAppMemberResult.Failure(failure)
+            }, { success ->
+                ObserveIsAppMemberResult.Success(success)
+            })
         }
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/app/ObserveIsAppMemberUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/app/ObserveIsAppMemberUseCase.kt
@@ -1,0 +1,64 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.app
+
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.isRight
+import com.wire.kalium.logic.data.app.AppRepository
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.user.UserId
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+public interface ObserveIsAppMemberUseCase {
+    /**
+     * This use case is responsible for observing if an App is member of given conversation.
+     * @param appId contains the ID of the App.
+     * @param conversationId ID of the conversation App will be seen, added or removed.
+     * @return a [Flow] of [ObserveIsAppMemberResult] with Success of a Qualified ID of App in User table or NULL or an error.
+     */
+    public suspend operator fun invoke(
+        appId: QualifiedID,
+        conversationId: ConversationId
+    ): Flow<ObserveIsAppMemberResult>
+}
+
+internal class ObserveIsAppMemberUseCaseImpl internal constructor(
+    private val appRepository: AppRepository
+) : ObserveIsAppMemberUseCase {
+
+    override suspend fun invoke(
+        appId: QualifiedID,
+        conversationId: ConversationId
+    ): Flow<ObserveIsAppMemberResult> =
+        appRepository.observeIsAppMember(
+            appId = appId,
+            conversationId = conversationId
+        ).map {
+            when (it.isRight()) {
+                true -> ObserveIsAppMemberResult.Success(it.value)
+                false -> ObserveIsAppMemberResult.Failure(it.value)
+            }
+        }
+}
+
+public sealed class ObserveIsAppMemberResult {
+    public data class Success(val userId: UserId?) : ObserveIsAppMemberResult()
+    public data class Failure(val failure: StorageFailure) : ObserveIsAppMemberResult()
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/app/SearchAppsByNameUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/app/SearchAppsByNameUseCase.kt
@@ -1,0 +1,50 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.app
+
+import com.wire.kalium.logic.data.app.AppRepository
+import com.wire.kalium.logic.data.service.ServiceDetails
+import com.wire.kalium.common.functional.fold
+import com.wire.kalium.logic.data.app.AppMapper
+import com.wire.kalium.logic.di.MapperProvider
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * This use case searches for Apps based on given name string.
+ *
+ * @param search The query to search for
+ * @return Flow<List<ServiceDetails>>
+ */
+public interface SearchAppsByNameUseCase {
+
+    public suspend operator fun invoke(search: String): Flow<List<ServiceDetails>>
+}
+
+internal class SearchAppsByNameUseCaseImpl internal constructor(
+    private val appRepository: AppRepository,
+    private val appMapper: AppMapper = MapperProvider.appMapper()
+) : SearchAppsByNameUseCase {
+
+    override suspend fun invoke(search: String): Flow<List<ServiceDetails>> =
+        appRepository.searchAppsByName(name = search).map {
+            it.fold({ emptyList() }, { it })
+        }.map { apps ->
+            apps.map { app -> appMapper.toServiceDetails(app) }
+        }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/app/GetAppByIdUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/app/GetAppByIdUseCaseTest.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.kalium.logic.feature.app
 
+import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.app.AppDetails
 import com.wire.kalium.logic.data.app.AppRepository
@@ -49,6 +50,34 @@ class GetAppByIdUseCaseTest {
         assertEquals(Arrangement.serviceDetails, result)
     }
 
+    @Test
+    fun givenAppId_whenGettingAppByIdAndDoesntExist_thenReturnsStorageFailure() = runTest {
+        // given
+        val (_, getAppById) = Arrangement()
+            .withGetAppByIdFailsWithStorageFailure(appId = Arrangement.APP_ID)
+            .arrange()
+
+        // when
+        val result = getAppById(appId = Arrangement.APP_ID)
+
+        // then
+        assertEquals(null, result)
+    }
+
+    @Test
+    fun givenAppId_whenGettingAppByIdReturnsNull_thenReturnNull() = runTest {
+        // given
+        val (_, getAppById) = Arrangement()
+            .withGetAppByIdReturnsNull(appId = Arrangement.APP_ID)
+            .arrange()
+
+        // when
+        val result = getAppById(appId = Arrangement.APP_ID)
+
+        // then
+        assertEquals(null, result)
+    }
+
     private class Arrangement {
         private val appRepository = mock(AppRepository::class)
 
@@ -64,6 +93,22 @@ class GetAppByIdUseCaseTest {
             coEvery {
                 appRepository.getAppById(eq(appId))
             }.returns(Either.Right(appDetails))
+        }
+
+        suspend fun withGetAppByIdFailsWithStorageFailure(
+            appId: QualifiedID
+        ) = apply {
+            coEvery {
+                appRepository.getAppById(eq(appId))
+            }.returns(Either.Left(StorageFailure.DataNotFound))
+        }
+
+        suspend fun withGetAppByIdReturnsNull(
+            appId: QualifiedID
+        ) = apply {
+            coEvery {
+                appRepository.getAppById(eq(appId))
+            }.returns(Either.Right(null))
         }
 
         companion object {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/app/GetAppByIdUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/app/GetAppByIdUseCaseTest.kt
@@ -24,9 +24,9 @@ import com.wire.kalium.logic.data.app.AppRepository
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.service.ServiceDetails
 import com.wire.kalium.logic.data.service.ServiceId
-import io.mockative.coEvery
-import io.mockative.eq
-import io.mockative.mock
+import dev.mokkery.answering.returns
+import dev.mokkery.mock
+import dev.mokkery.everySuspend
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -79,7 +79,7 @@ class GetAppByIdUseCaseTest {
     }
 
     private class Arrangement {
-        private val appRepository = mock(AppRepository::class)
+        private val appRepository = mock<AppRepository>()
 
         private val getAppById = GetAppByIdUseCaseImpl(
             appRepository = appRepository
@@ -90,24 +90,24 @@ class GetAppByIdUseCaseTest {
         suspend fun withGetAppByIdSuccess(
             appId: QualifiedID
         ) = apply {
-            coEvery {
-                appRepository.getAppById(eq(appId))
-            }.returns(Either.Right(appDetails))
+            everySuspend {
+                appRepository.getAppById(appId)
+            } returns Either.Right(appDetails)
         }
 
         suspend fun withGetAppByIdFailsWithStorageFailure(
             appId: QualifiedID
         ) = apply {
-            coEvery {
-                appRepository.getAppById(eq(appId))
+            everySuspend {
+                appRepository.getAppById(appId)
             }.returns(Either.Left(StorageFailure.DataNotFound))
         }
 
         suspend fun withGetAppByIdReturnsNull(
             appId: QualifiedID
         ) = apply {
-            coEvery {
-                appRepository.getAppById(eq(appId))
+            everySuspend {
+                appRepository.getAppById(appId)
             }.returns(Either.Right(null))
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/app/GetAppByIdUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/app/GetAppByIdUseCaseTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.app
+
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.app.AppDetails
+import com.wire.kalium.logic.data.app.AppRepository
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.service.ServiceDetails
+import com.wire.kalium.logic.data.service.ServiceId
+import io.mockative.coEvery
+import io.mockative.eq
+import io.mockative.mock
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.uuid.Uuid
+
+class GetAppByIdUseCaseTest {
+
+    @Test
+    fun givenAppId_whenGettingAppById_thenReturnServiceDetails() = runTest {
+        // given
+        val (_, getAppById) = Arrangement()
+            .withGetAppByIdSuccess(appId = Arrangement.APP_ID)
+            .arrange()
+
+        // when
+        val result = getAppById(appId = Arrangement.APP_ID)
+
+        // then
+        assertIs<ServiceDetails>(result)
+        assertEquals(Arrangement.serviceDetails, result)
+    }
+
+    private class Arrangement {
+        private val appRepository = mock(AppRepository::class)
+
+        private val getAppById = GetAppByIdUseCaseImpl(
+            appRepository = appRepository
+        )
+
+        fun arrange() = this to getAppById
+
+        suspend fun withGetAppByIdSuccess(
+            appId: QualifiedID
+        ) = apply {
+            coEvery {
+                appRepository.getAppById(eq(appId))
+            }.returns(Either.Right(appDetails))
+        }
+
+        companion object {
+            val APP_ID = QualifiedID(
+                value = Uuid.random().toString(),
+                domain = "wire.com"
+            )
+            const val APP_NAME = "App Name"
+            const val APP_DESCRIPTION = "App Description"
+            const val APP_CATEGORY = "DEVELOPER"
+
+            val appDetails = AppDetails(
+                id = APP_ID,
+                name = APP_NAME,
+                description = APP_DESCRIPTION,
+                category = APP_CATEGORY,
+                previewAssetId = null,
+                completeAssetId = null
+            )
+
+            val serviceDetails = ServiceDetails(
+                id = ServiceId(
+                    id = APP_ID.value,
+                    provider = APP_ID.domain
+                ),
+                name = APP_NAME,
+                description = APP_DESCRIPTION,
+                summary = "",
+                enabled = true,
+                tags = emptyList(),
+                previewAssetId = null,
+                completeAssetId = null
+            )
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/app/ObserveAllAppsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/app/ObserveAllAppsUseCaseTest.kt
@@ -1,0 +1,127 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.app
+
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.app.AppDetails
+import com.wire.kalium.logic.data.app.AppRepository
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.service.ServiceDetails
+import com.wire.kalium.logic.data.service.ServiceId
+import io.mockative.coEvery
+import io.mockative.mock
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.uuid.Uuid
+
+class ObserveAllAppsUseCaseTest {
+
+    @Test
+    fun givenSuccess_whenObservingAllApps_thenResultIsServiceDetails() = runTest {
+        // given
+        val expected: List<ServiceDetails> = listOf(Arrangement.serviceDetails)
+
+        val (_, observeAllApps) = Arrangement()
+            .withObserveAllApps(
+                flowOf(
+                    Either.Right(listOf(Arrangement.appDetails))
+                )
+            )
+            .arrange()
+
+        // when
+        observeAllApps().first().also {
+            // then
+            assertEquals(expected, it)
+        }
+    }
+
+    @Test
+    fun givenError_whenObservingAllApps_thenResultIsEmpty() = runTest {
+        // given
+        val error = StorageFailure.DataNotFound
+
+        val (_, observeAllApps) = Arrangement()
+            .withObserveAllApps(
+                flowOf(
+                    Either.Left(error)
+                )
+            )
+            .arrange()
+
+        // when
+        observeAllApps().first().also {
+            // then
+            assertEquals(emptyList(), it)
+        }
+    }
+
+    private class Arrangement {
+        private val appRepository = mock(AppRepository::class)
+
+        private val useCase: ObserveAllAppsUseCase = ObserveAllAppsUseCaseImpl(
+            appRepository = appRepository
+        )
+
+        suspend fun withObserveAllApps(result: Flow<Either<StorageFailure, List<AppDetails>>>) = apply {
+            coEvery {
+                appRepository.observeAllApps()
+            }.returns(result)
+        }
+
+        fun arrange() = this to useCase
+
+        companion object {
+            val APP_ID = QualifiedID(
+                value = Uuid.random().toString(),
+                domain = "wire.com"
+            )
+            const val APP_NAME = "App Name"
+            const val APP_DESCRIPTION = "App Description"
+            const val APP_CATEGORY = "DEVELOPER"
+
+            val appDetails = AppDetails(
+                id = APP_ID,
+                name = APP_NAME,
+                description = APP_DESCRIPTION,
+                category = APP_CATEGORY,
+                previewAssetId = null,
+                completeAssetId = null
+            )
+
+            val serviceDetails = ServiceDetails(
+                id = ServiceId(
+                    id = APP_ID.value,
+                    provider = APP_ID.domain
+                ),
+                name = APP_NAME,
+                description = APP_DESCRIPTION,
+                summary = "",
+                enabled = true,
+                tags = emptyList(),
+                previewAssetId = null,
+                completeAssetId = null
+            )
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/app/ObserveAllAppsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/app/ObserveAllAppsUseCaseTest.kt
@@ -76,6 +76,24 @@ class ObserveAllAppsUseCaseTest {
         }
     }
 
+    @Test
+    fun givenNoAppsExist_whenObservingAllApps_thenResultIsEmpty() = runTest {
+        // given
+        val (_, observeAllApps) = Arrangement()
+            .withObserveAllApps(
+                flowOf(
+                    Either.Right(emptyList())
+                )
+            )
+            .arrange()
+
+        // when
+        observeAllApps().first().also {
+            // then
+            assertEquals(emptyList(), it)
+        }
+    }
+
     private class Arrangement {
         private val appRepository = mock(AppRepository::class)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/app/ObserveAllAppsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/app/ObserveAllAppsUseCaseTest.kt
@@ -24,8 +24,9 @@ import com.wire.kalium.logic.data.app.AppRepository
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.service.ServiceDetails
 import com.wire.kalium.logic.data.service.ServiceId
-import io.mockative.coEvery
-import io.mockative.mock
+import dev.mokkery.answering.returns
+import dev.mokkery.mock
+import dev.mokkery.everySuspend
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
@@ -95,16 +96,16 @@ class ObserveAllAppsUseCaseTest {
     }
 
     private class Arrangement {
-        private val appRepository = mock(AppRepository::class)
+        private val appRepository = mock<AppRepository>()
 
         private val useCase: ObserveAllAppsUseCase = ObserveAllAppsUseCaseImpl(
             appRepository = appRepository
         )
 
         suspend fun withObserveAllApps(result: Flow<Either<StorageFailure, List<AppDetails>>>) = apply {
-            coEvery {
+            everySuspend {
                 appRepository.observeAllApps()
-            }.returns(result)
+            } returns result
         }
 
         fun arrange() = this to useCase

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/app/ObserveIsAppMemberUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/app/ObserveIsAppMemberUseCaseTest.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.kalium.logic.feature.app
 
+import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.app.AppRepository
 import com.wire.kalium.logic.data.id.ConversationId
@@ -55,6 +56,27 @@ class ObserveIsAppMemberUseCaseTest {
         assertEquals(Arrangement.APP_ID, result.userId)
     }
 
+    @Test
+    fun givenAppIdAndConversationId_whenObservingIsAppMemberAndAppDoesntExist_thenReturnStorageFailure() = runTest {
+        // given
+        val (_, observeIsAppMember) = Arrangement()
+            .withObserveIsAppMemberFailure(
+                appId = Arrangement.APP_ID,
+                conversationId = Arrangement.CONVERSATION_ID
+            )
+            .arrange()
+
+        // when
+        val result = observeIsAppMember.invoke(
+            appId = Arrangement.APP_ID,
+            conversationId = Arrangement.CONVERSATION_ID
+        ).first()
+
+        // then
+        assertIs<ObserveIsAppMemberResult.Failure>(result)
+        assertIs<StorageFailure.DataNotFound>(result.failure)
+    }
+
     private class Arrangement {
         private val appRepository = mock(AppRepository::class)
 
@@ -69,6 +91,15 @@ class ObserveIsAppMemberUseCaseTest {
             coEvery {
                 appRepository.observeIsAppMember(eq(appId), eq(conversationId))
             }.returns(flowOf(Either.Right(APP_ID)))
+        }
+
+        suspend fun withObserveIsAppMemberFailure(
+            appId: QualifiedID,
+            conversationId: ConversationId
+        ) = apply {
+            coEvery {
+                appRepository.observeIsAppMember(eq(appId), eq(conversationId))
+            }.returns(flowOf(Either.Left(StorageFailure.DataNotFound)))
         }
 
         fun arrange() = this to useCase

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/app/ObserveIsAppMemberUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/app/ObserveIsAppMemberUseCaseTest.kt
@@ -22,9 +22,9 @@ import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.app.AppRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
-import io.mockative.coEvery
-import io.mockative.eq
-import io.mockative.mock
+import dev.mokkery.answering.returns
+import dev.mokkery.mock
+import dev.mokkery.everySuspend
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -78,7 +78,7 @@ class ObserveIsAppMemberUseCaseTest {
     }
 
     private class Arrangement {
-        private val appRepository = mock(AppRepository::class)
+        private val appRepository = mock<AppRepository>()
 
         private val useCase: ObserveIsAppMemberUseCase = ObserveIsAppMemberUseCaseImpl(
             appRepository = appRepository
@@ -88,18 +88,18 @@ class ObserveIsAppMemberUseCaseTest {
             appId: QualifiedID,
             conversationId: ConversationId
         ) = apply {
-            coEvery {
-                appRepository.observeIsAppMember(eq(appId), eq(conversationId))
-            }.returns(flowOf(Either.Right(APP_ID)))
+            everySuspend {
+                appRepository.observeIsAppMember(appId, conversationId)
+            } returns flowOf(Either.Right(APP_ID))
         }
 
         suspend fun withObserveIsAppMemberFailure(
             appId: QualifiedID,
             conversationId: ConversationId
         ) = apply {
-            coEvery {
-                appRepository.observeIsAppMember(eq(appId), eq(conversationId))
-            }.returns(flowOf(Either.Left(StorageFailure.DataNotFound)))
+            everySuspend {
+                appRepository.observeIsAppMember(appId, conversationId)
+            } returns flowOf(Either.Left(StorageFailure.DataNotFound))
         }
 
         fun arrange() = this to useCase

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/app/ObserveIsAppMemberUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/app/ObserveIsAppMemberUseCaseTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.app
+
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.app.AppRepository
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.QualifiedID
+import io.mockative.coEvery
+import io.mockative.eq
+import io.mockative.mock
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.uuid.Uuid
+
+class ObserveIsAppMemberUseCaseTest {
+
+    @Test
+    fun givenAppIdAndConversationId_whenObservingIsAppMember_thenReturnAppId() = runTest {
+        // given
+        val (_, observeIsAppMember) = Arrangement()
+            .withObserveIsAppMemberSuccess(
+                appId = Arrangement.APP_ID,
+                conversationId = Arrangement.CONVERSATION_ID
+            )
+            .arrange()
+
+        // when
+        val result = observeIsAppMember.invoke(
+            appId = Arrangement.APP_ID,
+            conversationId = Arrangement.CONVERSATION_ID
+        ).first()
+
+        // then
+        assertIs<ObserveIsAppMemberResult.Success>(result)
+        assertEquals(Arrangement.APP_ID, result.userId)
+    }
+
+    private class Arrangement {
+        private val appRepository = mock(AppRepository::class)
+
+        private val useCase: ObserveIsAppMemberUseCase = ObserveIsAppMemberUseCaseImpl(
+            appRepository = appRepository
+        )
+
+        suspend fun withObserveIsAppMemberSuccess(
+            appId: QualifiedID,
+            conversationId: ConversationId
+        ) = apply {
+            coEvery {
+                appRepository.observeIsAppMember(eq(appId), eq(conversationId))
+            }.returns(flowOf(Either.Right(APP_ID)))
+        }
+
+        fun arrange() = this to useCase
+
+        companion object {
+            val APP_ID = QualifiedID(
+                value = Uuid.random().toString(),
+                domain = "wire.com"
+            )
+
+            val CONVERSATION_ID = QualifiedID(
+                value = Uuid.random().toString(),
+                domain = "wire.com"
+            )
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/app/SearchAppsByNameUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/app/SearchAppsByNameUseCaseTest.kt
@@ -24,9 +24,10 @@ import com.wire.kalium.logic.data.app.AppRepository
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.service.ServiceDetails
 import com.wire.kalium.logic.data.service.ServiceId
-import io.mockative.coEvery
-import io.mockative.eq
-import io.mockative.mock
+
+import dev.mokkery.answering.returns
+import dev.mokkery.mock
+import dev.mokkery.everySuspend
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
@@ -97,16 +98,16 @@ class SearchAppsByNameUseCaseTest {
     }
 
     private class Arrangement {
-        private val appRepository = mock(AppRepository::class)
+        private val appRepository = mock<AppRepository>()
 
         private val useCase: SearchAppsByNameUseCase = SearchAppsByNameUseCaseImpl(
             appRepository = appRepository
         )
 
         suspend fun withSearchAppsByName(query: String, result: Flow<Either<StorageFailure, List<AppDetails>>>) = apply {
-            coEvery {
-                appRepository.searchAppsByName(eq(query))
-            }.returns(result)
+            everySuspend {
+                appRepository.searchAppsByName(query)
+            } returns result
         }
 
         fun arrange() = this to useCase

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/app/SearchAppsByNameUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/app/SearchAppsByNameUseCaseTest.kt
@@ -1,0 +1,131 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.app
+
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.app.AppDetails
+import com.wire.kalium.logic.data.app.AppRepository
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.service.ServiceDetails
+import com.wire.kalium.logic.data.service.ServiceId
+import io.mockative.coEvery
+import io.mockative.eq
+import io.mockative.mock
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.uuid.Uuid
+
+class SearchAppsByNameUseCaseTest {
+
+    @Test
+    fun givenSuccess_whenSearchingAppsByName_thenResultIsServiceDetails() = runTest {
+        // given
+        val query = "random query"
+        val expected = listOf(
+            Arrangement.serviceDetails
+        )
+
+        val (_, searchAppsByName) = Arrangement()
+            .withSearchAppsByName(
+                query,
+                flowOf(
+                    Either.Right(
+                        listOf(Arrangement.appDetails)
+                    )
+                )
+            )
+            .arrange()
+
+        // when
+        searchAppsByName(query).first().also {
+            // then
+            assertEquals(expected, it)
+        }
+    }
+
+    @Test
+    fun givenError_whenSearchingAppsByName_thenResultIsEmpty() = runTest {
+        // given
+        val query = "random query"
+        val error = StorageFailure.DataNotFound
+
+        val (_, searchAppsByName) = Arrangement()
+            .withSearchAppsByName(query, flowOf(Either.Left(error)))
+            .arrange()
+
+        // when
+        searchAppsByName(query).first().also {
+            // then
+            assertEquals(emptyList(), it)
+        }
+    }
+
+    private class Arrangement {
+        private val appRepository = mock(AppRepository::class)
+
+        private val useCase: SearchAppsByNameUseCase = SearchAppsByNameUseCaseImpl(
+            appRepository = appRepository
+        )
+
+        suspend fun withSearchAppsByName(query: String, result: Flow<Either<StorageFailure, List<AppDetails>>>) = apply {
+            coEvery {
+                appRepository.searchAppsByName(eq(query))
+            }.returns(result)
+        }
+
+        fun arrange() = this to useCase
+
+        companion object {
+            val APP_ID = QualifiedID(
+                value = Uuid.random().toString(),
+                domain = "wire.com"
+            )
+            const val APP_NAME = "App Name"
+            const val APP_DESCRIPTION = "App Description"
+            const val APP_CATEGORY = "DEVELOPER"
+
+            val appDetails = AppDetails(
+                id = APP_ID,
+                name = APP_NAME,
+                description = APP_DESCRIPTION,
+                category = APP_CATEGORY,
+                previewAssetId = null,
+                completeAssetId = null
+            )
+
+            val serviceDetails = ServiceDetails(
+                id = ServiceId(
+                    id = APP_ID.value,
+                    provider = APP_ID.domain
+                ),
+                name = APP_NAME,
+                description = APP_DESCRIPTION,
+                summary = "",
+                enabled = true,
+                tags = emptyList(),
+                previewAssetId = null,
+                completeAssetId = null
+            )
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/app/SearchAppsByNameUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/app/SearchAppsByNameUseCaseTest.kt
@@ -80,6 +80,22 @@ class SearchAppsByNameUseCaseTest {
         }
     }
 
+    @Test
+    fun givenNoAppsExist_whenSearchingAppsByName_thenResultIsEmpty() = runTest {
+        // given
+        val query = "random query"
+
+        val (_, searchAppsByName) = Arrangement()
+            .withSearchAppsByName(query, flowOf(Either.Right(emptyList())))
+            .arrange()
+
+        // when
+        searchAppsByName(query).first().also {
+            // then
+            assertEquals(emptyList(), it)
+        }
+    }
+
     private class Arrangement {
         private val appRepository = mock(AppRepository::class)
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Add usecase to get an App by Id, returning ServiceDetails
- Add usecase to observe all Apps returning a list of ServiceDetails
- Add usecase to observe if App is member of a conversation returning its id
- Add usecase to search Apps by name, returning a list of found ServiceDetails

Usecases returning `ServiceDetails` instead of `AppDetails` in order to keep using the existing logics for showing old bots and new Apps as they still need to coexist.

### Dependencies (Optional)

Needs releases with:

- [X] #4025 
- [X] #4034 

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

"No way to test yet"

If running this branch (after Part 1 was merged) with Android, in an team where Apps are enabled and doing a sync, it should save existing Apps from the team into the Apps table.