### PR TITLE
fix(apps): skip fake one on one proteus conversations for system messages about apps (WPB-24535)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
@@ -182,6 +182,7 @@ internal class ConversationGroupRepositoryImpl(
                 conversationId = conversationEntity.id.toModel(),
                 hasAppsAccessEnabled = conversationResponse.hasAppsAccessEnabled(),
                 creatorId = selfUserId,
+                type = conversationEntity.type
             )
         }.flatMap {
             when (protocol) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/NewGroupConversationSystemMessagesCreator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/NewGroupConversationSystemMessagesCreator.kt
@@ -71,7 +71,16 @@ internal interface NewGroupConversationSystemMessagesCreator {
         eventId: String = LocalId.generate(),
         conversationId: ConversationId,
         hasAppsAccessEnabled: Boolean,
-        creatorId: UserId
+        creatorId: UserId,
+        type: ConversationEntity.Type
+    ): Either<CoreFailure, Unit>
+
+    suspend fun conversationAppsAccessIfEnabled(
+        eventId: String = LocalId.generate(),
+        conversationId: ConversationId,
+        hasAppsAccessEnabled: Boolean,
+        creatorId: UserId,
+        type: ConversationResponse.Type
     ): Either<CoreFailure, Unit>
 }
 
@@ -257,24 +266,51 @@ internal class NewGroupConversationSystemMessagesCreatorImpl(
         eventId: String,
         conversationId: ConversationId,
         hasAppsAccessEnabled: Boolean,
-        creatorId: UserId
-    ): Either<CoreFailure, Unit> {
-        return if (hasAppsAccessEnabled) {
-            persistMessage(
-                Message.System(
-                    eventId,
-                    MessageContent.ConversationAppsEnabledChanged(isEnabled = true),
-                    conversationId,
-                    Clock.System.now(),
-                    creatorId,
-                    Message.Status.Sent,
-                    Message.Visibility.VISIBLE,
-                    expirationData = null
-                )
+        creatorId: UserId,
+        type: ConversationEntity.Type
+    ): Either<CoreFailure, Unit> = persistAppsAccessIfEnabled(
+        eventId = eventId,
+        conversationId = conversationId,
+        hasAppsAccessEnabled = hasAppsAccessEnabled,
+        creatorId = creatorId,
+        isGroup = type == ConversationEntity.Type.GROUP
+    )
+
+    override suspend fun conversationAppsAccessIfEnabled(
+        eventId: String,
+        conversationId: ConversationId,
+        hasAppsAccessEnabled: Boolean,
+        creatorId: UserId,
+        type: ConversationResponse.Type
+    ): Either<CoreFailure, Unit> = persistAppsAccessIfEnabled(
+        eventId = eventId,
+        conversationId = conversationId,
+        hasAppsAccessEnabled = hasAppsAccessEnabled,
+        creatorId = creatorId,
+        isGroup = type == ConversationResponse.Type.GROUP
+    )
+
+    private suspend fun persistAppsAccessIfEnabled(
+        eventId: String,
+        conversationId: ConversationId,
+        hasAppsAccessEnabled: Boolean,
+        creatorId: UserId,
+        isGroup: Boolean,
+    ): Either<CoreFailure, Unit> = if (hasAppsAccessEnabled && isGroup) {
+        persistMessage(
+            Message.System(
+                eventId,
+                MessageContent.ConversationAppsEnabledChanged(isEnabled = true),
+                conversationId,
+                Clock.System.now(),
+                creatorId,
+                Message.Status.Sent,
+                Message.Visibility.VISIBLE,
+                expirationData = null
             )
-        } else {
-            Unit.right()
-        }
+        )
+    } else {
+        Unit.right()
     }
 
     private suspend fun isSelfATeamMember() = selfTeamIdProvider().fold({ false }, { it != null })

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/NewGroupConversationSystemMessagesCreator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/NewGroupConversationSystemMessagesCreator.kt
@@ -84,6 +84,7 @@ internal interface NewGroupConversationSystemMessagesCreator {
     ): Either<CoreFailure, Unit>
 }
 
