### PR TITLE
feat: Search for Apps - Part4 (Apps Allowed logic rework) [WPB-20357]

### DIFF
--- a/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
+++ b/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/Conversation.kt
@@ -207,12 +207,15 @@ data class Conversation(
     val supportsUnreadMessageCount
         get() = type is Type.OneOnOne || type is Type.Group
 
+    @Serializable
     sealed interface ProtocolInfo {
+        @Serializable
         data object Proteus : ProtocolInfo {
             override fun name() = "Proteus"
             override fun toLogMap() = mapOf("name" to name())
         }
 
+        @Serializable
         data class MLS(
             override val groupId: GroupID,
             override val groupState: MLSCapable.GroupState,
@@ -232,6 +235,7 @@ data class Conversation(
             )
         }
 
+        @Serializable
         data class Mixed(
             override val groupId: GroupID,
             override val groupState: MLSCapable.GroupState,

--- a/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedId.kt
+++ b/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/id/QualifiedId.kt
@@ -49,6 +49,8 @@ val FEDERATION_REGEX = """[^@.]+@[^@.]+\.[^@]+""".toRegex()
 typealias ConversationId = QualifiedID
 
 @JvmInline
+@Serializable
+@Suppress("EnforceSerializableFields")
 value class GroupID(val value: String) {
     fun toLogString() = value
 }

--- a/data/persistence/src/commonMain/db_user/migrations/130.sqm
+++ b/data/persistence/src/commonMain/db_user/migrations/130.sqm
@@ -1,0 +1,10 @@
+import com.wire.kalium.persistence.dao.QualifiedIDEntity;
+
+CREATE TABLE App (
+    id TEXT AS QualifiedIDEntity PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL,
+    category TEXT,
+    preview_asset_id TEXT AS QualifiedIDEntity,
+    complete_asset_id TEXT AS QualifiedIDEntity
+);

--- a/data/persistence/src/commonMain/db_user/migrations/130.sqm
+++ b/data/persistence/src/commonMain/db_user/migrations/130.sqm
@@ -1,6 +1,6 @@
 import com.wire.kalium.persistence.dao.QualifiedIDEntity;
 
-CREATE TABLE App (
+CREATE TABLE IF NOT EXISTS App (
     id TEXT AS QualifiedIDEntity PRIMARY KEY,
     name TEXT NOT NULL,
     description TEXT NOT NULL,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/ObserveIsAppsAllowedForUsageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/ObserveIsAppsAllowedForUsageUseCase.kt
@@ -21,6 +21,7 @@ import com.wire.kalium.common.functional.getOrNull
 import com.wire.kalium.common.functional.mapToRightOr
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.id.SelfTeamIdProvider
+import com.wire.kalium.logic.data.user.SupportedProtocol
 import io.mockative.Mockable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -30,21 +31,64 @@ import kotlinx.coroutines.flow.map
  * Based on the feature config and if the user belongs to a team or not.
  *
  * It returns a boolean indicating whether the apps feature is enabled or not for this user session.
- * In case the team or session does not have the apps feature enabled, it will return false.
+ * In case the team or session does not have the apps feature enabled, it will return AppsAllowedResult.Disabled.
  */
 @Mockable
 public interface ObserveIsAppsAllowedForUsageUseCase {
-    public suspend operator fun invoke(): Flow<Boolean>
+    public suspend operator fun invoke(): Flow<AppsAllowedResult>
 }
 
 internal class ObserveIsAppsAllowedForUsageUseCaseImpl(
     private val userConfigRepository: UserConfigRepository,
     private val selfTeamIdProvider: SelfTeamIdProvider
 ) : ObserveIsAppsAllowedForUsageUseCase {
-    override suspend fun invoke(): Flow<Boolean> = userConfigRepository.observeAppsEnabled()
+
+    override suspend fun invoke(): Flow<AppsAllowedResult> =
+        userConfigRepository
+        .observeAppsEnabled()
         .mapToRightOr(false)
-        .map { appsEnabled ->
-            val belongsToTeam = selfTeamIdProvider().getOrNull() != null
-            appsEnabled && belongsToTeam
+        .map { appsEnabled -> resolveResult(appsEnabled) }
+
+    @Suppress("ReturnCount")
+    private suspend fun resolveResult(appsEnabled: Boolean): AppsAllowedResult {
+        val defaultProtocol = userConfigRepository.getDefaultProtocol().getOrNull()
+            ?: return AppsAllowedResult.Disabled
+        val supportedProtocols = userConfigRepository.getSupportedProtocols().getOrNull()
+            ?: return AppsAllowedResult.Disabled
+        val belongsToTeam = selfTeamIdProvider().getOrNull() != null
+        if (!belongsToTeam) return AppsAllowedResult.Disabled
+
+        val isMLSDefault = defaultProtocol == SupportedProtocol.MLS
+        val isProteusDefault = defaultProtocol == SupportedProtocol.PROTEUS
+        val isMixed = supportedProtocols.containsAll(listOf(SupportedProtocol.MLS, SupportedProtocol.PROTEUS))
+
+        return when {
+            isMixed && isMLSDefault && appsEnabled ->
+                AppsAllowedResult.Enabled(AppsAllowedProtocol.MIXED(SupportedProtocol.MLS))
+
+            isMixed && isProteusDefault ->
+                AppsAllowedResult.Enabled(
+                    AppsAllowedProtocol.MIXED(if (appsEnabled) SupportedProtocol.MLS else SupportedProtocol.PROTEUS)
+                )
+
+            isMLSDefault && appsEnabled ->
+                AppsAllowedResult.Enabled(AppsAllowedProtocol.MLS)
+
+            isProteusDefault ->
+                AppsAllowedResult.Enabled(AppsAllowedProtocol.PROTEUS)
+
+            else -> AppsAllowedResult.Disabled
         }
+    }
+}
+
+public sealed interface AppsAllowedResult {
+    public data object Disabled : AppsAllowedResult
+    public data class Enabled(val protocol: AppsAllowedProtocol) : AppsAllowedResult
+}
+
+public sealed interface AppsAllowedProtocol {
+    public data object MLS : AppsAllowedProtocol
+    public data object PROTEUS : AppsAllowedProtocol
+    public data class MIXED(val defaultProtocol: SupportedProtocol) : AppsAllowedProtocol
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/ObserveIsAppsAllowedForUsageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/ObserveIsAppsAllowedForUsageUseCaseTest.kt
@@ -131,15 +131,6 @@ class ObserveIsAppsAllowedForUsageUseCaseTest {
         }
     }
 
-    data class AppsAllowedResultTestCase(
-        val description: String,
-        val appsEnabled: Either<StorageFailure, Boolean>,
-        val defaultProtocol: Either<StorageFailure, SupportedProtocol>,
-        val supportedProtocols: Either<StorageFailure, Set<SupportedProtocol>>,
-        val selfTeamId: Either<StorageFailure, TeamId?>,
-        val expectedResult: AppsAllowedResult
-    )
-
     private val testCases = listOf(
         AppsAllowedResultTestCase(
             description = "Proteus Default Protocol, Proteus Supported Protocol, Apps Disabled",
@@ -248,5 +239,13 @@ class ObserveIsAppsAllowedForUsageUseCaseTest {
             return this to ObserveIsAppsAllowedForUsageUseCaseImpl(userConfigRepository, selfTeamIdProvider)
         }
     }
-
 }
+
+data class AppsAllowedResultTestCase(
+    val description: String,
+    val appsEnabled: Either<StorageFailure, Boolean>,
+    val defaultProtocol: Either<StorageFailure, SupportedProtocol>,
+    val supportedProtocols: Either<StorageFailure, Set<SupportedProtocol>>,
+    val selfTeamId: Either<StorageFailure, TeamId?>,
+    val expectedResult: AppsAllowedResult
+)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/ObserveIsAppsAllowedForUsageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/ObserveIsAppsAllowedForUsageUseCaseTest.kt
@@ -25,11 +25,12 @@ import com.wire.kalium.common.functional.right
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.id.SelfTeamIdProvider
 import com.wire.kalium.logic.data.id.TeamId
+import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.framework.TestTeam
-import io.mockative.coEvery
-import io.mockative.coVerify
-import io.mockative.mock
-import io.mockative.once
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -42,6 +43,8 @@ class ObserveIsAppsAllowedForUsageUseCaseTest {
     fun givenAnErrorWhileGettingUserDoesBelongToTeam_whenObservingAppsEnabledConfig_thenReturnFalse() = runTest {
         val (arrangement, observeAppsEnabledConfigUseCase) = Arrangement()
             .withObserveAppsEnabledResult(flowOf(Either.Right(true)))
+            .withDefaultProtocol(Either.Right(SupportedProtocol.MLS))
+            .withSupportedProtocols(Either.Right(setOf(SupportedProtocol.MLS)))
             .withSelfTeamIdProviderResult(StorageFailure.DataNotFound.left())
             .arrange()
 
@@ -49,13 +52,13 @@ class ObserveIsAppsAllowedForUsageUseCaseTest {
 
         result.test {
             val item = awaitItem()
-            assertEquals(false, item)
+            assertEquals(AppsAllowedResult.Disabled, item)
 
             cancelAndIgnoreRemainingEvents()
 
-            coVerify {
+            verifySuspend {
                 arrangement.userConfigRepository.observeAppsEnabled()
-            }.wasInvoked(exactly = once)
+            }
         }
     }
 
@@ -63,6 +66,8 @@ class ObserveIsAppsAllowedForUsageUseCaseTest {
     fun givenUserDoesNotBelongToTeam_whenObservingAppsEnabledConfig_thenReturnFalse() = runTest {
         val (arrangement, observeAppsEnabledConfigUseCase) = Arrangement()
             .withObserveAppsEnabledResult(flowOf(Either.Right(true)))
+            .withDefaultProtocol(Either.Right(SupportedProtocol.MLS))
+            .withSupportedProtocols(Either.Right(setOf(SupportedProtocol.MLS)))
             .withSelfTeamIdProviderResult(null.right())
             .arrange()
 
@@ -70,13 +75,13 @@ class ObserveIsAppsAllowedForUsageUseCaseTest {
 
         result.test {
             val item = awaitItem()
-            assertEquals(false, item)
+            assertEquals(AppsAllowedResult.Disabled, item)
 
             cancelAndIgnoreRemainingEvents()
 
-            coVerify {
+            verifySuspend {
                 arrangement.userConfigRepository.observeAppsEnabled()
-            }.wasInvoked(exactly = once)
+            }
         }
     }
 
@@ -84,6 +89,8 @@ class ObserveIsAppsAllowedForUsageUseCaseTest {
     fun givenUserConfigRepositoryFailureOrNotPresent_whenObservingAppsEnabledConfig_thenReturnFalse() = runTest {
         val (arrangement, observeAppsEnabledConfigUseCase) = Arrangement()
             .withObserveAppsEnabledResult(flowOf(StorageFailure.DataNotFound.left()))
+            .withDefaultProtocol(Either.Right(SupportedProtocol.MLS))
+            .withSupportedProtocols(Either.Right(setOf(SupportedProtocol.MLS)))
             .withSelfTeamIdProviderResult(TestTeam.TEAM_ID.right())
             .arrange()
 
@@ -91,13 +98,13 @@ class ObserveIsAppsAllowedForUsageUseCaseTest {
 
         result.test {
             val item = awaitItem()
-            assertEquals(false, item)
+            assertEquals(AppsAllowedResult.Disabled, item)
 
             cancelAndIgnoreRemainingEvents()
 
-            coVerify {
+            verifySuspend {
                 arrangement.userConfigRepository.observeAppsEnabled()
-            }.wasInvoked(exactly = once)
+            }
         }
     }
 
@@ -105,6 +112,8 @@ class ObserveIsAppsAllowedForUsageUseCaseTest {
     fun givenUserConfigRepositorySuccess_whenObservingAppsEnabledConfig_thenReturnTrue() = runTest {
         val (arrangement, observeAppsEnabledConfigUseCase) = Arrangement()
             .withObserveAppsEnabledResult(flowOf(Either.Right(true)))
+            .withDefaultProtocol(Either.Right(SupportedProtocol.MLS))
+            .withSupportedProtocols(Either.Right(setOf(SupportedProtocol.MLS)))
             .withSelfTeamIdProviderResult(TestTeam.TEAM_ID.right())
             .arrange()
 
@@ -112,26 +121,127 @@ class ObserveIsAppsAllowedForUsageUseCaseTest {
 
         result.test {
             val item = awaitItem()
-            assertEquals(true, item)
+            assertEquals(AppsAllowedResult.Enabled(AppsAllowedProtocol.MLS), item)
 
             cancelAndIgnoreRemainingEvents()
 
-            coVerify {
+            verifySuspend {
                 arrangement.userConfigRepository.observeAppsEnabled()
-            }.wasInvoked(exactly = once)
+            }
+        }
+    }
+
+    data class AppsAllowedResultTestCase(
+        val description: String,
+        val appsEnabled: Either<StorageFailure, Boolean>,
+        val defaultProtocol: Either<StorageFailure, SupportedProtocol>,
+        val supportedProtocols: Either<StorageFailure, Set<SupportedProtocol>>,
+        val selfTeamId: Either<StorageFailure, TeamId?>,
+        val expectedResult: AppsAllowedResult
+    )
+
+    private val testCases = listOf(
+        AppsAllowedResultTestCase(
+            description = "Proteus Default Protocol, Proteus Supported Protocol, Apps Disabled",
+            appsEnabled = false.right(),
+            defaultProtocol = SupportedProtocol.PROTEUS.right(),
+            supportedProtocols = setOf(SupportedProtocol.PROTEUS).right(),
+            selfTeamId = TestTeam.TEAM_ID.right(),
+            expectedResult = AppsAllowedResult.Enabled(AppsAllowedProtocol.PROTEUS)
+        ),
+        AppsAllowedResultTestCase(
+            description = "Proteus Default Protocol, Proteus Supported Protocol, Apps Enabled",
+            appsEnabled = true.right(),
+            defaultProtocol = SupportedProtocol.PROTEUS.right(),
+            supportedProtocols = setOf(SupportedProtocol.PROTEUS).right(),
+            selfTeamId = TestTeam.TEAM_ID.right(),
+            expectedResult = AppsAllowedResult.Enabled(AppsAllowedProtocol.PROTEUS)
+        ),
+        AppsAllowedResultTestCase(
+            description = "Proteus Default Protocol, Mixed Supported Protocol, Apps Disabled",
+            appsEnabled = false.right(),
+            defaultProtocol = SupportedProtocol.PROTEUS.right(),
+            supportedProtocols = setOf(SupportedProtocol.PROTEUS, SupportedProtocol.MLS).right(),
+            selfTeamId = TestTeam.TEAM_ID.right(),
+            expectedResult = AppsAllowedResult.Enabled(AppsAllowedProtocol.MIXED(SupportedProtocol.PROTEUS))
+        ),
+        AppsAllowedResultTestCase(
+            description = "Proteus Default Protocol, Mixed Supported Protocol, Apps Enabled",
+            appsEnabled = true.right(),
+            defaultProtocol = SupportedProtocol.PROTEUS.right(),
+            supportedProtocols = setOf(SupportedProtocol.PROTEUS, SupportedProtocol.MLS).right(),
+            selfTeamId = TestTeam.TEAM_ID.right(),
+            expectedResult = AppsAllowedResult.Enabled(AppsAllowedProtocol.MIXED(SupportedProtocol.MLS))
+        ),
+        AppsAllowedResultTestCase(
+            description = "MLS Default Protocol, MLS Supported Protocol, Apps Disabled",
+            appsEnabled = false.right(),
+            defaultProtocol = SupportedProtocol.MLS.right(),
+            supportedProtocols = setOf(SupportedProtocol.MLS).right(),
+            selfTeamId = TestTeam.TEAM_ID.right(),
+            expectedResult = AppsAllowedResult.Disabled
+        ),
+        AppsAllowedResultTestCase(
+            description = "MLS Default Protocol, Mixed Supported Protocol, Apps Disabled",
+            appsEnabled = false.right(),
+            defaultProtocol = SupportedProtocol.MLS.right(),
+            supportedProtocols = setOf(SupportedProtocol.PROTEUS, SupportedProtocol.MLS).right(),
+            selfTeamId = TestTeam.TEAM_ID.right(),
+            expectedResult = AppsAllowedResult.Disabled
+        ),
+        AppsAllowedResultTestCase(
+            description = "MLS Default Protocol, MLS Supported Protocol, Apps Enabled",
+            appsEnabled = true.right(),
+            defaultProtocol = SupportedProtocol.MLS.right(),
+            supportedProtocols = setOf(SupportedProtocol.MLS).right(),
+            selfTeamId = TestTeam.TEAM_ID.right(),
+            expectedResult = AppsAllowedResult.Enabled(AppsAllowedProtocol.MLS)
+        ),
+        AppsAllowedResultTestCase(
+            description = "MLS Default Protocol, Mixed Supported Protocol, Apps Enabled",
+            appsEnabled = true.right(),
+            defaultProtocol = SupportedProtocol.MLS.right(),
+            supportedProtocols = setOf(SupportedProtocol.PROTEUS, SupportedProtocol.MLS).right(),
+            selfTeamId = TestTeam.TEAM_ID.right(),
+            expectedResult = AppsAllowedResult.Enabled(AppsAllowedProtocol.MIXED(SupportedProtocol.MLS))
+        ),
+    )
+
+    @Test
+    fun givenDifferentConfigs_whenObservingAppsEnabled_thenReturnExpectedResult() = runTest {
+        testCases.forEach { case ->
+            val (_, useCase) = Arrangement()
+                .withObserveAppsEnabledResult(flowOf(case.appsEnabled))
+                .withDefaultProtocol(case.defaultProtocol)
+                .withSupportedProtocols(case.supportedProtocols)
+                .withSelfTeamIdProviderResult(case.selfTeamId)
+                .arrange()
+
+            useCase().test {
+                assertEquals(case.expectedResult, awaitItem(), "Failed for: ${case.description}")
+                cancelAndIgnoreRemainingEvents()
+            }
         }
     }
 
     private class Arrangement {
-        val userConfigRepository: UserConfigRepository = mock(UserConfigRepository::class)
-        val selfTeamIdProvider: SelfTeamIdProvider = mock(SelfTeamIdProvider::class)
+        val userConfigRepository: UserConfigRepository = mock<UserConfigRepository>()
+        val selfTeamIdProvider: SelfTeamIdProvider = mock<SelfTeamIdProvider>()
 
         suspend fun withObserveAppsEnabledResult(result: Flow<Either<StorageFailure, Boolean>>) = apply {
-            coEvery { userConfigRepository.observeAppsEnabled() } returns result
+            everySuspend { userConfigRepository.observeAppsEnabled() } returns result
         }
 
         suspend fun withSelfTeamIdProviderResult(result: Either<StorageFailure, TeamId?>) = apply {
-            coEvery { selfTeamIdProvider() } returns result
+            everySuspend { selfTeamIdProvider() } returns result
+        }
+
+        suspend fun withDefaultProtocol(result: Either<StorageFailure, SupportedProtocol>) = apply {
+            everySuspend { userConfigRepository.getDefaultProtocol() } returns result
+        }
+
+        suspend fun withSupportedProtocols(result: Either<StorageFailure, Set<SupportedProtocol>>) = apply {
+            everySuspend { userConfigRepository.getSupportedProtocols() } returns result
         }
 
         fun arrange(): Pair<Arrangement, ObserveIsAppsAllowedForUsageUseCase> {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Previous logic was missing some cases due to not having all the information at the time

### Solutions

Update logic for observing if Apps are allowed based on the matrix table provided and returning the default protocol in case of a mixed protocol usage.

- Matrix table used: [link here](https://wearezeta.atlassian.net/wiki/spaces/integrations/pages/2716401836/App+Flow+with+Feature+flag+and+Protocols+for+Clients+Test+cases+-+Bots+and+New+Apps)

### Dependencies (Optional)

Needs releases with:

- [X] #4025 
- [X] #4034 
- [X] #4041 

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

Tested on Android only