### PR TITLE
fix: iOS Mockative matcher placeholders in logic tests [WPB-23964]

### DIFF
--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/provider/CryptoTransactionProviderArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/provider/CryptoTransactionProviderArrangement.kt
@@ -119,7 +119,10 @@ internal class CryptoTransactionProviderArrangementMockativeImpl : CryptoTransac
 
     override suspend fun <R> withTransactionReturning(result: Either<CoreFailure, R>): CryptoTransactionProviderArrangement = apply {
         coEvery {
-            cryptoTransactionProvider.transaction<R>(any(), any())
+            cryptoTransactionProvider.transaction<R>(
+                any(null),
+                any<suspend (CryptoTransactionContext) -> Either<CoreFailure, R>> { result }
+            )
         }.invokes { args ->
             @Suppress("UNCHECKED_CAST")
             val block = args[1] as suspend (CryptoTransactionContext) -> Either<CoreFailure, R>
@@ -131,7 +134,10 @@ internal class CryptoTransactionProviderArrangementMockativeImpl : CryptoTransac
         result: Either<CoreFailure, R>
     ): CryptoTransactionProviderArrangement = apply {
         coEvery {
-            cryptoTransactionProvider.proteusTransaction<R>(any(), any())
+            cryptoTransactionProvider.proteusTransaction<R>(
+                any(null),
+                any<suspend (ProteusCoreCryptoContext) -> Either<CoreFailure, R>> { result }
+            )
         }.invokes { args ->
             @Suppress("UNCHECKED_CAST")
             val block = args[1] as suspend (ProteusCoreCryptoContext) -> Either<CoreFailure, R>
@@ -143,13 +149,19 @@ internal class CryptoTransactionProviderArrangementMockativeImpl : CryptoTransac
         result: Either<CoreFailure, R>
     ): CryptoTransactionProviderArrangement = apply {
         coEvery {
-            cryptoTransactionProvider.proteusTransaction<R>(any(), any())
+            cryptoTransactionProvider.proteusTransaction<R>(
+                any(null),
+                any<suspend (ProteusCoreCryptoContext) -> Either<CoreFailure, R>> { result }
+            )
         }.returns(result)
     }
 
     override suspend fun <R> withMLSTransactionReturning(result: Either<CoreFailure, R>): CryptoTransactionProviderArrangement = apply {
         coEvery {
-            cryptoTransactionProvider.mlsTransaction<R>(any(), any())
+            cryptoTransactionProvider.mlsTransaction<R>(
+                any(null),
+                any<suspend (MlsCoreCryptoContext) -> Either<CoreFailure, R>> { result }
+            )
         }.invokes { args ->
             @Suppress("UNCHECKED_CAST")
             val block = args[1] as suspend (MlsCoreCryptoContext) -> Either<CoreFailure, R>

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/ClientRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/ClientRepositoryArrangement.kt
@@ -34,6 +34,9 @@ import io.mockative.matchers.Matcher
 import io.mockative.matches
 import io.mockative.mock
 
+private val MOCKATIVE_USER_ID = UserId("mockative-user", "mockative.test")
+private val MOCKATIVE_CLIENT_ID = ClientId("mockative-client")
+
 internal interface ClientRepositoryArrangement {
     val clientRepository: ClientRepository
 
@@ -46,7 +49,7 @@ internal interface ClientRepositoryArrangement {
 
     suspend fun withStoreUserClientIdList(
         result: Either<StorageFailure, Unit>,
-        userId: Matcher<UserId> = AnyMatcher(valueOf()),
+        userId: Matcher<UserId> = AnyMatcher(MOCKATIVE_USER_ID),
         clientIds: Matcher<List<ClientId>> = AnyMatcher(valueOf())
     )
 
@@ -69,13 +72,13 @@ internal open class ClientRepositoryArrangementImpl : ClientRepositoryArrangemen
 
     override suspend fun withUpdateClientProteusVerificationStatus(result: Either<StorageFailure, Unit>) = apply {
         coEvery {
-            clientRepository.updateClientProteusVerificationStatus(any(), any(), any())
+            clientRepository.updateClientProteusVerificationStatus(any(MOCKATIVE_USER_ID), any(MOCKATIVE_CLIENT_ID), any())
         }.returns(result)
     }
 
     override suspend fun withClientsByUserId(result: Either<StorageFailure, List<OtherUserClient>>) = apply {
         coEvery {
-            clientRepository.getClientsByUserId(any())
+            clientRepository.getClientsByUserId(any(MOCKATIVE_USER_ID))
         }.returns(result)
     }
 
@@ -94,7 +97,10 @@ internal open class ClientRepositoryArrangementImpl : ClientRepositoryArrangemen
         clientIds: Matcher<List<ClientId>>
     ) {
         coEvery {
-            clientRepository.storeUserClientIdList(any(), any())
+            clientRepository.storeUserClientIdList(
+                matches(MOCKATIVE_USER_ID) { userId.matches(it) },
+                matches(emptyList()) { clientIds.matches(it) }
+            )
         }.returns(result)
     }
 
@@ -112,7 +118,7 @@ internal open class ClientRepositoryArrangementImpl : ClientRepositoryArrangemen
         clients: Matcher<List<InsertClientParam>>
     ) {
         coEvery {
-            clientRepository.storeUserClientListAndRemoveRedundantClients(any())
+            clientRepository.storeUserClientListAndRemoveRedundantClients(matches(emptyList()) { clients.matches(it) })
         }.returns(result)
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/ConversationRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/ConversationRepositoryArrangement.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.mls.EpochChangesData
 import com.wire.kalium.logic.data.conversation.mls.NameAndHandle
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.framework.TestConversation
@@ -41,6 +42,12 @@ import io.mockative.matchers.Matcher
 import io.mockative.matches
 import io.mockative.mock
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.datetime.Instant
+
+private val MOCKATIVE_CONVERSATION_ID = ConversationId("mockative-conversation", "mockative.test")
+private val MOCKATIVE_USER_ID = UserId("mockative-user", "mockative.test")
+private val MOCKATIVE_GROUP_ID = GroupID("mockative-group")
+private val MOCKATIVE_INSTANT = Instant.fromEpochMilliseconds(0)
 
 internal interface ConversationRepositoryArrangement {
     val conversationRepository: ConversationRepository
@@ -55,10 +62,10 @@ internal interface ConversationRepositoryArrangement {
         domain: Matcher<String> = AnyMatcher(valueOf())
     )
 
-    suspend fun withSetConversationDeletedLocallySucceeding(conversationId: Matcher<ConversationId> = AnyMatcher(valueOf()))
-    suspend fun withSetConversationDeletedLocallyFailing(conversationId: Matcher<ConversationId> = AnyMatcher(valueOf()))
-    suspend fun withDeletingConversationLocallySucceeding(conversationId: Matcher<ConversationId> = AnyMatcher(valueOf()))
-    suspend fun withDeletingConversationLocallyFailing(conversationId: Matcher<ConversationId> = AnyMatcher(valueOf()))
+    suspend fun withSetConversationDeletedLocallySucceeding(conversationId: Matcher<ConversationId> = AnyMatcher(MOCKATIVE_CONVERSATION_ID))
+    suspend fun withSetConversationDeletedLocallyFailing(conversationId: Matcher<ConversationId> = AnyMatcher(MOCKATIVE_CONVERSATION_ID))
+    suspend fun withDeletingConversationLocallySucceeding(conversationId: Matcher<ConversationId> = AnyMatcher(MOCKATIVE_CONVERSATION_ID))
+    suspend fun withDeletingConversationLocallyFailing(conversationId: Matcher<ConversationId> = AnyMatcher(MOCKATIVE_CONVERSATION_ID))
     suspend fun withGetConversationByIdReturning(conversation: Conversation? = TestConversation.CONVERSATION)
     suspend fun withSetInformedAboutDegradedMLSVerificationFlagResult(result: Either<StorageFailure, Unit> = Either.Right(Unit))
     suspend fun withInformedAboutDegradedMLSVerification(isInformed: Either<StorageFailure, Boolean>): ConversationRepositoryArrangement
@@ -86,13 +93,16 @@ internal interface ConversationRepositoryArrangement {
 
     suspend fun withUpdateGroupStateReturning(result: Either<StorageFailure, Unit>) {
         coEvery {
-            conversationRepository.updateConversationGroupState(any(), any())
+            conversationRepository.updateConversationGroupState(
+                any(MOCKATIVE_GROUP_ID),
+                any(Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN)
+            )
         }.returns(result)
     }
 
     suspend fun withUpdateConversationModifiedDate(result: Either<StorageFailure, Unit>) {
         coEvery {
-            conversationRepository.updateConversationModifiedDate(any(), any())
+            conversationRepository.updateConversationModifiedDate(any(MOCKATIVE_CONVERSATION_ID), any(MOCKATIVE_INSTANT))
         }.returns(result)
     }
 
@@ -137,109 +147,109 @@ internal open class ConversationRepositoryArrangementImpl : ConversationReposito
 
     override suspend fun withSetConversationDeletedLocallySucceeding(conversationId: Matcher<ConversationId>) {
         coEvery {
-            conversationRepository.setConversationDeletedLocally(matches { conversationId.matches(it) }, any())
+            conversationRepository.setConversationDeletedLocally(matches(MOCKATIVE_CONVERSATION_ID) { conversationId.matches(it) }, any())
         }.returns(Either.Right(Unit))
     }
 
     override suspend fun withSetConversationDeletedLocallyFailing(conversationId: Matcher<ConversationId>) {
         coEvery {
-            conversationRepository.setConversationDeletedLocally(matches { conversationId.matches(it) }, any())
+            conversationRepository.setConversationDeletedLocally(matches(MOCKATIVE_CONVERSATION_ID) { conversationId.matches(it) }, any())
         }.returns(Either.Left(CoreFailure.Unknown(RuntimeException("some error"))))
     }
 
     override suspend fun withDeletingConversationLocallySucceeding(conversationId: Matcher<ConversationId>) {
         coEvery {
-            conversationRepository.deleteConversationLocally(matches { conversationId.matches(it) })
+            conversationRepository.deleteConversationLocally(matches(MOCKATIVE_CONVERSATION_ID) { conversationId.matches(it) })
         }.returns(Either.Right(true))
     }
 
     override suspend fun withDeletingConversationLocallyFailing(conversationId: Matcher<ConversationId>) {
         coEvery {
-            conversationRepository.deleteConversationLocally(matches { conversationId.matches(it) })
+            conversationRepository.deleteConversationLocally(matches(MOCKATIVE_CONVERSATION_ID) { conversationId.matches(it) })
         }.returns(Either.Left(CoreFailure.Unknown(RuntimeException("some error"))))
     }
 
     override suspend fun withSetInformedAboutDegradedMLSVerificationFlagResult(result: Either<StorageFailure, Unit>) {
         coEvery {
-            conversationRepository.setInformedAboutDegradedMLSVerificationFlag(any(), any())
+            conversationRepository.setInformedAboutDegradedMLSVerificationFlag(any(MOCKATIVE_CONVERSATION_ID), any())
         }.returns(result)
     }
 
     override suspend fun withInformedAboutDegradedMLSVerification(isInformed: Either<StorageFailure, Boolean>) = apply {
         coEvery {
-            conversationRepository.isInformedAboutDegradedMLSVerification(any())
+            conversationRepository.isInformedAboutDegradedMLSVerification(any(MOCKATIVE_CONVERSATION_ID))
         }.returns(isInformed)
     }
 
     override suspend fun withConversationProtocolInfo(result: Either<StorageFailure, Conversation.ProtocolInfo>) = apply {
         coEvery {
-            conversationRepository.getConversationProtocolInfo(any())
+            conversationRepository.getConversationProtocolInfo(any(MOCKATIVE_CONVERSATION_ID))
         }.returns(result)
     }
 
     override suspend fun withUpdateVerificationStatus(result: Either<StorageFailure, Unit>) = apply {
         coEvery {
-            conversationRepository.updateMlsVerificationStatus(any(), any())
+            conversationRepository.updateMlsVerificationStatus(any(Conversation.VerificationStatus.NOT_VERIFIED), any(MOCKATIVE_CONVERSATION_ID))
         }.returns(result)
     }
 
     override suspend fun withConversationByMLSGroupId(result: Either<StorageFailure, Conversation>) = apply {
         coEvery {
-            conversationRepository.getConversationByMLSGroupId(any())
+            conversationRepository.getConversationByMLSGroupId(any(MOCKATIVE_GROUP_ID))
         }.returns(result)
     }
 
     override suspend fun withUpdateProtocolLocally(result: Either<CoreFailure, ConversationProtocolUpdateStatus>) {
         coEvery {
-            conversationRepository.updateProtocolLocally(any(), any())
+            conversationRepository.updateProtocolLocally(any(MOCKATIVE_CONVERSATION_ID), any(Conversation.Protocol.PROTEUS))
         }.returns(result)
     }
 
     override suspend fun withConversationsForUserIdReturning(result: Either<CoreFailure, List<Conversation>>) {
         coEvery {
-            conversationRepository.getConversationsByUserId(any())
+            conversationRepository.getConversationsByUserId(any(MOCKATIVE_USER_ID))
         }.returns(result)
     }
 
     override suspend fun withFetchMlsOneToOneConversation(result: Either<CoreFailure, ConversationResponse>) {
         coEvery {
-            conversationRepository.fetchMlsOneToOneConversation(any())
+            conversationRepository.fetchMlsOneToOneConversation(any(MOCKATIVE_USER_ID))
         }.returns(result)
     }
 
     override suspend fun withObserveOneToOneConversationWithOtherUserReturning(result: Either<CoreFailure, Conversation>) {
         coEvery {
-            conversationRepository.observeOneToOneConversationWithOtherUser(any())
+            conversationRepository.observeOneToOneConversationWithOtherUser(any(MOCKATIVE_USER_ID))
         }.returns(flowOf(result))
     }
 
     override suspend fun withObserveConversationDetailsByIdReturning(vararg results: Either<StorageFailure, ConversationDetails>) {
         coEvery {
-            conversationRepository.observeConversationDetailsById(any())
+            conversationRepository.observeConversationDetailsById(any(MOCKATIVE_CONVERSATION_ID))
         }.returns(flowOf(*results))
     }
 
     override suspend fun withGetConversationIdsReturning(result: Either<StorageFailure, List<QualifiedID>>) {
         coEvery {
-            conversationRepository.getConversationIds(any(), any())
+            conversationRepository.getConversationIds(any(TestConversation.CONVERSATION.type), any(Conversation.Protocol.PROTEUS))
         }.returns(result)
     }
 
     override suspend fun withGetOneOnOneConversationsWithOtherUserReturning(result: Either<StorageFailure, List<QualifiedID>>) {
         coEvery {
-            conversationRepository.getOneOnOneConversationsWithOtherUser(any(), any())
+            conversationRepository.getOneOnOneConversationsWithOtherUser(any(MOCKATIVE_USER_ID), any(Conversation.Protocol.PROTEUS))
         }.returns(result)
     }
 
     override suspend fun withGetConversationProtocolInfo(result: Either<StorageFailure, Conversation.ProtocolInfo>) {
         coEvery {
-            conversationRepository.getConversationProtocolInfo(any())
+            conversationRepository.getConversationProtocolInfo(any(MOCKATIVE_CONVERSATION_ID))
         }.returns(result)
     }
 
     override suspend fun withGetConversationByIdReturning(conversation: Conversation?) {
         coEvery {
-            conversationRepository.getConversationById(any())
+            conversationRepository.getConversationById(any(MOCKATIVE_CONVERSATION_ID))
         }.returns(
             if (conversation != null) Either.Right(conversation)
             else Either.Left(StorageFailure.DataNotFound)
@@ -248,35 +258,35 @@ internal open class ConversationRepositoryArrangementImpl : ConversationReposito
 
     override suspend fun withSetDegradedConversationNotifiedFlag(result: Either<CoreFailure, Unit>) {
         coEvery {
-            conversationRepository.setDegradedConversationNotifiedFlag(any(), any())
+            conversationRepository.setDegradedConversationNotifiedFlag(any(MOCKATIVE_CONVERSATION_ID), any())
         }.returns(result)
     }
 
     override suspend fun withSelectGroupStatusMembersNamesAndHandles(result: Either<StorageFailure, EpochChangesData>) {
         coEvery {
-            conversationRepository.getGroupStatusMembersNamesAndHandles(any())
+            conversationRepository.getGroupStatusMembersNamesAndHandles(any(MOCKATIVE_GROUP_ID))
         }.returns(result)
     }
 
     override suspend fun withConversationDetailsByIdReturning(result: Either<StorageFailure, Conversation>) {
         coEvery {
-            conversationRepository.getConversationById(any())
+            conversationRepository.getConversationById(any(MOCKATIVE_CONVERSATION_ID))
         }.returns(result)
     }
 
     override suspend fun withPersistMembers(result: Either<StorageFailure, Unit>) {
-        coEvery { conversationRepository.persistMembers(any(), any()) }.returns(result)
+        coEvery { conversationRepository.persistMembers(any(emptyList()), any(MOCKATIVE_CONVERSATION_ID)) }.returns(result)
     }
 
     override suspend fun withMembersNameAndHandle(result: Either<StorageFailure, Map<UserId, NameAndHandle>>) {
-        coEvery { conversationRepository.selectMembersNameAndHandle(any()) }.returns(result)
+        coEvery { conversationRepository.selectMembersNameAndHandle(any(MOCKATIVE_CONVERSATION_ID)) }.returns(result)
     }
 
     override suspend fun withClearContentSucceeding() {
-        coEvery { conversationRepository.clearContent(any()) }.returns(Either.Right(Unit))
+        coEvery { conversationRepository.clearContent(any(MOCKATIVE_CONVERSATION_ID)) }.returns(Either.Right(Unit))
     }
 
     override suspend fun withGetConversationMembers(result: List<UserId>) {
-        coEvery { conversationRepository.getConversationMembers(any()) }.returns(Either.Right(result))
+        coEvery { conversationRepository.getConversationMembers(any(MOCKATIVE_CONVERSATION_ID)) }.returns(Either.Right(result))
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/UserRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/UserRepositoryArrangement.kt
@@ -22,8 +22,10 @@ import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.mls.NameAndHandle
+import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.User
@@ -32,7 +34,6 @@ import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.framework.TestUser
 import io.mockative.any
 import io.mockative.coEvery
-import io.mockative.fake.valueOf
 import io.mockative.matchers.AnyMatcher
 import io.mockative.matchers.Matcher
 import io.mockative.matches
@@ -40,11 +41,28 @@ import io.mockative.mock
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 
+private val MOCKATIVE_USER_ID = UserId("mockative-user", "mockative.test")
+private val MOCKATIVE_CONVERSATION_ID = ConversationId("mockative-conversation", "mockative.test")
+private val MOCKATIVE_CLIENT_ID = ClientId("mockative-client")
+private val MOCKATIVE_TEAM_ID = TeamId("mockative-team")
+private val MOCKATIVE_USER_UPDATE_EVENT = Event.User.Update(
+    id = "mockative-event",
+    userId = MOCKATIVE_USER_ID,
+    accentId = null,
+    ssoIdDeleted = null,
+    name = null,
+    handle = null,
+    email = null,
+    previewAssetId = null,
+    completeAssetId = null,
+    supportedProtocols = null
+)
+
 @Suppress("INAPPLICABLE_JVM_NAME")
 internal interface UserRepositoryArrangement {
     val userRepository: UserRepository
-    suspend fun withDefederateUser(result: Either<CoreFailure, Unit>, userId: Matcher<UserId> = AnyMatcher(valueOf()))
-    suspend fun withObserveUser(result: Flow<User?> = flowOf(TestUser.OTHER), userId: Matcher<UserId> = AnyMatcher(valueOf()))
+    suspend fun withDefederateUser(result: Either<CoreFailure, Unit>, userId: Matcher<UserId> = AnyMatcher(MOCKATIVE_USER_ID))
+    suspend fun withObserveUser(result: Flow<User?> = flowOf(TestUser.OTHER), userId: Matcher<UserId> = AnyMatcher(MOCKATIVE_USER_ID))
 
     suspend fun withUpdateUserSuccess()
 
@@ -52,7 +70,7 @@ internal interface UserRepositoryArrangement {
 
     suspend fun withMarkUserAsDeletedAndRemoveFromGroupConversationsSuccess(
         result: List<ConversationId>,
-        userIdMatcher: Matcher<UserId> = AnyMatcher(valueOf())
+        userIdMatcher: Matcher<UserId> = AnyMatcher(MOCKATIVE_USER_ID)
     )
 
     suspend fun withSelfUserReturning(result: Either<StorageFailure, SelfUser>)
@@ -73,33 +91,33 @@ internal interface UserRepositoryArrangement {
 
     suspend fun withFetchUsersByIdReturning(
         result: Either<CoreFailure, Boolean>,
-        userIdList: Matcher<Set<UserId>> = AnyMatcher(valueOf())
+        userIdList: Matcher<Set<UserId>> = AnyMatcher(emptySet())
     )
 
     suspend fun withFetchUsersIfUnknownByIdsReturning(
         result: Either<CoreFailure, Unit>,
-        userIdList: Matcher<Set<UserId>> = AnyMatcher(valueOf())
+        userIdList: Matcher<Set<UserId>> = AnyMatcher(emptySet())
     )
 
     suspend fun withIsAtLeastOneUserATeamMember(
         result: Either<StorageFailure, Boolean>,
-        userIdList: Matcher<List<UserId>> = AnyMatcher(valueOf())
+        userIdList: Matcher<List<UserId>> = AnyMatcher(emptyList())
     )
 
     suspend fun withMarkAsDeleted(result: Either<StorageFailure, Unit>, userId: Matcher<List<UserId>>)
-    suspend fun withOneOnOnConversationId(result: Either<StorageFailure, ConversationId>, userId: Matcher<UserId> = AnyMatcher(valueOf()))
+    suspend fun withOneOnOnConversationId(result: Either<StorageFailure, ConversationId>, userId: Matcher<UserId> = AnyMatcher(MOCKATIVE_USER_ID))
     suspend fun withUpdateActiveOneOnOneConversationIfNotSet(
         result: Either<CoreFailure, Unit>,
-        userId: Matcher<UserId> = AnyMatcher(valueOf()),
-        conversationId: Matcher<ConversationId> = AnyMatcher(valueOf())
+        userId: Matcher<UserId> = AnyMatcher(MOCKATIVE_USER_ID),
+        conversationId: Matcher<ConversationId> = AnyMatcher(MOCKATIVE_CONVERSATION_ID)
     )
 
-    suspend fun withNameAndHandle(result: Either<StorageFailure, NameAndHandle>, userId: Matcher<UserId> = AnyMatcher(valueOf()))
+    suspend fun withNameAndHandle(result: Either<StorageFailure, NameAndHandle>, userId: Matcher<UserId> = AnyMatcher(MOCKATIVE_USER_ID))
 
     suspend fun withIsClientMlsCapable(
         result: Either<StorageFailure, Boolean>,
-        userId: Matcher<UserId> = AnyMatcher(valueOf()),
-        clientId: Matcher<ClientId> = AnyMatcher(valueOf())
+        userId: Matcher<UserId> = AnyMatcher(MOCKATIVE_USER_ID),
+        clientId: Matcher<ClientId> = AnyMatcher(MOCKATIVE_CLIENT_ID)
     )
 
     suspend fun withFetchSelfUser(result: Either<CoreFailure, Unit>)
@@ -121,25 +139,25 @@ internal open class UserRepositoryArrangementImpl : UserRepositoryArrangement {
         userId: Matcher<UserId>
     ) {
         coEvery {
-            userRepository.defederateUser(matches { userId.matches(it) })
+            userRepository.defederateUser(matches(MOCKATIVE_USER_ID) { userId.matches(it) })
         }.returns(result)
     }
 
     override suspend fun withObserveUser(result: Flow<User?>, userId: Matcher<UserId>) {
         coEvery {
-            userRepository.observeUser(matches { userId.matches(it) })
+            userRepository.observeUser(matches(MOCKATIVE_USER_ID) { userId.matches(it) })
         }.returns(result)
     }
 
     override suspend fun withUpdateUserSuccess() {
         coEvery {
-            userRepository.updateUserFromEvent(any())
+            userRepository.updateUserFromEvent(any(MOCKATIVE_USER_UPDATE_EVENT))
         }.returns(Either.Right(Unit))
     }
 
     override suspend fun withUpdateUserFailure(coreFailure: CoreFailure) {
         coEvery {
-            userRepository.updateUserFromEvent(any())
+            userRepository.updateUserFromEvent(any(MOCKATIVE_USER_UPDATE_EVENT))
         }.returns(Either.Left(coreFailure))
     }
 
@@ -147,7 +165,9 @@ internal open class UserRepositoryArrangementImpl : UserRepositoryArrangement {
         result: List<ConversationId>,
         userIdMatcher: Matcher<UserId>
     ) {
-        coEvery { userRepository.markUserAsDeletedAndRemoveFromGroupConversations(matches { userIdMatcher.matches(it) }) }
+        coEvery {
+            userRepository.markUserAsDeletedAndRemoveFromGroupConversations(matches(MOCKATIVE_USER_ID) { userIdMatcher.matches(it) })
+        }
             .returns(Either.Right(result))
     }
 
@@ -165,19 +185,19 @@ internal open class UserRepositoryArrangementImpl : UserRepositoryArrangement {
 
     override suspend fun withUserByIdReturning(result: Either<CoreFailure, OtherUser>) {
         coEvery {
-            userRepository.userById(any())
+            userRepository.userById(any(MOCKATIVE_USER_ID))
         }.returns(result)
     }
 
     override suspend fun withUpdateOneOnOneConversationReturning(result: Either<CoreFailure, Unit>) {
         coEvery {
-            userRepository.updateActiveOneOnOneConversation(any(), any())
+            userRepository.updateActiveOneOnOneConversation(any(MOCKATIVE_USER_ID), any(MOCKATIVE_CONVERSATION_ID))
         }.returns(result)
     }
 
     override suspend fun withGetKnownUserReturning(result: Flow<OtherUser?>) {
         coEvery {
-            userRepository.getKnownUser(any())
+            userRepository.getKnownUser(any(MOCKATIVE_USER_ID))
         }.returns(result)
     }
 
@@ -195,7 +215,7 @@ internal open class UserRepositoryArrangementImpl : UserRepositoryArrangement {
 
     override suspend fun withFetchUserInfoReturning(result: Either<CoreFailure, Unit>) {
         coEvery {
-            userRepository.fetchUserInfo(any())
+            userRepository.fetchUserInfo(any(MOCKATIVE_USER_ID))
         }.returns(result)
     }
 
@@ -204,30 +224,30 @@ internal open class UserRepositoryArrangementImpl : UserRepositoryArrangement {
         userIdList: Matcher<Set<UserId>>
     ) {
         coEvery {
-            userRepository.fetchUsersByIds(matches { userIdList.matches(it) })
+            userRepository.fetchUsersByIds(matches(emptySet()) { userIdList.matches(it) })
         }.returns(result)
     }
 
     override suspend fun withFetchUsersIfUnknownByIdsReturning(result: Either<CoreFailure, Unit>, userIdList: Matcher<Set<UserId>>) {
         coEvery {
-            userRepository.fetchUsersIfUnknownByIds(matches { userIdList.matches(it) })
+            userRepository.fetchUsersIfUnknownByIds(matches(emptySet()) { userIdList.matches(it) })
         }.returns(result)
     }
 
     override suspend fun withIsAtLeastOneUserATeamMember(result: Either<StorageFailure, Boolean>, userIdList: Matcher<List<UserId>>) {
         coEvery {
-            userRepository.isAtLeastOneUserATeamMember(matches { userIdList.matches(it) }, any())
+            userRepository.isAtLeastOneUserATeamMember(matches(emptyList()) { userIdList.matches(it) }, any(MOCKATIVE_TEAM_ID))
         }.returns(result)
     }
 
     override suspend fun withMarkAsDeleted(result: Either<StorageFailure, Unit>, userId: Matcher<List<UserId>>) {
         coEvery {
-            userRepository.markAsDeleted(matches { userId.matches(it) })
+            userRepository.markAsDeleted(matches(emptyList()) { userId.matches(it) })
         }.returns(result)
     }
 
     override suspend fun withOneOnOnConversationId(result: Either<StorageFailure, ConversationId>, userId: Matcher<QualifiedID>) {
-        coEvery { userRepository.getOneOnOnConversationId(matches { userId.matches(it) }) }
+        coEvery { userRepository.getOneOnOnConversationId(matches(MOCKATIVE_USER_ID) { userId.matches(it) }) }
             .returns(result)
     }
 
@@ -238,14 +258,14 @@ internal open class UserRepositoryArrangementImpl : UserRepositoryArrangement {
     ) {
         coEvery {
             userRepository.updateActiveOneOnOneConversationIfNotSet(
-                matches { userId.matches(it) },
-                matches { conversationId.matches(it) })
+                matches(MOCKATIVE_USER_ID) { userId.matches(it) },
+                matches(MOCKATIVE_CONVERSATION_ID) { conversationId.matches(it) })
         }
             .returns(result)
     }
 
     override suspend fun withNameAndHandle(result: Either<StorageFailure, NameAndHandle>, userId: Matcher<UserId>) {
-        coEvery { userRepository.getNameAndHandle(matches { userId.matches(it) }) }.returns(result)
+        coEvery { userRepository.getNameAndHandle(matches(MOCKATIVE_USER_ID) { userId.matches(it) }) }.returns(result)
     }
 
     override suspend fun withIsClientMlsCapable(
@@ -255,8 +275,8 @@ internal open class UserRepositoryArrangementImpl : UserRepositoryArrangement {
     ) {
         coEvery {
             userRepository.isClientMlsCapable(
-                userId = matches { userId.matches(it) },
-                clientId = matches { clientId.matches(it) }
+                userId = matches(MOCKATIVE_USER_ID) { userId.matches(it) },
+                clientId = matches(MOCKATIVE_CLIENT_ID) { clientId.matches(it) }
             )
         }.returns(result)
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-23964
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- iOS logic tests were failing during Mockative stubbing/verification with Kotlin/Native `ClassCastException`s, for example `Unit` being cast to `QualifiedID`, `ClientId`, or transaction block function types.

### Causes (Optional)

- Mockative’s parameterless `any()` / `matches { ... }` helpers rely on generated placeholder values.
- On Kotlin/Native, object placeholders can be produced as `Unit as T`, which now crashes before the matcher is evaluated.

### Solutions

- Replaced Native-unsafe wildcard matchers in shared logic test arrangements with concrete placeholder values passed to `any(...)` / `matches(...)`.
- Kept matcher semantics unchanged: placeholders are only used while Mockative records calls; actual matching still accepts the intended arguments.