### PR TITLE
fix: nomad marking as read/unread upon restoring (WPB-25143)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -277,7 +277,11 @@ public class ConversationScope internal constructor(
         )
 
     public val markConversationAsReadLocally: MarkConversationAsReadLocallyUseCase
-        get() = MarkConversationAsReadLocallyUseCaseImpl(conversationRepository)
+        get() = MarkConversationAsReadLocallyUseCaseImpl(
+            conversationRepository,
+            persistenceEventHookNotifier,
+            selfUserId
+        )
 
     public val updateConversationAccess: UpdateConversationAccessRoleUseCase
         get() = UpdateConversationAccessRoleUseCaseImpl(conversationRepository, conversationGroupRepository, syncManager)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/MarkConversationAsReadLocallyUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/MarkConversationAsReadLocallyUseCase.kt
@@ -19,10 +19,14 @@
 package com.wire.kalium.logic.feature.conversation
 
 import com.wire.kalium.common.error.CoreFailure
-import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.fold
+import com.wire.kalium.common.logger.kaliumLogger
+import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.messaging.hooks.ConversationLastReadEventData
+import com.wire.kalium.messaging.hooks.PersistenceEventHookNotifier
 import kotlinx.datetime.Instant
 
 /**
@@ -54,7 +58,10 @@ public sealed class MarkConversationAsReadResult {
 }
 
 internal class MarkConversationAsReadLocallyUseCaseImpl internal constructor(
-    private val conversationRepository: ConversationRepository
+    private val conversationRepository: ConversationRepository,
+    private val persistenceEventHookNotifier: PersistenceEventHookNotifier,
+    private val selfUserId: UserId,
+    private val logger: KaliumLogger = kaliumLogger,
 ) : MarkConversationAsReadLocallyUseCase {
 
     override suspend fun invoke(
@@ -63,6 +70,13 @@ internal class MarkConversationAsReadLocallyUseCaseImpl internal constructor(
     ): MarkConversationAsReadResult =
         conversationRepository.updateReadDateAndGetHasUnreadEvents(conversationId, time).fold(
             { failure -> MarkConversationAsReadResult.Failure(failure) },
-            { hasUnreadEvents -> MarkConversationAsReadResult.Success(hasUnreadEvents) }
+            { hasUnreadEvents ->
+                logger.d("Persisted local last-read for '${conversationId.toLogString()}' at $time")
+                persistenceEventHookNotifier.onConversationLastReadPersisted(
+                    ConversationLastReadEventData(conversationId, time),
+                    selfUserId
+                )
+                MarkConversationAsReadResult.Success(hasUnreadEvents)
+            }
         )
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
@@ -96,6 +96,7 @@ public class UpdateConversationReadDateUseCase internal constructor(
                 logger.w("Failed to update conversation read date; StorageFailure $it")
             }.onSuccess { conversation ->
                 if (conversation.lastReadDate >= time) {
+                    logger.d("Skipping last-read update for '${conversationId.toLogString()}': stored=${conversation.lastReadDate} >= requested=$time")
                     // Skipping, as current lastRead is already newer than the scheduled one
                     return@onSuccess
                 }
@@ -105,6 +106,7 @@ public class UpdateConversationReadDateUseCase internal constructor(
                 launch {
                     val updateResult = conversationRepository.updateConversationReadDate(conversationId, time)
                     updateResult.onSuccess {
+                        logger.d("Persisted last-read for '${conversationId.toLogString()}' at $time")
                         persistenceEventHookNotifier.onConversationLastReadPersisted(
                             ConversationLastReadEventData(conversationId, time),
                             selfUserId

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
@@ -42,8 +42,11 @@ import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.messaging.hooks.ConversationLastReadEventData
 import com.wire.kalium.messaging.hooks.PersistenceEventHookNotifier
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 
@@ -103,10 +106,16 @@ public class UpdateConversationReadDateUseCase internal constructor(
                     // Skipping, as current lastRead is already newer than the scheduled one
                     return@onSuccess
                 }
-                launch {
-                    sendConfirmation(conversationId, conversation.lastReadDate, time)
+
+                val shouldRunOptionalSideEffects = currentCoroutineContext()[kotlinx.coroutines.Job] != NonCancellable
+
+                if (shouldRunOptionalSideEffects) {
+                    launch {
+                        sendConfirmation(conversationId, conversation.lastReadDate, time)
+                    }
                 }
-                launch {
+
+                withContext(NonCancellable) {
                     val updateResult = conversationRepository.updateConversationReadDate(conversationId, time)
                     updateResult.onSuccess {
                         logger.d("Persisted last-read for '${conversationId.toLogString()}' at $time")
@@ -116,10 +125,12 @@ public class UpdateConversationReadDateUseCase internal constructor(
                         )
                     }
                 }
-                launch {
-                    selfConversationIdProvider().flatMap { selfConversationIds ->
-                        selfConversationIds.foldToEitherWhileRight(Unit) { selfConversationId, _ ->
-                            sendLastReadMessageToOtherClients(conversationId, selfConversationId, time)
+                if (shouldRunOptionalSideEffects) {
+                    launch {
+                        selfConversationIdProvider().flatMap { selfConversationIds ->
+                            selfConversationIds.foldToEitherWhileRight(Unit) { selfConversationId, _ ->
+                                sendLastReadMessageToOtherClients(conversationId, selfConversationId, time)
+                            }
                         }
                     }
                 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
@@ -96,7 +96,10 @@ public class UpdateConversationReadDateUseCase internal constructor(
                 logger.w("Failed to update conversation read date; StorageFailure $it")
             }.onSuccess { conversation ->
                 if (conversation.lastReadDate >= time) {
-                    logger.d("Skipping last-read update for '${conversationId.toLogString()}': stored=${conversation.lastReadDate} >= requested=$time")
+                    logger.d(
+                        "Skipping last-read update for '${conversationId.toLogString()}': " +
+                            "stored=${conversation.lastReadDate} >= requested=$time"
+                    )
                     // Skipping, as current lastRead is already newer than the scheduled one
                     return@onSuccess
                 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/MarkConversationAsReadLocallyUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/MarkConversationAsReadLocallyUseCaseTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.messaging.hooks.ConversationLastReadEventData
+import com.wire.kalium.messaging.hooks.PersistenceEventHookNotifier
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.eq
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.seconds
+
+class MarkConversationAsReadLocallyUseCaseTest {
+
+    @Test
+    fun givenNewerTimestamp_whenMarkingLocally_thenHookIsTriggered() = runTest {
+        val conversation = TestConversation.CONVERSATION.copy(
+            lastReadDate = Clock.System.now()
+        )
+        val newLastRead = conversation.lastReadDate + 1.seconds
+        val conversationRepository = mock<ConversationRepository>()
+        val hookNotifier = mock<PersistenceEventHookNotifier>(mode = MockMode.autoUnit)
+        val useCase = MarkConversationAsReadLocallyUseCaseImpl(
+            conversationRepository = conversationRepository,
+            persistenceEventHookNotifier = hookNotifier,
+            selfUserId = TestUser.SELF.id,
+        )
+
+        everySuspend { conversationRepository.getConversationById(eq(conversation.id)) } returns Either.Right(conversation)
+        everySuspend {
+            conversationRepository.updateReadDateAndGetHasUnreadEvents(eq(conversation.id), eq(newLastRead))
+        } returns Either.Right(false)
+
+        useCase(conversation.id, newLastRead)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            hookNotifier.onConversationLastReadPersisted(
+                eq(ConversationLastReadEventData(conversation.id, newLastRead)),
+                eq(TestUser.SELF.id)
+            )
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCaseTest.kt
@@ -17,24 +17,26 @@
  */
 package com.wire.kalium.logic.feature.conversation
 
