### PR TITLE
fix: change order of inserting data when creating non-incoming call [WPB-24829]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
@@ -283,6 +283,7 @@ internal class CallDataSource(
                     "| status: [$status] | isCallInCurrentSession: [$isCallInCurrentSession]"
         )
         if (status == CallStatus.INCOMING && !isCallInCurrentSession) {
+            // Save into metadata
             _callMetadataProfile.update { callMetadataProfile ->
                 callMetadataProfile.plus(conversationId = conversationId, metadata = metadata)
             }
@@ -319,14 +320,14 @@ internal class CallDataSource(
                 }
             } else if (lastCallStatus !in activeCallStatus || (status == CallStatus.STARTED)) {
                 callingLogger.i("[CallRepository][createCall] -> Insert Call")
-                // Save into database
-                wrapStorageRequest {
-                    callDAO.insertCall(call = callEntity)
-                }
-
                 // Save into metadata
                 _callMetadataProfile.update { callMetadataProfile ->
                     callMetadataProfile.plus(conversationId = conversationId, metadata = metadata)
+                }
+
+                // Save into database
+                wrapStorageRequest {
+                    callDAO.insertCall(call = callEntity)
                 }
             }
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24829
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sometimes starting a foreground `CallService` for the outgoing call fails with: `java.lang.IllegalArgumentException: person must have a non-empty a name`.

### Causes (Optional)

The app cannot create a valid outgoing call notification - `CallStyle` requires the `Person` data and the name cannot be empty. 
The order of actions when creating a call in some cases is such that the call is inserted into database first and only then the metadata is stored, and the app takes the info from the database to start the service, so it's possible to start a foreground CallService and try to create outgoing call even before the metadata is saved.

### Solutions

Change the order for all created calls so that it first saves metadata and only then inserts into a database, so that when fetching calls from database, the metadata is already available.
For new incoming calls the order is already correct, so the change was required for others.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
