### PR TITLE
fix: logout race condition while wiping data (WPB-23549)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
@@ -175,6 +175,6 @@ internal class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
 
     companion object {
         const val TAG = "LogoutUseCase"
-        const val SCOPE_DRAIN_TIMEOUT_MS = 2_000L
+        const val SCOPE_DRAIN_TIMEOUT_MS = 3_000L
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
@@ -35,10 +35,11 @@ import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.sync.UserSessionWorkScheduler
 import io.mockative.Mockable
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * Logs out the user from the current session
@@ -90,6 +91,8 @@ internal class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
             sessionRepository.logout(userId = userId, reason)
             logoutRepository.onLogout(reason)
             userSessionWorkScheduler.cancelScheduledSendingOfPendingMessages()
+            userConfigRepository.clearE2EISettings()
+            drainSessionScope()
 
             when (reason) {
                 LogoutReason.SELF_HARD_LOGOUT -> wipeAllData()
@@ -116,11 +119,23 @@ internal class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
                 kaliumLogger.withTextTag(TAG).d("Logout reason: $reason")
             }
 
-            userConfigRepository.clearE2EISettings()
-            userSessionScopeProvider.get(userId)?.cancel()
             userSessionScopeProvider.delete(userId)
             logoutCallback(userId, reason)
         }.let { if (waitUntilCompletes) it.join() else it }
+    }
+
+    private suspend fun drainSessionScope() {
+        userSessionScopeProvider.get(userId)?.also { scope ->
+            scope.cancel()
+            scope.coroutineContext[Job]?.let { job ->
+                val drained = withTimeoutOrNull(SCOPE_DRAIN_TIMEOUT_MS) { job.join() }
+                if (drained == null) {
+                    kaliumLogger.withTextTag(TAG).w(
+                        "UserSessionScope did not drain within ${SCOPE_DRAIN_TIMEOUT_MS}ms; proceeding anyway"
+                    )
+                }
+            }
+        }
     }
 
     private suspend fun prepareForCoreCryptoMigrationRecovery() {
@@ -140,9 +155,6 @@ internal class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
     }
 
     private suspend fun wipeAllData() {
-        // we put this delay here to avoid a race condition when
-        // receiving web socket events at the exact time of logging put
-        delay(CLEAR_DATA_DELAY)
         clearClientDataUseCase()
         clearUserDataUseCase() // this clears also current client id
     }
