### PR TITLE
fix: stabilize Keychain service name for iOS to prevent orphaned entries [WPB-25123]

### DIFF
--- a/data/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/config/UserConfigStorageFactory.kt
+++ b/data/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/config/UserConfigStorageFactory.kt
@@ -34,17 +34,18 @@ actual class UserConfigStorageFactory actual constructor() {
      * Creates a [UserConfigStorage] instance for Apple platforms.
      * @param userId The user ID entity
      * @param shouldEncryptData Whether to encrypt the data (ignored on Apple, uses Keychain)
-     * @param platformParam Must be a [String] representing the service name for Keychain
+     * @param platformParam Ignored on Apple — the Keychain service name is derived from the
+     *  host app's bundle identifier so it stays stable across container path changes.
      */
+    @Suppress("UNUSED_PARAMETER")
     actual fun create(
         userId: UserIDEntity,
         shouldEncryptData: Boolean,
         platformParam: Any
     ): UserConfigStorage {
-        require(platformParam is String) { "platformParam must be a String (service name)" }
         val settings = buildSettings(
             SettingOptions.UserSettings(shouldEncryptData, userId),
-            EncryptedSettingsPlatformParam(platformParam)
+            EncryptedSettingsPlatformParam()
         )
         return UserConfigStorageImpl(KaliumPreferencesSettings(settings))
     }

--- a/data/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/config/UserConfigStorageFactory.kt
+++ b/data/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/config/UserConfigStorageFactory.kt
@@ -18,6 +18,7 @@
 package com.wire.kalium.persistence.config
 
 import com.wire.kalium.persistence.dao.UserIDEntity
+import com.wire.kalium.persistence.kmmSettings.ApplePersistenceConfig
 import com.wire.kalium.persistence.kmmSettings.EncryptedSettingsPlatformParam
 import com.wire.kalium.persistence.kmmSettings.KaliumPreferencesSettings
 import com.wire.kalium.persistence.kmmSettings.SettingOptions
@@ -34,18 +35,18 @@ actual class UserConfigStorageFactory actual constructor() {
      * Creates a [UserConfigStorage] instance for Apple platforms.
      * @param userId The user ID entity
      * @param shouldEncryptData Whether to encrypt the data (ignored on Apple, uses Keychain)
-     * @param platformParam Ignored on Apple — the Keychain service name is derived from the
-     *  host app's bundle identifier so it stays stable across container path changes.
+     * @param platformParam Must be an [ApplePersistenceConfig] supplied by the consumer via
+     *  `CoreLogic`. The `serviceName` inside it must NOT be derived from `NSHomeDirectory()`.
      */
-    @Suppress("UNUSED_PARAMETER")
     actual fun create(
         userId: UserIDEntity,
         shouldEncryptData: Boolean,
         platformParam: Any
     ): UserConfigStorage {
+        require(platformParam is ApplePersistenceConfig) { "platformParam must be an ApplePersistenceConfig" }
         val settings = buildSettings(
             SettingOptions.UserSettings(shouldEncryptData, userId),
-            EncryptedSettingsPlatformParam()
+            EncryptedSettingsPlatformParam(platformParam)
         )
         return UserConfigStorageImpl(KaliumPreferencesSettings(settings))
     }

--- a/data/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/kmmSettings/ApplePersistenceConfig.kt
+++ b/data/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/kmmSettings/ApplePersistenceConfig.kt
@@ -1,0 +1,39 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.persistence.kmmSettings
+
+/**
+ * Apple-platform configuration for Kalium's encrypted key/value storage.
+ *
+ * Consumers (host apps) construct this and hand it to `CoreLogic`. It is then carried
+ * through to every Apple-side site that talks to the iOS Keychain.
+ *
+ * Extend this class — do NOT add new top-level parameters to `CoreLogic` — when new
+ * iOS Keychain options (access group, accessibility class, synchronizable, etc.) need
+ * to be exposed.
+ *
+ * @property serviceName Stable identifier used as the iOS Keychain `kSecAttrService`
+ *  value for all Kalium-managed entries (auth tokens, passphrases, per-user config).
+ *  Must be stable across app reinstalls — typically the host app's bundle identifier.
+ *  Must NOT be derived from `NSHomeDirectory()`, which embeds the iOS Application UUID
+ *  and changes on every reinstall, orphaning every previously stored entry.
+ */
+public data class ApplePersistenceConfig(
+    val serviceName: String,
+)

--- a/data/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
+++ b/data/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
@@ -21,17 +21,11 @@ package com.wire.kalium.persistence.kmmSettings
 import com.russhwolf.settings.ExperimentalSettingsImplementation
 import com.russhwolf.settings.KeychainSettings
 import com.russhwolf.settings.Settings
-import platform.Foundation.NSBundle
 
 @OptIn(ExperimentalSettingsImplementation::class)
 internal actual fun buildSettings(
     options: SettingOptions,
     param: EncryptedSettingsPlatformParam
-): Settings = KeychainSettings(stableKeychainServiceName())
+): Settings = KeychainSettings(param.keychainConfig.serviceName)
 
-internal actual class EncryptedSettingsPlatformParam
-
-private const val FALLBACK_KEYCHAIN_SERVICE_NAME = "com.wire.kalium.keychain"
-
-private fun stableKeychainServiceName(): String =
-    NSBundle.mainBundle.bundleIdentifier ?: FALLBACK_KEYCHAIN_SERVICE_NAME
+internal actual class EncryptedSettingsPlatformParam(val keychainConfig: ApplePersistenceConfig)

--- a/data/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
+++ b/data/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
@@ -21,11 +21,17 @@ package com.wire.kalium.persistence.kmmSettings
 import com.russhwolf.settings.ExperimentalSettingsImplementation
 import com.russhwolf.settings.KeychainSettings
 import com.russhwolf.settings.Settings
+import platform.Foundation.NSBundle
 
 @OptIn(ExperimentalSettingsImplementation::class)
 internal actual fun buildSettings(
     options: SettingOptions,
     param: EncryptedSettingsPlatformParam
-): Settings = KeychainSettings(param.serviceName)
+): Settings = KeychainSettings(stableKeychainServiceName())
 