+import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.MessageContent
-import com.wire.kalium.messaging.sending.MessageTarget
+import com.wire.kalium.logic.feature.message.MessageOperationResult
 import com.wire.kalium.logic.feature.message.receipt.ConversationWorkQueue
 import com.wire.kalium.logic.feature.message.receipt.InstantConversationWorkQueue
+import com.wire.kalium.logic.feature.message.receipt.ParallelConversationWorkQueue
 import com.wire.kalium.logic.feature.message.receipt.SendConfirmationUseCase
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
-import com.wire.kalium.common.functional.Either
-import com.wire.kalium.logic.feature.message.MessageOperationResult
 import com.wire.kalium.logic.util.arrangement.MessageSenderArrangement
 import com.wire.kalium.logic.util.arrangement.MessageSenderArrangementImpl
 import com.wire.kalium.logic.util.arrangement.SelfConversationIdProviderArrangement
 import com.wire.kalium.logic.util.arrangement.SelfConversationIdProviderArrangementImpl
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangement
 import com.wire.kalium.logic.util.arrangement.repository.ConversationRepositoryArrangementImpl
+import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.messaging.hooks.PersistenceEventHookNotifier
+import com.wire.kalium.messaging.sending.MessageTarget
 import io.mockative.any
 import io.mockative.coEvery
 import io.mockative.coVerify
