### PR TITLE
fix: avoid double external-commit race and sync welcome metadata

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1935,7 +1935,8 @@ public class UserSessionScope internal constructor(
             revocationListChecker = checkRevocationList,
             certificateRevocationListRepository = certificateRevocationListRepository,
             joinExistingMLSConversation = joinExistingMLSConversationUseCase,
-            fetchConversationIfUnknown = fetchConversationIfUnknownUseCase
+            fetchConversationIfUnknown = fetchConversationIfUnknownUseCase,
+            mlsConversationRepository = mlsConversationRepository
         )
 
     private val renamedConversationHandler: RenamedConversationEventHandler

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandler.kt
@@ -40,6 +40,7 @@ import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.FetchConversationIfUnknownUseCase
 import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCase
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.e2ei.CertificateRevocationListRepository
 import com.wire.kalium.logic.data.e2ei.RevocationListChecker
 import com.wire.kalium.logic.data.event.Event
@@ -50,6 +51,7 @@ import com.wire.kalium.logic.feature.conversation.mls.OneOnOneResolver
 import com.wire.kalium.logic.feature.keypackage.RefillKeyPackagesResult
 import com.wire.kalium.logic.feature.keypackage.RefillKeyPackagesUseCase
 import com.wire.kalium.logic.util.createEventProcessingLogger
+import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 import io.mockative.Mockable
 import kotlinx.coroutines.flow.first
 import kotlin.io.encoding.Base64