+@Suppress("TooManyFunctions")
 internal class NewGroupConversationSystemMessagesCreatorImpl(
     private val persistMessage: PersistMessageUseCase,
     private val selfTeamIdProvider: SelfTeamIdProvider,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandler.kt
@@ -78,7 +78,7 @@ internal class NewConversationEventHandlerImpl(
                     }
                     .map { isNewUnhandledConversation }
             }.onSuccess { isNewUnhandledConversation ->
-                createSystemMessagesForNewConversation(isNewUnhandledConversation, event)
+                createSystemMessagesForNewConversation(selfUserTeamId, isNewUnhandledConversation, event)
                 eventLogger.logSuccess()
             }.onFailure {
                 eventLogger.logFailure(it)
@@ -108,6 +108,7 @@ internal class NewConversationEventHandlerImpl(
      * @param event new conversation event
      */
     private suspend fun createSystemMessagesForNewConversation(
+        selfUserTeamId: TeamId?,
         isNewUnhandledConversation: Boolean,
         event: Event.Conversation.NewConversation
     ) {
@@ -134,7 +135,8 @@ internal class NewConversationEventHandlerImpl(
                 eventId = event.id,
                 conversationId = event.conversationId,
                 hasAppsAccessEnabled = event.conversation.hasAppsAccessEnabled(),
-                creatorId = event.senderUserId
+                creatorId = event.senderUserId,
+                type = event.conversation.toConversationType(selfUserTeamId)
             )
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
@@ -215,7 +215,13 @@ class ConversationGroupRepositoryTest {
         result.shouldSucceed()
 
         coVerify {
-            arrangement.newGroupConversationSystemMessagesCreator.conversationAppsAccessIfEnabled(any(), any(), any(), any())
+            arrangement.newGroupConversationSystemMessagesCreator.conversationAppsAccessIfEnabled(
+                any(),
+                any(),
+                any(),
+                any(),
+                any<ConversationEntity.Type>()
+            )
         }.wasInvoked(once)
     }
 
@@ -2130,7 +2136,13 @@ class ConversationGroupRepositoryTest {
 
         suspend fun withConversationAppsAccessIfEnabled() = apply {
             coEvery {
-                newGroupConversationSystemMessagesCreator.conversationAppsAccessIfEnabled(any(), any(), any(), any())
+                newGroupConversationSystemMessagesCreator.conversationAppsAccessIfEnabled(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any<ConversationEntity.Type>()
+                )
             }.returns(Unit.right())
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandlerTest.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.common.functional.right
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.NewGroupConversationSystemMessagesCreator
 import com.wire.kalium.logic.data.conversation.PersistConversationUseCase
+import com.wire.kalium.logic.data.conversation.toConversationType
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
@@ -190,7 +191,8 @@ class NewConversationEventHandlerTest {
                 eq(event.id),
                 eq(event.conversation.id.toModel()),
                 eq(event.conversation.hasAppsAccessEnabled()),
-                eq(event.senderUserId)
+                eq(event.senderUserId),
+                eq(event.conversation.toConversationType(teamId))
             )
         }.wasInvoked(exactly = once)
     }
@@ -396,7 +398,13 @@ class NewConversationEventHandlerTest {
 
         suspend fun withConversationAppsAccessIfEnabled() = apply {
             coEvery {
-                newGroupConversationSystemMessagesCreator.conversationAppsAccessIfEnabled(any(), any(), any(), any())
+                newGroupConversationSystemMessagesCreator.conversationAppsAccessIfEnabled(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any<ConversationResponse.Type>()
+                )
             }.returns(Unit.right())
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24535
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Fake 1:1 proteus group conversations display system messages about apps.

### Causes (Optional)

Overlooked while implementing the system message addition #3704

### Solutions

Check additionally for real group conversations in order to add the sys message or not.

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
