### PR TITLE
fix(asset-upload): avoid downloading temporary image assets after upload [WPB-24950]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/upload/UploadAssetUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/upload/UploadAssetUseCase.kt
@@ -79,10 +79,6 @@ internal class UploadAssetUseCaseImpl(
         ).onFailure {
             updateAssetMessageTransferStatus(AssetTransferStatus.FAILED_UPLOAD, message.conversationId, message.id)
             messageSendFailureHandler.handleFailureAndUpdateMessageStatus(it, message.conversationId, message.id, TYPE)
-        }.onSuccess {
-            updateAssetMessageTransferStatus(AssetTransferStatus.UPLOADED, message.conversationId, message.id)
-            // We delete asset added temporarily that was used to show the loading
-            assetDataSource.deleteAssetLocally(metadata.assetId.key)
         }.flatMap { (assetId, sha256) ->
             // We update the message with the remote data (assetId & sha256 key) obtained by the successful asset upload,
             // we also update the generated audio normalized loudness if applicable,
@@ -104,6 +100,9 @@ internal class UploadAssetUseCaseImpl(
                         "There was an error when trying to persist the updated asset message with the information returned by the backend"
                     )
                 }.onSuccess {
+                    updateAssetMessageTransferStatus(AssetTransferStatus.UPLOADED, message.conversationId, message.id)
+                    // Keep the temporary asset around until the message points at the uploaded asset id.
+                    assetDataSource.deleteAssetLocally(metadata.assetId.key)
                     // Finally we try to send the Asset Message to the recipients of the given conversation
                     messageSender.sendMessage(updatedMessage).onFailure {
                         messageSendFailureHandler.handleFailureAndUpdateMessageStatus(it, message.conversationId, message.id, TYPE)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/upload/UploadAssetUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/upload/UploadAssetUseCaseTest.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.logic.feature.asset.upload
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.functional.left
 import com.wire.kalium.common.functional.right
+import com.wire.kalium.common.functional.Either
 import com.wire.kalium.cryptography.utils.AES256Key
 import com.wire.kalium.cryptography.utils.SHA256Key
 import com.wire.kalium.logic.data.asset.AssetRepository
@@ -91,6 +92,38 @@ class UploadAssetUseCaseTest {
         coVerify {
             arrangement.assetDataSource.deleteAssetLocally(any())
         }.wasInvoked(once)
+    }
+
+    @Test
+    fun givenPersistingUpdatedMessageFails_whenUploadSucceeds_thenLocalFileIsNotRemoved() = runTest(testDispatcher.default) {
+        val (arrangement, uploadAsset) = Arrangement().arrange {
+            withUploadSuccess()
+            withPersistMessageFailure()
+        }
+
+        uploadAsset(assetMessage(), uploadMetadata)
+
+        coVerify {
+            arrangement.assetDataSource.deleteAssetLocally(any())
+        }.wasNotInvoked()
+    }
+
+    @Test
+    fun givenPersistingUpdatedMessageFails_whenUploadSucceeds_thenUploadedStatusIsNotSet() = runTest(testDispatcher.default) {
+        val (arrangement, uploadAsset) = Arrangement().arrange {
+            withUploadSuccess()
+            withPersistMessageFailure()
+        }
+
+        uploadAsset(assetMessage(), uploadMetadata)
+
+        coVerify {
+            arrangement.updateAssetMessageTransferStatus(
+                transferStatus = eq(AssetTransferStatus.UPLOADED),
+                conversationId = any(),
+                messageId = any()
+            )
+        }.wasNotInvoked()
     }
 
     @Test
@@ -180,12 +213,17 @@ class UploadAssetUseCaseTest {
             audioNormalizedLoudnessBuilder.every(filePath, result)
         }
 
+        fun withPersistMessageFailure() = apply {
+            persistMessageResult = CoreFailure.Unknown(null).left()
+        }
+
         val assetDataSource: AssetRepository = mock(AssetRepository::class)
         val messageSender: MessageSender = mock(MessageSender::class)
         val messageSendFailureHandler: MessageSendFailureHandler = mock(MessageSendFailureHandler::class)
         val updateAssetMessageTransferStatus: UpdateAssetMessageTransferStatusUseCase = mock(UpdateAssetMessageTransferStatusUseCase::class)
         val persistMessage: PersistMessageUseCase = mock(PersistMessageUseCase::class)
         val audioNormalizedLoudnessBuilder = AudioNormalizedLoudnessBuilderMock()
+        var persistMessageResult: Either<CoreFailure, Unit> = Unit.right()
 
         suspend fun arrange(block: suspend Arrangement.() -> Unit): Pair<Arrangement, UploadAssetUseCaseImpl> {
             block()
@@ -200,7 +238,7 @@ class UploadAssetUseCaseTest {
 
             coEvery {
                 persistMessage(any())
-            }.returns(Unit.right())
+            }.returns(persistMessageResult)
 
             coEvery {
                 messageSender.sendMessage(any(), any())


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24950
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-24950

# What's new in this PR?

### Issues

Image previews for newly sent non-Cells assets could sometimes fail to load right after upload.
In that window the app could try to download the temporary local asset UUID instead of using the final uploaded asset id.

### Causes

The temporary local asset was deleted before the message was persisted with the final uploaded asset id.

### Solutions

Keep the temporary local asset until the updated message has been persisted with the final remote asset id.
Add regression tests to cover the failure path and make sure the temp asset is not removed too early.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Verified with:
- `./gradlew logic:jvmTest --tests "com.wire.kalium.logic.feature.asset.upload.UploadAssetUseCaseTest"`

Manual verification:
- Send an image in a non-Cells conversation
- Confirm the preview keeps showing correctly after upload
- Confirm no backend download is attempted for the temporary asset UUID

### Notes (Optional)