### PR TITLE
fix: handle empty response body when downloading crypto state

### DIFF
--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/NomadDeviceSyncApiV0.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/NomadDeviceSyncApiV0.kt
@@ -47,6 +47,7 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.content.OutgoingContent
+import io.ktor.http.contentLength
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.ByteWriteChannel
@@ -142,8 +143,21 @@ internal open class NomadDeviceSyncApiV0 internal constructor(
                 setNomadUrlIfAvailable(PATH_EVENT, PATH_CRYPTO_STATE)
             }.execute { httpResponse ->
                 when {
-                    httpResponse.status.isSuccess() ->
-                        handleCryptoStateDownload(httpResponse, tempBackupFileSink)
+                    httpResponse.status.isSuccess() -> {
+                        if (httpResponse.contentLength() == 0L) {
+                            NetworkResponse.Error(
+                                KaliumException.InvalidRequestError(
+                                    GenericAPIErrorResponse(
+                                        code = httpResponse.status.value,
+                                        label = NetworkErrorLabel.NO_CRYPTO_STATE,
+                                        message = "Empty response body"
+                                    )
+                                )
+                            )
+                        } else {
+                            handleCryptoStateDownload(httpResponse, tempBackupFileSink)
+                        }
+                    }
 
                     httpResponse.status == HttpStatusCode.Unauthorized ->
                         handleLabeledError(httpResponse, NetworkErrorLabel.USER_NOT_FOUND, UNAUTHORIZED_CODE)

--- a/data/network/src/commonTest/kotlin/com/wire/kalium/api/v0/nomaddevice/NomadDeviceSyncApiV0Test.kt
+++ b/data/network/src/commonTest/kotlin/com/wire/kalium/api/v0/nomaddevice/NomadDeviceSyncApiV0Test.kt
@@ -44,6 +44,7 @@ import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.URLProtocol
 import io.ktor.utils.io.ByteReadChannel
@@ -519,6 +520,26 @@ internal class NomadDeviceSyncApiV0Test : ApiTest() {
 
         assertTrue(response.isSuccessful())
         assertEquals(responseContent, sink.readUtf8())
+    }
+
+    @Test
+    fun givenSuccessfulResponseWithZeroContentLength_whenDownloadingCryptoState_thenReturnNoCryptoStateError() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(
+            responseBody = "",
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertGet()
+                assertPathEqual("/event/crypto/state")
+            },
+            headers = mapOf(HttpHeaders.ContentLength to "0")
+        )
+
+        val api: NomadDeviceSyncApi = NomadDeviceSyncApiV0(networkClient, nomadServiceUrl = "https://nomad.example.com")
+        val response = api.downloadCryptoState(Buffer())
+
+        val error = assertIs<NetworkResponse.Error>(response)
+        val exception = assertIs<KaliumException.InvalidRequestError>(error.kException)
+        assertTrue(exception.isNoCryptoState())
     }
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/backup/CryptoStateBackupRemoteRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/backup/CryptoStateBackupRemoteRepositoryTest.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.base.authenticated.nomaddevice.NomadDeviceSyncApi
 import com.wire.kalium.network.api.model.ErrorResponse
+import com.wire.kalium.network.api.model.GenericAPIErrorResponse
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
 import io.mockative.any
@@ -91,6 +92,23 @@ class CryptoStateBackupRemoteRepositoryTest {
         )
         val (arrangement, repository) = Arrangement()
             .withDownloadCryptoState(NetworkResponse.Error(noCryptoStateError))
+            .arrange()
+
+        val result = repository.downloadCryptoState(Buffer())
+
+        result.shouldFail { failure ->
+            assertIs<BackupFailure.NoCryptoStateAvailable>(failure)
+        }
+        coVerify { arrangement.nomadDeviceSyncApi.downloadCryptoState(any()) }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenApiReturnsSuccessWithZeroContentLength_whenDownloadingCryptoState_thenReturnNoCryptoStateAvailable() = runTest {
+        val emptyResponseError = KaliumException.InvalidRequestError(
+            GenericAPIErrorResponse(200, "Empty response body", "no_crypto_state")
+        )
+        val (arrangement, repository) = Arrangement()
+            .withDownloadCryptoState(NetworkResponse.Error(emptyResponseError))
             .arrange()
 
         val result = repository.downloadCryptoState(Buffer())


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

nomad service can return 200 with empty content for the fetch crypto data endpoint

### Solutions

consider 200 + 0B content len as 404 error and register a new clients 

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
