### PR TITLE
feat: check admin leave conditions (WPB-25277)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/CheckConversationLeaveConditionsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/CheckConversationLeaveConditionsUseCase.kt
@@ -1,0 +1,73 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.user.UserId
+import kotlinx.coroutines.flow.firstOrNull
+
+/**
+ * Checks whether the self user is allowed to leave the given group conversation.
+ *
+ * Returns [Result.Allow] when leaving is safe, [Result.DoNotAllow] when self is the sole admin
+ * and other members remain (with [Result.DoNotAllow.eligibleUsersAvailable] indicating whether
+ * any of them can be promoted), or [Result.Error] on a storage failure.
+ */
+public interface CheckConversationLeaveConditionsUseCase {
+    public suspend operator fun invoke(conversationId: ConversationId): Result
+
+    public sealed interface Result {
+        public data object Allow : Result
+        public data class DoNotAllow(val eligibleUsersAvailable: Boolean) : Result
+        public data class Error(val cause: CoreFailure) : Result
+    }
+}
+
+internal class CheckConversationLeaveConditionsUseCaseImpl(
+    private val conversationRepository: ConversationRepository,
+    private val observeEligibleMembers: ObserveEligibleMembersForConversationAdminRoleUseCase,
+    private val selfUserId: UserId,
+) : CheckConversationLeaveConditionsUseCase {
+
+    override suspend fun invoke(conversationId: ConversationId): CheckConversationLeaveConditionsUseCase.Result {
+        val members = conversationRepository.observeConversationMembers(conversationId).firstOrNull()
+        return when {
+            members.isNullOrEmpty() -> CheckConversationLeaveConditionsUseCase.Result.Error(StorageFailure.DataNotFound)
+            isSelfUserNotAdmin(members) -> CheckConversationLeaveConditionsUseCase.Result.Allow
+            groupHasOtherAdmins(members) -> CheckConversationLeaveConditionsUseCase.Result.Allow
+            noOtherMembers(members) -> CheckConversationLeaveConditionsUseCase.Result.Allow
+            else -> {
+                val eligibleUsersAvailable = observeEligibleMembers(conversationId).firstOrNull().isNullOrEmpty().not()
+                CheckConversationLeaveConditionsUseCase.Result.DoNotAllow(eligibleUsersAvailable)
+            }
+        }
+    }
+
+    private fun isSelfUserNotAdmin(members: List<Conversation.Member>) =
+        members.find { it.id == selfUserId }?.role !is Conversation.Member.Role.Admin
+
+    private fun groupHasOtherAdmins(members: List<Conversation.Member>) =
+        members.count { it.role is Conversation.Member.Role.Admin } > 1
+
+    private fun noOtherMembers(members: List<Conversation.Member>) = members.size == 1
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -173,6 +173,9 @@ public class ConversationScope internal constructor(
     public val getMembersToMention: MembersToMentionUseCase
         get() = MembersToMentionUseCase(observeConversationMembers = observeConversationMembers, selfUserId = selfUserId)
 
+    public val observeEligibleMembersForConversationAdminRole: ObserveEligibleMembersForConversationAdminRoleUseCase
+        get() = ObserveEligibleMembersForConversationAdminRoleUseCaseImpl(observeConversationMembers, selfUserId)
+
     public val observeUserListById: ObserveUserListByIdUseCase
         get() = ObserveUserListByIdUseCase(userRepository)
 
@@ -301,6 +304,13 @@ public class ConversationScope internal constructor(
 
     public val leaveConversation: LeaveConversationUseCase
         get() = LeaveConversationUseCaseImpl(conversationGroupRepository, selfUserId)
+
+    public val checkConversationLeaveConditions: CheckConversationLeaveConditionsUseCase
+        get() = CheckConversationLeaveConditionsUseCaseImpl(
+            conversationRepository,
+            observeEligibleMembersForConversationAdminRole,
+            selfUserId
+        )
 
     public val renameConversation: RenameConversationUseCase
         get() = RenameConversationUseCaseImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveEligibleMembersForConversationAdminRoleUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ObserveEligibleMembersForConversationAdminRoleUseCase.kt
@@ -1,0 +1,60 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.data.conversation.MemberDetails
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.user.User
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.data.user.type.isAppOrBot
+import com.wire.kalium.logic.data.user.type.isFederated
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * Observes the list of conversation members that are eligible to be promoted to admin role.
+ *
+ * A member is eligible if they are not the self user and satisfy all of:
+ * - not federated
+ * - not a bot/service
+ * - has a non-empty name
+ * - has a non-empty handle
+ * - not a temporary/guest user (no expiry)
+ */
+public interface ObserveEligibleMembersForConversationAdminRoleUseCase {
+    public suspend operator fun invoke(conversationId: ConversationId): Flow<List<MemberDetails>>
+}
+
+internal class ObserveEligibleMembersForConversationAdminRoleUseCaseImpl(
+    private val observeConversationMembers: ObserveConversationMembersUseCase,
+    private val selfUserId: UserId,
+) : ObserveEligibleMembersForConversationAdminRoleUseCase {
+
+    override suspend fun invoke(conversationId: ConversationId): Flow<List<MemberDetails>> =
+        observeConversationMembers(conversationId).map { members ->
+            members.filter { it.user.id != selfUserId && it.user.isEligibleForAdminPromotion() }
+        }
+
+    private fun User.isEligibleForAdminPromotion(): Boolean =
+        !userType.isFederated() &&
+                !userType.isAppOrBot() &&
+                !name.isNullOrEmpty() &&
+                !handle.isNullOrEmpty() &&
+                expiresAt == null
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/CheckConversationLeaveConditionsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/CheckConversationLeaveConditionsUseCaseTest.kt
@@ -1,0 +1,163 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.MemberDetails
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class CheckConversationLeaveConditionsUseCaseTest {
+
+    @Test
+    fun givenSelfIsRegularMember_whenCheckingLeaveConditions_thenReturnAllow() = runTest {
+        val members = listOf(
+            Conversation.Member(TestUser.USER_ID, Conversation.Member.Role.Member),
+        )
+        val (_, useCase) = Arrangement()
+            .withMembers(members)
+            .arrange()
+
+        val result = useCase(TestConversation.ID)
+
+        assertIs<CheckConversationLeaveConditionsUseCase.Result.Allow>(result)
+    }
+
+    @Test
+    fun givenSelfIsNotInConversation_whenCheckingLeaveConditions_thenReturnAllow() = runTest {
+        val members = listOf(
+            Conversation.Member(TestUser.OTHER_USER_ID, Conversation.Member.Role.Admin),
+        )
+        val (_, useCase) = Arrangement()
+            .withMembers(members)
+            .arrange()
+
+        val result = useCase(TestConversation.ID)
+
+        assertIs<CheckConversationLeaveConditionsUseCase.Result.Allow>(result)
+    }
+
+    @Test
+    fun givenSelfIsAdminAndAnotherAdminExists_whenCheckingLeaveConditions_thenReturnAllow() = runTest {
+        val members = listOf(
+            Conversation.Member(TestUser.USER_ID, Conversation.Member.Role.Admin),
+            Conversation.Member(TestUser.OTHER_USER_ID, Conversation.Member.Role.Admin),
+        )
+        val (_, useCase) = Arrangement()
+            .withMembers(members)
+            .arrange()
+
+        val result = useCase(TestConversation.ID)
+
+        assertIs<CheckConversationLeaveConditionsUseCase.Result.Allow>(result)
+    }
+
+    @Test
+    fun givenSelfIsSoleAdminWithNoOtherMembers_whenCheckingLeaveConditions_thenReturnAllow() = runTest {
+        val members = listOf(
+            Conversation.Member(TestUser.USER_ID, Conversation.Member.Role.Admin),
+        )
+        val (_, useCase) = Arrangement()
+            .withMembers(members)
+            .arrange()
+
+        val result = useCase(TestConversation.ID)
+
+        assertIs<CheckConversationLeaveConditionsUseCase.Result.Allow>(result)
+    }
+
+    @Test
+    fun givenSelfIsSoleAdminAndEligibleUsersExist_whenCheckingLeaveConditions_thenReturnDoNotAllowWithEligibleUsers() = runTest {
+        val eligibleMember = MemberDetails(TestUser.OTHER, Conversation.Member.Role.Member)
+        val members = listOf(
+            Conversation.Member(TestUser.USER_ID, Conversation.Member.Role.Admin),
+            Conversation.Member(TestUser.OTHER_USER_ID, Conversation.Member.Role.Member),
+        )
+        val (_, useCase) = Arrangement()
+            .withMembers(members)
+            .withEligibleMembers(listOf(eligibleMember))
+            .arrange()
+
+        val result = useCase(TestConversation.ID)
+
+        assertIs<CheckConversationLeaveConditionsUseCase.Result.DoNotAllow>(result)
+        assertEquals(true, result.eligibleUsersAvailable)
+    }
+
+    @Test
+    fun givenSelfIsSoleAdminAndNoEligibleUsers_whenCheckingLeaveConditions_thenReturnDoNotAllowWithNoEligibleUsers() = runTest {
+        val members = listOf(
+            Conversation.Member(TestUser.USER_ID, Conversation.Member.Role.Admin),
+            Conversation.Member(TestUser.OTHER_USER_ID, Conversation.Member.Role.Member),
+        )
+        val (_, useCase) = Arrangement()
+            .withMembers(members)
+            .withEligibleMembers(emptyList())
+            .arrange()
+
+        val result = useCase(TestConversation.ID)
+
+        assertIs<CheckConversationLeaveConditionsUseCase.Result.DoNotAllow>(result)
+        assertEquals(false, result.eligibleUsersAvailable)
+    }
+
+    @Test
+    fun givenEmptyMembers_whenCheckingLeaveConditions_thenReturnError() = runTest {
+        val (_, useCase) = Arrangement()
+            .withMembers(emptyList())
+            .arrange()
+
+        val result = useCase(TestConversation.ID)
+
+        assertIs<CheckConversationLeaveConditionsUseCase.Result.Error>(result)
+    }
+
+    private class Arrangement {
+        val conversationRepository = mock<ConversationRepository>()
+        val observeEligibleMembers = mock<ObserveEligibleMembersForConversationAdminRoleUseCase>()
+
+        fun withMembers(members: List<Conversation.Member>) = apply {
+            everySuspend {
+                conversationRepository.observeConversationMembers(any())
+            } returns flowOf(members)
+        }
+
+        fun withEligibleMembers(members: List<MemberDetails>) = apply {
+            everySuspend {
+                observeEligibleMembers(any())
+            } returns flowOf(members)
+        }
+
+        fun arrange() = this to CheckConversationLeaveConditionsUseCaseImpl(
+            conversationRepository,
+            observeEligibleMembers,
+            TestUser.USER_ID,
+        )
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveEligibleMembersForConversationAdminRoleUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/ObserveEligibleMembersForConversationAdminRoleUseCaseTest.kt
@@ -1,0 +1,201 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.MemberDetails
+import com.wire.kalium.logic.data.user.type.UserType
+import com.wire.kalium.logic.data.user.type.UserTypeInfo
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ObserveEligibleMembersForConversationAdminRoleUseCaseTest {
+
+    @Test
+    fun givenSelfUser_whenObserving_thenFilteredOut() = runTest {
+        val selfMember = MemberDetails(TestUser.SELF, Conversation.Member.Role.Admin)
+        val (_, useCase) = Arrangement()
+            .withMembers(listOf(selfMember))
+            .arrange()
+
+        val result = useCase(TestConversation.ID).first()
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun givenFederatedMember_whenObserving_thenFilteredOut() = runTest {
+        val federatedUser = TestUser.OTHER.copy(userType = UserTypeInfo.Regular(UserType.FEDERATED))
+        val member = MemberDetails(federatedUser, Conversation.Member.Role.Member)
+        val (_, useCase) = Arrangement()
+            .withMembers(listOf(member))
+            .arrange()
+
+        val result = useCase(TestConversation.ID).first()
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun givenBotMember_whenObserving_thenFilteredOut() = runTest {
+        val botUser = TestUser.OTHER.copy(userType = UserTypeInfo.Bot)
+        val member = MemberDetails(botUser, Conversation.Member.Role.Member)
+        val (_, useCase) = Arrangement()
+            .withMembers(listOf(member))
+            .arrange()
+
+        val result = useCase(TestConversation.ID).first()
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun givenMemberWithNullName_whenObserving_thenFilteredOut() = runTest {
+        val userWithNullName = TestUser.OTHER.copy(name = null)
+        val member = MemberDetails(userWithNullName, Conversation.Member.Role.Member)
+        val (_, useCase) = Arrangement()
+            .withMembers(listOf(member))
+            .arrange()
+
+        val result = useCase(TestConversation.ID).first()
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun givenMemberWithEmptyName_whenObserving_thenFilteredOut() = runTest {
+        val userWithEmptyName = TestUser.OTHER.copy(name = "")
+        val member = MemberDetails(userWithEmptyName, Conversation.Member.Role.Member)
+        val (_, useCase) = Arrangement()
+            .withMembers(listOf(member))
+            .arrange()
+
+        val result = useCase(TestConversation.ID).first()
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun givenMemberWithNullHandle_whenObserving_thenFilteredOut() = runTest {
+        val userWithNullHandle = TestUser.OTHER.copy(handle = null)
+        val member = MemberDetails(userWithNullHandle, Conversation.Member.Role.Member)
+        val (_, useCase) = Arrangement()
+            .withMembers(listOf(member))
+            .arrange()
+
+        val result = useCase(TestConversation.ID).first()
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun givenMemberWithEmptyHandle_whenObserving_thenFilteredOut() = runTest {
+        val userWithEmptyHandle = TestUser.OTHER.copy(handle = "")
+        val member = MemberDetails(userWithEmptyHandle, Conversation.Member.Role.Member)
+        val (_, useCase) = Arrangement()
+            .withMembers(listOf(member))
+            .arrange()
+
+        val result = useCase(TestConversation.ID).first()
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun givenTemporaryMember_whenObserving_thenFilteredOut() = runTest {
+        val temporaryUser = TestUser.OTHER.copy(expiresAt = Instant.fromEpochMilliseconds(9999999999L))
+        val member = MemberDetails(temporaryUser, Conversation.Member.Role.Member)
+        val (_, useCase) = Arrangement()
+            .withMembers(listOf(member))
+            .arrange()
+
+        val result = useCase(TestConversation.ID).first()
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun givenEligibleMember_whenObserving_thenIncluded() = runTest {
+        val eligibleUser = TestUser.OTHER.copy(
+            userType = UserTypeInfo.Regular(UserType.INTERNAL),
+            name = "Alice",
+            handle = "alice",
+            expiresAt = null,
+        )
+        val member = MemberDetails(eligibleUser, Conversation.Member.Role.Member)
+        val (_, useCase) = Arrangement()
+            .withMembers(listOf(member))
+            .arrange()
+
+        val result = useCase(TestConversation.ID).first()
+
+        assertEquals(1, result.size)
+        assertEquals(member, result.first())
+    }
+
+    @Test
+    fun givenMixedMembers_whenObserving_thenOnlyEligibleIncluded() = runTest {
+        val eligibleUser = TestUser.OTHER.copy(
+            userType = UserTypeInfo.Regular(UserType.INTERNAL),
+            name = "Alice",
+            handle = "alice",
+            expiresAt = null,
+        )
+        val federatedUser = TestUser.OTHER.copy(
+            id = TestUser.OTHER_USER_ID_2,
+            userType = UserTypeInfo.Regular(UserType.FEDERATED),
+        )
+        val selfMember = MemberDetails(TestUser.SELF, Conversation.Member.Role.Admin)
+        val eligibleMember = MemberDetails(eligibleUser, Conversation.Member.Role.Member)
+        val ineligibleMember = MemberDetails(federatedUser, Conversation.Member.Role.Member)
+        val (_, useCase) = Arrangement()
+            .withMembers(listOf(selfMember, eligibleMember, ineligibleMember))
+            .arrange()
+
+        val result = useCase(TestConversation.ID).first()
+
+        assertEquals(1, result.size)
+        assertEquals(eligibleMember, result.first())
+    }
+
+    private class Arrangement {
+        val observeConversationMembers = mock<ObserveConversationMembersUseCase>(mode = MockMode.autoUnit)
+
+        fun withMembers(members: List<MemberDetails>) = apply {
+            everySuspend { observeConversationMembers(any()) } returns flowOf(members)
+        }
+
+        fun arrange() = this to ObserveEligibleMembersForConversationAdminRoleUseCaseImpl(
+            observeConversationMembers,
+            TestUser.USER_ID,
+        )
+    }
+}


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25277
<!--jira-description-action-hidden-marker-end-->

https://wearezeta.atlassian.net/browse/WPB-25277
----

# What's new in this PR?

New use-cases for Admin-less groups handling feature. 
- Check conditions for allowing or not allowing user admin to leave conversation
- Return a list of conversation members eligible for admin role promotion