### PR TITLE
fix: upload iOS and Android test reports [WPB-8645]

### DIFF
--- a/.github/workflows/gradle-android-instrumented-tests.yml
+++ b/.github/workflows/gradle-android-instrumented-tests.yml
@@ -103,7 +103,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: test-reports
-          path: ./**/build/reports/tests/**
+          path: |
+            ./**/build/reports/tests/**
+            ./**/build/reports/androidTests/**
 
       - name: Archive Test Results
         if: always()

--- a/.github/workflows/gradle-ios-tests.yml
+++ b/.github/workflows/gradle-ios-tests.yml
@@ -41,12 +41,18 @@ jobs:
             GITHUB_USER: ${{ github.actor }}
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Generate aggregated iOS test report
+        if: always()
+        run: ./gradlew aggregateIosSimulatorArm64TestReport
+
       - name: Archive Test Reports
         if: always()
         uses: actions/upload-artifact@v7
         with:
             name: test-reports
-            path: ./**/build/reports/tests/**
+            path: |
+              build/reports/tests/iosSimulatorArm64Test/**
+              ./**/build/reports/tests/**
 
       - name: Archive Test Results
         if: always()
@@ -56,6 +62,7 @@ jobs:
             path: |
               ./**/build/test-results/testDebugUnitTest/**/*.xml
               ./**/build/test-results/**/*.xml
+              ./**/build/test-results/iosSimulatorArm64Test/**
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action/macos@v2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -263,6 +263,17 @@ tasks.register("aggregateTestResults") {
     }
 }
 
+tasks.register<org.gradle.api.tasks.testing.TestReport>("aggregateIosSimulatorArm64TestReport") {
+    description = "Aggregates iOS Simulator ARM64 test binary results into a single HTML report."
+
+    destinationDirectory.set(layout.buildDirectory.dir("reports/tests/iosSimulatorArm64Test"))
+    testResults.from(
+        subprojects.map { subproject ->
+            subproject.layout.buildDirectory.dir("test-results/iosSimulatorArm64Test/binary")
+        }
+    )
+}
+
 tasks.wrapper {
     distributionType = Wrapper.DistributionType.ALL
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8645
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- iOS test failures did not produce downloadable test report artifacts in GitHub Actions.
- Android instrumented test failures did not upload the generated HTML report artifact.

### Causes (Optional)

- Kotlin/Native test tasks keep JUnit XML and HTML reports disabled, so iOS test runs only leave Gradle binary test results under `build/test-results/iosSimulatorArm64Test`.
- Android instrumented tests generate HTML reports under `build/reports/androidTests`, while the workflow only uploaded `build/reports/tests`.

### Solutions

- Added an aggregated `iosSimulatorArm64Test` HTML report generated from Gradle binary test results.
- Updated the iOS test workflow to generate and upload the aggregated report, and to include native test result directories.
- Updated the Android instrumented test workflow to upload `build/reports/androidTests` reports.
