### PR TITLE
fix: clear deleted_locally flag on re-join (WPB-25078)

### DIFF
--- a/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -81,10 +81,10 @@ DELETE FROM Conversation;
 deleteConversation:
 DELETE FROM Conversation WHERE qualified_id = ?;
 
-markAsDeletedLocally:
+setDeletedLocally:
 UPDATE Conversation
-SET deleted_locally = 1
-WHERE qualified_id = ?;
+SET deleted_locally = :deletedLocally
+WHERE qualified_id = :qualifiedId;
 
 insertConversation:
 INSERT INTO Conversation(qualified_id, name, type, team_id, mls_group_id, mls_group_state, mls_epoch, protocol, muted_status, muted_time, creator_id, last_modified_date, last_notified_date, access_list, access_role_list, last_read_date, mls_last_keying_material_update_date, mls_cipher_suite, receipt_mode, message_timer, user_message_timer, incomplete_metadata, archived, archived_date_time, is_channel, channel_access, channel_add_permission, wire_cell, history_sharing_retention_seconds)

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
@@ -103,7 +103,7 @@ interface ConversationDAO {
     suspend fun getConversationIdByGroupID(groupID: String): QualifiedIDEntity?
     suspend fun getConversationsByGroupState(groupState: ConversationEntity.GroupState): List<ConversationEntity>
     suspend fun deleteConversationByQualifiedID(qualifiedID: QualifiedIDEntity): Boolean
-    suspend fun markConversationAsDeletedLocally(qualifiedID: QualifiedIDEntity): Boolean
+    suspend fun setConversationDeletedLocally(qualifiedID: QualifiedIDEntity, deletedLocally: Boolean)
 
     suspend fun updateConversationMutedStatus(
         conversationId: QualifiedIDEntity,

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
@@ -420,12 +420,10 @@ internal class ConversationDAOImpl internal constructor(
         }
     }
 
-    override suspend fun markConversationAsDeletedLocally(qualifiedID: QualifiedIDEntity) = withContext(writeDispatcher.value) {
-        conversationQueries.transactionWithResult {
-            conversationQueries.markAsDeletedLocally(qualifiedID)
-            conversationQueries.selectChanges().executeAsOne() > 0
+    override suspend fun setConversationDeletedLocally(qualifiedID: QualifiedIDEntity, deletedLocally: Boolean): Unit =
+        withContext(writeDispatcher.value) {
+            conversationQueries.setDeletedLocally(deletedLocally = deletedLocally, qualifiedId = qualifiedID)
         }
-    }
 
     override suspend fun updateConversationMutedStatus(
         conversationId: QualifiedIDEntity,

--- a/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -2491,22 +2491,20 @@ class ConversationDAOTest : BaseDatabaseTest() {
     @Test
     fun givenExistingConversation_whenMarkedAsDeletedLocally_thenDoNotReturnConversationDetails() = runTest(dispatcher) {
         conversationDAO.insertConversation(conversationEntity1)
-        val markResult = conversationDAO.markConversationAsDeletedLocally(conversationEntity1.id)
+        conversationDAO.setConversationDeletedLocally(conversationEntity1.id, true)
         val getResult = try {
             conversationDAO.getConversationDetailsById(conversationEntity1.id)
         } catch (npe: NullPointerException) {
             null
         }
-        assertTrue(markResult)
         assertNull(getResult)
     }
 
     @Test
     fun givenExistingConversation_whenMarkedAsDeletedLocally_thenConversationCanStillBeDeleted() = runTest(dispatcher) {
         conversationDAO.insertConversation(conversationEntity1)
-        val markResult = conversationDAO.markConversationAsDeletedLocally(conversationEntity1.id)
+        conversationDAO.setConversationDeletedLocally(conversationEntity1.id, true)
         val deleteResult = conversationDAO.deleteConversationByQualifiedID(conversationEntity1.id)
-        assertTrue(markResult)
         assertTrue(deleteResult)
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -235,7 +235,7 @@ internal interface ConversationRepository {
     )
     suspend fun deleteConversationLocally(conversationId: ConversationId): Either<CoreFailure, Boolean>
 
-    suspend fun markConversationAsDeletedLocally(conversationId: ConversationId): Either<CoreFailure, Boolean>
+    suspend fun setConversationDeletedLocally(conversationId: ConversationId, deletedLocally: Boolean): Either<CoreFailure, Unit>
 
     suspend fun updateChannelAddPermissionLocally(
         conversationId: ConversationId,
@@ -794,8 +794,8 @@ internal class ConversationDataSource internal constructor(
         conversationDAO.deleteConversationByQualifiedID(conversationId.toDao())
     }
 
-    override suspend fun markConversationAsDeletedLocally(conversationId: ConversationId) = wrapStorageRequest {
-        conversationDAO.markConversationAsDeletedLocally(conversationId.toDao())
+    override suspend fun setConversationDeletedLocally(conversationId: ConversationId, deletedLocally: Boolean) = wrapStorageRequest {
+        conversationDAO.setConversationDeletedLocally(conversationId.toDao(), deletedLocally)
     }
 
     override suspend fun clearContent(conversationId: ConversationId): Either<StorageFailure, Unit> =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/delete/MarkConversationAsDeletedLocallyUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/delete/MarkConversationAsDeletedLocallyUseCase.kt
@@ -41,7 +41,7 @@ internal class MarkConversationAsDeletedLocallyUseCaseImpl(
 ) : MarkConversationAsDeletedLocallyUseCase {
 
     override suspend fun invoke(conversationId: ConversationId): MarkConversationAsDeletedResult =
-        conversationRepository.markConversationAsDeletedLocally(conversationId).fold(
+        conversationRepository.setConversationDeletedLocally(conversationId, true).fold(
             { failure -> MarkConversationAsDeletedResult.Failure(failure) },
             {
                 MarkConversationAsDeletedResult.Success

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandler.kt
@@ -87,6 +87,12 @@ internal class MemberJoinEventHandlerImpl(
                 }
                 // Even if unable to fetch conversation details, at least attempt adding the members
                 userRepository.fetchUsersIfUnknownByIds(event.members.map { it.id }.toSet())
+
+                if (event.members.any { it.id == selfUserId }) {
+                    conversationRepository.setConversationDeletedLocally(event.conversationId, false)
+                        .onFailure { logger.w("Failed to clear deleted_locally flag for ${event.conversationId}: $it") }
+                }
+
                 conversationRepository.persistMembers(event.members, event.conversationId)
             }.onSuccess {
                 conversationRepository.getConversationById(event.conversationId).onSuccess { conversation ->

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -411,15 +411,15 @@ class ConversationRepositoryTest {
     fun givenProteusConversation_WhenMarkingAsDeletedLocally_ThenShouldCallProperUseCaseAndSucceed() = runTest {
         val (arrangement, conversationRepository) = Arrangement()
             .withGetConversationProtocolInfoReturns(PROTEUS_PROTOCOL_INFO)
-            .withSuccessfulMarkAsDeletedLocally()
+            .withSuccessfulSetConversationDeletedLocally()
             .arrange()
         val conversationId = ConversationId("conv_id", "conv_domain")
 
-        conversationRepository.markConversationAsDeletedLocally(conversationId).shouldSucceed()
+        conversationRepository.setConversationDeletedLocally(conversationId, true).shouldSucceed()
 
         with(arrangement) {
             coVerify {
-                conversationDAO.markConversationAsDeletedLocally(eq(conversationId.toDao()))
+                conversationDAO.setConversationDeletedLocally(eq(conversationId.toDao()), eq(true))
             }.wasInvoked(once)
         }
     }
@@ -1317,10 +1317,10 @@ class ConversationRepositoryTest {
             }.returns(true)
         }
 
-        suspend fun withSuccessfulMarkAsDeletedLocally() = apply {
+        suspend fun withSuccessfulSetConversationDeletedLocally() = apply {
             coEvery {
-                conversationDAO.markConversationAsDeletedLocally(any())
-            }.returns(true)
+                conversationDAO.setConversationDeletedLocally(any(), any())
+            }.returns(Unit)
         }
 
         suspend fun withExpectedIsUserMemberFlow(expectedIsUserMember: Flow<Boolean>) = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/delete/MarkConversationAsDeletedLocallyUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/delete/MarkConversationAsDeletedLocallyUseCaseTest.kt
@@ -32,7 +32,7 @@ class MarkConversationAsDeletedLocallyUseCaseTest {
     fun givenSuccess_whenInvoking_thenSuccessResultIsPropagated() = runTest {
         // given
         val (arrangement, useCase) = Arrangement().arrange {
-            withMarkConversationAsDeletedLocallySucceeding()
+            withSetConversationDeletedLocallySucceeding()
         }
 
         // when
@@ -40,14 +40,14 @@ class MarkConversationAsDeletedLocallyUseCaseTest {
 
         // then
         assertIs<MarkConversationAsDeletedResult.Success>(result)
-        coVerify { arrangement.conversationRepository.markConversationAsDeletedLocally(eq(CONVERSATION_ID)) }.wasInvoked(exactly = 1)
+        coVerify { arrangement.conversationRepository.setConversationDeletedLocally(eq(CONVERSATION_ID), eq(true)) }.wasInvoked(exactly = 1)
     }
 
     @Test
     fun givenFailure_whenInvoking_thenErrorResultIsPropagated() = runTest {
         // given
         val (arrangement, useCase) = Arrangement().arrange {
-            withMarkConversationAsDeletedLocallyFailing()
+            withSetConversationDeletedLocallyFailing()
         }
 
         // when
@@ -55,7 +55,7 @@ class MarkConversationAsDeletedLocallyUseCaseTest {
 
         // then
         assertIs<MarkConversationAsDeletedResult.Failure>(result)
-        coVerify { arrangement.conversationRepository.markConversationAsDeletedLocally(eq(CONVERSATION_ID)) }.wasInvoked(exactly = 1)
+        coVerify { arrangement.conversationRepository.setConversationDeletedLocally(eq(CONVERSATION_ID), eq(true)) }.wasInvoked(exactly = 1)
     }
 
     private class Arrangement : ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl() {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandlerTest.kt
@@ -271,6 +271,40 @@ class MemberJoinEventHandlerTest {
     }
 
     @Test
+    fun givenSelfUserReAddedToConversation_whenHandlingMemberJoinEvent_thenShouldClearDeletedLocallyFlag() = runTest {
+        val newMembers = listOf(Member(TEST_SELF_USER_ID, Member.Role.Member))
+        val event = TestEvent.memberJoin(members = newMembers)
+
+        val (arrangement, eventHandler) = arrange {
+            withFetchConversationSucceeding(any(), any(), reason = eq(ConversationSyncReason.Other))
+            withConversationDetailsByIdReturning(TEST_GROUP_CONVERSATION.right())
+        }
+
+        eventHandler.handle(arrangement.transactionContext, event)
+
+        coVerify {
+            arrangement.conversationRepository.setConversationDeletedLocally(eq(event.conversationId), eq(false))
+        }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenOtherUserAddedToConversation_whenHandlingMemberJoinEvent_thenShouldNotClearDeletedLocallyFlag() = runTest {
+        val newMembers = listOf(Member(TestUser.OTHER_USER_ID, Member.Role.Member))
+        val event = TestEvent.memberJoin(members = newMembers)
+
+        val (arrangement, eventHandler) = arrange {
+            withFetchConversationSucceeding(any(), any(), reason = eq(ConversationSyncReason.Other))
+            withConversationDetailsByIdReturning(TEST_GROUP_CONVERSATION.right())
+        }
+
+        eventHandler.handle(arrangement.transactionContext, event)
+
+        coVerify {
+            arrangement.conversationRepository.setConversationDeletedLocally(any(), any())
+        }.wasNotInvoked()
+    }
+
+    @Test
     fun givenMemberJoinEvent_whenHandlingIt_thenShouldUpdateConversationLegalHoldIfNeeded() = runTest {
         // given
         val newMembers = listOf(Member(TestUser.USER_ID, Member.Role.Admin))
@@ -311,6 +345,7 @@ class MemberJoinEventHandlerTest {
             withPersistingMessage(Unit.right())
             withFetchUsersIfUnknownByIdsReturning(Unit.right())
             withPersistMembers(Unit.right())
+            withSetConversationDeletedLocallySucceeding()
             withHandleConversationMembersChanged(Unit.right())
             withPersistUnverifiedWarningMessageSuccess()
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/ConversationRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/ConversationRepositoryArrangement.kt
@@ -55,8 +55,8 @@ internal interface ConversationRepositoryArrangement {
         domain: Matcher<String> = AnyMatcher(valueOf())
     )
 
-    suspend fun withMarkConversationAsDeletedLocallySucceeding(conversationId: Matcher<ConversationId> = AnyMatcher(valueOf()))
-    suspend fun withMarkConversationAsDeletedLocallyFailing(conversationId: Matcher<ConversationId> = AnyMatcher(valueOf()))
+    suspend fun withSetConversationDeletedLocallySucceeding(conversationId: Matcher<ConversationId> = AnyMatcher(valueOf()))
+    suspend fun withSetConversationDeletedLocallyFailing(conversationId: Matcher<ConversationId> = AnyMatcher(valueOf()))
     suspend fun withDeletingConversationLocallySucceeding(conversationId: Matcher<ConversationId> = AnyMatcher(valueOf()))
     suspend fun withDeletingConversationLocallyFailing(conversationId: Matcher<ConversationId> = AnyMatcher(valueOf()))
     suspend fun withGetConversationByIdReturning(conversation: Conversation? = TestConversation.CONVERSATION)
@@ -135,15 +135,15 @@ internal open class ConversationRepositoryArrangementImpl : ConversationReposito
         }.returns(result)
     }
 
-    override suspend fun withMarkConversationAsDeletedLocallySucceeding(conversationId: Matcher<ConversationId>) {
+    override suspend fun withSetConversationDeletedLocallySucceeding(conversationId: Matcher<ConversationId>) {
         coEvery {
-            conversationRepository.markConversationAsDeletedLocally(matches { conversationId.matches(it) })
-        }.returns(Either.Right(true))
+            conversationRepository.setConversationDeletedLocally(matches { conversationId.matches(it) }, any())
+        }.returns(Either.Right(Unit))
     }
 
-    override suspend fun withMarkConversationAsDeletedLocallyFailing(conversationId: Matcher<ConversationId>) {
+    override suspend fun withSetConversationDeletedLocallyFailing(conversationId: Matcher<ConversationId>) {
         coEvery {
-            conversationRepository.markConversationAsDeletedLocally(matches { conversationId.matches(it) })
+            conversationRepository.setConversationDeletedLocally(matches { conversationId.matches(it) }, any())
         }.returns(Either.Left(CoreFailure.Unknown(RuntimeException("some error"))))
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25078
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-25078
----

# What's new in this PR?

### Issues

After leaving and deleting a conversation locally, then being re-added to it by an admin, the conversation does not appear in the conversation list on Android. It remains permanently hidden.

### Causes (Optional)

The local deletion is a two-step process: first deleted_locally = 1 is set on the conversation row (hiding it immediately), then a background worker clears the content. The conversation row is never hard-deleted — the deleted_locally flag acts as a persistent soft-delete tombstone.

  When the user is re-added, a MemberJoinEvent is received. The handler fetches and re-persists the conversation via insertConversation, which uses an ON CONFLICT DO UPDATE statement. That statement does not include deleted_locally, so the flag stays 1 and the conversation remains hidden indefinitely.

### Solutions

In MemberJoinEventHandlerImpl, when the event members list contains selfUserId, explicitly reset deleted_locally = 0 before persisting members. The reset is placed unconditionally outside the persistMembers success branch — the MemberJoinEvent is server-authoritative evidence that the user is a member, so the conversation should become visible regardless of whether the local member write succeeds.