@@ -42,12 +44,17 @@ import io.mockative.eq
 import io.mockative.matches
 import io.mockative.mock
 import io.mockative.once
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 class UpdateConversationReadDateUseCaseTest {
@@ -217,6 +224,33 @@ class UpdateConversationReadDateUseCaseTest {
         assertEquals(expectedTime, enqueuedInstant)
     }
 
+    @Test
+    fun givenCallerCancelledAfterEnqueue_whenQueued_thenWorkStillExecutes() = runTest {
+        val persistedLastRead = Clock.System.now()
+        val newLastRead = persistedLastRead + 1.seconds
+        val conversationId = TestConversation.CONVERSATION.id
+        val workQueue = ParallelConversationWorkQueue(backgroundScope, kaliumLogger, StandardTestDispatcher(testScheduler))
+        val (arrangement, updateConversationReadDateUseCase) = arrange {
+            withObserveByIdReturning(
+                TestConversation.CONVERSATION.copy(lastReadDate = persistedLastRead)
+            )
+            this.workQueue = workQueue
+        }
+
+        val job = launch {
+            updateConversationReadDateUseCase(conversationId, newLastRead)
+        }
+        runCurrent()
+        job.cancel()
+
+        advanceTimeBy(3.seconds + 1.milliseconds)
+        runCurrent()
+
+        coVerify {
+            arrangement.conversationRepository.updateConversationReadDate(eq(conversationId), eq(newLastRead))
+        }.wasInvoked(exactly = once)
+    }
+
     private class Arrangement(
         private val configure: suspend Arrangement.() -> Unit
     ) : ConversationRepositoryArrangement by ConversationRepositoryArrangementImpl(),
@@ -251,7 +285,8 @@ class UpdateConversationReadDateUseCaseTest {
                 selfConversationIdProvider,
                 sendConfirmation,
                 workQueue,
-                persistenceEventHookNotifier
+                persistenceEventHookNotifier,
+                kaliumLogger
             )
         }
     }

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCaseIntegrationTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCaseIntegrationTest.kt
@@ -68,6 +68,7 @@ import kotlinx.datetime.Instant
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertNotNull
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -86,7 +87,7 @@ class UpdateConversationReadDateUseCaseIntegrationTest {
     }
 
     @Test
