### PR TITLE
ci(github-actions): fix workflow failures for external fork PRs [WPB-8645]

### DIFF
--- a/.github/workflows/jira-lint-and-link.yml
+++ b/.github/workflows/jira-lint-and-link.yml
@@ -10,7 +10,8 @@ permissions:
 jobs:
   get-version:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && github.repository_owner == 'wireapp' }}
+    # Skip for fork PRs — head.repo.full_name differs from the base repo for forks
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     outputs:
       version_name: ${{ steps.version.outputs.version_name }}
     steps:
@@ -29,7 +30,7 @@ jobs:
           echo "version_name=$VERSION" >> "$GITHUB_OUTPUT"
 
   add-jira-description:
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     needs: get-version
     uses: wireapp/.github/.github/workflows/jira-link-pr-reusable.yml@b00595235816b9a935c7463b990fae39864903a5
     with:

--- a/.github/workflows/pr-author-assigner.yml
+++ b/.github/workflows/pr-author-assigner.yml
@@ -1,6 +1,6 @@
 name: "Auto Author Assign"
 on:
-  pull_request:
+  pull_request_target:
     types: [ opened, reopened ]
 
 permissions:

--- a/.github/workflows/semantic-commit-lint.yml
+++ b/.github/workflows/semantic-commit-lint.yml
@@ -12,10 +12,6 @@ jobs:
       CUSTOM_PR_LABEL: "Fix PR Title 🤦‍♂️"
       HEAD: ${{github.head_ref}}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases
       - name: Run Semantic Commint Linter


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8645
<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

Three GitHub Actions workflows fail or produce incorrect behaviour when a PR is opened from an external contributor's fork:

- **`jira-lint-and-link`**: The fork-detection guard (`github.repository_owner == 'wireapp'`) always evaluates to `true`, even for fork PRs, because GitHub runs the workflow in the base repo context. As a result the workflow attempted to use `JIRA_TOKEN` on fork PRs where the secret is unavailable, causing a failure instead of a clean skip.
- **`pr-author-assigner`**: Used the `pull_request` trigger, which does not grant `pull-requests: write` permission for fork PRs. Auto-assignment silently failed.
- **`semantic-commit-lint`**: Already correctly used `pull_request_target`, but retained an `actions/checkout` step that is not needed (the action reads the PR title from the event payload via the GitHub API) and introduced an unnecessary code-execution surface.

### Solutions

- **`jira-lint-and-link.yml`**: Replaced the broken fork check (`github.repository_owner == 'wireapp'`) with the correct expression (`github.event.pull_request.head.repo.full_name == github.repository`) on both jobs. Fork PRs now skip cleanly; GitHub branch protection treats a conditionally-skipped required check as passing.
- **`pr-author-assigner.yml`**: Switched trigger from `pull_request` to `pull_request_target`. The action only calls the GitHub API to assign the PR author — no fork code is checked out or executed, so this is safe.
- **`semantic-commit-lint.yml`**: Removed the unnecessary `actions/checkout` step. The semantic PR linter reads the PR title directly from the event payload and requires no local checkout.

### Notes

`pull_request_target` is safe for `pr-author-assigner` and `semantic-commit-lint` because neither workflow checks out or executes code from the fork's tree. The workflow YAML itself always runs from the base branch when using `pull_request_target`, so a fork contributor cannot modify the workflow to exfiltrate secrets.