### PR TITLE
fix(mls): map Apple CoreCrypto MLS exceptions [WPB-8645]

### DIFF
--- a/core/common/src/appleMain/kotlin/com/wire/kalium/common/error/CoreCryptoExceptionMapper.kt
+++ b/core/common/src/appleMain/kotlin/com/wire/kalium/common/error/CoreCryptoExceptionMapper.kt
@@ -17,9 +17,49 @@
  */
 package com.wire.kalium.common.error
 
-actual fun commonizeMLSException(
-    exception: Exception
-): CommonizedMLSException = CommonizedMLSException(
-    failure = MLSFailure.Generic(exception),
-    cause = NotImplementedError("CoreCrypto(Apple) exception mapping was not implemented")
-)
+import com.wire.crypto.CoreCryptoException
+import com.wire.crypto.MlsException
+
+@Suppress("CyclomaticComplexMethod")
+actual fun commonizeMLSException(exception: Exception): CommonizedMLSException {
+    return if (exception is CoreCryptoException.Mls) {
+        when (val mlsError = exception.mlsError) {
+            is MlsException.WrongEpoch -> MLSFailure.WrongEpoch
+            is MlsException.DuplicateMessage -> MLSFailure.DuplicateMessage
+            is MlsException.BufferedFutureMessage -> MLSFailure.BufferedFutureMessage
+            is MlsException.SelfCommitIgnored -> MLSFailure.SelfCommitIgnored
+            is MlsException.UnmergedPendingGroup -> MLSFailure.UnmergedPendingGroup
+            is MlsException.StaleProposal -> MLSFailure.StaleProposal
+            is MlsException.StaleCommit -> MLSFailure.StaleCommit
+            is MlsException.ConversationAlreadyExists -> MLSFailure.ConversationAlreadyExists
+            is MlsException.MessageEpochTooOld -> MLSFailure.MessageEpochTooOld
+
+            is MlsException.Other -> {
+                val otherError = mlsError.msg
+                if (otherError.startsWith(COMMIT_FOR_MISSING_PROPOSAL)) {
+                    MLSFailure.CommitForMissingProposal
+                } else if (otherError.startsWith(CONVERSATION_NOT_FOUND)) {
+                    MLSFailure.ConversationNotFound
+                } else if (otherError.startsWith(INVALID_GROUP_ID)) {
+                    MLSFailure.InvalidGroupId
+                } else {
+                    MLSFailure.Other(mlsError.msg)
+                }
+            }
+
+            is MlsException.OrphanWelcome -> MLSFailure.OrphanWelcome
+            is MlsException.BufferedCommit -> MLSFailure.BufferedCommit
+            is MlsException.MessageRejected -> mapMessageRejected(mlsError)
+        }
+    } else {
+        MLSFailure.Generic(exception)
+    }.run { CommonizedMLSException(this, exception) }
+}
+
+private fun mapMessageRejected(mlsError: MlsException.MessageRejected): MLSFailure {
+    return MLSTransportFailureSerialization.parseString(mlsError.reason)
+}
+
+private const val COMMIT_FOR_MISSING_PROPOSAL = "Incoming message is a commit for which we have not yet received all the proposals"
+private const val CONVERSATION_NOT_FOUND = "Couldn't find conversation"
+private const val INVALID_GROUP_ID = "Message group ID differs from the group's group ID"

--- a/core/common/src/appleTest/kotlin/com/wire/kalium/common/error/CoreCryptoExceptionMapperAppleTest.kt
+++ b/core/common/src/appleTest/kotlin/com/wire/kalium/common/error/CoreCryptoExceptionMapperAppleTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.common.error
+
+import com.wire.crypto.CoreCryptoException
+import com.wire.crypto.MlsException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class CoreCryptoExceptionMapperAppleTest {
+
+    @Test
+    fun givenOrphanWelcomeException_whenCommonizing_thenMapsToOrphanWelcomeFailure() {
+        val result = commonizeMLSException(CoreCryptoException.Mls(MlsException.OrphanWelcome()))
+
+        assertEquals(MLSFailure.OrphanWelcome, result.failure)
+        assertIs<CoreCryptoException.Mls>(result.cause)
+    }
+
+    @Test
+    fun givenConversationNotFoundOtherException_whenCommonizing_thenMapsToConversationNotFoundFailure() {
+        val result = commonizeMLSException(
+            CoreCryptoException.Mls(MlsException.Other("Couldn't find conversation for orphan welcome replay"))
+        )
+
+        assertEquals(MLSFailure.ConversationNotFound, result.failure)
+        assertIs<CoreCryptoException.Mls>(result.cause)
+    }
+
+    @Test
+    fun givenMessageRejectedException_whenCommonizing_thenPreservesRejectedReason() {
+        val serializedReason = MLSTransportFailureSerialization.serialize(
+            NetworkFailure.MlsMessageRejectedFailure.InvalidLeafNodeSignature
+        )
+
+        val result = commonizeMLSException(CoreCryptoException.Mls(MlsException.MessageRejected(serializedReason)))
+
+        assertEquals(
+            MLSFailure.MessageRejected(NetworkFailure.MlsMessageRejectedFailure.InvalidLeafNodeSignature),
+            result.failure,
+        )
+        assertIs<CoreCryptoException.Mls>(result.cause)
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8645
<!--jira-description-action-hidden-marker-end-->
## Summary
- implement the Apple `commonizeMLSException` mapper to match the existing JVM/Android MLS failure mapping
- restore native handling for concrete MLS failures such as `OrphanWelcome`, `ConversationNotFound`, `InvalidGroupId`, and serialized `MessageRejected` reasons
- add Apple regression coverage for the orphan welcome, conversation-not-found, and message-rejected paths

## Verification
- ./gradlew :core:common:macosArm64Test --tests \"com.wire.kalium.common.error.CoreCryptoExceptionMapperAppleTest\" -PUSE_UNIFIED_CORE_CRYPTO=true
- ./gradlew detekt -PUSE_UNIFIED_CORE_CRYPTO=true