-internal actual class EncryptedSettingsPlatformParam(val serviceName: String)
+internal actual class EncryptedSettingsPlatformParam
+
+private const val FALLBACK_KEYCHAIN_SERVICE_NAME = "com.wire.kalium.keychain"
+
+private fun stableKeychainServiceName(): String =
+    NSBundle.mainBundle.bundleIdentifier ?: FALLBACK_KEYCHAIN_SERVICE_NAME

--- a/data/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/kmmSettings/GlobalPrefProvider.kt
+++ b/data/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/kmmSettings/GlobalPrefProvider.kt
@@ -26,15 +26,14 @@ import com.wire.kalium.persistence.dbPassphrase.PassphraseStorage
 import com.wire.kalium.persistence.dbPassphrase.PassphraseStorageImpl
 
 actual class GlobalPrefProvider(
-    @Suppress("UNUSED_PARAMETER", "unused")
-    rootPath: String,
+    keychainConfig: ApplePersistenceConfig,
     shouldEncryptData: Boolean = true
 ) {
     private val kaliumPref =
         KaliumPreferencesSettings(
             buildSettings(
                 SettingOptions.AppSettings(shouldEncryptData),
-                EncryptedSettingsPlatformParam()
+                EncryptedSettingsPlatformParam(keychainConfig)
             )
         )
 

--- a/data/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/kmmSettings/GlobalPrefProvider.kt
+++ b/data/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/kmmSettings/GlobalPrefProvider.kt
@@ -26,6 +26,7 @@ import com.wire.kalium.persistence.dbPassphrase.PassphraseStorage
 import com.wire.kalium.persistence.dbPassphrase.PassphraseStorageImpl
 
 actual class GlobalPrefProvider(
+    @Suppress("UNUSED_PARAMETER", "unused")
     rootPath: String,
     shouldEncryptData: Boolean = true
 ) {
@@ -33,7 +34,7 @@ actual class GlobalPrefProvider(
         KaliumPreferencesSettings(
             buildSettings(
                 SettingOptions.AppSettings(shouldEncryptData),
-                EncryptedSettingsPlatformParam(rootPath)
+                EncryptedSettingsPlatformParam()
             )
         )
 

--- a/domain/userstorage/src/appleMain/kotlin/com/wire/kalium/userstorage/di/PlatformUserStorageProperties.kt
+++ b/domain/userstorage/src/appleMain/kotlin/com/wire/kalium/userstorage/di/PlatformUserStorageProperties.kt
@@ -18,7 +18,10 @@
 
 package com.wire.kalium.userstorage.di
 
+import com.wire.kalium.persistence.kmmSettings.ApplePersistenceConfig
+
 public actual class PlatformUserStorageProperties(
     public val rootPath: String,
+    public val keychainConfig: ApplePersistenceConfig,
     internal val rootStoragePath: String
 )

--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
@@ -34,6 +34,7 @@ import com.wire.kalium.persistence.db.GlobalDatabaseBuilder
 import com.wire.kalium.persistence.db.PlatformDatabaseData
 import com.wire.kalium.persistence.db.StorageData
 import com.wire.kalium.persistence.db.globalDatabaseProvider
+import com.wire.kalium.persistence.kmmSettings.ApplePersistenceConfig
 import com.wire.kalium.persistence.kmmSettings.GlobalPrefProvider
 import com.wire.kalium.usernetwork.di.PlatformUserAuthenticatedNetworkProvider
 import com.wire.kalium.usernetwork.di.UserAuthenticatedNetworkProvider
@@ -42,6 +43,14 @@ import kotlinx.coroutines.cancel
 
 public actual class CoreLogic(
     rootPath: String,
+    /**
+     * Apple-specific encrypted-storage configuration. Must be supplied by the consumer
+     * (host app). The `serviceName` inside must be stable across app reinstalls —
+     * typically the host app's bundle identifier — and must NOT be derived from
+     * `NSHomeDirectory()`, which embeds the iOS Application UUID and changes on every
+     * reinstall, orphaning all previously stored keychain entries.
+     */
+    private val keychainConfig: ApplePersistenceConfig,
     kaliumConfigs: KaliumConfigs,
     userAgent: String,
     useInMemoryStorage: Boolean = false,
@@ -53,7 +62,7 @@ public actual class CoreLogic(
 ) {
     actual override val globalPreferences: GlobalPrefProvider =
         GlobalPrefProvider(
-            rootPath = rootPath,
+            keychainConfig = keychainConfig,
             shouldEncryptData = kaliumConfigs.shouldEncryptData()
         )
 
@@ -84,7 +93,8 @@ public actual class CoreLogic(
             userAuthenticatedNetworkProvider,
             networkStateObserver,
             logoutCallbackManager,
-            userAgent
+            userAgent,
+            keychainConfig
         )
     }
 

--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/di/UserConfigStorageFactory.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/di/UserConfigStorageFactory.kt
@@ -34,6 +34,6 @@ internal actual class UserConfigStorageFactory actual constructor() {
     ): UserConfigStorage = persistenceFactory.create(
         userId = userId.toDao(),
         shouldEncryptData = shouldEncryptData,
-        platformParam = platformProperties.rootPath
+        platformParam = platformProperties.keychainConfig
     )
 }

--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
@@ -33,6 +33,7 @@ import com.wire.kalium.logic.feature.call.GlobalCallManager
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.network.NetworkStateObserver
 import com.wire.kalium.persistence.db.GlobalDatabaseBuilder
+import com.wire.kalium.persistence.kmmSettings.ApplePersistenceConfig
 import com.wire.kalium.persistence.kmmSettings.GlobalPrefProvider
 import com.wire.kalium.usernetwork.di.UserAuthenticatedNetworkProvider
 import com.wire.kalium.userstorage.di.PlatformUserStorageProperties
@@ -51,7 +52,8 @@ internal actual open class UserSessionScopeProviderImpl(
     private val userAuthenticatedNetworkProvider: UserAuthenticatedNetworkProvider,
     private val networkStateObserver: NetworkStateObserver,
     private val logoutCallback: LogoutCallback,
-    userAgent: String
+    userAgent: String,
+    private val keychainConfig: ApplePersistenceConfig,
 ) : UserSessionScopeProviderCommon(
         globalCallManager,
         userStorageProvider,
@@ -67,7 +69,11 @@ internal actual open class UserSessionScopeProviderImpl(
         val dbPath = DBFolder("$rootAccountPath/database")
         val dataStoragePaths = DataStoragePaths(rootFileSystemPath, rootCachePath, dbPath)
         return UserSessionScope(
-            PlatformUserStorageProperties(rootPathsProvider.rootPath, rootStoragePath),
+            PlatformUserStorageProperties(
+                rootPath = rootPathsProvider.rootPath,
+                keychainConfig = keychainConfig,
+                rootStoragePath = rootStoragePath,
+            ),
             userId,
             globalScope,
             globalCallManager,

--- a/sample/cli/src/appleMain/kotlin/com/wire/kalium/cli/coreLogic.kt
+++ b/sample/cli/src/appleMain/kotlin/com/wire/kalium/cli/coreLogic.kt
@@ -20,8 +20,16 @@ package com.wire.kalium.cli
 
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
+import com.wire.kalium.persistence.kmmSettings.ApplePersistenceConfig
+
+private val CLI_KEYCHAIN_CONFIG = ApplePersistenceConfig(serviceName = "com.wire.kalium.cli")
 
 actual fun coreLogic(
     rootPath: String,
     kaliumConfigs: KaliumConfigs
-): CoreLogic = CoreLogic(rootPath, kaliumConfigs, "Kalium CLI/apple")
+): CoreLogic = CoreLogic(
+    rootPath = rootPath,
+    keychainConfig = CLI_KEYCHAIN_CONFIG,
+    kaliumConfigs = kaliumConfigs,
+    userAgent = "Kalium CLI/apple",
+)


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25123
<!--jira-description-action-hidden-marker-end-->

# What's new in this PR?

### Issues

On iOS, every new app deployment assigns a fresh Application UUID, changing `NSHomeDirectory()` and thus the absolute container path. iOS migrates filesystem data to the new path, but the Keychain is independent of the filesystem — entries written under the old path are orphaned. Result: stored auth tokens become unreadable → `SESSION_EXPIRED` → forced logout.

### Solutions
ask consumer apps to deal with it and they can provide a stable identifier