### PR TITLE
feat: promote user to admin and leave (WPB-25279)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -305,6 +305,9 @@ public class ConversationScope internal constructor(
     public val leaveConversation: LeaveConversationUseCase
         get() = LeaveConversationUseCaseImpl(conversationGroupRepository, selfUserId)
 
+    public val promoteAdminAndLeaveConversation: PromoteAdminAndLeaveConversationUseCase
+        get() = PromoteAdminAndLeaveConversationUseCaseImpl(updateConversationMemberRole, leaveConversation)
+
     public val checkConversationLeaveConditions: CheckConversationLeaveConditionsUseCase
         get() = CheckConversationLeaveConditionsUseCaseImpl(
             conversationRepository,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/PromoteAdminAndLeaveConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/PromoteAdminAndLeaveConversationUseCase.kt
@@ -1,0 +1,67 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.user.UserId
+
+public interface PromoteAdminAndLeaveConversationUseCase {
+    /**
+     * Promotes the given [userId] to admin role in [conversationId], then removes the self user from that conversation.
+     *
+     * @return [Result.Success] if both operations succeed,
+     *         [Result.FailedToPromoteUser] if the promotion fails (leave is not attempted),
+     *         [Result.FailedToLeaveConversation] if promotion succeeds but leave fails.
+     */
+    public suspend operator fun invoke(
+        conversationId: ConversationId,
+        userId: UserId,
+    ): Result
+
+    public sealed interface Result {
+        public data object Success : Result
+        public data object FailedToPromoteUser : Result
+        public data object FailedToLeaveConversation : Result
+    }
+}
+
+internal class PromoteAdminAndLeaveConversationUseCaseImpl(
+    private val updateConversationMemberRole: UpdateConversationMemberRoleUseCase,
+    private val leaveConversation: LeaveConversationUseCase,
+) : PromoteAdminAndLeaveConversationUseCase {
+
+    @Suppress("ReturnCount")
+    override suspend fun invoke(
+        conversationId: ConversationId,
+        userId: UserId,
+    ): PromoteAdminAndLeaveConversationUseCase.Result {
+        val promoteResult = updateConversationMemberRole(conversationId, userId, Conversation.Member.Role.Admin)
+        if (promoteResult is UpdateConversationMemberRoleResult.Failure) {
+            return PromoteAdminAndLeaveConversationUseCase.Result.FailedToPromoteUser
+        }
+
+        val leaveResult = leaveConversation(conversationId)
+        if (leaveResult is RemoveMemberFromConversationUseCase.Result.Failure) {
+            return PromoteAdminAndLeaveConversationUseCase.Result.FailedToLeaveConversation
+        }
+
+        return PromoteAdminAndLeaveConversationUseCase.Result.Success
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/PromoteAdminAndLeaveConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/PromoteAdminAndLeaveConversationUseCaseTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertIs
+
+class PromoteAdminAndLeaveConversationUseCaseTest {
+
+    @Test
+    fun givenPromoteSucceedsAndLeaveSucceeds_whenInvoked_thenReturnSuccess() = runTest {
+        val (_, useCase) = Arrangement()
+            .withPromoteResult(UpdateConversationMemberRoleResult.Success)
+            .withLeaveResult(RemoveMemberFromConversationUseCase.Result.Success)
+            .arrange()
+
+        val result = useCase(TestConversation.ID, TestUser.OTHER_USER_ID)
+
+        assertIs<PromoteAdminAndLeaveConversationUseCase.Result.Success>(result)
+    }
+
+    @Test
+    fun givenPromoteFails_whenInvoked_thenReturnFailedToPromoteUserAndLeaveNotCalled() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withPromoteResult(UpdateConversationMemberRoleResult.Failure)
+            .arrange()
+
+        val result = useCase(TestConversation.ID, TestUser.OTHER_USER_ID)
+
+        assertIs<PromoteAdminAndLeaveConversationUseCase.Result.FailedToPromoteUser>(result)
+        verifySuspend(VerifyMode.not) { arrangement.leaveConversation(any()) }
+    }
+
+    @Test
+    fun givenPromoteSucceedsAndLeaveFails_whenInvoked_thenReturnFailedToLeaveConversation() = runTest {
+        val (_, useCase) = Arrangement()
+            .withPromoteResult(UpdateConversationMemberRoleResult.Success)
+            .withLeaveResult(RemoveMemberFromConversationUseCase.Result.Failure(StorageFailure.DataNotFound))
+            .arrange()
+
+        val result = useCase(TestConversation.ID, TestUser.OTHER_USER_ID)
+
+        assertIs<PromoteAdminAndLeaveConversationUseCase.Result.FailedToLeaveConversation>(result)
+    }
+
+    private class Arrangement {
+        val updateConversationMemberRole: UpdateConversationMemberRoleUseCase = mock()
+        val leaveConversation: LeaveConversationUseCase = mock()
+
+        init {
+            everySuspend { updateConversationMemberRole(any(), any(), any()) } returns UpdateConversationMemberRoleResult.Success
+            everySuspend { leaveConversation(any()) } returns RemoveMemberFromConversationUseCase.Result.Success
+        }
+
+        fun withPromoteResult(result: UpdateConversationMemberRoleResult) = apply {
+            everySuspend { updateConversationMemberRole(any(), any(), any()) } returns result
+        }
+
+        fun withLeaveResult(result: RemoveMemberFromConversationUseCase.Result) = apply {
+            everySuspend { leaveConversation(any()) } returns result
+        }
+
+        fun arrange() = this to PromoteAdminAndLeaveConversationUseCaseImpl(updateConversationMemberRole, leaveConversation)
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25279
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-25279
----

# What's new in this PR?

New use case for promoting another user to admin role and leaving group conversation.