### PR TITLE
feat: insert unread events when restoring messages from nomad serrcive [WPB-24531]

### DIFF
--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/NomadMessagesDAO.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/NomadMessagesDAO.kt
@@ -77,6 +77,17 @@ internal class NomadMessagesDAOImpl internal constructor(
     private val writeDispatcher: WriteDispatcher,
 ) : NomadMessagesDAO {
 
+    private val contentWriter = NomadMessageContentWriter(
+        messagesQueries = messagesQueries,
+        messageAttachmentsQueries = messageAttachmentsQueries,
+    )
+
+    private val unreadEventWriter = NomadUnreadEventWriter(
+        messagesQueries = messagesQueries,
+        unreadEventsQueries = unreadEventsQueries,
+        selfUserId = selfUserId,
+    )
+
     override suspend fun storeMessages(
         messages: List<NomadMessageToInsert>,
         batchSize: Int,
@@ -91,7 +102,7 @@ internal class NomadMessagesDAOImpl internal constructor(
                 messagesQueries.transaction {
                     insertPlaceholderUsers(batch)
                     insertPlaceholderConversations(batch)
-                    val lastReadDatesByConversation = batch.lastReadDatesByConversation()
+                    val lastReadDatesByConversation = batch.lastReadDatesByConversation(conversationsQueries)
                     insertedMessages += insertMessages(batch, lastReadDatesByConversation)
                 }
                 batches += 1
@@ -154,13 +165,13 @@ internal class NomadMessagesDAOImpl internal constructor(
             return false
         }
 
-        val insertedContent = insertRegularContent(message)
+        val insertedContent = contentWriter.insertRegularContent(message)
         check(insertedContent) {
             "Nomad import inserted base message '${message.id}' without its content row."
         }
         insertReactions(message)
         insertReadReceipts(message)
-        insertUnreadEvent(message, lastReadDatesByConversation)
+        unreadEventWriter.insertUnreadEvent(message, lastReadDatesByConversation)
         return true
     }
 
@@ -190,7 +201,30 @@ internal class NomadMessagesDAOImpl internal constructor(
         }
     }
 
-    private fun insertUnreadEvent(
+    private companion object {
+        const val MIN_BATCH_SIZE = 1
+        const val RECEIPT_TYPE_READ = "READ"
+    }
+}
+
+private fun List<NomadMessageToInsert>.lastReadDatesByConversation(
+    conversationsQueries: ConversationsQueries,
+): Map<QualifiedIDEntity, Instant> =
+    asSequence()
+        .map { it.conversationId }
+        .distinct()
+        .associateWith { conversationId ->
+            conversationsQueries.getConversationLastReadDate(conversationId).executeAsOneOrNull()
+                ?: Instant.DISTANT_PAST
+        }
+
+private class NomadUnreadEventWriter(
+    private val messagesQueries: MessagesQueries,
+    private val unreadEventsQueries: UnreadEventsQueries,
+    private val selfUserId: UserIDEntity,
+) {
+
+    fun insertUnreadEvent(
         message: NomadMessageToInsert,
         lastReadDatesByConversation: Map<QualifiedIDEntity, Instant>,
     ) {
@@ -250,17 +284,14 @@ internal class NomadMessagesDAOImpl internal constructor(
             message.date
         )
     }
+}
 
-    private fun List<NomadMessageToInsert>.lastReadDatesByConversation(): Map<QualifiedIDEntity, Instant> =
-        asSequence()
-            .map { it.conversationId }
-            .distinct()
-            .associateWith { conversationId ->
-                conversationsQueries.getConversationLastReadDate(conversationId).executeAsOneOrNull()
-                    ?: Instant.DISTANT_PAST
-            }
+private class NomadMessageContentWriter(
+    private val messagesQueries: MessagesQueries,
+    private val messageAttachmentsQueries: MessageAttachmentsQueries,
+) {
 
-    private fun insertRegularContent(message: NomadMessageToInsert): Boolean {
+    fun insertRegularContent(message: NomadMessageToInsert): Boolean {
         val content = message.payload
         return when (content) {
             is SyncableMessagePayloadEntity.Text -> insertTextContent(message, content)
@@ -413,10 +444,5 @@ internal class NomadMessagesDAOImpl internal constructor(
             unknown_type_name = typeName,
         )
         return messagesQueries.selectChanges().executeAsOne() > 0
-    }
-
-    private companion object {
-        const val MIN_BATCH_SIZE = 1
-        const val RECEIPT_TYPE_READ = "READ"
     }
 }

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/NomadMessagesDAO.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/NomadMessagesDAO.kt
@@ -23,9 +23,12 @@ import com.wire.kalium.persistence.MessageAttachmentsQueries
 import com.wire.kalium.persistence.MessagesQueries
 import com.wire.kalium.persistence.ReactionsQueries
 import com.wire.kalium.persistence.ReceiptsQueries
+import com.wire.kalium.persistence.UnreadEventsQueries
 import com.wire.kalium.persistence.UsersQueries
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.dao.message.MessageEntity
+import com.wire.kalium.persistence.dao.unread.UnreadEventTypeEntity
 import com.wire.kalium.persistence.db.WriteDispatcher
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Instant
@@ -69,6 +72,8 @@ internal class NomadMessagesDAOImpl internal constructor(
     private val messageAttachmentsQueries: MessageAttachmentsQueries,
     private val reactionsQueries: ReactionsQueries,
     private val receiptsQueries: ReceiptsQueries,
+    private val unreadEventsQueries: UnreadEventsQueries,
+    private val selfUserId: UserIDEntity,
     private val writeDispatcher: WriteDispatcher,
 ) : NomadMessagesDAO {
 
@@ -86,7 +91,8 @@ internal class NomadMessagesDAOImpl internal constructor(
                 messagesQueries.transaction {
                     insertPlaceholderUsers(batch)
                     insertPlaceholderConversations(batch)
-                    insertedMessages += insertMessages(batch)
+                    val lastReadDatesByConversation = batch.lastReadDatesByConversation()
+                    insertedMessages += insertMessages(batch, lastReadDatesByConversation)
                 }
                 batches += 1
             }
@@ -117,12 +123,18 @@ internal class NomadMessagesDAOImpl internal constructor(
             }
     }
 
-    private fun insertMessages(messages: List<NomadMessageToInsert>): Int =
+    private fun insertMessages(
+        messages: List<NomadMessageToInsert>,
+        lastReadDatesByConversation: Map<QualifiedIDEntity, Instant>,
+    ): Int =
         messages.count { message ->
-            insertMessageWithContentOrThrow(message)
+            insertMessageWithContentOrThrow(message, lastReadDatesByConversation)
         }
 
-    private fun insertMessageWithContentOrThrow(message: NomadMessageToInsert): Boolean {
+    private fun insertMessageWithContentOrThrow(
+        message: NomadMessageToInsert,
+        lastReadDatesByConversation: Map<QualifiedIDEntity, Instant>,
+    ): Boolean {
         messagesQueries.insertOrIgnoreMessage(
             id = message.id,
             content_type = message.payload.contentType,
@@ -148,6 +160,7 @@ internal class NomadMessagesDAOImpl internal constructor(
         }
         insertReactions(message)
         insertReadReceipts(message)
+        insertUnreadEvent(message, lastReadDatesByConversation)
         return true
     }
 
@@ -176,6 +189,76 @@ internal class NomadMessagesDAOImpl internal constructor(
             )
         }
     }
+
+    private fun insertUnreadEvent(
+        message: NomadMessageToInsert,
+        lastReadDatesByConversation: Map<QualifiedIDEntity, Instant>,
+    ) {
+        val lastRead = lastReadDatesByConversation[message.conversationId] ?: Instant.DISTANT_PAST
+        if (message.payload.senderUserId == selfUserId || message.date <= lastRead) {
+            return
+        }
+
+        when (val content = message.payload) {
+            is SyncableMessagePayloadEntity.Text -> insertUnreadTextLikeContent(
+                message = message,
+                quotedMessageId = content.quotedMessageId,
+                mentions = content.mentions
+            )
+
+            is SyncableMessagePayloadEntity.Multipart -> insertUnreadTextLikeContent(
+                message = message,
+                quotedMessageId = content.quotedMessageId,
+                mentions = content.mentions
+            )
+
+            is SyncableMessagePayloadEntity.Asset,
+            is SyncableMessagePayloadEntity.Location -> {
+                unreadEventsQueries.insertEvent(
+                    message.id,
+                    UnreadEventTypeEntity.MESSAGE,
+                    message.conversationId,
+                    message.date
+                )
+            }
+
+            is SyncableMessagePayloadEntity.Unsupported -> {
+                /* no-op */
+            }
+        }
+    }
+
+    private fun insertUnreadTextLikeContent(
+        message: NomadMessageToInsert,
+        quotedMessageId: String?,
+        mentions: List<MessageEntity.Mention>,
+    ) {
+        val isQuotingSelfUser = quotedMessageId?.let { quotedId ->
+            messagesQueries.getMessageSenderId(quotedId, message.conversationId).executeAsOneOrNull() == selfUserId
+        } ?: false
+
+        val unreadType = when {
+            isQuotingSelfUser -> UnreadEventTypeEntity.REPLY
+            mentions.any { it.userId == selfUserId } -> UnreadEventTypeEntity.MENTION
+            else -> UnreadEventTypeEntity.MESSAGE
+        }
+
+        unreadEventsQueries.insertEvent(
+            message.id,
+            unreadType,
+            message.conversationId,
+            message.date
+        )
+    }
+
+    private fun List<NomadMessageToInsert>.lastReadDatesByConversation(): Map<QualifiedIDEntity, Instant> =
+        asSequence()
+            .map { it.conversationId }
+            .distinct()
+            .associateWith { conversationId ->
+                conversationsQueries.getConversationLastReadDate(conversationId).executeAsOneOrNull()
+                    ?: Instant.DISTANT_PAST
+            }
 
     private fun insertRegularContent(message: NomadMessageToInsert): Boolean {
         val content = message.payload

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
@@ -404,6 +404,8 @@ class UserDatabaseBuilder internal constructor(
             messageAttachmentsQueries = database.messageAttachmentsQueries,
             reactionsQueries = database.reactionsQueries,
             receiptsQueries = database.receiptsQueries,
+            unreadEventsQueries = database.unreadEventsQueries,
+            selfUserId = userId,
             writeDispatcher = writeDispatcher,
         )
 

--- a/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/backup/NomadMessagesDAOTest.kt
+++ b/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/backup/NomadMessagesDAOTest.kt
@@ -1,0 +1,191 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.persistence.dao.backup
+
+import com.wire.kalium.persistence.BaseDatabaseTest
+import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.persistence.dao.UserDAO
+import com.wire.kalium.persistence.dao.conversation.ConversationDAO
+import com.wire.kalium.persistence.dao.message.MessageDAO
+import com.wire.kalium.persistence.dao.message.MessageEntity
+import com.wire.kalium.persistence.dao.message.MessageEntityContent
+import com.wire.kalium.persistence.dao.unread.UnreadEventTypeEntity
+import com.wire.kalium.persistence.utils.stubs.newConversationEntity
+import com.wire.kalium.persistence.utils.stubs.newRegularMessageEntity
+import com.wire.kalium.persistence.utils.stubs.newUserEntity
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.seconds
+
+class NomadMessagesDAOTest : BaseDatabaseTest() {
+
+    private lateinit var nomadMessagesDAO: NomadMessagesDAO
+    private lateinit var messageDAO: MessageDAO
+    private lateinit var conversationDAO: ConversationDAO
+    private lateinit var userDAO: UserDAO
+
+    private val selfUser = newUserEntity("self-user")
+    private val otherUser = newUserEntity("other-user")
+    private val conversation = newConversationEntity("nomad-conversation")
+
+    @BeforeTest
+    fun setUp() {
+        deleteDatabase(selfUser.id)
+        val db = createDatabase(selfUser.id, encryptedDBSecret, true)
+        nomadMessagesDAO = db.nomadMessagesDAO
+        messageDAO = db.messageDAO
+        conversationDAO = db.conversationDAO
+        userDAO = db.userDAO
+    }
+
+    @Test
+    fun givenNomadRemoteMessageAfterLastRead_whenRestoringMessages_thenShouldCreateUnreadIndicator() = runTest {
+        insertInitialData()
+        val lastRead = Instant.parse("2026-04-17T10:00:00Z")
+        conversationDAO.updateConversationReadDate(conversation.id, lastRead)
+
+        nomadMessagesDAO.storeMessages(
+            messages = listOf(
+                nomadTextMessage(
+                    id = "remote-message",
+                    senderUserId = otherUser.id,
+                    date = lastRead + 1.seconds
+                )
+            ),
+            batchSize = 10
+        )
+
+        val unreadEvents = unreadEventsForConversation()
+        assertEquals(1, unreadEvents?.get(UnreadEventTypeEntity.MESSAGE))
+    }
+
+    @Test
+    fun givenNomadMessageMentioningSelf_whenRestoringMessages_thenShouldCreateMentionUnreadIndicator() = runTest {
+        insertInitialData()
+        val lastRead = Instant.parse("2026-04-17T10:00:00Z")
+        conversationDAO.updateConversationReadDate(conversation.id, lastRead)
+
+        nomadMessagesDAO.storeMessages(
+            messages = listOf(
+                nomadTextMessage(
+                    id = "mention-message",
+                    senderUserId = otherUser.id,
+                    date = lastRead + 1.seconds,
+                    mentions = listOf(MessageEntity.Mention(start = 0, length = 5, userId = selfUser.id))
+                )
+            ),
+            batchSize = 10
+        )
+
+        val unreadEvents = unreadEventsForConversation()
+        assertEquals(1, unreadEvents?.get(UnreadEventTypeEntity.MENTION))
+    }
+
+    @Test
+    fun givenNomadMessageReplyingToSelf_whenRestoringMessages_thenShouldCreateReplyUnreadIndicator() = runTest {
+        insertInitialData()
+        val lastRead = Instant.parse("2026-04-17T10:00:00Z")
+        conversationDAO.updateConversationReadDate(conversation.id, lastRead)
+
+        messageDAO.insertOrIgnoreMessage(
+            newRegularMessageEntity(
+                id = "self-message",
+                conversationId = conversation.id,
+                senderUserId = selfUser.id,
+                content = MessageEntityContent.Text("Question"),
+                date = lastRead - 1.seconds,
+                status = MessageEntity.Status.SENT
+            )
+        )
+
+        nomadMessagesDAO.storeMessages(
+            messages = listOf(
+                nomadTextMessage(
+                    id = "reply-message",
+                    senderUserId = otherUser.id,
+                    date = lastRead + 1.seconds,
+                    quotedMessageId = "self-message"
+                )
+            ),
+            batchSize = 10
+        )
+
+        val unreadEvents = unreadEventsForConversation()
+        assertEquals(1, unreadEvents?.get(UnreadEventTypeEntity.REPLY))
+    }
+
+    @Test
+    fun givenNomadSelfOrAlreadyReadMessages_whenRestoringMessages_thenShouldNotCreateUnreadIndicator() = runTest {
+        insertInitialData()
+        val lastRead = Instant.parse("2026-04-17T10:00:00Z")
+        conversationDAO.updateConversationReadDate(conversation.id, lastRead)
+
+        nomadMessagesDAO.storeMessages(
+            messages = listOf(
+                nomadTextMessage(
+                    id = "self-message",
+                    senderUserId = selfUser.id,
+                    date = lastRead + 1.seconds
+                ),
+                nomadTextMessage(
+                    id = "already-read-message",
+                    senderUserId = otherUser.id,
+                    date = lastRead - 1.seconds
+                )
+            ),
+            batchSize = 10
+        )
+
+        assertNull(unreadEventsForConversation())
+    }
+
+    private suspend fun insertInitialData() {
+        userDAO.upsertUsers(listOf(selfUser, otherUser))
+        conversationDAO.insertConversation(conversation)
+    }
+
+    private suspend fun unreadEventsForConversation() =
+        messageDAO.observeConversationsUnreadEvents().first().firstOrNull { it.conversationId == conversation.id }?.unreadEvents
+
+    private fun nomadTextMessage(
+        id: String,
+        senderUserId: QualifiedIDEntity,
+        date: Instant,
+        quotedMessageId: String? = null,
+        mentions: List<MessageEntity.Mention> = emptyList(),
+    ) = NomadMessageToInsert(
+        id = id,
+        conversationId = conversation.id,
+        date = date,
+        payload = SyncableMessagePayloadEntity.Text(
+            creationDate = date,
+            senderUserId = senderUserId,
+            senderClientId = "client-$id",
+            lastEditDate = null,
+            text = "message-$id",
+            quotedMessageId = quotedMessageId,
+            mentions = mentions
+        )
+    )
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24531
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

when restoring messages via the nomad service the unread events are not restored

### Causes (Optional)

they were never inserted

### Solutions

calculate and insert unread events

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
