### PR TITLE
fix: revert welcome recovery [WPB-21119]

### DIFF
--- a/core/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/MLSClientTest.kt
+++ b/core/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/MLSClientTest.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -111,98 +110,6 @@ class MLSClientTest : BaseMLSClientTest() {
         val result = aliceClient.transaction { it.decryptMessage(welcomeBundle.groupId, keyMaterialCommit.first.commit) }
 
         assertNull(result.first().message)
-    }
-
-    @Test
-    fun givenLocalConversationExists_whenProcessingWelcome_thenIgnoringItDoesNotAllowCommunication() = runTest {
-        val aliceArrangement = create(
-            ALICE1,
-            ::createMLSClient,
-        )
-
-        val bobArrangement = create(
-            BOB1,
-            ::createMLSClient,
-        )
-
-        val aliceClient = aliceArrangement.mlsClient
-        val bobClient = bobArrangement.mlsClient
-
-        // Both clients locally create the same conversation (race scenario).
-        aliceClient.transaction { it.createConversation(MLS_CONVERSATION_ID, externalSenderKey) }
-        bobClient.transaction { it.createConversation(MLS_CONVERSATION_ID, externalSenderKey) }
-
-        // Bob adds Alice and produces a welcome.
-        val aliceKeyPackage = aliceClient.transaction { it.generateKeyPackages(1).first() }
-        bobClient.transaction {
-            it.addMember(MLS_CONVERSATION_ID, listOf(aliceKeyPackage))
-        }
-        val welcome = bobArrangement.sendCommitBundleFlow.first().first.welcome!!
-
-
-        val exception = assertFailsWith<Throwable> {
-            aliceClient.transaction { it.processWelcomeMessage(welcome) }
-        }
-        assertTrue(
-            exception.toString().contains("ConversationAlreadyExists"),
-            "Expected ConversationAlreadyExists when processing welcome for an already created local group. Got: $exception"
-        )
-
-        // If we ignore the welcome and keep the local group, Alice should not decrypt Bob's message.
-        val applicationMessage = bobClient.transaction { it.encryptMessage(MLS_CONVERSATION_ID, PLAIN_TEXT.encodeToByteArray()) }
-        val decryptedResult = runCatching {
-            aliceClient.transaction { it.decryptMessage(MLS_CONVERSATION_ID, applicationMessage) }
-        }
-        val decryptedBundles = decryptedResult.getOrNull().orEmpty()
-        val decryptedText = decryptedBundles.firstOrNull()?.message?.decodeToString()
-        assertTrue(
-            decryptedResult.isFailure || decryptedBundles.isEmpty() || decryptedText == null || decryptedText != PLAIN_TEXT,
-            "Without wiping the local group, Alice should not be able to decrypt Bob's message."
-        )
-    }
-
-    @Test
-    fun givenLocalConversationExists_whenWipingAndReprocessingWelcome_thenWeCanDecryptMessages() = runTest {
-        val aliceArrangement = create(
-            ALICE1,
-            ::createMLSClient,
-        )
-
-        val bobArrangement = create(
-            BOB1,
-            ::createMLSClient,
-        )
-
-        val aliceClient = aliceArrangement.mlsClient
-        val bobClient = bobArrangement.mlsClient
-
-        // Both clients locally create the same conversation (race scenario).
-        aliceClient.transaction { it.createConversation(MLS_CONVERSATION_ID, externalSenderKey) }
-        bobClient.transaction { it.createConversation(MLS_CONVERSATION_ID, externalSenderKey) }
-
-        // Bob adds Alice and produces a welcome.
-        val aliceKeyPackage = aliceClient.transaction { it.generateKeyPackages(1).first() }
-        bobClient.transaction {
-            it.addMember(MLS_CONVERSATION_ID, listOf(aliceKeyPackage))
-        }
-        val welcome = bobArrangement.sendCommitBundleFlow.first().first.welcome!!
-
-        // First processing should fail because Alice already created the local group.
-        assertFailsWith<Throwable> {
-            aliceClient.transaction { it.processWelcomeMessage(welcome) }
-        }
-
-        // Recovery: wipe local group and retry processing the welcome.
-        aliceClient.transaction { it.wipeConversation(MLS_CONVERSATION_ID) }
-        val welcomeBundle = aliceClient.transaction { it.processWelcomeMessage(welcome) }
-        assertEquals(MLS_CONVERSATION_ID, welcomeBundle.groupId)
-
-        // Now Alice should be able to decrypt Bob's messages.
-        val applicationMessage = bobClient.transaction { it.encryptMessage(MLS_CONVERSATION_ID, PLAIN_TEXT.encodeToByteArray()) }
-        val decryptedBundles = aliceClient.transaction { it.decryptMessage(MLS_CONVERSATION_ID, applicationMessage) }
-        val decryptedText = decryptedBundles.firstOrNull()?.message?.decodeToString()
-
-        assertEquals(PLAIN_TEXT, decryptedText)
     }
 
     @Test

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandler.kt
@@ -44,6 +44,7 @@ import com.wire.kalium.logic.data.e2ei.RevocationListChecker
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.GroupID
+import com.wire.kalium.logic.data.id.toCrypto
 import com.wire.kalium.logic.feature.conversation.mls.OneOnOneResolver
 import com.wire.kalium.logic.feature.keypackage.RefillKeyPackagesResult
 import com.wire.kalium.logic.feature.keypackage.RefillKeyPackagesUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandler.kt
