### PR TITLE
feat: disable team-wide app lock when using nomad - WPB-25543

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -2611,7 +2611,10 @@ public class UserSessionScope internal constructor(
         get() = MarkGuestLinkFeatureFlagAsNotChangedUseCaseImpl(userConfigRepository)
 
     public val appLockTeamFeatureConfigObserver: AppLockTeamFeatureConfigObserver
-        get() = AppLockTeamFeatureConfigObserverImpl(userConfigRepository, globalScope.sessionRepository)
+        get() = AppLockTeamFeatureConfigObserverImpl(
+            userConfigRepository = userConfigRepository,
+            nomadServiceUrl = nomadServiceUrl,
+        )
 
     public val markTeamAppLockStatusAsNotified: MarkTeamAppLockStatusAsNotifiedUseCase
         get() = MarkTeamAppLockStatusAsNotifiedUseCaseImpl(userConfigRepository)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -2611,7 +2611,7 @@ public class UserSessionScope internal constructor(
         get() = MarkGuestLinkFeatureFlagAsNotChangedUseCaseImpl(userConfigRepository)
 
     public val appLockTeamFeatureConfigObserver: AppLockTeamFeatureConfigObserver
-        get() = AppLockTeamFeatureConfigObserverImpl(userConfigRepository)
+        get() = AppLockTeamFeatureConfigObserverImpl(userConfigRepository, globalScope.sessionRepository)
 
     public val markTeamAppLockStatusAsNotified: MarkTeamAppLockStatusAsNotifiedUseCase
         get() = MarkTeamAppLockStatusAsNotifiedUseCaseImpl(userConfigRepository)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/applock/AppLockTeamFeatureConfigObserver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/applock/AppLockTeamFeatureConfigObserver.kt
@@ -17,14 +17,22 @@
  */
 package com.wire.kalium.logic.feature.applock
 
+import com.wire.kalium.common.functional.getOrElse
+import com.wire.kalium.common.functional.nullableFold
 import com.wire.kalium.logic.configuration.AppLockTeamConfig
 import com.wire.kalium.logic.configuration.UserConfigRepository
-import com.wire.kalium.common.functional.nullableFold
+import com.wire.kalium.logic.data.session.SessionRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 
 /**
- * observe app lock feature flag of the team
+ * Observes the team app lock feature flag.
+ *
+ * Nomad accounts are not subject to team-enforced app lock, so when a valid nomad
+ * account exists this observer emits `null` regardless of the team configuration.
  */
 public interface AppLockTeamFeatureConfigObserver {
     public operator fun invoke(): Flow<AppLockTeamConfig?>
@@ -32,9 +40,17 @@ public interface AppLockTeamFeatureConfigObserver {
 
 internal class AppLockTeamFeatureConfigObserverImpl internal constructor(
     private val userConfigRepository: UserConfigRepository,
+    private val sessionRepository: SessionRepository,
 ) : AppLockTeamFeatureConfigObserver {
-    override fun invoke(): Flow<AppLockTeamConfig?> =
-        userConfigRepository.observeAppLockConfig().map {
-            it.nullableFold({ null }, { it })
+    override fun invoke(): Flow<AppLockTeamConfig?> = flow {
+        if (sessionRepository.doesValidNomadAccountExist().getOrElse { false }) {
+            emitAll(flowOf(null))
+            return@flow
         }
+        emitAll(
+            userConfigRepository.observeAppLockConfig().map {
+                it.nullableFold({ null }, { it })
+            }
+        )
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/applock/AppLockTeamFeatureConfigObserver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/applock/AppLockTeamFeatureConfigObserver.kt
@@ -17,22 +17,18 @@
  */
 package com.wire.kalium.logic.feature.applock
 
-import com.wire.kalium.common.functional.getOrElse
 import com.wire.kalium.common.functional.nullableFold
 import com.wire.kalium.logic.configuration.AppLockTeamConfig
 import com.wire.kalium.logic.configuration.UserConfigRepository
-import com.wire.kalium.logic.data.session.SessionRepository
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emitAll
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 
 /**
  * Observes the team app lock feature flag.
  *
- * Nomad accounts are not subject to team-enforced app lock, so when a valid nomad
- * account exists this observer emits `null` regardless of the team configuration.
+ * Nomad accounts are not subject to team-enforced app lock, so when the self user is
+ * a nomad account this observer emits `null` regardless of the team configuration.
  */
 public interface AppLockTeamFeatureConfigObserver {
     public operator fun invoke(): Flow<AppLockTeamConfig?>
@@ -40,17 +36,14 @@ public interface AppLockTeamFeatureConfigObserver {
 
 internal class AppLockTeamFeatureConfigObserverImpl internal constructor(
     private val userConfigRepository: UserConfigRepository,
-    private val sessionRepository: SessionRepository,
+    private val nomadServiceUrl: String?,
 ) : AppLockTeamFeatureConfigObserver {
-    override fun invoke(): Flow<AppLockTeamConfig?> = flow {
-        if (sessionRepository.doesValidNomadAccountExist().getOrElse { false }) {
-            emitAll(flowOf(null))
-            return@flow
-        }
-        emitAll(
+    override fun invoke(): Flow<AppLockTeamConfig?> =
+        if (!nomadServiceUrl.isNullOrBlank()) {
+            flowOf(null)
+        } else {
             userConfigRepository.observeAppLockConfig().map {
                 it.nullableFold({ null }, { it })
             }
-        )
-    }
+        }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/applock/AppLockTeamFeatureConfigObserverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/applock/AppLockTeamFeatureConfigObserverTest.kt
@@ -23,11 +23,9 @@ import com.wire.kalium.logic.configuration.AppLockTeamConfig
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.featureConfig.AppLockModel
 import com.wire.kalium.logic.data.featureConfig.Status
-import com.wire.kalium.logic.data.session.SessionRepository
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.every
-import dev.mokkery.everySuspend
 import dev.mokkery.mock
 import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode
@@ -45,7 +43,7 @@ internal class AppLockTeamFeatureConfigObserverTest {
     fun givenRepositoryFailure_whenObservingAppLock_thenEmitNull() = runTest {
         val (arrangement, observer) = Arrangement()
             .withFailure()
-            .withValidNomadAccountExists(false)
+            .withNomadServiceUrl(null)
             .arrange()
 
         assertNull(observer.invoke().first())
@@ -64,7 +62,7 @@ internal class AppLockTeamFeatureConfigObserverTest {
         )
         val (arrangement, observer) = Arrangement()
             .withSuccess()
-            .withValidNomadAccountExists(false)
+            .withNomadServiceUrl(null)
             .arrange()
 
         assertEquals(expectedAppLockValue, observer.invoke().first())
@@ -75,34 +73,23 @@ internal class AppLockTeamFeatureConfigObserverTest {
     }
 
     @Test
-    fun givenValidNomadAccountExists_whenObservingAppLock_thenEmitNullRegardlessOfTeamConfig() = runTest {
-        val (_, observer) = Arrangement()
+    fun givenSelfIsNomad_whenObservingAppLock_thenEmitNullRegardlessOfTeamConfig() = runTest {
+        val (arrangement, observer) = Arrangement()
             .withSuccess()
-            .withValidNomadAccountExists(true)
+            .withNomadServiceUrl("https://nomad.service.url")
             .arrange()
 
         assertNull(observer.invoke().first())
-    }
 
-    @Test
-    fun givenNomadCheckFails_whenObservingAppLock_thenFallBackToTeamConfig() = runTest {
-        val expectedAppLockValue = AppLockTeamConfig(
-            appLockConfigModel.status.toBoolean(),
-            appLockConfigModel.inactivityTimeoutSecs.seconds,
-            isStatusChanged = false
-        )
-        val (_, observer) = Arrangement()
-            .withSuccess()
-            .withNomadCheckFailure()
-            .arrange()
-
-        assertEquals(expectedAppLockValue, observer.invoke().first())
+        verify(VerifyMode.exactly(0)) {
+            arrangement.userConfigRepository.observeAppLockConfig()
+        }
     }
 
     private class Arrangement {
 
         val userConfigRepository = mock<UserConfigRepository>(mode = MockMode.autoUnit)
-        val sessionRepository = mock<SessionRepository>(mode = MockMode.autoUnit)
+        private var nomadServiceUrl: String? = null
 
         fun withFailure(): Arrangement = apply {
             every {
@@ -116,21 +103,13 @@ internal class AppLockTeamFeatureConfigObserverTest {
             } returns flowOf(Either.Right(appLockTeamConfig))
         }
 
-        suspend fun withValidNomadAccountExists(exists: Boolean): Arrangement = apply {
-            everySuspend {
-                sessionRepository.doesValidNomadAccountExist()
-            } returns Either.Right(exists)
-        }
-
-        suspend fun withNomadCheckFailure(): Arrangement = apply {
-            everySuspend {
-                sessionRepository.doesValidNomadAccountExist()
-            } returns Either.Left(StorageFailure.DataNotFound)
+        fun withNomadServiceUrl(nomadServiceUrl: String?): Arrangement = apply {
+            this.nomadServiceUrl = nomadServiceUrl
         }
 
         fun arrange() = this to AppLockTeamFeatureConfigObserverImpl(
             userConfigRepository = userConfigRepository,
-            sessionRepository = sessionRepository,
+            nomadServiceUrl = nomadServiceUrl,
         )
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/applock/AppLockTeamFeatureConfigObserverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/applock/AppLockTeamFeatureConfigObserverTest.kt
@@ -18,17 +18,19 @@
 package com.wire.kalium.logic.feature.applock
 
 import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.configuration.AppLockTeamConfig
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.featureConfig.AppLockModel
 import com.wire.kalium.logic.data.featureConfig.Status
-import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.session.SessionRepository
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.every
+import dev.mokkery.everySuspend
 import dev.mokkery.mock
-import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -40,45 +42,67 @@ import kotlin.time.Duration.Companion.seconds
 internal class AppLockTeamFeatureConfigObserverTest {
 
     @Test
-    fun givenRepositoryFailure_whenObservingAppLock_thenEmitNull() =
-        runTest {
+    fun givenRepositoryFailure_whenObservingAppLock_thenEmitNull() = runTest {
+        val (arrangement, observer) = Arrangement()
+            .withFailure()
+            .withValidNomadAccountExists(false)
+            .arrange()
 
-            val (arrangement, observer) = Arrangement()
-                .withFailure()
-                .arrange()
+        assertNull(observer.invoke().first())
 
-            val result = observer.invoke()
-
-            verify(VerifyMode.exactly(1)) {
-                arrangement.userConfigRepository.observeAppLockConfig()
-            }
-            assertNull(result.first())
+        verify(VerifyMode.exactly(1)) {
+            arrangement.userConfigRepository.observeAppLockConfig()
         }
+    }
 
     @Test
-    fun givenRepositorySuccess_whenObservingAppLock_thenEmitAppLockConfigWithValueFromRepository() {
-        runTest {
-            val expectedAppLockValue = AppLockTeamConfig(
-                appLockConfigModel.status.toBoolean(),
-                appLockConfigModel.inactivityTimeoutSecs.seconds,
-                isStatusChanged = false
-            )
-            val (arrangement, observer) = Arrangement()
-                .withSuccess()
-                .arrange()
+    fun givenRepositorySuccess_whenObservingAppLock_thenEmitAppLockConfigWithValueFromRepository() = runTest {
+        val expectedAppLockValue = AppLockTeamConfig(
+            appLockConfigModel.status.toBoolean(),
+            appLockConfigModel.inactivityTimeoutSecs.seconds,
+            isStatusChanged = false
+        )
+        val (arrangement, observer) = Arrangement()
+            .withSuccess()
+            .withValidNomadAccountExists(false)
+            .arrange()
 
-            val result = observer.invoke()
+        assertEquals(expectedAppLockValue, observer.invoke().first())
 
-            verify(VerifyMode.exactly(1)) {
-                arrangement.userConfigRepository.observeAppLockConfig()
-            }
-            assertEquals(expectedAppLockValue, result.first())
+        verify(VerifyMode.exactly(1)) {
+            arrangement.userConfigRepository.observeAppLockConfig()
         }
+    }
+
+    @Test
+    fun givenValidNomadAccountExists_whenObservingAppLock_thenEmitNullRegardlessOfTeamConfig() = runTest {
+        val (_, observer) = Arrangement()
+            .withSuccess()
+            .withValidNomadAccountExists(true)
+            .arrange()
+
+        assertNull(observer.invoke().first())
+    }
+
+    @Test
+    fun givenNomadCheckFails_whenObservingAppLock_thenFallBackToTeamConfig() = runTest {
+        val expectedAppLockValue = AppLockTeamConfig(
+            appLockConfigModel.status.toBoolean(),
+            appLockConfigModel.inactivityTimeoutSecs.seconds,
+            isStatusChanged = false
+        )
+        val (_, observer) = Arrangement()
+            .withSuccess()
+            .withNomadCheckFailure()
+            .arrange()
+
+        assertEquals(expectedAppLockValue, observer.invoke().first())
     }
 
     private class Arrangement {
 
         val userConfigRepository = mock<UserConfigRepository>(mode = MockMode.autoUnit)
+        val sessionRepository = mock<SessionRepository>(mode = MockMode.autoUnit)
 
         fun withFailure(): Arrangement = apply {
             every {
@@ -92,8 +116,21 @@ internal class AppLockTeamFeatureConfigObserverTest {
             } returns flowOf(Either.Right(appLockTeamConfig))
         }
 
+        suspend fun withValidNomadAccountExists(exists: Boolean): Arrangement = apply {
+            everySuspend {
+                sessionRepository.doesValidNomadAccountExist()
+            } returns Either.Right(exists)
+        }
+
+        suspend fun withNomadCheckFailure(): Arrangement = apply {
+            everySuspend {
+                sessionRepository.doesValidNomadAccountExist()
+            } returns Either.Left(StorageFailure.DataNotFound)
+        }
+
         fun arrange() = this to AppLockTeamFeatureConfigObserverImpl(
-            userConfigRepository = userConfigRepository
+            userConfigRepository = userConfigRepository,
+            sessionRepository = sessionRepository,
         )
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25543
<!--jira-description-action-hidden-marker-end-->
When an account is configured as a nomad profile, that account should not see any app lock prompt, even if the team administrator enforces app lock for the team.
Testing

I've manually tested this on Fulu on a team with app lock enabled