### PR TITLE
feat: implement SyncServicesUseCase to sync services from backend and update ObserveAllServicesUseCase to avoid network calls [WPB-25762]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/service/ObserveAllServicesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/service/ObserveAllServicesUseCase.kt
@@ -17,25 +17,16 @@
  */
 package com.wire.kalium.logic.feature.service
 
-import com.wire.kalium.logic.data.id.SelfTeamIdProvider
 import com.wire.kalium.logic.data.service.ServiceDetails
 import com.wire.kalium.logic.data.service.ServiceRepository
-import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.common.functional.fold
-import com.wire.kalium.common.functional.getOrNull
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emitAll
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.launch
 
 /**
- * This use case returns all services currently in the database.
- * In case it is empty, the repository will request the list from the API.
- *
- * @return Flow<List<ServiceDetails>>
+ * Emits the list of services currently persisted in the database.
+ * Does not trigger a network sync — callers should invoke [SyncServicesUseCase] explicitly
+ * when a remote refresh is desired.
  */
 public interface ObserveAllServicesUseCase {
 
@@ -43,29 +34,14 @@ public interface ObserveAllServicesUseCase {
 }
 
 internal class ObserveAllServicesUseCaseImpl internal constructor(
-    private val serviceRepository: ServiceRepository,
-    private val teamRepository: TeamRepository,
-    private val selfTeamIdProvider: SelfTeamIdProvider
+    private val serviceRepository: ServiceRepository
 ) : ObserveAllServicesUseCase {
 
-    override suspend fun invoke(): Flow<List<ServiceDetails>> = flow {
-        // TODO: This should be called only one time preferably by the view model to
-        //  avoid unnecessary updates each time the use case is invoked
-        //  or have a in memory timer to avoid calling it too often
-        val scope = CoroutineScope(currentCoroutineContext())
-        scope.launch {
-            selfTeamIdProvider().getOrNull()?.let { teamId ->
-                teamRepository.syncServices(teamId = teamId)
-            }
+    override suspend fun invoke(): Flow<List<ServiceDetails>> =
+        serviceRepository.observeAllServices().map { either ->
+            either.fold(
+                { emptyList() },
+                { it }
+            )
         }
-
-        emitAll(
-            serviceRepository.observeAllServices().map { either ->
-                either.fold(
-                    { emptyList() },
-                    { it }
-                )
-            }
-        )
-    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/service/ServiceScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/service/ServiceScope.kt
@@ -43,7 +43,11 @@ public class ServiceScope internal constructor(
 
     public val observeAllServices: ObserveAllServicesUseCase
         get() = ObserveAllServicesUseCaseImpl(
-            serviceRepository = serviceRepository,
+            serviceRepository = serviceRepository
+        )
+
+    public val syncServices: SyncServicesUseCase
+        get() = SyncServicesUseCaseImpl(
             teamRepository = teamRepository,
             selfTeamIdProvider = selfTeamIdProvider
         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/service/SyncServicesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/service/SyncServicesUseCase.kt
@@ -1,0 +1,44 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.service
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.getOrNull
+import com.wire.kalium.logic.data.id.SelfTeamIdProvider
+import com.wire.kalium.logic.data.team.TeamRepository
+
+/**
+ * Syncs the list of services available for the current self-team from the backend.
+ * No-op when the self user does not belong to a team.
+ */
+public interface SyncServicesUseCase {
+
+    public suspend operator fun invoke(): Either<CoreFailure, Unit>
+}
+
+internal class SyncServicesUseCaseImpl internal constructor(
+    private val teamRepository: TeamRepository,
+    private val selfTeamIdProvider: SelfTeamIdProvider
+) : SyncServicesUseCase {
+
+    override suspend fun invoke(): Either<CoreFailure, Unit> =
+        selfTeamIdProvider().getOrNull()?.let { teamId ->
+            teamRepository.syncServices(teamId = teamId)
+        } ?: Either.Right(Unit)
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/service/SyncServicesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/service/SyncServicesUseCase.kt
@@ -44,10 +44,12 @@ internal class SyncServicesUseCaseImpl internal constructor(
 ) : SyncServicesUseCase {
 
     override suspend fun invoke(): SyncServicesUseCase.Result =
-        (selfTeamIdProvider().getOrNull()?.let { teamId ->
-            teamRepository.syncServices(teamId = teamId)
-        } ?: Either.Right(Unit)).fold(
-            { SyncServicesUseCase.Result.Failure(it) },
-            { SyncServicesUseCase.Result.Success }
-        )
+        (
+                selfTeamIdProvider().getOrNull()?.let { teamId ->
+                    teamRepository.syncServices(teamId = teamId)
+                } ?: Either.Right(Unit)
+                ).fold(
+                { SyncServicesUseCase.Result.Failure(it) },
+                { SyncServicesUseCase.Result.Success }
+            )
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/service/SyncServicesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/service/SyncServicesUseCase.kt
@@ -19,6 +19,7 @@ package com.wire.kalium.logic.feature.service
 
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.fold
 import com.wire.kalium.common.functional.getOrNull
 import com.wire.kalium.logic.data.id.SelfTeamIdProvider
 import com.wire.kalium.logic.data.team.TeamRepository
@@ -29,7 +30,12 @@ import com.wire.kalium.logic.data.team.TeamRepository
  */
 public interface SyncServicesUseCase {
 
-    public suspend operator fun invoke(): Either<CoreFailure, Unit>
+    public suspend operator fun invoke(): Result
+
+    public sealed interface Result {
+        public data object Success : Result
+        public data class Failure(val error: CoreFailure) : Result
+    }
 }
 
 internal class SyncServicesUseCaseImpl internal constructor(
@@ -37,8 +43,11 @@ internal class SyncServicesUseCaseImpl internal constructor(
     private val selfTeamIdProvider: SelfTeamIdProvider
 ) : SyncServicesUseCase {
 
-    override suspend fun invoke(): Either<CoreFailure, Unit> =
-        selfTeamIdProvider().getOrNull()?.let { teamId ->
+    override suspend fun invoke(): SyncServicesUseCase.Result =
+        (selfTeamIdProvider().getOrNull()?.let { teamId ->
             teamRepository.syncServices(teamId = teamId)
-        } ?: Either.Right(Unit)
+        } ?: Either.Right(Unit)).fold(
+            { SyncServicesUseCase.Result.Failure(it) },
+            { SyncServicesUseCase.Result.Success }
+        )
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/service/ObserveAllServicesUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/service/ObserveAllServicesUseCaseTest.kt
@@ -17,10 +17,7 @@
  */
 package com.wire.kalium.logic.feature.service
 
-import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.StorageFailure
-import com.wire.kalium.logic.data.id.SelfTeamIdProvider
-import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.service.ServiceDetails
 import com.wire.kalium.logic.data.service.ServiceId
 import com.wire.kalium.logic.data.service.ServiceRepository
@@ -49,8 +46,6 @@ class ObserveAllServicesUseCaseTest {
         )
 
         val (_, observeAllServicesUseCase) = Arrangement()
-            .withSelfUserTeamId(Either.Right(TestUser.SELF.teamId))
-            .withSyncingServices()
             .withObserveAllServices(flowOf(Either.Right(expected)))
             .arrange()
 
@@ -64,8 +59,6 @@ class ObserveAllServicesUseCaseTest {
         val error = StorageFailure.DataNotFound
 
         val (_, observeAllServicesUseCase) = Arrangement()
-            .withSelfUserTeamId(Either.Right(TestUser.SELF.teamId))
-            .withSyncingServices()
             .withObserveAllServices(flowOf(Either.Left(error)))
             .arrange()
 
@@ -91,31 +84,13 @@ class ObserveAllServicesUseCaseTest {
 
     private class Arrangement {
         val serviceRepository: ServiceRepository = mock<ServiceRepository>(mode = MockMode.autoUnit)
-        val teamRepository: TeamRepository = mock<TeamRepository>(mode = MockMode.autoUnit)
-        val selfTeamIdProvider = mock<SelfTeamIdProvider>(mode = MockMode.autoUnit)
 
-        private val useCase: ObserveAllServicesUseCase = ObserveAllServicesUseCaseImpl(
-            serviceRepository,
-            teamRepository,
-            selfTeamIdProvider
-        )
+        private val useCase: ObserveAllServicesUseCase = ObserveAllServicesUseCaseImpl(serviceRepository)
 
         suspend fun withObserveAllServices(result: Flow<Either<StorageFailure, List<ServiceDetails>>>) = apply {
             everySuspend {
                 serviceRepository.observeAllServices()
             } returns result
-        }
-
-        suspend fun withSelfUserTeamId(either: Either<CoreFailure, TeamId?>) = apply {
-            everySuspend {
-                selfTeamIdProvider.invoke()
-            } returns either
-        }
-
-        suspend fun withSyncingServices() = apply {
-            everySuspend {
-                teamRepository.syncServices(any())
-            } returns Either.Right(Unit)
         }
 
         fun arrange() = this to useCase

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/service/ObserveAllServicesUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/service/ObserveAllServicesUseCaseTest.kt
@@ -17,17 +17,11 @@
  */
 package com.wire.kalium.logic.feature.service
 
-import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.StorageFailure
-import com.wire.kalium.logic.data.id.SelfTeamIdProvider
-import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.service.ServiceDetails
 import com.wire.kalium.logic.data.service.ServiceId
 import com.wire.kalium.logic.data.service.ServiceRepository
-import com.wire.kalium.logic.data.team.TeamRepository
-import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.common.functional.Either
-import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.mock
 import kotlinx.coroutines.flow.Flow
@@ -47,8 +41,6 @@ class ObserveAllServicesUseCaseTest {
         )
 
         val (_, observeAllServicesUseCase) = Arrangement()
-            .withSelfUserTeamId(Either.Right(TestUser.SELF.teamId))
-            .withSyncingServices()
             .withObserveAllServices(flowOf(Either.Right(expected)))
             .arrange()
 
@@ -62,8 +54,6 @@ class ObserveAllServicesUseCaseTest {
         val error = StorageFailure.DataNotFound
 
         val (_, observeAllServicesUseCase) = Arrangement()
-            .withSelfUserTeamId(Either.Right(TestUser.SELF.teamId))
-            .withSyncingServices()
             .withObserveAllServices(flowOf(Either.Left(error)))
             .arrange()
 
@@ -89,31 +79,13 @@ class ObserveAllServicesUseCaseTest {
 
     private class Arrangement {
         val serviceRepository: ServiceRepository = mock(ServiceRepository::class)
-        val teamRepository: TeamRepository = mock(TeamRepository::class)
-        val selfTeamIdProvider = mock(SelfTeamIdProvider::class)
 
-        private val useCase: ObserveAllServicesUseCase = ObserveAllServicesUseCaseImpl(
-            serviceRepository,
-            teamRepository,
-            selfTeamIdProvider
-        )
+        private val useCase: ObserveAllServicesUseCase = ObserveAllServicesUseCaseImpl(serviceRepository)
 
         suspend fun withObserveAllServices(result: Flow<Either<StorageFailure, List<ServiceDetails>>>) = apply {
             coEvery {
                 serviceRepository.observeAllServices()
             }.returns(result)
-        }
-
-        suspend fun withSelfUserTeamId(either: Either<CoreFailure, TeamId?>) = apply {
-            coEvery {
-                selfTeamIdProvider.invoke()
-            }.returns(either)
-        }
-
-        suspend fun withSyncingServices() = apply {
-            coEvery {
-                teamRepository.syncServices(any())
-            }.returns(Either.Right(Unit))
         }
 
         fun arrange() = this to useCase

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/service/SyncServicesUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/service/SyncServicesUseCaseTest.kt
@@ -24,12 +24,12 @@ import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.common.functional.Either
-import io.mockative.any
-import io.mockative.coEvery
-import io.mockative.coVerify
-import io.mockative.eq
-import io.mockative.mock
-import io.mockative.once
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -47,10 +47,10 @@ class SyncServicesUseCaseTest {
 
         val result = useCase()
 
-        assertEquals(Either.Right(Unit), result)
-        coVerify {
-            arrangement.teamRepository.syncServices(eq(teamId))
-        }.wasInvoked(exactly = once)
+        assertEquals(SyncServicesUseCase.Result.Success, result)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.teamRepository.syncServices(teamId)
+        }
     }
 
     @Test
@@ -61,10 +61,10 @@ class SyncServicesUseCaseTest {
 
         val result = useCase()
 
-        assertEquals(Either.Right(Unit), result)
-        coVerify {
+        assertEquals(SyncServicesUseCase.Result.Success, result)
+        verifySuspend(VerifyMode.not) {
             arrangement.teamRepository.syncServices(any())
-        }.wasNotInvoked()
+        }
     }
 
     @Test
@@ -78,29 +78,29 @@ class SyncServicesUseCaseTest {
 
         val result = useCase()
 
-        assertTrue(result is Either.Left)
-        assertEquals(failure, (result as Either.Left).value)
+        assertTrue(result is SyncServicesUseCase.Result.Failure)
+        assertEquals(failure, result.error)
     }
 
     private class Arrangement {
-        val teamRepository: TeamRepository = mock(TeamRepository::class)
-        val selfTeamIdProvider = mock(SelfTeamIdProvider::class)
+        val teamRepository: TeamRepository = mock()
+        val selfTeamIdProvider: SelfTeamIdProvider = mock()
 
         private val useCase: SyncServicesUseCase = SyncServicesUseCaseImpl(
             teamRepository = teamRepository,
             selfTeamIdProvider = selfTeamIdProvider
         )
 
-        suspend fun withSelfUserTeamId(either: Either<CoreFailure, TeamId?>) = apply {
-            coEvery {
-                selfTeamIdProvider.invoke()
-            }.returns(either)
+        fun withSelfUserTeamId(either: Either<CoreFailure, TeamId?>) = apply {
+            everySuspend {
+                selfTeamIdProvider()
+            } returns (either)
         }
 
-        suspend fun withSyncingServices(result: Either<CoreFailure, Unit>) = apply {
-            coEvery {
+        fun withSyncingServices(result: Either<CoreFailure, Unit>) = apply {
+            everySuspend {
                 teamRepository.syncServices(any())
-            }.returns(result)
+            } returns (result)
         }
 
         fun arrange() = this to useCase

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/service/SyncServicesUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/service/SyncServicesUseCaseTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.service
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.NetworkFailure
+import com.wire.kalium.logic.data.id.SelfTeamIdProvider
+import com.wire.kalium.logic.data.id.TeamId
+import com.wire.kalium.logic.data.team.TeamRepository
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.common.functional.Either
+import io.mockative.any
+import io.mockative.coEvery
+import io.mockative.coVerify
+import io.mockative.eq
+import io.mockative.mock
+import io.mockative.once
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SyncServicesUseCaseTest {
+
+    @Test
+    fun givenTeamId_whenInvoked_thenCallsTeamRepositorySyncServicesWithThatTeamId() = runTest {
+        val teamId = TestUser.SELF.teamId!!
+        val (arrangement, useCase) = Arrangement()
+            .withSelfUserTeamId(Either.Right(teamId))
+            .withSyncingServices(Either.Right(Unit))
+            .arrange()
+
+        val result = useCase()
+
+        assertEquals(Either.Right(Unit), result)
+        coVerify {
+            arrangement.teamRepository.syncServices(eq(teamId))
+        }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenNoTeamId_whenInvoked_thenReturnsRightUnitWithoutSyncingServices() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withSelfUserTeamId(Either.Right(null))
+            .arrange()
+
+        val result = useCase()
+
+        assertEquals(Either.Right(Unit), result)
+        coVerify {
+            arrangement.teamRepository.syncServices(any())
+        }.wasNotInvoked()
+    }
+
+    @Test
+    fun givenSyncFails_whenInvoked_thenPropagatesFailure() = runTest {
+        val teamId = TestUser.SELF.teamId!!
+        val failure = NetworkFailure.NoNetworkConnection(cause = null)
+        val (_, useCase) = Arrangement()
+            .withSelfUserTeamId(Either.Right(teamId))
+            .withSyncingServices(Either.Left(failure))
+            .arrange()
+
+        val result = useCase()
+
+        assertTrue(result is Either.Left)
+        assertEquals(failure, (result as Either.Left).value)
+    }
+
+    private class Arrangement {
+        val teamRepository: TeamRepository = mock(TeamRepository::class)
+        val selfTeamIdProvider = mock(SelfTeamIdProvider::class)
+
+        private val useCase: SyncServicesUseCase = SyncServicesUseCaseImpl(
+            teamRepository = teamRepository,
+            selfTeamIdProvider = selfTeamIdProvider
+        )
+
+        suspend fun withSelfUserTeamId(either: Either<CoreFailure, TeamId?>) = apply {
+            coEvery {
+                selfTeamIdProvider.invoke()
+            }.returns(either)
+        }
+
+        suspend fun withSyncingServices(result: Either<CoreFailure, Unit>) = apply {
+            coEvery {
+                teamRepository.syncServices(any())
+            }.returns(result)
+        }
+
+        fun arrange() = this to useCase
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25762
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

ObserveAllServicesUseCase only return after a remote API update even tho the list of bots is 

### Causes (Optional)

the use case will update first and then return

### Solutions

split it into ObserveAllServicesUseCase and SyncServicesUseCase and call SyncServicesUseCase from the view model when needed to update 

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