@@ -32,7 +32,6 @@ import com.wire.kalium.common.functional.right
 import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.cryptography.CryptoTransactionContext
 import com.wire.kalium.cryptography.MlsCoreCryptoContext
-import com.wire.kalium.cryptography.WelcomeBundle
 import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.client.wrapInMLSContext
 import com.wire.kalium.logic.data.conversation.Conversation
@@ -45,7 +44,6 @@ import com.wire.kalium.logic.data.e2ei.RevocationListChecker
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.GroupID
-import com.wire.kalium.logic.data.id.toCrypto
 import com.wire.kalium.logic.feature.conversation.mls.OneOnOneResolver
 import com.wire.kalium.logic.feature.keypackage.RefillKeyPackagesResult
 import com.wire.kalium.logic.feature.keypackage.RefillKeyPackagesUseCase
@@ -83,7 +81,9 @@ internal class MLSWelcomeEventHandlerImpl(
         return fetchConversationIfUnknown(transactionContext, event.conversationId)
             .flatMap {
                 kaliumLogger.d("$TAG: Processing MLS welcome message")
-                processWelcomeMessageWithRecovery(mlsContext, event.conversationId, event.message)
+                wrapMLSRequest {
+                    mlsContext.processWelcomeMessage(Base64.decode(event.message))
+                }
             }
             .flatMap { welcomeBundle ->
                 welcomeBundle.crlNewDistributionPoints?.let {
@@ -98,6 +98,11 @@ internal class MLSWelcomeEventHandlerImpl(
             }
             .flatMapLeft {
                 when (it) {
+                    is MLSFailure.ConversationAlreadyExists -> {
+                        kaliumLogger.w("$TAG: Discarding welcome since the conversation already exists")
+                        Either.Right(Unit)
+                    }
+
                     is MLSFailure.OrphanWelcome -> {
                         if (isAlreadyEstablishedLocally(mlsContext, event.conversationId)) {
                             kaliumLogger.w(
@@ -157,40 +162,6 @@ internal class MLSWelcomeEventHandlerImpl(
             }
         }
         .fold({ false }, { it })
-
-    private suspend fun processWelcomeMessageWithRecovery(
-        mlsContext: MlsCoreCryptoContext,
-        conversationId: ConversationId,
-        base64Message: String
-    ): Either<CoreFailure, WelcomeBundle> {
-        return wrapMLSRequest { mlsContext.processWelcomeMessage(Base64.decode(base64Message)) }
-            .flatMapLeft { failure ->
-                if (failure is MLSFailure.ConversationAlreadyExists) {
-                    kaliumLogger.w("$TAG: Welcome processing failed due to existing local group, wiping and retrying")
-                    wipeLocalConversation(mlsContext, conversationId).flatMap {
-                        wrapMLSRequest {
-                            mlsContext.processWelcomeMessage(Base64.decode(base64Message))
-                        }
-                    }
-                } else {
-                    Either.Left(failure)
-                }
-            }
-    }
-
-    private suspend fun wipeLocalConversation(
-        mlsContext: MlsCoreCryptoContext,
-        conversationId: ConversationId
-    ): Either<CoreFailure, Unit> =
-        conversationRepository.getConversationProtocolInfo(conversationId)
-            .flatMap { protocol ->
-                if (protocol is Conversation.ProtocolInfo.MLSCapable) {
-                    wrapMLSRequest { mlsContext.wipeConversation(protocol.groupId.toCrypto()) }
-                } else {
-                    Either.Left(CoreFailure.Unknown(IllegalStateException("Conversation is not MLS capable")))
-                }
-            }
-
     private suspend fun markConversationAsEstablished(groupID: GroupID): Either<CoreFailure, Unit> =
         conversationRepository.updateConversationGroupState(groupID, Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED)
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandlerTest.kt
@@ -25,7 +25,6 @@ import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.cryptography.MLSGroupId
 import com.wire.kalium.cryptography.WelcomeBundle
-import com.wire.kalium.logic.data.MockConversation
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCase
 import com.wire.kalium.logic.data.e2ei.CertificateRevocationListRepository
@@ -54,7 +53,6 @@ import io.mockative.coVerify
 import io.mockative.eq
 import io.mockative.mock
 import io.mockative.once
-import io.mockative.twice
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -259,29 +257,6 @@ class MLSWelcomeEventHandlerTest {
     }
 
     @Test
-    fun givenLocalConversationExists_whenHandlingWelcome_thenShouldWipeAndRetryProcessing() = runTest {
-        val (arrangement, mlsWelcomeEventHandler) = arrange {
-            withMLSClientProcessingOfWelcomeMessageFailingOnceWithConversationAlreadyExistsThenSuccess()
-            withFetchConversationIfUnknownSucceeding()
-            withConversationProtocolInfo(Either.Right(MockConversation.MLS_PROTOCOL_INFO))
-            withWipeConversationReturningSuccessfully()
-            withUpdateGroupStateReturning(Either.Right(Unit))
-            withObserveConversationDetailsByIdReturning(Either.Right(CONVERSATION_GROUP))
-            withRefillKeyPackagesReturning(RefillKeyPackagesResult.Success)
-        }
-
-        mlsWelcomeEventHandler.handle(arrangement.transactionContext, WELCOME_EVENT).shouldSucceed()
-
-        coVerify {
-            arrangement.mlsContext.wipeConversation(any())
-        }.wasInvoked(exactly = once)
-
-        coVerify {
-            arrangement.mlsContext.processWelcomeMessage(any())
-        }.wasInvoked(exactly = twice)
-    }
-
-    @Test
     fun givenOrphanWelcomeAndLocalGroupAlreadyEstablished_whenHandlingWelcome_thenShouldSkipExternalCommitRejoin() = runTest {
         val orphanWelcomeException = CommonizedMLSException(
             MLSFailure.OrphanWelcome,
@@ -338,7 +313,6 @@ class MLSWelcomeEventHandlerTest {
             arrangement.joinExistingMLSConversation.invoke(any(), eq(CONVERSATION_ID), any(), eq(true))
         }.wasInvoked(exactly = once)
     }
-
     private class Arrangement(private val block: suspend Arrangement.() -> Unit) :
         ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
         FetchConversationIfUnknownUseCaseArrangement by FetchConversationIfUnknownUseCaseArrangementImpl(),
@@ -355,35 +329,10 @@ class MLSWelcomeEventHandlerTest {
             }.throws(exception)
         }
 
-        suspend fun withMLSClientProcessingOfWelcomeMessageFailingOnceWithConversationAlreadyExistsThenSuccess(
-            callCountToFail: Int = 1,
-            welcomeBundle: WelcomeBundle = WELCOME_BUNDLE
-        ) = apply {
-            var callCount = 0
-            coEvery {
-                mlsContext.processWelcomeMessage(any())
-            }.invokes {
-                callCount += 1
-                if (callCount == callCountToFail) {
-                    throw CommonizedMLSException(
-                        MLSFailure.ConversationAlreadyExists,
-                        IllegalStateException("conversation already exists")
-                    )
-                }
-                welcomeBundle
-            }
-        }
-
         suspend fun withMLSClientProcessingOfWelcomeMessageReturnsSuccessfully(welcomeBundle: WelcomeBundle = WELCOME_BUNDLE) = apply {
             coEvery {
                 mlsContext.processWelcomeMessage(any())
             }.returns(welcomeBundle)
-        }
-
-        suspend fun withWipeConversationReturningSuccessfully() = apply {
-            coEvery {
-                mlsContext.wipeConversation(any())
-            }.returns(Unit)
         }
 
         suspend fun withMLSConversationExists(exists: Boolean) = apply {
@@ -397,7 +346,6 @@ class MLSWelcomeEventHandlerTest {
                 joinExistingMLSConversation.invoke(any(), any(), any(), eq(true))
             }.returns(result)
         }
-
         suspend fun withCheckRevocationListResult() {
             coEvery {
                 checkRevocationList.check(any(), any())
@@ -407,6 +355,12 @@ class MLSWelcomeEventHandlerTest {
         suspend fun withRefillKeyPackagesReturning(result: RefillKeyPackagesResult) = apply {
             coEvery {
                 refillKeyPackagesUseCase.invoke(any())
+            }.returns(result)
+        }
+
+        suspend fun withJoinExistingMLSConversationReturning(result: Either<CoreFailure, Unit>) = apply {
+            coEvery {
+                joinExistingMLSConversation(any(), conversationId = any())
             }.returns(result)
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandlerTest.kt
@@ -358,12 +358,6 @@ class MLSWelcomeEventHandlerTest {
             }.returns(result)
         }
 
-        suspend fun withJoinExistingMLSConversationReturning(result: Either<CoreFailure, Unit>) = apply {
-            coEvery {
-                joinExistingMLSConversation(any(), conversationId = any())
-            }.returns(result)
-        }
-
         suspend fun arrange() = run {
             block()
             this@Arrangement to MLSWelcomeEventHandlerImpl(

--- a/test/data-mocks/src/commonMain/kotlin/com/wire/kalium/logic/data/MockConversation.kt
+++ b/test/data-mocks/src/commonMain/kotlin/com/wire/kalium/logic/data/MockConversation.kt
@@ -4,9 +4,7 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.TeamId
-import com.wire.kalium.logic.data.mls.CipherSuite
 import com.wire.kalium.persistence.dao.ConversationIDEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.conversation.ConversationEntity
@@ -18,15 +16,6 @@ object MockConversation {
 
     val ID = ConversationId(conversationValue, conversationDomain)
     val ENTITY_ID = QualifiedIDEntity(conversationValue, conversationDomain)
-    val GROUP_ID = GroupID("mlsGroupId")
-
-    val MLS_PROTOCOL_INFO = ProtocolInfo.MLS(
-        GROUP_ID,
-        ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN,
-        0UL,
-        Instant.parse("2021-03-30T15:36:00.000Z"),
-        cipherSuite = CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
-    )
 
     fun id(suffix: Int = 0) = ConversationId("${conversationValue}_$suffix", conversationDomain)
 
@@ -133,29 +122,5 @@ object MockConversation {
         channelAddPermission = null,
         wireCell = null,
         historySharingRetentionSeconds = 0,
-    )
-
-    val MLS_CONVERSATION = Conversation(
-        ID,
-        "MLS Name",
-        Conversation.Type.OneOnOne,
-        null,
-        MLS_PROTOCOL_INFO,
-        MutedConversationStatus.AllAllowed,
-        null,
-        null,
-        null,
-        access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),
-        accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST),
-        lastReadDate = Instant.parse("2022-03-30T15:36:00.000Z"),
-        creatorId = null,
-        receiptMode = Conversation.ReceiptMode.DISABLED,
-        messageTimer = null,
-        userMessageTimer = null,
-        archived = false,
-        archivedDateTime = null,
-        mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
-        proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
-        legalHoldStatus = Conversation.LegalHoldStatus.DISABLED
     )
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-21119
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Reverts `df99ed031a9e1d15ccefa56f36aab69c9fb5f449` and removes `processWelcomeMessageWithRecovery` (wipe + retry path).

- Restores previous `ConversationAlreadyExists` behavior: discard welcome.
- Removes tests tied to wipe/retry.
- Keeps current `OrphanWelcome` handling/tests.