@@ -67,6 +69,7 @@ internal class MLSWelcomeEventHandlerImpl(
     private val revocationListChecker: RevocationListChecker,
     private val joinExistingMLSConversation: JoinExistingMLSConversationUseCase,
     private val fetchConversationIfUnknown: FetchConversationIfUnknownUseCase,
+    private val mlsConversationRepository: MLSConversationRepository,
     private val certificateRevocationListRepository: CertificateRevocationListRepository
 ) : MLSWelcomeEventHandler {
     override suspend fun handle(
@@ -90,8 +93,15 @@ internal class MLSWelcomeEventHandlerImpl(
                     kaliumLogger.d("$TAG: checking revocation list")
                     checkRevocationList(mlsContext, it)
                 }
-                kaliumLogger.d("$TAG: Marking conversation as established ${welcomeBundle.groupId.obfuscateId()}")
-                markConversationAsEstablished(GroupID(welcomeBundle.groupId))
+                kaliumLogger.d(
+                    "$TAG: Syncing local MLS metadata for ${event.conversationId.toLogString()} " +
+                        "with group ${welcomeBundle.groupId.obfuscateId()}"
+                )
+                syncConversationMetadata(
+                    mlsContext = mlsContext,
+                    conversationId = event.conversationId,
+                    groupID = GroupID(welcomeBundle.groupId)
+                )
             }.flatMap {
                 kaliumLogger.d("$TAG: Resolving conversation if one-on-one ${event.conversationId.toLogString()}")
                 resolveConversationIfOneOnOne(transactionContext, event.conversationId)
@@ -191,8 +201,19 @@ internal class MLSWelcomeEventHandlerImpl(
                 }
             }
 
-    private suspend fun markConversationAsEstablished(groupID: GroupID): Either<CoreFailure, Unit> =
-        conversationRepository.updateConversationGroupState(groupID, Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED)
+    private suspend fun syncConversationMetadata(
+        mlsContext: MlsCoreCryptoContext,
+        conversationId: ConversationId,
+        groupID: GroupID
+    ): Either<CoreFailure, Unit> =
+        mlsConversationRepository.getLocalGroupEpoch(mlsContext, groupID).flatMap { localEpoch ->
+            mlsConversationRepository.updateGroupIdAndState(
+                conversationId = conversationId,
+                newGroupId = groupID,
+                newEpoch = localEpoch.toLong(),
+                groupState = ConversationEntity.GroupState.ESTABLISHED
+            )
+        }
 
     private suspend fun checkRevocationList(mlsContext: MlsCoreCryptoContext, crlNewDistributionPoints: List<String>) {
         crlNewDistributionPoints.forEach { url ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandler.kt
@@ -131,13 +131,17 @@ internal class MemberJoinEventHandlerImpl(
      * - Only group conversations (not 1:1 or self): 1:1 MLS establishment is handled separately.
      * - Only PENDING_JOIN state: ESTABLISHED means a Welcome was already processed; firing an
      *   external commit would create a conflicting epoch.
+     * - Only self-initiated joins (`addedBy == selfUserId`): when another user adds us, a Welcome
+     *   is expected and should establish the local MLS state without preemptive external commits.
      */
     private suspend fun joinMLSGroupIfSelfJoinedPendingGroup(
         transactionContext: CryptoTransactionContext,
         event: Event.Conversation.MemberJoin,
         conversation: Conversation
     ) {
-        if (event.members.any { it.id == selfUserId } && conversation.protocol.isPendingJoin()) {
+        val selfWasAdded = event.members.any { it.id == selfUserId }
+        val isSelfJoinFlow = event.addedBy == selfUserId
+        if (selfWasAdded && isSelfJoinFlow && conversation.protocol.isPendingJoin()) {
             joinExistingMLSConversation(transactionContext, event.conversationId)
                 .onFailure { logger.w("Failed to join MLS group after MemberJoin event: $it") }
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandlerTest.kt
@@ -43,10 +43,13 @@ import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProvider
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMockativeImpl
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangementImpl
+import com.wire.kalium.logic.util.arrangement.repository.MLSConversationRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.repository.MLSConversationRepositoryArrangementImpl
 import com.wire.kalium.logic.util.arrangement.usecase.FetchConversationIfUnknownUseCaseArrangement
 import com.wire.kalium.logic.util.arrangement.usecase.FetchConversationIfUnknownUseCaseArrangementImpl
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
+import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 import io.ktor.util.encodeBase64
 import io.mockative.any
 import io.mockative.coEvery
@@ -73,7 +76,7 @@ class MLSWelcomeEventHandlerTest {
         mlsWelcomeEventHandler.handle(arrangement.transactionContext, WELCOME_EVENT).shouldFail()
 
         coVerify {
-            arrangement.conversationRepository.updateConversationGroupState(any(), any())
+            arrangement.mlsConversationRepository.updateGroupIdAndState(any(), any(), any(), any())
         }.wasNotInvoked()
     }
 
@@ -88,7 +91,7 @@ class MLSWelcomeEventHandlerTest {
         mlsWelcomeEventHandler.handle(arrangement.transactionContext, WELCOME_EVENT).shouldFail()
 
         coVerify {
-            arrangement.conversationRepository.updateConversationGroupState(any(), any())
+            arrangement.mlsConversationRepository.updateGroupIdAndState(any(), any(), any(), any())
         }.wasNotInvoked()
     }
 
@@ -98,7 +101,7 @@ class MLSWelcomeEventHandlerTest {
             withRefillKeyPackagesReturning(RefillKeyPackagesResult.Success)
             withMLSClientProcessingOfWelcomeMessageReturnsSuccessfully()
             withFetchConversationIfUnknownSucceeding()
-            withUpdateGroupStateReturning(Either.Right(Unit))
+            withSyncConversationMetadataReturning(Either.Right(Unit))
             withObserveConversationDetailsByIdReturning(Either.Right(CONVERSATION_GROUP))
         }
 
@@ -115,16 +118,18 @@ class MLSWelcomeEventHandlerTest {
             withRefillKeyPackagesReturning(RefillKeyPackagesResult.Success)
             withMLSClientProcessingOfWelcomeMessageReturnsSuccessfully()
             withFetchConversationIfUnknownSucceeding()
-            withUpdateGroupStateReturning(Either.Right(Unit))
+            withSyncConversationMetadataReturning(Either.Right(Unit))
             withObserveConversationDetailsByIdReturning(Either.Right(CONVERSATION_GROUP))
         }
 
         mlsWelcomeEventHandler.handle(arrangement.transactionContext, WELCOME_EVENT).shouldSucceed()
 
         coVerify {
-            arrangement.conversationRepository.updateConversationGroupState(
+            arrangement.mlsConversationRepository.updateGroupIdAndState(
+                eq(CONVERSATION_ID),
                 eq(GroupID(MLS_GROUP_ID)),
-                eq(Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED)
+                eq(LOCAL_EPOCH.toLong()),
+                eq(ConversationEntity.GroupState.ESTABLISHED)
             )
         }.wasInvoked(exactly = once)
     }
@@ -135,7 +140,7 @@ class MLSWelcomeEventHandlerTest {
             withRefillKeyPackagesReturning(RefillKeyPackagesResult.Success)
             withMLSClientProcessingOfWelcomeMessageReturnsSuccessfully()
             withFetchConversationIfUnknownSucceeding()
-            withUpdateGroupStateReturning(Either.Right(Unit))
+            withSyncConversationMetadataReturning(Either.Right(Unit))
             withObserveConversationDetailsByIdReturning(Either.Right(CONVERSATION_ONE_ONE))
             withResolveOneOnOneConversationWithUserReturning(Either.Right(CONVERSATION_ID))
         }
@@ -153,7 +158,7 @@ class MLSWelcomeEventHandlerTest {
             withRefillKeyPackagesReturning(RefillKeyPackagesResult.Success)
             withMLSClientProcessingOfWelcomeMessageReturnsSuccessfully()
             withFetchConversationIfUnknownSucceeding()
-            withUpdateGroupStateReturning(Either.Right(Unit))
+            withSyncConversationMetadataReturning(Either.Right(Unit))
             withObserveConversationDetailsByIdReturning(Either.Right(CONVERSATION_GROUP))
         }
 
@@ -165,13 +170,13 @@ class MLSWelcomeEventHandlerTest {
     }
 
     @Test
-    fun givenUpdateGroupStateFails_thenShouldPropagateError() = runTest {
+    fun givenSyncConversationMetadataFails_thenShouldPropagateError() = runTest {
 
         val failure = Either.Left(StorageFailure.DataNotFound)
         val (arrangement, mlsWelcomeEventHandler) = arrange {
             withMLSClientProcessingOfWelcomeMessageReturnsSuccessfully()
             withFetchConversationIfUnknownSucceeding()
-            withUpdateGroupStateReturning(failure)
+            withSyncConversationMetadataReturning(failure)
         }
 
         mlsWelcomeEventHandler.handle(arrangement.transactionContext, WELCOME_EVENT).shouldFail {
@@ -186,7 +191,7 @@ class MLSWelcomeEventHandlerTest {
         val (arrangement, mlsWelcomeEventHandler) = arrange {
             withMLSClientProcessingOfWelcomeMessageReturnsSuccessfully()
             withFetchConversationIfUnknownSucceeding()
-            withUpdateGroupStateReturning(Either.Right(Unit))
+            withSyncConversationMetadataReturning(Either.Right(Unit))
             withObserveConversationDetailsByIdReturning(Either.Right(CONVERSATION_ONE_ONE))
             withResolveOneOnOneConversationWithUserReturning(failure)
         }
@@ -202,7 +207,7 @@ class MLSWelcomeEventHandlerTest {
         val (arrangement, mlsWelcomeEventHandler) = arrange {
             withMLSClientProcessingOfWelcomeMessageReturnsSuccessfully()
             withFetchConversationIfUnknownSucceeding()
-            withUpdateGroupStateReturning(Either.Right(Unit))
+            withSyncConversationMetadataReturning(Either.Right(Unit))
             withObserveConversationDetailsByIdReturning(Either.Right(CONVERSATION_ONE_ONE))
             withResolveOneOnOneConversationWithUserReturning(failure)
         }
@@ -220,7 +225,7 @@ class MLSWelcomeEventHandlerTest {
             withRefillKeyPackagesReturning(RefillKeyPackagesResult.Success)
             withMLSClientProcessingOfWelcomeMessageReturnsSuccessfully()
             withFetchConversationIfUnknownSucceeding()
-            withUpdateGroupStateReturning(Either.Right(Unit))
+            withSyncConversationMetadataReturning(Either.Right(Unit))
             withObserveConversationDetailsByIdReturning(Either.Right(CONVERSATION_GROUP))
         }
 
@@ -240,7 +245,7 @@ class MLSWelcomeEventHandlerTest {
             )
             withFetchConversationIfUnknownSucceeding()
             withCheckRevocationListResult()
-            withUpdateGroupStateReturning(failure)
+            withSyncConversationMetadataReturning(failure)
         }
 
         mlsWelcomeEventHandler.handle(arrangement.transactionContext, WELCOME_EVENT)
@@ -265,7 +270,7 @@ class MLSWelcomeEventHandlerTest {
             withFetchConversationIfUnknownSucceeding()
             withConversationProtocolInfo(Either.Right(MockConversation.MLS_PROTOCOL_INFO))
             withWipeConversationReturningSuccessfully()
-            withUpdateGroupStateReturning(Either.Right(Unit))
+            withSyncConversationMetadataReturning(Either.Right(Unit))
             withObserveConversationDetailsByIdReturning(Either.Right(CONVERSATION_GROUP))
             withRefillKeyPackagesReturning(RefillKeyPackagesResult.Success)
         }
@@ -308,7 +313,7 @@ class MLSWelcomeEventHandlerTest {
         }.wasNotInvoked()
 
         coVerify {
-            arrangement.conversationRepository.updateConversationGroupState(any(), any())
+            arrangement.mlsConversationRepository.updateGroupIdAndState(any(), any(), any(), any())
         }.wasNotInvoked()
     }
 
@@ -341,6 +346,7 @@ class MLSWelcomeEventHandlerTest {
 
     private class Arrangement(private val block: suspend Arrangement.() -> Unit) :
         ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
+        MLSConversationRepositoryArrangement by MLSConversationRepositoryArrangementImpl(),
         FetchConversationIfUnknownUseCaseArrangement by FetchConversationIfUnknownUseCaseArrangementImpl(),
         CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMockativeImpl(),
         OneOnOneResolverArrangement by OneOnOneResolverArrangementImpl() {
@@ -410,6 +416,20 @@ class MLSWelcomeEventHandlerTest {
             }.returns(result)
         }
 
+        suspend fun withSyncConversationMetadataReturning(result: Either<CoreFailure, Unit>) = apply {
+            coEvery {
+                mlsConversationRepository.getLocalGroupEpoch(any(), eq(GroupID(MLS_GROUP_ID)))
+            }.returns(Either.Right(LOCAL_EPOCH))
+            coEvery {
+                mlsConversationRepository.updateGroupIdAndState(
+                    eq(CONVERSATION_ID),
+                    eq(GroupID(MLS_GROUP_ID)),
+                    eq(LOCAL_EPOCH.toLong()),
+                    eq(ConversationEntity.GroupState.ESTABLISHED)
+                )
+            }.returns(result)
+        }
+
         suspend fun arrange() = run {
             block()
             this@Arrangement to MLSWelcomeEventHandlerImpl(
@@ -419,7 +439,8 @@ class MLSWelcomeEventHandlerTest {
                 revocationListChecker = checkRevocationList,
                 certificateRevocationListRepository = certificateRevocationListRepository,
                 joinExistingMLSConversation = joinExistingMLSConversation,
-                fetchConversationIfUnknown = fetchConversationIfUnknown
+                fetchConversationIfUnknown = fetchConversationIfUnknown,
+                mlsConversationRepository = mlsConversationRepository
             )
         }
     }
@@ -428,6 +449,7 @@ class MLSWelcomeEventHandlerTest {
         suspend fun arrange(configuration: suspend Arrangement.() -> Unit) = Arrangement(configuration).arrange()
 
         const val MLS_GROUP_ID: MLSGroupId = "test-mlsGroupId"
+        const val LOCAL_EPOCH: ULong = 1UL
         val CONVERSATION_ONE_ONE = TestConversationDetails.CONVERSATION_ONE_ONE
         val CONVERSATION_GROUP = TestConversationDetails.CONVERSATION_GROUP
         val CONVERSATION_ID = TestConversation.ID

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandlerTest.kt
@@ -302,7 +302,10 @@ class MemberJoinEventHandlerTest {
     fun givenSelfMemberJoinEventInMLSConversation_whenHandlingIt_thenShouldJoinMLSGroup() = runTest {
         val newMembers = listOf(Member(TEST_SELF_USER_ID, Member.Role.Member))
         val mlsConversation = TestConversation.GROUP(TestConversation.MLS_PROTOCOL_INFO)
-        val event = TestEvent.memberJoin(members = newMembers).copy(conversationId = mlsConversation.id)
+        val event = TestEvent.memberJoin(members = newMembers).copy(
+            conversationId = mlsConversation.id,
+            addedBy = TEST_SELF_USER_ID
+        )
 
         val (arrangement, eventHandler) = arrange {
             withFetchConversationSucceeding(any(), any(), reason = eq(ConversationSyncReason.Other))
@@ -396,7 +399,10 @@ class MemberJoinEventHandlerTest {
     fun givenSelfMemberJoinEventInMLSConversationAndJoinFails_whenHandlingIt_thenShouldStillSucceed() = runTest {
         val newMembers = listOf(Member(TEST_SELF_USER_ID, Member.Role.Member))
         val mlsConversation = TestConversation.GROUP(TestConversation.MLS_PROTOCOL_INFO)
-        val event = TestEvent.memberJoin(members = newMembers).copy(conversationId = mlsConversation.id)
+        val event = TestEvent.memberJoin(members = newMembers).copy(
+            conversationId = mlsConversation.id,
+            addedBy = TEST_SELF_USER_ID
+        )
 
         val (arrangement, eventHandler) = arrange {
             withFetchConversationSucceeding(any(), any(), reason = eq(ConversationSyncReason.Other))
@@ -410,6 +416,27 @@ class MemberJoinEventHandlerTest {
         coVerify {
             arrangement.legalHoldHandler.handleConversationMembersChanged(eq(event.conversationId))
         }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenSelfAddedByAnotherUserInPendingMLSConversation_whenHandlingIt_thenShouldNotJoinMLSGroup() = runTest {
+        val newMembers = listOf(Member(TEST_SELF_USER_ID, Member.Role.Member))
+        val mlsConversation = TestConversation.GROUP(TestConversation.MLS_PROTOCOL_INFO)
+        val event = TestEvent.memberJoin(members = newMembers).copy(
+            conversationId = mlsConversation.id,
+            addedBy = TestUser.OTHER_USER_ID
+        )
+
+        val (arrangement, eventHandler) = arrange {
+            withFetchConversationSucceeding(any(), any(), reason = eq(ConversationSyncReason.Other))
+            withConversationDetailsByIdReturning(mlsConversation.right())
+        }
+
+        eventHandler.handle(arrangement.transactionContext, event)
+
+        coVerify {
+            arrangement.joinExistingMLSConversationUseCase.invoke(any(), any(), any(), eq(true))
+        }.wasNotInvoked()
     }
 
     private class Arrangement(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- In MLS flows after logout without local data wipe, the app could end up with inconsistent local MLS state (DB vs CoreCrypto), leading to decryption failures (`MessageEpochTooOld` / `StaleCommit`).
- In the `MemberJoin -> MLSWelcome` sequence for the same conversation, we could trigger two external commits, which artificially advanced the local epoch and caused subsequent messages to be treated as stale.

### Causes (Optional)

- After successful `MLSWelcome`, we were updating only `groupState`, without fully syncing `conversationId -> groupId + epoch` from local CoreCrypto state.
- `MemberJoinEventHandler` attempted auto-join for `PENDING_JOIN` even when the user was added by someone else (`addedBy != self`), although in that flow a `Welcome` is expected and no preemptive external commit is needed.

### Solutions

- After successful `MLSWelcome`, we now fully sync conversation MLS metadata with CoreCrypto by persisting `groupId`, `epoch`, and `ESTABLISHED` state by `conversationId`.
- We restricted `MemberJoinEventHandler` auto-join to self-initiated joins only (`addedBy == selfUserId`) to avoid duplicate external commits in flows where `Welcome` will establish the group.
- Added/updated unit tests to cover both fixes.