### PR TITLE
fix: fallback to proteus apps config when disabled [WPB-24956]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/ObserveIsAppsAllowedForUsageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/ObserveIsAppsAllowedForUsageUseCase.kt
@@ -63,10 +63,7 @@ internal class ObserveIsAppsAllowedForUsageUseCaseImpl(
         val isMixed = supportedProtocols.containsAll(listOf(SupportedProtocol.MLS, SupportedProtocol.PROTEUS))
 
         return when {
-            isMixed && isMLSDefault && appsEnabled ->
-                AppsAllowedResult.Enabled(AppsAllowedProtocol.MIXED(SupportedProtocol.MLS))
-
-            isMixed && isProteusDefault ->
+            isMixed ->
                 AppsAllowedResult.Enabled(
                     AppsAllowedProtocol.MIXED(if (appsEnabled) SupportedProtocol.MLS else SupportedProtocol.PROTEUS)
                 )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/ObserveIsAppsAllowedForUsageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/ObserveIsAppsAllowedForUsageUseCaseTest.kt
@@ -178,7 +178,7 @@ class ObserveIsAppsAllowedForUsageUseCaseTest {
             defaultProtocol = SupportedProtocol.MLS.right(),
             supportedProtocols = setOf(SupportedProtocol.PROTEUS, SupportedProtocol.MLS).right(),
             selfTeamId = TestTeam.TEAM_ID.right(),
-            expectedResult = AppsAllowedResult.Disabled
+            expectedResult = AppsAllowedResult.Enabled(AppsAllowedProtocol.MIXED(SupportedProtocol.PROTEUS))
         ),
         AppsAllowedResultTestCase(
             description = "MLS Default Protocol, MLS Supported Protocol, Apps Enabled",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24956
<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

Mixed-protocol teams with Apps disabled should still expose the Proteus fallback instead of returning a fully disabled Apps result.

### Causes (Optional)

The mixed-protocol branch only returned a mixed result when Apps were enabled or Proteus was the default protocol.

### Solutions

Return  when Apps are disabled, allowing consumers to decide per conversation protocol.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Updated the existing apps-allowed use case expectation for mixed MLS-default teams with Apps disabled.