@@ -161,7 +173,7 @@ internal class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
     }
 
     companion object {
-        const val CLEAR_DATA_DELAY = 1000L
         const val TAG = "LogoutUseCase"
+        const val SCOPE_DRAIN_TIMEOUT_MS = 2_000L
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
@@ -128,6 +128,7 @@ internal class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
         userSessionScopeProvider.get(userId)?.also { scope ->
             scope.cancel()
             scope.coroutineContext[Job]?.let { job ->
+                // don't want to wait indefinitely in case of any issues with the session scope, so we use a timeout and log if it happens
                 val drained = withTimeoutOrNull(SCOPE_DRAIN_TIMEOUT_MS) { job.join() }
                 if (drained == null) {
                     kaliumLogger.withTextTag(TAG).w(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClearClientDataUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClearClientDataUseCase.kt
@@ -52,10 +52,10 @@ internal class ClearClientDataUseCaseImpl internal constructor(
         withContext(dispatchers.io) {
             clearCrypto()
                 .onSuccess {
-                    kaliumLogger.e("Did not clear crypto storage")
+                    kaliumLogger.d("Crypto storage cleared successfully")
                 }
                 .onFailure {
-                    kaliumLogger.e("Error clearing crypto storage: $it")
+                    kaliumLogger.e("Did not clear crypto storage: $it")
                 }
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCaseTest.kt
@@ -56,6 +56,7 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class LogoutUseCaseTest {
@@ -377,6 +378,36 @@ class LogoutUseCaseTest {
     }
 
     @Test
+    fun givenHardLogout_whenLoggingOut_thenE2EISettingsClearedBeforeWipe() = runTest {
+        var e2eiCalledBeforeWipe = false
+        var e2eiWasCalled = false
+
+        val (arrangement, logoutUseCase) = Arrangement()
+            .withLogoutResult(Either.Right(Unit))
+            .withSessionLogoutResult(Either.Right(Unit))
+            .withAllValidSessionsResult(Either.Right(listOf(Arrangement.VALID_ACCOUNT_INFO)))
+            .withDeregisterTokenResult(DeregisterTokenUseCase.Result.Success)
+            .withClearCurrentClientIdResult(Either.Right(Unit))
+            .withClearRetainedClientIdResult(Either.Right(Unit))
+            .withUserSessionScopeGetResult(null)
+            .withFirebaseTokenUpdate()
+            .withNoOngoingCalls()
+            .arrange()
+
+        coEvery { arrangement.userConfigRepository.clearE2EISettings() }.invokes { _ ->
+            e2eiWasCalled = true
+        }
+        coEvery { arrangement.clearUserDataUseCase.invoke() }.invokes { _ ->
+            e2eiCalledBeforeWipe = e2eiWasCalled
+        }
+
+        logoutUseCase.invoke(LogoutReason.SELF_HARD_LOGOUT)
+        arrangement.globalTestScope.advanceUntilIdle()
+
+        assertTrue(e2eiCalledBeforeWipe, "clearE2EISettings must be called before clearUserDataUseCase (wipe)")
+    }
+
+    @Test
     fun givenAMigrationFailedLogout_whenLoggingOut_thenExecuteAllRequiredActions() = runTest {
         val reason = LogoutReason.MIGRATION_TO_CC_FAILED
         val (arrangement, logoutUseCase) = Arrangement()
@@ -542,6 +573,22 @@ class LogoutUseCaseTest {
 
             coEvery {
                 userConfigRepository.clearE2EISettings()
+            }.returns(Unit)
+
+            coEvery {
+                userSessionWorkScheduler.cancelScheduledSendingOfPendingMessages()
+            }.returns(Unit)
+
+            coEvery {
+                logoutRepository.onLogout(any())
+            }.returns(Unit)
+
+            coEvery {
+                logoutCallback(any(), any())
+            }.returns(Unit)
+
+            coEvery {
+                userSessionScopeProvider.delete(any())
             }.returns(Unit)
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/ClearClientDataUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/ClearClientDataUseCaseTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.client
+
+import com.wire.kalium.logic.data.client.MLSClientProvider
+import com.wire.kalium.logic.data.client.ProteusClientProvider
+import com.wire.kalium.logic.test_util.testKaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcher
+import io.mockative.coEvery
+import io.mockative.coVerify
+import io.mockative.mock
+import io.mockative.once
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class ClearClientDataUseCaseTest {
+
+    @Test
+    fun givenBothProvidersSucceed_whenInvoked_thenBothLocalFilesAreCleared() = runTest {
+        val (arrangement, useCase) = Arrangement(StandardTestDispatcher(testScheduler).testKaliumDispatcher())
+            .withProteusClientClearSuccess()
+            .withMLSClientClearSuccess()
+            .arrange()
+
+        useCase()
+
+        coVerify { arrangement.proteusClientProvider.clearLocalFiles() }.wasInvoked(exactly = once)
+        coVerify { arrangement.mlsClientProvider.clearLocalFiles() }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenProteusClearFails_whenInvoked_thenFunctionCompletesWithoutThrowing() = runTest {
+        val (_, useCase) = Arrangement(StandardTestDispatcher(testScheduler).testKaliumDispatcher())
+            .withProteusClientClearThrows()
+            .arrange()
+        useCase()
+    }
+
+    @Test
+    fun givenMLSClearFails_whenInvoked_thenFunctionCompletesWithoutThrowing() = runTest {
+        val (_, useCase) = Arrangement(StandardTestDispatcher(testScheduler).testKaliumDispatcher())
+            .withProteusClientClearSuccess()
+            .withMLSClientClearThrows()
+            .arrange()
+        useCase()
+    }
+
+    private class Arrangement(private val dispatcher: KaliumDispatcher) {
+        val proteusClientProvider: ProteusClientProvider = mock(ProteusClientProvider::class)
+        val mlsClientProvider: MLSClientProvider = mock(MLSClientProvider::class)
+
+        suspend fun withProteusClientClearSuccess() = apply {
+            coEvery { proteusClientProvider.clearLocalFiles() }.returns(Unit)
+        }
+
+        suspend fun withMLSClientClearSuccess() = apply {
+            coEvery { mlsClientProvider.clearLocalFiles() }.returns(Unit)
+        }
+
+        suspend fun withProteusClientClearThrows() = apply {
+            coEvery { proteusClientProvider.clearLocalFiles() }.throws(RuntimeException("proteus clear failed"))
+        }
+
+        suspend fun withMLSClientClearThrows() = apply {
+            coEvery { mlsClientProvider.clearLocalFiles() }.throws(RuntimeException("mls clear failed"))
+        }
+
+        fun arrange() = this to ClearClientDataUseCaseImpl(
+            mlsClientProvider = mlsClientProvider,
+            proteusClientProvider = proteusClientProvider,
+            dispatchers = dispatcher
+        )
+    }
+}


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-23549
<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

While testing nomad, we figured it out a race condition can happen while trying to wipe data on logout. Now there is a `1.seconds` "delay," but it is not a reliable mechanism. 

### Causes (Optional)

Not correctly cleaned up state on logout.

### Solutions

Takes inspiration from: 
- https://github.com/wireapp/kalium/pull/3898
----

- `scope.cancel()` — signals all child coroutines to stop                                                                                                                                   
- `withTimeoutOrNull(2_000L) { job.join() }` waits up to 2 seconds for them to finish                                                                                                           
- If timeout expires, logs a warning and proceeds with the wipe anyway (hard cancel in effect, since cancel() was already called)
- Fixes incorrect/misleading log.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.