### PR TITLE
chore: update kover version and adjust report configuration [WPB-8645]

### DIFF
--- a/.github/workflows/gradle-jvm-tests.yml
+++ b/.github/workflows/gradle-jvm-tests.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Test with Gradle
         run: |
-          ./gradlew jvmTest koverXmlReport -Djava.library.path=$LD_LIBRARY_PATH
+          ./gradlew jvmTest koverXmlReportJvmOnly -Djava.library.path=$LD_LIBRARY_PATH
           ./gradlew jsTest -PUSE_UNIFIED_CORE_CRYPTO=true
 
       - name: Archive Test Reports
@@ -98,13 +98,13 @@ jobs:
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: "build/reports/kover/report.xml"
+          files: "build/reports/kover/reportJvmOnly.xml"
 
       - name: Archive Kover report
         uses: actions/upload-artifact@v7
         with:
           name: kover-report
-          path: build/reports/kover/report.xml
+          path: build/reports/kover/reportJvmOnly.xml
 
       - name: Cleanup Gradle Cache
         # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.

--- a/.github/workflows/semantic-commit-lint.yml
+++ b/.github/workflows/semantic-commit-lint.yml
@@ -47,10 +47,14 @@ jobs:
           validateSingleCommit: true
       - name: Add Failure Label
         if: failure()
+        env:
+          REPO: ${{ github.repository }}
         run: |
           gh api repos/{owner}/{repo}/labels -f name="${CUSTOM_PR_LABEL}" -f color="FF0000" || true
-          gh pr edit "${HEAD}" --add-label "${CUSTOM_PR_LABEL}"
+          gh pr edit "${HEAD}" --repo "${REPO}" --add-label "${CUSTOM_PR_LABEL}"
       - name: Remove Failure Label
         if: success()
+        env:
+          REPO: ${{ github.repository }}
         run: |
-          gh pr edit "${HEAD}" --remove-label "${CUSTOM_PR_LABEL}"
+          gh pr edit "${HEAD}" --repo "${REPO}" --remove-label "${CUSTOM_PR_LABEL}"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -126,43 +126,30 @@ allprojects {
     }
 }
 
-kover {
-    useJacoco()
-}
-koverReport {
-    filters {
-        includes {
-            packages("com.wire.kalium")
-        }
-    }
-}
-
-fun Project.configureKover() {
-    pluginManager.apply("org.jetbrains.kotlinx.kover")
-
-    kover {
-        useJacoco()
-    }
-    koverReport {
-        filters {
-            includes {
-                packages("com.wire.kalium")
-            }
-        }
-    }
-}
-
 // We only want coverage reports of actual Kalium
 // Samples and other side-projects can have their own rules
-val modulesWithKover = subprojects.filter {
-    it.name !in setOf("buildSrc", "monkeys", "testservice", "cli", "android")
-}
-modulesWithKover.forEach {
-    it.configureKover()
-}
-dependencies {
-    modulesWithKover.forEach {
-        kover(project(it.path))
+val excludedFromCoverage = setOf("buildSrc", "monkeys", "testservice", "cli", "android")
+
+kover {
+    useJacoco()
+    merge {
+        // Aggregate coverage across all subprojects except samples/tools.
+        // Kover applies its plugin and configuration to each merged project automatically.
+        allProjects { project -> project.name !in excludedFromCoverage }
+        // Restrict the merged report to the JVM target only — Android variants would
+        // require the Android SDK at configuration time, which the JVM-only CI lacks.
+        createVariant("jvmOnly") {
+            add("jvm", optional = true)
+        }
+    }
+    reports {
+        variant("jvmOnly") {
+            filters {
+                includes {
+                    packages("com.wire.kalium")
+                }
+            }
+        }
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ androidx-sqlite = "2.6.2"
 ktx-datetime = { strictly = "0.6.1" }
 ktx-serialization = "1.8.1"
 ktx-atomicfu = "0.32.1"
-kover = "0.7.6"
+kover = "0.9.8"
 multiplatform-settings = "1.3.0"
 moduleGraph = "0.13.0"
 sqldelight = "2.2.1"


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8645
<!--jira-description-action-hidden-marker-end-->


# What's new in this PR?

### Issues

Android Studio Gradle sync executes `:logic:jvmTest` (and other `jvmTest` tasks) on every sync, slowing down project loading.

### Causes

Kover `0.7.6` with `useJacoco()` combined with cross-module aggregation (`dependencies { kover(project(...)) }`) produces a `koverGenerateArtifact` outgoing variant that depends on test task output. When AS resolves the `kover` configuration during sync to build the IDE dependency model, it transitively realizes and executes the test tasks (visible as `koverFindJar` → `jvmTest` in the sync log).

### Solutions

- Bumped Kover `0.7.6` → `0.9.8`. The newer version lazy-resolves coverage artifacts and decouples them from test execution at sync time.
- Migrated the report DSL from the removed `koverReport { … }` extension to the nested `kover { reports { … } }` form (Kover 0.9 API).
- Replaced the per-subproject `configureKover()` loop and root-level `kover(project(...))` aggregation with the new `kover { merge { ... } }` API. The merge block creates a custom `jvmOnly` variant that pulls only the JVM compilation, skipping Android variants entirely. This is required because Kover 0.9's default `koverXmlReport` aggregates **all** variants (including Android) and resolves `compileAndroidMain` at configuration time, which fails on the JVM-only CI container that has no Android SDK.
- Updated `gradle-jvm-tests.yml` to use `koverXmlReportJvmOnly` and the new report path `build/reports/kover/reportJvmOnly.xml`.

### Dependencies

_None._

### Testing

#### How to Test

1. Open the project in Android Studio and trigger a Gradle sync. Confirm `:logic:jvmTest` (and other `jvmTest` tasks) no longer execute during sync.
2. Run `./gradlew jvmTest koverXmlReportJvmOnly -Djava.library.path=./native/libs` and verify the report is generated at `build/reports/kover/reportJvmOnly.xml`.
3. Confirm the JVM-tests CI job passes without an Android SDK installed in the runner container.

### Notes

Coverage aggregation is now scoped to the JVM target only. Android-target coverage was never measured by this CI job (it only runs `jvmTest`), so the report content is unchanged in practice — only the variant boundary is now explicit. If Android-side coverage is ever needed, a separate variant (e.g. `add("debug")`) can be added to the `merge` block.