-    fun givenQueuedLastRead_whenSessionScopeCancelledDuringDebounce_thenLastReadAndNomadChangeLogArePersisted() = runTest {
+    fun givenQueuedLastRead_whenSessionScopeCancelledDuringDebounce_thenLastReadIsNotPersisted() = runTest {
         val dispatcher = StandardTestDispatcher(testScheduler)
         val persistedLastRead = stableNow()
         val newLastRead = persistedLastRead + 1.seconds
@@ -100,8 +101,8 @@ class UpdateConversationReadDateUseCaseIntegrationTest {
         runCurrent()
         advanceUntilIdle()
 
-        assertPersisted(arrangement.database, newLastRead)
-        assertNomadChangeLogPersisted(arrangement.database)
+        assertPersisted(arrangement.database, persistedLastRead)
+        assertNomadChangeLogNotPersisted(arrangement.database)
     }
 
     @Test
@@ -225,6 +226,12 @@ class UpdateConversationReadDateUseCaseIntegrationTest {
         val metadataChange = pendingChanges.singleOrNull { it.eventType == ChangeLogEventType.CONVERSATION_METADATA_SYNC }
         assertNotNull(metadataChange)
         assertEquals(TestConversation.ENTITY_GROUP.id, metadataChange.conversationId)
+    }
+
+    private suspend fun assertNomadChangeLogNotPersisted(database: TestUserDatabase) {
+        val pendingChanges = database.builder.remoteBackupChangeLogDAO.getPendingChanges()
+        val metadataChange = pendingChanges.singleOrNull { it.eventType == ChangeLogEventType.CONVERSATION_METADATA_SYNC }
+        assertNull(metadataChange)
     }
 
     private data class Arrangement(

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCaseIntegrationTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCaseIntegrationTest.kt
@@ -1,0 +1,277 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.logger.kaliumLogger
+import com.wire.kalium.logic.cache.SelfConversationIdProvider
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationDataSource
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.CurrentClientIdProvider
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.message.MessageOperationResult
+import com.wire.kalium.logic.feature.message.receipt.ParallelConversationWorkQueue
+import com.wire.kalium.logic.feature.message.receipt.SendConfirmationUseCase
+import com.wire.kalium.logic.framework.TestClient
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.util.stubs.ClientApiStub
+import com.wire.kalium.logic.util.stubs.ConversationApiStub
+import com.wire.kalium.messaging.hooks.PersistenceEventHookNotifier
+import com.wire.kalium.messaging.sending.BroadcastMessage
+import com.wire.kalium.messaging.sending.BroadcastMessageTarget
+import com.wire.kalium.messaging.sending.MessageSender
+import com.wire.kalium.nomaddevice.NomadAuthenticatedNetworkAccess
+import com.wire.kalium.nomaddevice.NomadRemoteBackupDebouncedSyncConfig
+import com.wire.kalium.nomaddevice.createUserScopedDebouncedNomadRemoteBackupChangeLogHookNotifier
+import com.wire.kalium.persistence.TestUserDatabase
+import com.wire.kalium.persistence.dao.UserIDEntity
+import com.wire.kalium.persistence.dao.backup.ChangeLogEventType
+import com.wire.kalium.usernetwork.di.PlatformUserAuthenticatedNetworkProvider
+import com.wire.kalium.userstorage.di.DatabaseStorageType
+import com.wire.kalium.userstorage.di.PlatformUserStorageProperties
+import com.wire.kalium.userstorage.di.UserStorage
+import com.wire.kalium.userstorage.di.UserStorageProvider
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class UpdateConversationReadDateUseCaseIntegrationTest {
+
+    private val selfUserId = TestUser.SELF.id
+    private val testUserIdEntity = UserIDEntity(selfUserId.value, selfUserId.domain)
+    private val conversationId = TestConversation.GROUP().id
+
+    private var testDatabase: TestUserDatabase? = null
+
+    @AfterTest
+    fun tearDown() {
+        testDatabase?.delete()
+    }
+
+    @Test
+    fun givenQueuedLastRead_whenSessionScopeCancelledDuringDebounce_thenLastReadAndNomadChangeLogArePersisted() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val persistedLastRead = stableNow()
+        val newLastRead = persistedLastRead + 1.seconds
+        val arrangement = arrange(dispatcher, persistedLastRead)
+
+        arrangement.subject(conversationId, newLastRead)
+        runCurrent()
+
+        advanceTimeBy(1.seconds)
+        arrangement.sessionScope.cancel()
+        runCurrent()
+        advanceUntilIdle()
+
+        assertPersisted(arrangement.database, newLastRead)
+        assertNomadChangeLogPersisted(arrangement.database)
+    }
+
+    @Test
+    fun givenQueuedLastRead_whenSessionScopeCancelledDuringDurablePersistence_thenLastReadAndNomadChangeLogArePersisted() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val persistedLastRead = stableNow()
+        val newLastRead = persistedLastRead + 1.seconds
+        val arrangement = arrange(
+            dispatcher = dispatcher,
+            persistedLastRead = persistedLastRead,
+            wrapRepository = { repository, sessionScope ->
+                object : ConversationRepository by repository {
+                    private var didCancel = false
+
+                    override suspend fun updateConversationReadDate(qualifiedID: QualifiedID, date: Instant): Either<StorageFailure, Unit> {
+                        if (!didCancel) {
+                            didCancel = true
+                            sessionScope.cancel()
+                        }
+                        return repository.updateConversationReadDate(qualifiedID, date)
+                    }
+                }
+            }
+        )
+
+        arrangement.subject(conversationId, newLastRead)
+        runCurrent()
+        advanceTimeBy(3.seconds + 1.milliseconds)
+        runCurrent()
+        advanceUntilIdle()
+
+        assertPersisted(arrangement.database, newLastRead)
+        assertNomadChangeLogPersisted(arrangement.database)
+    }
+
+    private suspend fun arrange(
+        dispatcher: TestDispatcher,
+        persistedLastRead: Instant,
+        wrapRepository: (ConversationRepository, TestScope) -> ConversationRepository = { repository, _ -> repository }
+    ): Arrangement {
+        val database = TestUserDatabase(testUserIdEntity, dispatcher)
+        testDatabase = database
+        database.builder.conversationDAO.insertConversation(
+            TestConversation.ENTITY_GROUP.copy(lastReadDate = persistedLastRead)
+        )
+
+        val sessionScope = TestScope(dispatcher)
+        val repository = wrapRepository(createRepository(database, persistedLastRead), sessionScope)
+        val hookNotifier = createPersistenceHookNotifier(database, sessionScope)
+        val queue = ParallelConversationWorkQueue(sessionScope, kaliumLogger, dispatcher)
+
+        return Arrangement(
+            database = database,
+            sessionScope = sessionScope,
+            subject = UpdateConversationReadDateUseCase(
+                conversationRepository = repository,
+                messageSender = FakeMessageSender(),
+                currentClientIdProvider = CurrentClientIdProvider { Either.Right(TestClient.CLIENT_ID) },
+                selfUserId = selfUserId,
+                selfConversationIdProvider = SelfConversationIdProvider { Either.Right(emptyList()) },
+                sendConfirmation = object : SendConfirmationUseCase {
+                    override suspend fun invoke(
+                        conversationId: ConversationId,
+                        afterDateTime: Instant,
+                        untilDateTime: Instant
+                    ): MessageOperationResult = MessageOperationResult.Success
+                },
+                workQueue = queue,
+                persistenceEventHookNotifier = hookNotifier,
+                logger = kaliumLogger
+            )
+        )
+    }
+
+    private fun createRepository(database: TestUserDatabase, persistedLastRead: Instant): ConversationRepository {
+        val delegate = ConversationDataSource(
+            selfUserId = selfUserId,
+            conversationDAO = database.builder.conversationDAO,
+            memberDAO = database.builder.memberDAO,
+            conversationApi = ConversationApiStub(),
+            messageDAO = database.builder.messageDAO,
+            messageDraftDAO = database.builder.messageDraftDAO,
+            clientDAO = database.builder.clientDAO,
+            clientApi = ClientApiStub(),
+            conversationMetaDataDAO = database.builder.conversationMetaDataDAO,
+        )
+        val observedConversation = TestConversation.GROUP().copy(lastReadDate = persistedLastRead)
+        return object : ConversationRepository by delegate {
+            override suspend fun observeConversationById(conversationId: ConversationId): Flow<Either<StorageFailure, Conversation>> =
+                flowOf(Either.Right(observedConversation))
+        }
+    }
+
+    private fun createPersistenceHookNotifier(
+        database: TestUserDatabase,
+        sessionScope: TestScope
+    ): PersistenceEventHookNotifier {
+        val userStorageProvider = TestUserStorageProvider(selfUserId, database)
+        return createUserScopedDebouncedNomadRemoteBackupChangeLogHookNotifier(
+            selfUserId = selfUserId,
+            userStorageProvider = userStorageProvider,
+            nomadAuthenticatedNetworkAccess = NomadAuthenticatedNetworkAccess(PlatformUserAuthenticatedNetworkProvider()),
+            scope = sessionScope,
+            config = NomadRemoteBackupDebouncedSyncConfig(
+                debounceMs = 1_000L,
+                maxWaitMs = 3_000L,
+                maxAttemptsTotal = 1,
+                retryDelaysMs = emptyList()
+            )
+        )
+    }
+
+    private suspend fun assertPersisted(database: TestUserDatabase, expectedLastRead: Instant) {
+        val persistedConversation = database.builder.conversationDAO.getConversationById(TestConversation.ENTITY_GROUP.id)
+        assertNotNull(persistedConversation)
+        assertEquals(expectedLastRead, persistedConversation.lastReadDate)
+    }
+
+    private suspend fun assertNomadChangeLogPersisted(database: TestUserDatabase) {
+        val pendingChanges = database.builder.remoteBackupChangeLogDAO.getPendingChanges()
+        val metadataChange = pendingChanges.singleOrNull { it.eventType == ChangeLogEventType.CONVERSATION_METADATA_SYNC }
+        assertNotNull(metadataChange)
+        assertEquals(TestConversation.ENTITY_GROUP.id, metadataChange.conversationId)
+    }
+
+    private data class Arrangement(
+        val database: TestUserDatabase,
+        val sessionScope: TestScope,
+        val subject: UpdateConversationReadDateUseCase,
+    )
+
+    private fun stableNow(): Instant = Instant.fromEpochMilliseconds(Clock.System.now().toEpochMilliseconds())
+
+    private class TestUserStorageProvider(
+        userId: UserId,
+        private val database: TestUserDatabase
+    ) : UserStorageProvider() {
+
+        init {
+            getOrCreate(
+                userId = userId,
+                platformUserStorageProperties = PlatformUserStorageProperties(
+                    rootPath = "",
+                    databaseInfo = DatabaseStorageType.InMemory
+                ),
+                shouldEncryptData = false,
+                dbInvalidationControlEnabled = false
+            )
+        }
+
+        override fun create(
+            userId: UserId,
+            shouldEncryptData: Boolean,
+            platformProperties: PlatformUserStorageProperties,
+            dbInvalidationControlEnabled: Boolean
+        ): UserStorage = UserStorage(database.builder)
+    }
+
+    private class FakeMessageSender : MessageSender {
+        override suspend fun sendPendingMessage(conversationId: ConversationId, messageUuid: String): Either<CoreFailure, Unit> =
+            Either.Right(Unit)
+
+        override suspend fun sendMessage(
+            message: Message.Sendable,
+            messageTarget: com.wire.kalium.messaging.sending.MessageTarget
+        ): Either<CoreFailure, Unit> = Either.Right(Unit)
+
+        override suspend fun broadcastMessage(
+            message: BroadcastMessage,
+            target: BroadcastMessageTarget
+        ): Either<CoreFailure, Unit> = Either.Right(Unit)
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25143
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

follow up on https://github.com/wireapp/kalium/pull/4093

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
