### PR TITLE
fix: failure message for adding user with no mls client (WPB-17105)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
@@ -40,6 +40,7 @@ import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.id.toApi
 import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.id.toModel
+import com.wire.kalium.logic.data.conversation.mls.MLSAdditionResult
 import com.wire.kalium.logic.data.message.MessageContent.MemberChange.FailedToAdd
 import com.wire.kalium.logic.data.mls.CipherSuite
 import com.wire.kalium.logic.data.service.ServiceId
@@ -185,7 +186,7 @@ internal class ConversationGroupRepositoryImpl(
             )
         }.flatMap {
             when (protocol) {
-                is Conversation.ProtocolInfo.Proteus -> Either.Right(setOf())
+                is Conversation.ProtocolInfo.Proteus -> Either.Right(MLSAdditionResult.Empty)
                 is Conversation.ProtocolInfo.MLSCapable ->
                     transactionProvider.mlsTransaction("handleGroupConversationCreated") { mlsContext ->
                         mlsConversationRepository.establishMLSGroup(
@@ -194,22 +195,32 @@ internal class ConversationGroupRepositoryImpl(
                             members = usersList + selfUserId,
                             publicKeys = mlsPublicKeys,
                             allowSkippingUsersWithoutKeyPackages = true,
-                        ).map { it.notAddedUsers }
+                        )
                     }
             }
-        }.flatMap { protocolSpecificAdditionFailures ->
+        }.flatMap { additionResult ->
             newConversationMembersRepository.persistMembersAdditionToTheConversation(
                 conversationEntity.id,
                 conversationResponse
             ).flatMap {
-                if (protocolSpecificAdditionFailures.isEmpty()) {
-                    Either.Right(Unit)
-                } else {
+                if (additionResult.usersWithoutKeyPackages.isNotEmpty()) {
                     newGroupConversationSystemMessagesCreator.value.conversationFailedToAddMembers(
                         conversationId = conversationEntity.id.toModel(),
-                        userIdList = protocolSpecificAdditionFailures.toList(),
+                        userIdList = additionResult.usersWithoutKeyPackages.toList(),
                         type = FailedToAdd.Type.MissingKeyPackages
                     )
+                } else {
+                    Either.Right(Unit)
+                }
+            }.flatMap {
+                if (additionResult.usersWithUnreachableBackend.isNotEmpty()) {
+                    newGroupConversationSystemMessagesCreator.value.conversationFailedToAddMembers(
+                        conversationId = conversationEntity.id.toModel(),
+                        userIdList = additionResult.usersWithUnreachableBackend.toList(),
+                        type = FailedToAdd.Type.Federation
+                    )
+                } else {
+                    Either.Right(Unit)
                 }
             }.flatMap {
                 when (lastUsersAttempt) {
@@ -399,7 +410,8 @@ internal class ConversationGroupRepositoryImpl(
                     type = when {
                         this.isMissingLegalHoldConsentError -> FailedToAdd.Type.LegalHold
                         this is CoreFailure.MissingKeyPackages -> FailedToAdd.Type.MissingKeyPackages
-                        else -> FailedToAdd.Type.Federation
+                        this is NetworkFailure.FederatedBackendFailure -> FailedToAdd.Type.Federation
+                        else -> FailedToAdd.Type.Unknown
                     }
                 ).flatMap {
                     Either.Left(this)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
@@ -208,7 +208,7 @@ internal class ConversationGroupRepositoryImpl(
                     newGroupConversationSystemMessagesCreator.value.conversationFailedToAddMembers(
                         conversationId = conversationEntity.id.toModel(),
                         userIdList = protocolSpecificAdditionFailures.toList(),
-                        type = FailedToAdd.Type.Federation
+                        type = FailedToAdd.Type.MissingKeyPackages
                     )
                 }
             }.flatMap {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -502,15 +502,26 @@ internal class MLSConversationDataSource(
             retryOnMissingUsers = retryOnMissingUsers
         ) {
             keyPackageRepository.claimKeyPackages(userIdList, cipherSuite).flatMap { result ->
-                if (result.usersWithoutKeyPackagesAvailable.isNotEmpty() && !allowPartialMemberList) {
-                    logger.d(
-                        "add members to MLS Group: failed " +
-                                "${result.usersWithoutKeyPackagesAvailable.count()} user(s) missing KeyPackages"
-                    )
-                    Either.Left(CoreFailure.MissingKeyPackages(result.usersWithoutKeyPackagesAvailable))
-                } else {
-                    logger.d("add members to MLS Group: claiming KeyPackages succeed")
-                    Either.Right(result)
+                when {
+                    result.usersWithoutKeyPackages.isNotEmpty() && !allowPartialMemberList -> {
+                        logger.d(
+                            "add members to MLS Group: failed " +
+                                    "${result.usersWithoutKeyPackages.count()} user(s) missing KeyPackages"
+                        )
+                        Either.Left(CoreFailure.MissingKeyPackages(result.usersWithoutKeyPackages))
+                    }
+                    result.usersWithUnreachableBackend.isNotEmpty() && !allowPartialMemberList -> {
+                        val domains = result.usersWithUnreachableBackend.map { it.domain }.distinct()
+                        logger.d(
+                            "add members to MLS Group: failed " +
+                                    "${result.usersWithUnreachableBackend.count()} user(s) on unreachable backend(s): $domains"
+                        )
+                        Either.Left(NetworkFailure.FederatedBackendFailure.FailedDomains(domains))
+                    }
+                    else -> {
+                        logger.d("add members to MLS Group: claiming KeyPackages succeed")
+                        Either.Right(result)
+                    }
                 }
             }.flatMap { result ->
                 val keyPackages = result.successfullyFetchedKeyPackages
@@ -533,11 +544,12 @@ internal class MLSConversationDataSource(
                         checkRevocationList(mlsContext, revocationList)
                     }
                 }.map {
-                    val additionResult = MLSAdditionResult(
-                        result.successfullyFetchedKeyPackages.map { user -> UserId(user.userId, user.domain) }.toSet(),
-                        result.usersWithoutKeyPackagesAvailable.toSet()
+                    MLSAdditionResult(
+                        successfullyAddedUsers = result.successfullyFetchedKeyPackages
+                            .map { user -> UserId(user.userId, user.domain) }.toSet(),
+                        usersWithoutKeyPackages = result.usersWithoutKeyPackages,
+                        usersWithUnreachableBackend = result.usersWithUnreachableBackend
                     )
-                    additionResult
                 }
             }
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/mls/KeyPackageResults.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/mls/KeyPackageResults.kt
@@ -22,10 +22,16 @@ import com.wire.kalium.network.api.authenticated.keypackage.KeyPackageDTO
 
 internal data class KeyPackageClaimResult(
     val successfullyFetchedKeyPackages: List<KeyPackageDTO>,
-    val usersWithoutKeyPackagesAvailable: Set<UserId>
+    val usersWithoutKeyPackages: Set<UserId>,
+    val usersWithUnreachableBackend: Set<UserId>
 )
 
 internal data class MLSAdditionResult(
     val successfullyAddedUsers: Set<UserId>,
-    val notAddedUsers: Set<UserId>
-)
+    val usersWithoutKeyPackages: Set<UserId>,
+    val usersWithUnreachableBackend: Set<UserId>
+) {
+    companion object {
+        val Empty = MLSAdditionResult(emptySet(), emptySet(), emptySet())
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepository.kt
@@ -50,9 +50,10 @@ internal interface KeyPackageRepository {
      *
      * @param userIds The list of user IDs for which to claim key packages.
      * @return An [Either] instance representing the result of the operation. If the operation is successful, it will be [Either.Right]
-     * with a [KeyPackageClaimResult] object containing the successfully fetched key packages and the user IDs without key packages
-     * available. If the operation fails, it will be [Either.Left] with a [CoreFailure] object indicating the reason for the failure.
-     * If **no** KeyPackages are available, [CoreFailure.MissingKeyPackages] will be the cause.
+     * with a [KeyPackageClaimResult] object containing the successfully fetched key packages,
+     * the user IDs that genuinely have no key packages ([KeyPackageClaimResult.usersWithoutKeyPackages]),
+     * and the user IDs whose backend was unreachable during claiming ([KeyPackageClaimResult.usersWithUnreachableBackend]).
+     * If the operation fails entirely (e.g. self client ID unavailable), it will be [Either.Left] with a [CoreFailure].
      */
     suspend fun claimKeyPackages(
         userIds: List<UserId>,
@@ -87,10 +88,11 @@ internal class KeyPackageDataSource(
         userIds: List<UserId>,
         cipherSuite: CipherSuite
     ): Either<CoreFailure, KeyPackageClaimResult> =
-        currentClientIdProvider().map { selfClientId ->
-            val failedUsers = mutableSetOf<UserId>()
+        currentClientIdProvider().flatMap { selfClientId ->
+            val noKeyPackageUsers = mutableSetOf<UserId>()
+            val federationFailedUsers = mutableSetOf<UserId>()
             val claimedKeyPackages = mutableListOf<KeyPackageDTO>()
-            userIds.forEach { userId ->
+            for (userId in userIds) {
                 wrapApiRequest {
                     keyPackageApi.claimKeyPackages(
                         KeyPackageApi.Param.SkipOwnClient(
@@ -99,16 +101,23 @@ internal class KeyPackageDataSource(
                             cipherSuite = cipherSuite.tag
                         )
                     )
-                }.fold({ failedUsers.add(userId) }) {
+                }.fold({ failure ->
+                    when (failure) {
+                        is NetworkFailure.NoNetworkConnection,
+                        is NetworkFailure.ProxyError -> return@flatMap Either.Left(failure)
+                        is NetworkFailure.FederatedBackendFailure -> federationFailedUsers.add(userId)
+                        else -> federationFailedUsers.add(userId)
+                    }
+                }) {
                     if (it.keyPackages.isEmpty() && userId != selfUserId) {
-                        failedUsers.add(userId)
+                        noKeyPackageUsers.add(userId)
                     } else {
                         claimedKeyPackages.addAll(it.keyPackages)
                     }
                 }
             }
 
-            KeyPackageClaimResult(claimedKeyPackages, failedUsers)
+            Either.Right(KeyPackageClaimResult(claimedKeyPackages, noKeyPackageUsers, federationFailedUsers))
         }
 
     override suspend fun uploadNewKeyPackages(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
@@ -551,7 +551,7 @@ class ConversationGroupRepositoryTest {
                     arrangement.newGroupConversationSystemMessagesCreator.conversationFailedToAddMembers(
                         any(),
                         matches { it.containsAll(missingMembersFromMLSGroup) },
-                        eq(MessageContent.MemberChange.FailedToAdd.Type.Federation)
+                        eq(MessageContent.MemberChange.FailedToAdd.Type.MissingKeyPackages)
                     )
                 }.wasInvoked(once)
             }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
@@ -473,7 +473,7 @@ class ConversationGroupRepositoryTest {
             .withCreateNewConversationAPIResponses(arrayOf(NetworkResponse.Success(conversationResponse, emptyMap(), 201)))
             .withSelfTeamId(Either.Right(TestUser.SELF.teamId))
             .withInsertConversationSuccess()
-            .withMlsConversationEstablished(MLSAdditionResult(setOf(TestUser.USER_ID), emptySet()))
+            .withMlsConversationEstablished(MLSAdditionResult(setOf(TestUser.USER_ID), emptySet(), emptySet()))
             .withConversationById(TestConversation.ENTITY_GROUP.copy(protocolInfo = PROTEUS_PROTOCOL_INFO))
             .withSuccessfulNewConversationGroupStartedHandled()
             .withSuccessfulNewConversationMemberHandled()
@@ -506,17 +506,23 @@ class ConversationGroupRepositoryTest {
     }
 
     @Test
-    fun givenMLSProtocolIsUsedAndSomeUsersAreNotAddedToMLSGroup_whenCallingCreateGroupConversation_thenMissingMembersArePersisted() =
+    fun givenMLSProtocolIsUsedAndSomeUsersHaveNoKeyPackages_whenCallingCreateGroupConversation_thenMissingKeyPackagesSystemMessageIsPersisted() =
         runTest {
             val conversationResponse = CONVERSATION_RESPONSE.copy(protocol = MLS)
-            val missingMembersFromMLSGroup = setOf(TestUser.OTHER_USER_ID, TestUser.OTHER_USER_ID_2)
+            val usersWithNoKeyPackages = setOf(TestUser.OTHER_USER_ID, TestUser.OTHER_USER_ID_2)
             val successfullyAddedUsers = setOf(TestUser.USER_ID)
-            val allWantedMembers = successfullyAddedUsers + missingMembersFromMLSGroup
+            val allWantedMembers = successfullyAddedUsers + usersWithNoKeyPackages
             val (arrangement, conversationGroupRepository) = Arrangement()
                 .withCreateNewConversationAPIResponses(arrayOf(NetworkResponse.Success(conversationResponse, emptyMap(), 201)))
                 .withSelfTeamId(Either.Right(TestUser.SELF.teamId))
                 .withInsertConversationSuccess()
-                .withMlsConversationEstablished(MLSAdditionResult(setOf(TestUser.USER_ID), notAddedUsers = missingMembersFromMLSGroup))
+                .withMlsConversationEstablished(
+                    MLSAdditionResult(
+                        successfullyAddedUsers = setOf(TestUser.USER_ID),
+                        usersWithoutKeyPackages = usersWithNoKeyPackages,
+                        usersWithUnreachableBackend = emptySet()
+                    )
+                )
                 .withConversationById(TestConversation.ENTITY_GROUP.copy(protocolInfo = PROTEUS_PROTOCOL_INFO))
                 .withSuccessfulNewConversationGroupStartedHandled()
                 .withSuccessfulNewConversationMemberHandled()
@@ -536,24 +542,77 @@ class ConversationGroupRepositoryTest {
 
             with(arrangement) {
                 coVerify {
-                    conversationDAO.insertConversation(any())
-                }.wasInvoked(once)
-
-                coVerify {
-                    mlsConversationRepository.establishMLSGroup(any(), any(), any(), any(), eq(true))
-                }.wasInvoked(once)
-
-                coVerify {
-                    newConversationMembersRepository.persistMembersAdditionToTheConversation(any(), any())
+                    arrangement.newGroupConversationSystemMessagesCreator.conversationFailedToAddMembers(
+                        any(),
+                        matches { it.containsAll(usersWithNoKeyPackages) },
+                        eq(MessageContent.MemberChange.FailedToAdd.Type.MissingKeyPackages)
+                    )
                 }.wasInvoked(once)
 
                 coVerify {
                     arrangement.newGroupConversationSystemMessagesCreator.conversationFailedToAddMembers(
                         any(),
-                        matches { it.containsAll(missingMembersFromMLSGroup) },
-                        eq(MessageContent.MemberChange.FailedToAdd.Type.MissingKeyPackages)
+                        any(),
+                        eq(MessageContent.MemberChange.FailedToAdd.Type.Federation)
+                    )
+                }.wasNotInvoked()
+            }
+        }
+
+    @Test
+    fun givenMLSProtocolIsUsedAndSomeUsersAreOnUnreachableBackend_whenCallingCreateGroupConversation_thenFederationSystemMessageIsPersisted() =
+        runTest {
+            val conversationResponse = CONVERSATION_RESPONSE.copy(protocol = MLS)
+            val usersOnUnreachableBackend = setOf(
+                TestUser.OTHER_USER_ID.copy(domain = "unreachable.com"),
+                TestUser.OTHER_USER_ID_2.copy(domain = "unreachable.com")
+            )
+            val successfullyAddedUsers = setOf(TestUser.USER_ID)
+            val allWantedMembers = successfullyAddedUsers + usersOnUnreachableBackend
+            val (arrangement, conversationGroupRepository) = Arrangement()
+                .withCreateNewConversationAPIResponses(arrayOf(NetworkResponse.Success(conversationResponse, emptyMap(), 201)))
+                .withSelfTeamId(Either.Right(TestUser.SELF.teamId))
+                .withInsertConversationSuccess()
+                .withMlsConversationEstablished(
+                    MLSAdditionResult(
+                        successfullyAddedUsers = setOf(TestUser.USER_ID),
+                        usersWithoutKeyPackages = emptySet(),
+                        usersWithUnreachableBackend = usersOnUnreachableBackend
+                    )
+                )
+                .withConversationById(TestConversation.ENTITY_GROUP.copy(protocolInfo = PROTEUS_PROTOCOL_INFO))
+                .withSuccessfulNewConversationGroupStartedHandled()
+                .withSuccessfulNewConversationMemberHandled()
+                .withSuccessfulNewConversationGroupStartedUnverifiedWarningHandled()
+                .withSuccessfulLegalHoldHandleConversationMembersChanged()
+                .withInsertFailedToAddSystemMessageSuccess()
+                .withConversationAppsAccessIfEnabled()
+                .arrange()
+
+            val result = conversationGroupRepository.createGroupConversation(
+                GROUP_NAME,
+                allWantedMembers.toList(),
+                CreateConversationParam(protocol = CreateConversationParam.Protocol.MLS)
+            )
+
+            result.shouldSucceed()
+
+            with(arrangement) {
+                coVerify {
+                    arrangement.newGroupConversationSystemMessagesCreator.conversationFailedToAddMembers(
+                        any(),
+                        matches { it.containsAll(usersOnUnreachableBackend) },
+                        eq(MessageContent.MemberChange.FailedToAdd.Type.Federation)
                     )
                 }.wasInvoked(once)
+
+                coVerify {
+                    arrangement.newGroupConversationSystemMessagesCreator.conversationFailedToAddMembers(
+                        any(),
+                        any(),
+                        eq(MessageContent.MemberChange.FailedToAdd.Type.MissingKeyPackages)
+                    )
+                }.wasNotInvoked()
             }
         }
 
@@ -1681,6 +1740,40 @@ class ConversationGroupRepositoryTest {
                 type = any()
             )
         }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenNoNetworkConnection_whenAddingMembers_thenUnknownSystemMessageIsPersistedAndOperationFails() = runTest {
+        // given
+        val expectedInitialUsers = listOf(TestConversation.USER_1, TestUser.OTHER_FEDERATED_USER_ID)
+        val (arrangement, conversationGroupRepository) = Arrangement()
+            .withConversationDetailsById(TestConversation.MLS_CONVERSATION)
+            .withProtocolInfoById(MLS_PROTOCOL_INFO)
+            .withAddingMemberToMlsGroupResults(
+                Either.Left(NetworkFailure.NoNetworkConnection(null))
+            )
+            .withInsertFailedToAddSystemMessageSuccess()
+            .arrange()
+
+        // when
+        conversationGroupRepository.addMembers(expectedInitialUsers, TestConversation.ID).shouldFail()
+
+        // then
+        coVerify {
+            arrangement.newGroupConversationSystemMessagesCreator.conversationFailedToAddMembers(
+                conversationId = any(),
+                userIdList = any(),
+                type = eq(MessageContent.MemberChange.FailedToAdd.Type.Unknown)
+            )
+        }.wasInvoked(exactly = once)
+
+        coVerify {
+            arrangement.newGroupConversationSystemMessagesCreator.conversationFailedToAddMembers(
+                conversationId = any(),
+                userIdList = any(),
+                type = eq(MessageContent.MemberChange.FailedToAdd.Type.Federation)
+            )
+        }.wasNotInvoked()
     }
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -219,7 +219,7 @@ class MLSConversationRepositoryTest {
             allowSkippingUsersWithoutKeyPackages = true
         )
         result.shouldSucceed {
-            assertEquals(usersMissingKeyPackages, it.notAddedUsers)
+            assertEquals(usersMissingKeyPackages, it.usersWithoutKeyPackages)
             assertEquals(usersWithKeyPackages, it.successfullyAddedUsers)
         }
 
@@ -1573,7 +1573,7 @@ class MLSConversationRepositoryTest {
         ) = apply {
             everySuspend {
                 keyPackageRepository.claimKeyPackages(any(), any())
-            } returns Either.Right(KeyPackageClaimResult(keyPackages, usersWithoutKeyPackages))
+            } returns Either.Right(KeyPackageClaimResult(keyPackages, usersWithoutKeyPackages, emptySet()))
         }
 
         fun withKeyPackageLimits(refillAmount: Int) = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ObservableMLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ObservableMLSConversationRepositoryTest.kt
@@ -135,7 +135,7 @@ class ObservableMLSConversationRepositoryTest {
         suspend fun withEstablishSuccess() = apply {
             everySuspend {
                 delegate.establishMLSGroup(any(), any(), any(), any(), any())
-            } returns Either.Right(MLSAdditionResult(emptySet(), emptySet()))
+            } returns Either.Right(MLSAdditionResult(emptySet(), emptySet(), emptySet()))
         }
 
         suspend fun withEstablishFailure() = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCaseTest.kt
@@ -509,7 +509,7 @@ class ResetMLSConversationUseCaseTest {
 
             everySuspend {
                 mlsConversationRepository.establishMLSGroup(any(), any(), any(), any(), any())
-            } returns MLSAdditionResult(emptySet(), emptySet()).right()
+            } returns MLSAdditionResult(emptySet(), emptySet(), emptySet()).right()
 
             everySuspend {
                 fetchConversationUseCase(any(), any(), reason = eq(ConversationSyncReason.ConversationReset))

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepositoryTest.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.logic.data.keypackage
 
+import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
@@ -28,6 +29,7 @@ import com.wire.kalium.logic.data.mls.CipherSuite
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
+import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.authenticated.keypackage.ClaimedKeyPackageList
 import com.wire.kalium.network.api.authenticated.keypackage.KeyPackage
@@ -35,6 +37,9 @@ import com.wire.kalium.network.api.authenticated.keypackage.KeyPackageCountDTO
 import com.wire.kalium.network.api.authenticated.keypackage.KeyPackageDTO
 import com.wire.kalium.network.api.authenticated.keypackage.KeyPackageRef
 import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageApi
+import com.wire.kalium.network.api.model.FederationErrorResponse
+import com.wire.kalium.network.exceptions.FederationError
+import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
 import io.ktor.util.encodeBase64
 import io.mockative.any
@@ -110,7 +115,7 @@ internal class KeyPackageRepositoryTest {
             )
             assertEquals(
                 setOf(userWithout),
-                keyPackageResult.usersWithoutKeyPackagesAvailable
+                keyPackageResult.usersWithoutKeyPackages
             )
         }
     }
@@ -134,7 +139,7 @@ internal class KeyPackageRepositoryTest {
 
             result.shouldSucceed { keyPackages ->
                 assertEquals(emptyList(), keyPackages.successfullyFetchedKeyPackages)
-                assertEquals(usersWithout, keyPackages.usersWithoutKeyPackagesAvailable)
+                assertEquals(usersWithout, keyPackages.usersWithoutKeyPackages)
             }
         }
 
@@ -150,7 +155,45 @@ internal class KeyPackageRepositoryTest {
 
         result.shouldSucceed { keyPackages ->
             assertEquals(emptyList(), keyPackages.successfullyFetchedKeyPackages)
-            assertEquals(setOf(Arrangement.USER_ID), keyPackages.usersWithoutKeyPackagesAvailable)
+            assertEquals(setOf(Arrangement.USER_ID), keyPackages.usersWithoutKeyPackages)
+        }
+    }
+
+    @Test
+    fun givenFederationBackendUnreachable_whenClaimingKeyPackages_thenUserIsInUnreachableBackendSetNotMissingKeyPackagesSet() = runTest {
+        val federatedUser = UserId("alice", "federated.com")
+        val (_, keyPackageRepository) = Arrangement()
+            .withCurrentClientId()
+            .withClaimKeyPackagesFederationError(federatedUser)
+            .arrange()
+
+        val result = keyPackageRepository.claimKeyPackages(listOf(federatedUser), CIPHER_SUITE)
+
+        result.shouldSucceed { keyPackageResult ->
+            assertEquals(emptyList(), keyPackageResult.successfullyFetchedKeyPackages)
+            assertEquals(emptySet(), keyPackageResult.usersWithoutKeyPackages)
+            assertEquals(setOf(federatedUser), keyPackageResult.usersWithUnreachableBackend)
+        }
+    }
+
+    @Test
+    fun givenMixedFailures_whenClaimingKeyPackages_thenUsersAreSeparatedByFailureType() = runTest {
+        val userWithNoKP = Arrangement.USER_ID.copy(value = "noKP")
+        val userFedFailed = UserId("bob", "unreachable.com")
+        val userSuccess = Arrangement.USER_ID
+        val (_, keyPackageRepository) = Arrangement()
+            .withCurrentClientId()
+            .withClaimKeyPackagesSuccessful(userSuccess)
+            .withClaimKeyPackagesSuccessfulWithEmptyResponse(userWithNoKP)
+            .withClaimKeyPackagesFederationError(userFedFailed)
+            .arrange()
+
+        val result = keyPackageRepository.claimKeyPackages(listOf(userSuccess, userWithNoKP, userFedFailed), CIPHER_SUITE)
+
+        result.shouldSucceed { keyPackageResult ->
+            assertEquals(listOf(Arrangement.CLAIMED_KEY_PACKAGES.keyPackages[0]), keyPackageResult.successfullyFetchedKeyPackages)
+            assertEquals(setOf(userWithNoKP), keyPackageResult.usersWithoutKeyPackages)
+            assertEquals(setOf(userFedFailed), keyPackageResult.usersWithUnreachableBackend)
         }
     }
 
@@ -166,6 +209,42 @@ internal class KeyPackageRepositoryTest {
 
         result.shouldSucceed { keyPackages ->
             assertEquals(emptyList(), keyPackages.successfullyFetchedKeyPackages)
+        }
+    }
+
+    @Test
+    fun givenNoNetworkConnection_whenClaimingKeyPackages_thenOperationIsAbortedWithFailure() = runTest {
+        val user1 = Arrangement.USER_ID.copy(value = "user1")
+        val user2 = Arrangement.USER_ID.copy(value = "user2")
+        val (arrangement, keyPackageRepository) = Arrangement()
+            .withCurrentClientId()
+            .withClaimKeyPackagesNoNetworkError(user1)
+            .arrange()
+
+        val result = keyPackageRepository.claimKeyPackages(listOf(user1, user2), CIPHER_SUITE)
+
+        result.shouldFail { assertIs<NetworkFailure.NoNetworkConnection>(it) }
+        coVerify {
+            arrangement.keyPackageApi.claimKeyPackages(
+                eq(KeyPackageApi.Param.SkipOwnClient(user2.toApi(), Arrangement.SELF_CLIENT_ID.value, CIPHER_SUITE.tag))
+            )
+        }.wasNotInvoked()
+    }
+
+    @Test
+    fun givenServerError_whenClaimingKeyPackages_thenUserIsInUnreachableBackendSetNotMissingKeyPackagesSet() = runTest {
+        val failingUser = Arrangement.USER_ID.copy(value = "serverErrorUser")
+        val (_, keyPackageRepository) = Arrangement()
+            .withCurrentClientId()
+            .withClaimKeyPackagesServerError(failingUser)
+            .arrange()
+
+        val result = keyPackageRepository.claimKeyPackages(listOf(failingUser), CIPHER_SUITE)
+
+        result.shouldSucceed { keyPackageResult ->
+            assertEquals(emptyList(), keyPackageResult.successfullyFetchedKeyPackages)
+            assertEquals(emptySet(), keyPackageResult.usersWithoutKeyPackages)
+            assertEquals(setOf(failingUser), keyPackageResult.usersWithUnreachableBackend)
         }
     }
 
@@ -217,6 +296,40 @@ internal class KeyPackageRepositoryTest {
                     )
                 )
             }.returns(NetworkResponse.Success(EMPTY_CLAIMED_KEY_PACKAGES, mapOf(), 200))
+        }
+
+        suspend fun withClaimKeyPackagesFederationError(userId: UserId) = apply {
+            coEvery {
+                keyPackageApi.claimKeyPackages(
+                    eq(KeyPackageApi.Param.SkipOwnClient(userId.toApi(), SELF_CLIENT_ID.value, CIPHER_SUITE.tag))
+                )
+            }.returns(
+                NetworkResponse.Error(
+                    FederationError(FederationErrorResponse.Unreachable(listOf(userId.domain)))
+                )
+            )
+        }
+
+        suspend fun withClaimKeyPackagesNoNetworkError(userId: UserId) = apply {
+            coEvery {
+                keyPackageApi.claimKeyPackages(
+                    eq(KeyPackageApi.Param.SkipOwnClient(userId.toApi(), SELF_CLIENT_ID.value, CIPHER_SUITE.tag))
+                )
+            }.returns(NetworkResponse.Error(KaliumException.NoNetwork()))
+        }
+
+        suspend fun withClaimKeyPackagesServerError(userId: UserId) = apply {
+            coEvery {
+                keyPackageApi.claimKeyPackages(
+                    eq(KeyPackageApi.Param.SkipOwnClient(userId.toApi(), SELF_CLIENT_ID.value, CIPHER_SUITE.tag))
+                )
+            }.returns(
+                NetworkResponse.Error(
+                    KaliumException.ServerError(
+                        com.wire.kalium.network.api.model.ErrorResponse(500, "internal server error", "server-error")
+                    )
+                )
+            )
         }
 
         fun arrange() = this to KeyPackageDataSource(currentClientIdProvider, keyPackageApi, SELF_USER_ID)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCaseTest.kt
@@ -137,7 +137,7 @@ class JoinExistingMLSConversationUseCaseTest {
                 .withHasRegisteredMLSClient(true)
                 .withGetConversationsByIdSuccessful(Arrangement.MLS_UNESTABLISHED_GROUP_CONVERSATION)
                 .withGetConversationMembersSuccessful(members)
-                .withEstablishMLSGroupSuccessful(MLSAdditionResult(emptySet(), emptySet()))
+                .withEstablishMLSGroupSuccessful(MLSAdditionResult(emptySet(), emptySet(), emptySet()))
                 .arrange()
 
             joinExistingMLSConversationsUseCase(
@@ -163,7 +163,7 @@ class JoinExistingMLSConversationUseCaseTest {
             .withIsMLSSupported(true)
             .withHasRegisteredMLSClient(true)
             .withGetConversationsByIdSuccessful(Arrangement.MLS_UNESTABLISHED_SELF_CONVERSATION)
-            .withEstablishMLSGroupSuccessful(MLSAdditionResult(emptySet(), emptySet()))
+            .withEstablishMLSGroupSuccessful(MLSAdditionResult(emptySet(), emptySet(), emptySet()))
             .arrange()
 
         // WHEN
@@ -192,7 +192,7 @@ class JoinExistingMLSConversationUseCaseTest {
                 .withHasRegisteredMLSClient(true)
                 .withGetConversationsByIdSuccessful(Arrangement.MLS_UNESTABLISHED_ONE_ONE_ONE_CONVERSATION)
                 .withGetConversationMembersSuccessful(members)
-                .withEstablishMLSGroupSuccessful(MLSAdditionResult(emptySet(), emptySet()))
+                .withEstablishMLSGroupSuccessful(MLSAdditionResult(emptySet(), emptySet(), emptySet()))
                 .arrange()
 
             joinExistingMLSConversationsUseCase(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigratorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/mlsmigration/MLSMigratorTest.kt
@@ -329,7 +329,7 @@ class MLSMigratorTest {
                 ErrorResponse(409, "", "mls-stale-message")
             )
             val MEMBERS = listOf(TestUser.USER_ID)
-            val SUCCESSFUL_ADDITION_RESULT = MLSAdditionResult(MEMBERS.toSet(), emptySet())
+            val SUCCESSFUL_ADDITION_RESULT = MLSAdditionResult(MEMBERS.toSet(), emptySet(), emptySet())
             val MIXED_PROTOCOL_INFO = Conversation.ProtocolInfo.Mixed(
                 TestConversation.GROUP_ID,
                 Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN,


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-17105
<!--jira-description-action-hidden-marker-end-->

https://wearezeta.atlassian.net/browse/WPB-17105
----

# What's new in this PR?

### Issue

When creating a new MLS group conversation where some invited users lack MLS-capable clients (no key packages available), the system message shown in the conversation incorrectly indicated a federation failure instead of a missing key packages failure. Users would see misleading error text and a "Learn More" link pointing to federation documentation rather than MLS documentation.

### Cause
When establishing an MLS group, key packages are fetched for each member via claimKeyPackages. If a user has no MLS client, an empty key packages response is returned. Users who return empty key packages are collected in noKeyPackageUsers, but any API error during that call is collected in federationFailedUsers — regardless of whether the error is actually a federation issue. In ConversationGroupRepository, noKeyPackageUsers were then mapped to FailedToAdd.Type.Federation, producing the wrong system message type and "Learn more" link.
  
  
### Solution
Changed the failure type from FailedToAdd.Type.Federation to FailedToAdd.Type.MissingKeyPackages for users skipped during MLS group establishment (allowSkippingUsersWithoutKeyPackages = true). This surfaces the correct system message with a "Learn more" link pointing to the MLS support article — even though the client cannot distinguish between "no MLS client" and "no key packages available".

### Open question
In KeyPackageDataSource.claimKeyPackages, the when block handling per-user API failures has a structural issue:

  when (failure) {
      is NetworkFailure.NoNetworkConnection,
      is NetworkFailure.ProxyError -> return@flatMap Either.Left(failure)
      is NetworkFailure.FederatedBackendFailure -> federationFailedUsers.add(userId)
      else -> federationFailedUsers.add(userId)  // ← same bucket, wrong label
  }

The else branch catches any other error (e.g. ServerMiscommunication, unknown failures) and adds the user to federationFailedUsers, even though the error may not be related to federation.

A more accurate fix would introduce a separate bucket for unclassified errors and map them to FailedToAdd.Type.Unknown. However, given this is an edge case with low user-visible impact, the additional complexity may not be justified at this time.
