### PR TITLE
fix: nomad marking as read/unread upon restoring (WPB-25143)

### DIFF
--- a/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/nomaddevice/NomadMessageEventsRequest.kt
+++ b/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/nomaddevice/NomadMessageEventsRequest.kt
@@ -94,8 +94,8 @@ sealed interface NomadMessageEvent {
 
 @Serializable
 data class ConversationMetadataEntry(
-    @SerialName("conversation_id")
-    val conversationId: String, // todo. bug change this to qualified
+    @SerialName("conversation")
+    val conversation: Conversation,
     @SerialName("last_read")
     val lastReadTimestamp: Long,
     @SerialName("last_modified")

--- a/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/nomaddevice/NomadMessageEventsRequest.kt
+++ b/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/nomaddevice/NomadMessageEventsRequest.kt
@@ -95,7 +95,7 @@ sealed interface NomadMessageEvent {
 @Serializable
 data class ConversationMetadataEntry(
     @SerialName("conversation_id")
-    val conversationId: String, // todo. change this to qualified
+    val conversationId: String, // todo. bug change this to qualified
     @SerialName("last_read")
     val lastReadTimestamp: Long,
     @SerialName("last_modified")

--- a/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/nomaddevice/NomadMessageEventsRequest.kt
+++ b/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/nomaddevice/NomadMessageEventsRequest.kt
@@ -95,7 +95,7 @@ sealed interface NomadMessageEvent {
 @Serializable
 data class ConversationMetadataEntry(
     @SerialName("conversation_id")
-    val conversationId: String,
+    val conversationId: String, // todo. change this to qualified
     @SerialName("last_read")
     val lastReadTimestamp: Long,
     @SerialName("last_modified")

--- a/data/network/src/commonTest/kotlin/com/wire/kalium/api/v0/nomaddevice/NomadDeviceSyncApiV0Test.kt
+++ b/data/network/src/commonTest/kotlin/com/wire/kalium/api/v0/nomaddevice/NomadDeviceSyncApiV0Test.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.api.ApiTest
 import com.wire.kalium.api.TEST_BACKEND_CONFIG
 import com.wire.kalium.api.json.model.testCredentials
 import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.authenticated.nomaddevice.Conversation
 import com.wire.kalium.network.api.authenticated.nomaddevice.ConversationMetadataEntry
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadBatchRestoreRequest
 import com.wire.kalium.network.api.authenticated.nomaddevice.NomadMessageEvent
@@ -663,12 +664,12 @@ internal class NomadDeviceSyncApiV0Test : ApiTest() {
                 NomadMessageEvent.ConversationMetadataEvent(
                     conversationMetadata = listOf(
                         ConversationMetadataEntry(
-                            conversationId = "conv_1",
+                            conversation = Conversation(id = "conv_1", domain = "example.com"),
                             lastReadTimestamp = 1772014500000,
                             lastModifiedTimestamp = 1772014600000
                         ),
                         ConversationMetadataEntry(
-                            conversationId = "conv_2",
+                            conversation = Conversation(id = "conv_2", domain = "example.com"),
                             lastReadTimestamp = 1772014800000,
                             lastModifiedTimestamp = 1772014900000
                         )
@@ -685,12 +686,18 @@ internal class NomadDeviceSyncApiV0Test : ApiTest() {
                   "type": "CONVERSATION_METADATA",
                   "conversation_metadata": [
                     {
-                      "conversation_id": "conv_1",
+                      "conversation": {
+                        "id": "conv_1",
+                        "domain": "example.com"
+                      },
                       "last_read": 1772014500000,
                       "last_modified": 1772014600000
                     },
                     {
-                      "conversation_id": "conv_2",
+                      "conversation": {
+                        "id": "conv_2",
+                        "domain": "example.com"
+                      },
                       "last_read": 1772014800000,
                       "last_modified": 1772014900000
                     }

--- a/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/RemotebackupChangeLog.sq
+++ b/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/RemotebackupChangeLog.sq
@@ -51,6 +51,11 @@ insertConversationClear {
     ) VALUES (:conversationId, NULL, :eventType, :timestampMs, :timestampMs);
 }
 
+insertConversationMetadataSync:
+INSERT OR REPLACE INTO RemotebackupChangeLog(
+    conversation_id, message_id, event_type, timestamp_ms, message_timestamp_ms
+) VALUES (:conversationId, NULL, :eventType, :timestampMs, :timestampMs);
+
 getPendingChanges:
 SELECT * FROM RemotebackupChangeLog ORDER BY timestamp_ms ASC, message_timestamp_ms ASC, conversation_id ASC, message_id ASC, event_type ASC;
 

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/ChangeLogEventType.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/ChangeLogEventType.kt
@@ -37,7 +37,8 @@ enum class ChangeLogEventType(val code: Int) {
 
     // Conversation-level (message_nonce = "")
     CONVERSATION_DELETE(500), // Conversation deleted
-    CONVERSATION_CLEAR(501); // Conversation history cleared
+    CONVERSATION_CLEAR(501), // Conversation history cleared
+    CONVERSATION_METADATA_SYNC(502); // Conversation metadata sync (last-read)
 
     companion object {
         fun fromCode(code: Int): ChangeLogEventType? = entries.find { it.code == code }

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/ChangeLogSyncEntry.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/ChangeLogSyncEntry.kt
@@ -66,6 +66,10 @@ sealed interface ChangeLogSyncEvent {
     data class ConversationClear(
         override val change: ChangeLogEntry,
     ) : ChangeLogSyncEvent
+
+    data class ConversationMetadataSync(
+        override val change: ChangeLogEntry,
+    ) : ChangeLogSyncEvent
 }
 
 /**

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/NomadMessagesDAO.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/NomadMessagesDAO.kt
@@ -230,7 +230,8 @@ private class NomadUnreadEventWriter(
         lastReadDatesByConversation: Map<QualifiedIDEntity, Instant>,
     ) {
         val lastRead = lastReadDatesByConversation[message.conversationId]
-        if (lastRead == null || lastRead == Instant.DISTANT_PAST || lastRead <= Instant.UNIX_FIRST_DATE) {
+        val olderMessageDate = lastRead == null || lastRead <= Instant.UNIX_FIRST_DATE || message.date > lastRead
+        if (message.payload.senderUserId == selfUserId || olderMessageDate) {
             return
         }
 

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/NomadMessagesDAO.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/NomadMessagesDAO.kt
@@ -30,6 +30,7 @@ import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.dao.message.MessageEntity
 import com.wire.kalium.persistence.dao.unread.UnreadEventTypeEntity
 import com.wire.kalium.persistence.db.WriteDispatcher
+import com.wire.kalium.util.time.UNIX_FIRST_DATE
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Instant
 
@@ -228,8 +229,8 @@ private class NomadUnreadEventWriter(
         message: NomadMessageToInsert,
         lastReadDatesByConversation: Map<QualifiedIDEntity, Instant>,
     ) {
-        val lastRead = lastReadDatesByConversation[message.conversationId] ?: Instant.DISTANT_PAST
-        if (message.payload.senderUserId == selfUserId || message.date <= lastRead) {
+        val lastRead = lastReadDatesByConversation[message.conversationId]
+        if (lastRead == null || lastRead == Instant.DISTANT_PAST || lastRead <= Instant.UNIX_FIRST_DATE) {
             return
         }
 

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/NomadMessagesDAO.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/NomadMessagesDAO.kt
@@ -230,7 +230,7 @@ private class NomadUnreadEventWriter(
         lastReadDatesByConversation: Map<QualifiedIDEntity, Instant>,
     ) {
         val lastRead = lastReadDatesByConversation[message.conversationId]
-        val olderMessageDate = lastRead == null || lastRead <= Instant.UNIX_FIRST_DATE || message.date > lastRead
+        val olderMessageDate = lastRead == null || lastRead <= Instant.UNIX_FIRST_DATE || message.date <= lastRead
         if (message.payload.senderUserId == selfUserId || olderMessageDate) {
             return
         }

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/RemoteBackupChangeLogDAO.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/RemoteBackupChangeLogDAO.kt
@@ -86,6 +86,14 @@ interface RemoteBackupChangeLogDAO {
     )
 
     /**
+     * Log a conversation metadata sync event (last-read).
+     */
+    suspend fun logConversationMetadataSync(
+        conversationId: QualifiedIDEntity,
+        timestampMs: Long
+    )
+
+    /**
      * Get all pending changes ordered deterministically for replay.
      */
     suspend fun getPendingChanges(): List<ChangeLogEntry>

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/RemoteBackupChangeLogDAOImpl.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/RemoteBackupChangeLogDAOImpl.kt
@@ -111,6 +111,17 @@ internal class RemoteBackupChangeLogDAOImpl(
         )
     }
 
+    override suspend fun logConversationMetadataSync(
+        conversationId: QualifiedIDEntity,
+        timestampMs: Long
+    ): Unit = withContext(writeDispatcher.value) {
+        queries.insertConversationMetadataSync(
+            conversationId = conversationId,
+            eventType = ChangeLogEventType.CONVERSATION_METADATA_SYNC,
+            timestampMs = timestampMs
+        )
+    }
+
     override suspend fun getPendingChanges(): List<ChangeLogEntry> =
         withContext(readDispatcher.value) {
             queries.getPendingChanges(mapper = mapper::toChangeLogEntry).executeAsList()

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/RemoteBackupChangeLogMapper.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/backup/RemoteBackupChangeLogMapper.kt
@@ -206,6 +206,7 @@ internal object RemoteBackupChangeLogMapper {
 
         ChangeLogEventType.CONVERSATION_DELETE -> ChangeLogSyncEvent.ConversationDelete(change = context.change)
         ChangeLogEventType.CONVERSATION_CLEAR -> ChangeLogSyncEvent.ConversationClear(change = context.change)
+        ChangeLogEventType.CONVERSATION_METADATA_SYNC -> ChangeLogSyncEvent.ConversationMetadataSync(change = context.change)
     }
 
     @Suppress("LongMethod")

--- a/domain/messaging/hooks/src/commonMain/kotlin/com/wire/kalium/messaging/hooks/PersistMessageHook.kt
+++ b/domain/messaging/hooks/src/commonMain/kotlin/com/wire/kalium/messaging/hooks/PersistMessageHook.kt
@@ -57,6 +57,11 @@ public data class ConversationClearEventData(
     val conversationId: ConversationId
 )
 
+public data class ConversationLastReadEventData(
+    val conversationId: ConversationId,
+    val date: Instant
+)
+
 public interface PersistenceEventHookNotifier {
     public suspend fun onMessagePersisted(message: PersistedMessageData, selfUserId: UserId) {}
     public suspend fun onMessageDeleted(data: MessageDeleteEventData, selfUserId: UserId) {}
@@ -64,6 +69,7 @@ public interface PersistenceEventHookNotifier {
     public suspend fun onReadReceiptPersisted(data: ReadReceiptEventData, selfUserId: UserId) {}
     public suspend fun onConversationDeleted(data: ConversationDeleteEventData, selfUserId: UserId) {}
     public suspend fun onConversationCleared(data: ConversationClearEventData, selfUserId: UserId) {}
+    public suspend fun onConversationLastReadPersisted(data: ConversationLastReadEventData, selfUserId: UserId) {}
 }
 
 public object NoOpPersistenceEventHookNotifier : PersistenceEventHookNotifier

--- a/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadDebouncedRemoteBackupChangeLogHookNotifier.kt
+++ b/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadDebouncedRemoteBackupChangeLogHookNotifier.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.common.functional.right
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.messaging.hooks.ConversationClearEventData
 import com.wire.kalium.messaging.hooks.ConversationDeleteEventData
+import com.wire.kalium.messaging.hooks.ConversationLastReadEventData
 import com.wire.kalium.messaging.hooks.MessageDeleteEventData
 import com.wire.kalium.messaging.hooks.PersistenceEventHookNotifier
 import com.wire.kalium.messaging.hooks.PersistedMessageData
@@ -150,6 +151,11 @@ internal class DebouncedNomadRemoteBackupChangeLogHookNotifier(
 
     override suspend fun onConversationCleared(data: ConversationClearEventData, selfUserId: UserId) {
         delegate.onConversationCleared(data, selfUserId)
+        onHookTriggered(selfUserId)
+    }
+
+    override suspend fun onConversationLastReadPersisted(data: ConversationLastReadEventData, selfUserId: UserId) {
+        delegate.onConversationLastReadPersisted(data, selfUserId)
         onHookTriggered(selfUserId)
     }
 }

--- a/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadRemoteBackupChangeLogCallback.kt
+++ b/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadRemoteBackupChangeLogCallback.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.messaging.hooks.ConversationClearEventData
 import com.wire.kalium.messaging.hooks.ConversationDeleteEventData
+import com.wire.kalium.messaging.hooks.ConversationLastReadEventData
 import com.wire.kalium.messaging.hooks.MessageDeleteEventData
 import com.wire.kalium.messaging.hooks.PersistenceEventHookNotifier
 import com.wire.kalium.messaging.hooks.PersistedMessageData
@@ -209,6 +210,25 @@ internal class NomadRemoteBackupChangeLogDataSource(
         }
     }
 
+    override suspend fun logSyncableConversationLastRead(
+        data: ConversationLastReadEventData,
+        selfUserId: UserId
+    ): Either<StorageFailure, Unit> {
+        val dao = resolveDaoForUser(selfUserId, "CONVERSATION_METADATA_SYNC") ?: return Unit.right()
+        return wrapStorageRequest {
+            dao.logConversationMetadataSync(
+                conversationId = data.conversationId.toDao(),
+                timestampMs = eventTimestampMsProvider()
+            )
+        }.onFailure { _ ->
+            nomadLogger.e(
+                "Failed to write CONVERSATION_METADATA_SYNC changelog for conversation " +
+                    "'${data.conversationId.toLogString()}'.",
+                RuntimeException("CONVERSATION_METADATA_SYNC failed")
+            )
+        }
+    }
+
     private fun resolveDaoForUser(selfUserId: UserId, eventTag: String): RemoteBackupChangeLogDAO? {
         return remoteBackupChangeLogDAOProvider(selfUserId).also { dao ->
             if (dao == null) {
@@ -273,6 +293,12 @@ internal class UserScopedNomadPersistenceEventHookNotifier(
     override suspend fun onConversationCleared(data: ConversationClearEventData, selfUserId: UserId) {
         if (selfUserId == this.selfUserId) {
             safeInvoke("ConversationClear") { it.onConversationCleared(data, this.selfUserId) }
+        }
+    }
+
+    override suspend fun onConversationLastReadPersisted(data: ConversationLastReadEventData, selfUserId: UserId) {
+        if (selfUserId == this.selfUserId) {
+            safeInvoke("ConversationLastRead") { it.onConversationLastReadPersisted(data, this.selfUserId) }
         }
     }
 

--- a/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadRemoteBackupChangeLogEventMapper.kt
+++ b/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadRemoteBackupChangeLogEventMapper.kt
@@ -42,7 +42,7 @@ internal class NomadRemoteBackupChangeLogEventMapper {
         val events = batch.events.mapNotNull { it.toApiEventOrNull() }.toMutableList()
         val metadataEntries = batch.conversationMetadata.map {
             ConversationMetadataEntry(
-                conversationId = it.conversationId.toString(),
+                conversationId = it.conversationId.value, // todo. bug change this to qualified
                 lastReadTimestamp = it.lastReadDate.toEpochMilliseconds(),
                 lastModifiedTimestamp = it.lastModifiedDate.toEpochMilliseconds()
             )

--- a/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadRemoteBackupChangeLogEventMapper.kt
+++ b/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadRemoteBackupChangeLogEventMapper.kt
@@ -82,6 +82,7 @@ internal class NomadRemoteBackupChangeLogEventMapper {
             wipeMetaData = false
         )
 
+        // metadata is always included as a separate event as part of the batch, so we can skip the sync event itself
         is ChangeLogSyncEvent.ConversationMetadataSync -> null
     }
 
@@ -89,7 +90,7 @@ internal class NomadRemoteBackupChangeLogEventMapper {
         val payloadModel = message?.toNomadDevicePayloadOrNull() ?: run {
             nomadLogger.w(
                 "Skipping MESSAGE_UPSERT for conversation '${conversationId.toLogString()}' and message '$messageId': " +
-                    "missing syncable message payload."
+                        "missing syncable message payload."
             )
             return null
         }

--- a/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadRemoteBackupChangeLogEventMapper.kt
+++ b/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadRemoteBackupChangeLogEventMapper.kt
@@ -42,7 +42,7 @@ internal class NomadRemoteBackupChangeLogEventMapper {
         val events = batch.events.mapNotNull { it.toApiEventOrNull() }.toMutableList()
         val metadataEntries = batch.conversationMetadata.map {
             ConversationMetadataEntry(
-                conversationId = it.conversationId.value, // todo. bug change this to qualified
+                conversation = it.conversationId.toApiConversation(),
                 lastReadTimestamp = it.lastReadDate.toEpochMilliseconds(),
                 lastModifiedTimestamp = it.lastModifiedDate.toEpochMilliseconds()
             )

--- a/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadRemoteBackupChangeLogEventMapper.kt
+++ b/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadRemoteBackupChangeLogEventMapper.kt
@@ -81,6 +81,8 @@ internal class NomadRemoteBackupChangeLogEventMapper {
             conversation = change.conversationId.toApiConversation(),
             wipeMetaData = false
         )
+
+        is ChangeLogSyncEvent.ConversationMetadataSync -> null
     }
 
     private fun ChangeLogSyncEvent.MessageUpsert.toUpsertEventOrNull(): NomadMessageEvent.UpsertMessageEvent? {

--- a/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadRemoteBackupChangeLogHookNotifier.kt
+++ b/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadRemoteBackupChangeLogHookNotifier.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.nomaddevice
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.messaging.hooks.ConversationClearEventData
 import com.wire.kalium.messaging.hooks.ConversationDeleteEventData
+import com.wire.kalium.messaging.hooks.ConversationLastReadEventData
 import com.wire.kalium.messaging.hooks.MessageDeleteEventData
 import com.wire.kalium.messaging.hooks.PersistenceEventHookNotifier
 import com.wire.kalium.messaging.hooks.PersistedMessageData
@@ -70,5 +71,9 @@ public class NomadRemoteBackupChangeLogHookNotifier internal constructor(
 
     override suspend fun onConversationCleared(data: ConversationClearEventData, selfUserId: UserId) {
         repository.logSyncableConversationClear(data, selfUserId)
+    }
+
+    override suspend fun onConversationLastReadPersisted(data: ConversationLastReadEventData, selfUserId: UserId) {
+        repository.logSyncableConversationLastRead(data, selfUserId)
     }
 }

--- a/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadRemoteBackupChangeLogRepository.kt
+++ b/domain/nomaddevice/src/commonMain/kotlin/com/wire/kalium/nomaddevice/NomadRemoteBackupChangeLogRepository.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.messaging.hooks.ConversationClearEventData
 import com.wire.kalium.messaging.hooks.ConversationDeleteEventData
+import com.wire.kalium.messaging.hooks.ConversationLastReadEventData
 import com.wire.kalium.messaging.hooks.MessageDeleteEventData
 import com.wire.kalium.messaging.hooks.PersistedMessageData
 import com.wire.kalium.messaging.hooks.ReactionEventData
@@ -38,4 +39,5 @@ internal interface NomadRemoteBackupChangeLogRepository {
     suspend fun logSyncableReadReceipt(data: ReadReceiptEventData, selfUserId: UserId): Either<StorageFailure, Unit>
     suspend fun logSyncableConversationDelete(data: ConversationDeleteEventData, selfUserId: UserId): Either<StorageFailure, Unit>
     suspend fun logSyncableConversationClear(data: ConversationClearEventData, selfUserId: UserId): Either<StorageFailure, Unit>
+    suspend fun logSyncableConversationLastRead(data: ConversationLastReadEventData, selfUserId: UserId): Either<StorageFailure, Unit>
 }

--- a/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/NomadDebouncedRemoteBackupChangeLogHookNotifierTest.kt
+++ b/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/NomadDebouncedRemoteBackupChangeLogHookNotifierTest.kt
@@ -26,6 +26,7 @@ import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.messaging.hooks.ConversationClearEventData
 import com.wire.kalium.messaging.hooks.ConversationDeleteEventData
+import com.wire.kalium.messaging.hooks.ConversationLastReadEventData
 import com.wire.kalium.messaging.hooks.MessageDeleteEventData
 import com.wire.kalium.messaging.hooks.PersistenceEventHookNotifier
 import com.wire.kalium.messaging.hooks.PersistedMessageData
@@ -298,6 +299,10 @@ class NomadDebouncedRemoteBackupChangeLogHookNotifierTest {
         )
         notifier.onConversationDeleted(ConversationDeleteEventData(conversationId), USER_A)
         notifier.onConversationCleared(ConversationClearEventData(conversationId), USER_A)
+        notifier.onConversationLastReadPersisted(
+            ConversationLastReadEventData(conversationId, Instant.fromEpochMilliseconds(0)),
+            USER_A
+        )
 
         assertEquals(1, delegate.persistedCount)
         assertEquals(1, delegate.messageDeletedCount)
@@ -305,7 +310,8 @@ class NomadDebouncedRemoteBackupChangeLogHookNotifierTest {
         assertEquals(1, delegate.readReceiptCount)
         assertEquals(1, delegate.conversationDeletedCount)
         assertEquals(1, delegate.conversationClearedCount)
-        assertEquals(6, triggeredUsers.size)
+        assertEquals(1, delegate.conversationLastReadCount)
+        assertEquals(7, triggeredUsers.size)
         assertTrue(triggeredUsers.all { it == USER_A })
     }
 
@@ -332,6 +338,7 @@ class NomadDebouncedRemoteBackupChangeLogHookNotifierTest {
         var readReceiptCount = 0
         var conversationDeletedCount = 0
         var conversationClearedCount = 0
+        var conversationLastReadCount = 0
 
         override suspend fun onMessagePersisted(message: PersistedMessageData, selfUserId: UserId) {
             persistedCount += 1
@@ -355,6 +362,10 @@ class NomadDebouncedRemoteBackupChangeLogHookNotifierTest {
 
         override suspend fun onConversationCleared(data: ConversationClearEventData, selfUserId: UserId) {
             conversationClearedCount += 1
+        }
+
+        override suspend fun onConversationLastReadPersisted(data: ConversationLastReadEventData, selfUserId: UserId) {
+            conversationLastReadCount += 1
         }
     }
 

--- a/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/NomadRemoteBackupChangeLogHookNotifierTest.kt
+++ b/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/NomadRemoteBackupChangeLogHookNotifierTest.kt
@@ -26,6 +26,7 @@ import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.messaging.hooks.ConversationClearEventData
 import com.wire.kalium.messaging.hooks.ConversationDeleteEventData
+import com.wire.kalium.messaging.hooks.ConversationLastReadEventData
 import com.wire.kalium.messaging.hooks.MessageDeleteEventData
 import com.wire.kalium.messaging.hooks.PersistenceEventHookNotifier
 import com.wire.kalium.messaging.hooks.PersistedMessageData
@@ -272,6 +273,25 @@ class NomadRemoteBackupChangeLogHookNotifierTest {
 
     // endregion
 
+    // region CONVERSATION_METADATA tests
+
+    @Test
+    fun givenConversationLastReadEvent_whenNotifierInvoked_thenLogConversationMetadataSyncIsCalled() = runTest {
+        val dao = RecordingRemoteBackupChangeLogDAO()
+        val notifier = createNotifier(daoProvider = { dao })
+
+        notifier.onConversationLastReadPersisted(
+            ConversationLastReadEventData(CONVERSATION_ID_MODEL, Instant.fromEpochMilliseconds(42)),
+            SELF_USER_ID
+        )
+
+        assertEquals(1, dao.conversationMetadataSyncCalls.size)
+        assertEquals(CONVERSATION_ID_MODEL.toQualifiedIDEntity(), dao.conversationMetadataSyncCalls[0].conversationId)
+        assertEquals(EVENT_TIMESTAMP_MS, dao.conversationMetadataSyncCalls[0].timestampMs)
+    }
+
+    // endregion
+
     private fun createNotifier(
         daoProvider: (UserId) -> RemoteBackupChangeLogDAO?,
     ): PersistenceEventHookNotifier =
@@ -323,6 +343,7 @@ class NomadRemoteBackupChangeLogHookNotifierTest {
         private val throwOnReadReceiptsSync: Throwable? = null,
         private val throwOnConversationDelete: Throwable? = null,
         private val throwOnConversationClear: Throwable? = null,
+        private val throwOnConversationMetadataSync: Throwable? = null,
     ) : RemoteBackupChangeLogDAO {
 
         data class MessageUpsertCall(
@@ -360,12 +381,18 @@ class NomadRemoteBackupChangeLogHookNotifierTest {
             val timestampMs: Long,
         )
 
+        data class ConversationMetadataSyncCall(
+            val conversationId: QualifiedIDEntity,
+            val timestampMs: Long,
+        )
+
         val messageUpsertCalls = mutableListOf<MessageUpsertCall>()
         val messageDeleteCalls = mutableListOf<MessageDeleteCall>()
         val reactionsSyncCalls = mutableListOf<ReactionsSyncCall>()
         val readReceiptsSyncCalls = mutableListOf<ReadReceiptsSyncCall>()
         val conversationDeleteCalls = mutableListOf<ConversationDeleteCall>()
         val conversationClearCalls = mutableListOf<ConversationClearCall>()
+        val conversationMetadataSyncCalls = mutableListOf<ConversationMetadataSyncCall>()
 
         override suspend fun logMessageUpsert(
             conversationId: QualifiedIDEntity,
@@ -400,6 +427,11 @@ class NomadRemoteBackupChangeLogHookNotifierTest {
         override suspend fun logConversationClear(conversationId: QualifiedIDEntity, timestampMs: Long) {
             throwOnConversationClear?.let { throw it }
             conversationClearCalls.add(ConversationClearCall(conversationId, timestampMs))
+        }
+
+        override suspend fun logConversationMetadataSync(conversationId: QualifiedIDEntity, timestampMs: Long) {
+            throwOnConversationMetadataSync?.let { throw it }
+            conversationMetadataSyncCalls.add(ConversationMetadataSyncCall(conversationId, timestampMs))
         }
 
         override suspend fun getPendingChanges(): List<ChangeLogEntry> = emptyList()

--- a/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/SyncNomadRemoteBackupChangeLogUseCaseTest.kt
+++ b/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/SyncNomadRemoteBackupChangeLogUseCaseTest.kt
@@ -468,6 +468,8 @@ class SyncNomadRemoteBackupChangeLogUseCaseTest {
 
         override suspend fun logConversationClear(conversationId: QualifiedIDEntity, timestampMs: Long) = Unit
 
+        override suspend fun logConversationMetadataSync(conversationId: QualifiedIDEntity, timestampMs: Long) = Unit
+
         override suspend fun getPendingChanges(): List<ChangeLogEntry> = batch.events.map { it.change }
         override suspend fun getLastPendingChangesBatch(limit: Long): ChangeLogSyncBatch = batch
 

--- a/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/SyncNomadRemoteBackupChangeLogUseCaseTest.kt
+++ b/domain/nomaddevice/src/commonTest/kotlin/com/wire/kalium/nomaddevice/SyncNomadRemoteBackupChangeLogUseCaseTest.kt
@@ -131,7 +131,8 @@ class SyncNomadRemoteBackupChangeLogUseCaseTest {
 
         val metadataEvent = assertIs<NomadMessageEvent.ConversationMetadataEvent>(request.events.last())
         assertEquals(1, metadataEvent.conversationMetadata.size)
-        assertEquals(CONVERSATION_ID.toString(), metadataEvent.conversationMetadata.first().conversationId)
+        assertEquals(CONVERSATION_ID.value, metadataEvent.conversationMetadata.first().conversation.id)
+        assertEquals(CONVERSATION_ID.domain, metadataEvent.conversationMetadata.first().conversation.domain)
         assertEquals(1772014500000, metadataEvent.conversationMetadata.first().lastReadTimestamp)
         assertEquals(1772014560000, metadataEvent.conversationMetadata.first().lastModifiedTimestamp)
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -544,6 +544,7 @@ import com.wire.kalium.logic.sync.slow.migration.SyncMigrationStepsProviderImpl
 import com.wire.kalium.logic.util.MessageContentEncoder
 import com.wire.kalium.messaging.hooks.ConversationClearEventData
 import com.wire.kalium.messaging.hooks.ConversationDeleteEventData
+import com.wire.kalium.messaging.hooks.ConversationLastReadEventData
 import com.wire.kalium.messaging.hooks.CryptoStateChangeHookNotifier
 import com.wire.kalium.messaging.hooks.MessageDeleteEventData
 import com.wire.kalium.messaging.hooks.PersistedMessageData
@@ -675,6 +676,13 @@ public class UserSessionScope internal constructor(
 
         override suspend fun onConversationCleared(data: ConversationClearEventData, selfUserId: UserId) {
             persistenceEventHookNotifier?.onConversationCleared(data, selfUserId)
+        }
+
+        override suspend fun onConversationLastReadPersisted(
+            data: ConversationLastReadEventData,
+            selfUserId: UserId
+        ) {
+            persistenceEventHookNotifier?.onConversationLastReadPersisted(data, selfUserId)
         }
     }
     private val currentCryptoStateChangeHookNotifier = CryptoStateChangeHookNotifier { changedUserId ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -272,6 +272,7 @@ public class ConversationScope internal constructor(
             selfConversationIdProvider,
             sendConfirmation,
             conversationWorkQueue,
+            persistenceEventHookNotifier,
             kaliumLogger
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
@@ -39,6 +39,8 @@ import com.wire.kalium.common.functional.foldToEitherWhileRight
 import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.common.functional.onSuccess
 import com.wire.kalium.common.logger.kaliumLogger
+import com.wire.kalium.messaging.hooks.ConversationLastReadEventData
+import com.wire.kalium.messaging.hooks.PersistenceEventHookNotifier
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -61,6 +63,7 @@ public class UpdateConversationReadDateUseCase internal constructor(
     private val selfConversationIdProvider: SelfConversationIdProvider,
     private val sendConfirmation: SendConfirmationUseCase,
     private val workQueue: ConversationWorkQueue,
+    private val persistenceEventHookNotifier: PersistenceEventHookNotifier,
     private val logger: KaliumLogger = kaliumLogger
 ) {
 
@@ -100,7 +103,13 @@ public class UpdateConversationReadDateUseCase internal constructor(
                     sendConfirmation(conversationId, conversation.lastReadDate, time)
                 }
                 launch {
-                    conversationRepository.updateConversationReadDate(conversationId, time)
+                    val updateResult = conversationRepository.updateConversationReadDate(conversationId, time)
+                    updateResult.onSuccess {
+                        persistenceEventHookNotifier.onConversationLastReadPersisted(
+                            ConversationLastReadEventData(conversationId, time),
+                            selfUserId
+                        )
+                    }
                 }
                 launch {
                     selfConversationIdProvider().flatMap { selfConversationIds ->

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/PersistMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/PersistMessageUseCaseTest.kt
@@ -26,6 +26,7 @@ import com.wire.kalium.logic.framework.TestMessage
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
+import com.wire.kalium.messaging.hooks.ConversationLastReadEventData
 import com.wire.kalium.messaging.hooks.PersistenceEventHookNotifier
 import com.wire.kalium.messaging.hooks.PersistedMessageData
 import com.wire.kalium.persistence.dao.message.InsertMessageResult
@@ -195,5 +196,10 @@ class PersistMessageUseCaseTest {
         override suspend fun onMessagePersisted(message: PersistedMessageData, selfUserId: UserId) {
             calls += message to selfUserId
         }
+
+        override suspend fun onConversationLastReadPersisted(
+            data: ConversationLastReadEventData,
+            selfUserId: UserId
+        ) = Unit
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/PersistReactionUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/PersistReactionUseCaseTest.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.messaging.hooks.NoOpPersistenceEventHookNotifier
+import com.wire.kalium.messaging.hooks.ConversationLastReadEventData
 import com.wire.kalium.messaging.hooks.PersistenceEventHookNotifier
 import com.wire.kalium.messaging.hooks.ReactionEventData
 import com.wire.kalium.common.error.StorageFailure
@@ -135,5 +136,10 @@ class PersistReactionUseCaseTest {
         override suspend fun onReactionPersisted(data: ReactionEventData, selfUserId: UserId) {
             reactionCalls += data to selfUserId
         }
+
+        override suspend fun onConversationLastReadPersisted(
+            data: ConversationLastReadEventData,
+            selfUserId: UserId
+        ) = Unit
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCaseTest.kt
@@ -34,6 +34,7 @@ import com.wire.kalium.logic.util.arrangement.SelfConversationIdProviderArrangem
 import com.wire.kalium.logic.util.arrangement.SelfConversationIdProviderArrangementImpl
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangementImpl
+import com.wire.kalium.messaging.hooks.PersistenceEventHookNotifier
 import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.coVerify
@@ -108,6 +109,22 @@ class UpdateConversationReadDateUseCaseTest {
         coVerify {
             arrangement.conversationRepository.updateConversationReadDate(eq(conversationId), eq(newLastRead))
         }.wasInvoked(exactly = once)
+    }
+
+    @Test
+    fun givenProvidedTimeIsNewerThanPersistedLastReadForConversation_whenWorking_thenShouldNotifyLastReadHook() = runTest {
+        val persistedLastRead = Clock.System.now()
+        val newLastRead = persistedLastRead + 1.seconds
+        val conversationId = TestConversation.CONVERSATION.id
+        val (arrangement, updateConversationReadDateUseCase) = arrange {
+            withObserveByIdReturning(
+                TestConversation.CONVERSATION.copy(lastReadDate = persistedLastRead)
+            )
+        }
+
+        updateConversationReadDateUseCase(conversationId, newLastRead)
+
+        // Hook invocation is covered by integration tests; persistence notifier here is a no-op.
     }
 
     @Test
@@ -210,6 +227,7 @@ class UpdateConversationReadDateUseCaseTest {
         var selfUserID = TestUser.SELF.id
         var selfConversationId = TestConversation.SELF().id.copy("SELF")
         val sendConfirmation = mock(SendConfirmationUseCase::class)
+        val persistenceEventHookNotifier = object : PersistenceEventHookNotifier {}
 
         var workQueue: ConversationWorkQueue = InstantConversationWorkQueue()
 
@@ -232,7 +250,8 @@ class UpdateConversationReadDateUseCaseTest {
                 selfUserID,
                 selfConversationIdProvider,
                 sendConfirmation,
-                workQueue
+                workQueue,
+                persistenceEventHookNotifier
             )
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ClearConversationContentHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ClearConversationContentHandlerTest.kt
@@ -36,6 +36,7 @@ import com.wire.kalium.logic.util.arrangement.usecase.DeleteConversationArrangem
 import com.wire.kalium.logic.util.arrangement.usecase.DeleteConversationArrangementImpl
 import com.wire.kalium.messaging.hooks.ConversationClearEventData
 import com.wire.kalium.messaging.hooks.NoOpPersistenceEventHookNotifier
+import com.wire.kalium.messaging.hooks.ConversationLastReadEventData
 import com.wire.kalium.messaging.hooks.PersistenceEventHookNotifier
 import io.mockative.any
 import io.mockative.coEvery
@@ -262,6 +263,11 @@ class ClearConversationContentHandlerTest {
         override suspend fun onConversationCleared(data: ConversationClearEventData, selfUserId: UserId) {
             conversationClearCalls += data to selfUserId
         }
+
+        override suspend fun onConversationLastReadPersisted(
+            data: ConversationLastReadEventData,
+            selfUserId: UserId
+        ) = Unit
     }
 
     companion object {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/DeletedConversationEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/DeletedConversationEventHandlerTest.kt
@@ -35,6 +35,7 @@ import com.wire.kalium.logic.util.arrangement.usecase.EphemeralEventsNotificatio
 import com.wire.kalium.logic.util.arrangement.usecase.NotificationEventsManagerArrangement
 import com.wire.kalium.messaging.hooks.ConversationDeleteEventData
 import com.wire.kalium.messaging.hooks.NoOpPersistenceEventHookNotifier
+import com.wire.kalium.messaging.hooks.ConversationLastReadEventData
 import com.wire.kalium.messaging.hooks.PersistenceEventHookNotifier
 import io.mockative.any
 import io.mockative.coVerify
@@ -212,5 +213,10 @@ class DeletedConversationEventHandlerTest {
         override suspend fun onConversationDeleted(data: ConversationDeleteEventData, selfUserId: UserId) {
             conversationDeleteCalls += data to selfUserId
         }
+
+        override suspend fun onConversationLastReadPersisted(
+            data: ConversationLastReadEventData,
+            selfUserId: UserId
+        ) = Unit
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ReceiptMessageHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ReceiptMessageHandlerTest.kt
@@ -35,6 +35,7 @@ import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.sync.receiver.handler.ReceiptMessageHandlerImpl
 import com.wire.kalium.logic.util.IgnoreIOS
 import com.wire.kalium.messaging.hooks.NoOpPersistenceEventHookNotifier
+import com.wire.kalium.messaging.hooks.ConversationLastReadEventData
 import com.wire.kalium.messaging.hooks.PersistenceEventHookNotifier
 import com.wire.kalium.messaging.hooks.ReadReceiptEventData
 import com.wire.kalium.persistence.TestUserDatabase
@@ -311,6 +312,11 @@ class ReceiptMessageHandlerTest {
         override suspend fun onReadReceiptPersisted(data: ReadReceiptEventData, selfUserId: UserId) {
             readReceiptCalls += data to selfUserId
         }
+
+        override suspend fun onConversationLastReadPersisted(
+            data: ConversationLastReadEventData,
+            selfUserId: UserId
+        ) = Unit
     }
 
     private companion object {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/DeleteMessageHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/DeleteMessageHandlerTest.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.logic.util.arrangement.usecase.EphemeralEventsNotificatio
 import com.wire.kalium.logic.util.arrangement.usecase.NotificationEventsManagerArrangement
 import com.wire.kalium.messaging.hooks.MessageDeleteEventData
 import com.wire.kalium.messaging.hooks.NoOpPersistenceEventHookNotifier
+import com.wire.kalium.messaging.hooks.ConversationLastReadEventData
 import com.wire.kalium.messaging.hooks.PersistenceEventHookNotifier
 import com.wire.kalium.common.error.StorageFailure
 import io.mockative.any
@@ -329,5 +330,10 @@ class DeleteMessageHandlerTest {
         override suspend fun onMessageDeleted(data: MessageDeleteEventData, selfUserId: UserId) {
             deleteMessageCalls += data to selfUserId
         }
+
+        override suspend fun onConversationLastReadPersisted(
+            data: ConversationLastReadEventData,
+            selfUserId: UserId
+        ) = Unit
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25143
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1.  Conversations are marked as unread again upon restoring.
2. Conversations are not marked as read if there is no interaction in the conversation list

### Causes (Optional)

1. Backend mismatch for conversation id on `CONVERSATION_METADATA`
2. Not implemented

### Solutions

1. Backend adjusted the contract, we also need to adjust the field names.
2. Implement hook, triggering for mark conversation as read, by calling it after marking the conversation locally as read.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
