### PR TITLE
feat: support multi-ingress SSO lookup by email [WPB-23280]

### DIFF
--- a/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/unauthenticated/sso/SSOSettingsResponse.kt
+++ b/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/unauthenticated/sso/SSOSettingsResponse.kt
@@ -26,3 +26,15 @@ data class SSOSettingsResponse(
     @SerialName("default_sso_code")
     val defaultCode: String?
 )
+
+@Serializable
+data class SSOCodeRequest(
+    @SerialName("email")
+    val email: String
+)
+
+@Serializable
+data class SSOCodeResponse(
+    @SerialName("sso_code")
+    val ssoCode: String?
+)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unauthenticated/sso/SSOLoginApi.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unauthenticated/sso/SSOLoginApi.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.network.api.base.unauthenticated.sso
 
 import com.wire.kalium.network.api.model.AuthenticationResultDTO
 import com.wire.kalium.network.api.unauthenticated.sso.InitiateParam
+import com.wire.kalium.network.api.unauthenticated.sso.SSOCodeResponse
 import com.wire.kalium.network.api.unauthenticated.sso.SSOSettingsResponse
 import com.wire.kalium.network.utils.NetworkResponse
 
@@ -35,4 +36,6 @@ interface SSOLoginApi {
     suspend fun metaData(): NetworkResponse<String>
 
     suspend fun settings(): NetworkResponse<SSOSettingsResponse>
+
+    suspend fun getByEmail(email: String): NetworkResponse<SSOCodeResponse>
 }

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/SSOLoginApiV0.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/unauthenticated/SSOLoginApiV0.kt
@@ -26,6 +26,7 @@ import com.wire.kalium.network.api.model.SelfUserDTO
 import com.wire.kalium.network.api.model.toSessionDto
 import com.wire.kalium.network.api.unauthenticated.sso.InitiateParam
 import com.wire.kalium.network.api.base.unauthenticated.sso.SSOLoginApi
+import com.wire.kalium.network.api.unauthenticated.sso.SSOCodeResponse
 import com.wire.kalium.network.api.unauthenticated.sso.SSOSettingsResponse
 import com.wire.kalium.network.exceptions.APINotSupported
 import com.wire.kalium.network.utils.CustomErrors.MISSING_REFRESH_TOKEN
@@ -117,12 +118,18 @@ internal open class SSOLoginApiV0 internal constructor(
         httpClient.get("$PATH_SSO/$PATH_SETTINGS")
     }
 
+    override suspend fun getByEmail(email: String): NetworkResponse<SSOCodeResponse> =
+        NetworkResponse.Error(
+            APINotSupported("${this::class.simpleName}: ${::getByEmail.name} is only available on API V15")
+        )
+
     protected companion object {
         const val PATH_SSO = "sso"
         const val PATH_INITIATE = "initiate-login"
         const val PATH_FINALIZE = "finalize-login"
         const val PATH_METADATA = "metadata"
         const val PATH_SETTINGS = "settings"
+        const val PATH_GET_BY_EMAIL = "get-by-email"
         const val PATH_ACCESS = "access"
         const val PATH_SELF = "self"
         const val QUERY_SUCCESS_REDIRECT = "success_redirect"

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v15/unauthenticated/SSOLoginApiV15.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v15/unauthenticated/SSOLoginApiV15.kt
@@ -20,14 +20,19 @@ package com.wire.kalium.network.api.v15.unauthenticated
 
 import com.wire.kalium.network.UnauthenticatedNetworkClient
 import com.wire.kalium.network.api.unauthenticated.sso.InitiateParam
+import com.wire.kalium.network.api.unauthenticated.sso.SSOCodeRequest
+import com.wire.kalium.network.api.unauthenticated.sso.SSOCodeResponse
 import com.wire.kalium.network.api.v14.unauthenticated.SSOLoginApiV14
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.mapSuccess
 import com.wire.kalium.network.utils.wrapRequest
+import com.wire.kalium.network.utils.wrapKaliumResponse
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.accept
 import io.ktor.client.request.head
 import io.ktor.client.request.parameter
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.appendPathSegments
 
@@ -47,6 +52,13 @@ internal open class SSOLoginApiV15 internal constructor(
         val url = httpRequest.call.request.url.toString()
         wrapRequest<String> { httpRequest }.mapSuccess {
             url
+        }
+    }
+
+    override suspend fun getByEmail(email: String): NetworkResponse<SSOCodeResponse> = wrapKaliumResponse {
+        httpClient.post {
+            url.appendPathSegments(PATH_SSO, PATH_GET_BY_EMAIL)
+            setBody(SSOCodeRequest(email))
         }
     }
 }

--- a/data/network/src/commonTest/kotlin/com/wire/kalium/api/v15/user/login/SSOLoginApiV15Test.kt
+++ b/data/network/src/commonTest/kotlin/com/wire/kalium/api/v15/user/login/SSOLoginApiV15Test.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.network.api.base.unauthenticated.sso.SSOLoginApi
 import com.wire.kalium.network.api.unauthenticated.sso.InitiateParam
 import com.wire.kalium.network.api.v15.unauthenticated.SSOLoginApiV15
 import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 import io.ktor.http.protocolWithAuthority
@@ -31,6 +32,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 internal class SSOLoginApiV15Test : ApiTest() {
 
@@ -78,7 +80,27 @@ internal class SSOLoginApiV15Test : ApiTest() {
         assertEquals("${Url(TEST_BACKEND.links.api).protocolWithAuthority}$expectedPathAndQuery", actual.value)
     }
 
+    @Test
+    fun givenV15_whenCallingGetByEmail_thenRequestConfiguredCorrectly() = runTest {
+        val email = "user@example.com"
+        val networkClient = mockUnauthenticatedNetworkClient(
+            SSO_CODE_RESPONSE,
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertPost()
+                assertPathEqual(PATH_SSO_GET_BY_EMAIL)
+                assertJsonBodyContent("""{"email":"$email"}""")
+            }
+        )
+
+        val response = SSOLoginApiV15(networkClient).getByEmail(email)
+
+        assertTrue(response.isSuccessful())
+    }
+
     private companion object {
         const val PATH_SSO_INITIATE = "/sso/initiate-login"
+        const val PATH_SSO_GET_BY_EMAIL = "sso/get-by-email"
+        const val SSO_CODE_RESPONSE = """{"sso_code":"99db9768-04e3-4b5d-9268-831b6a25c4ab"}"""
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/login/SSOLoginRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/auth/login/SSOLoginRepository.kt
@@ -46,6 +46,7 @@ internal interface SSOLoginRepository {
     suspend fun metaData(): Either<NetworkFailure, String>
 
     suspend fun settings(): Either<NetworkFailure, SSOSettingsResponse>
+    suspend fun getByEmail(email: String): Either<NetworkFailure, String?>
     suspend fun domainLookup(domain: String): Either<NetworkFailure, DomainLookupResult>
 }
 
@@ -81,6 +82,12 @@ internal class SSOLoginRepositoryImpl(
 
     override suspend fun settings(): Either<NetworkFailure, SSOSettingsResponse> = wrapApiRequest {
         ssoLogin.settings()
+    }
+
+    override suspend fun getByEmail(email: String): Either<NetworkFailure, String?> = wrapApiRequest {
+        ssoLogin.getByEmail(email)
+    }.map {
+        it.ssoCode
     }
 
      override suspend fun domainLookup(domain: String): Either<NetworkFailure, DomainLookupResult> = wrapApiRequest {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthenticationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/AuthenticationScope.kt
@@ -134,7 +134,7 @@ public class AuthenticationScope internal constructor(
         get() = UnauthorizedSettingsRepositoryImpl(unauthenticatedNetworkContainer.unauthorizedSettingsApi)
 
     public val getLoginFlowForDomainUseCase: GetLoginFlowForDomainUseCase
-        get() = GetLoginFlowForDomainUseCase(loginRepository, customServerConfigRepository)
+        get() = GetLoginFlowForDomainUseCase(loginRepository, ssoLoginRepository, customServerConfigRepository)
 
     public val login: LoginUseCase
         get() = LoginUseCaseImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/GetLoginFlowForDomainUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/GetLoginFlowForDomainUseCase.kt
@@ -31,8 +31,10 @@ import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.logic.configuration.server.CustomServerConfigRepository
 import com.wire.kalium.logic.data.auth.LoginDomainPath
 import com.wire.kalium.logic.data.auth.login.LoginRepository
+import com.wire.kalium.logic.data.auth.login.SSOLoginRepository
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.exceptions.isEnterpriseServiceNotEnabled
+import com.wire.kalium.network.exceptions.isNotFound
 
 /**
  * Use case to get the login flow for the client app/user to follow.
@@ -47,10 +49,42 @@ public interface GetLoginFlowForDomainUseCase {
 @Suppress("FunctionNaming")
 internal fun GetLoginFlowForDomainUseCase(
     loginRepository: LoginRepository,
+    ssoLoginRepository: SSOLoginRepository,
     customServerConfigRepository: CustomServerConfigRepository,
     mapper: LoginRedirectMapper = LoginRedirectMapperImpl
 ) = object : GetLoginFlowForDomainUseCase {
     override suspend fun invoke(email: String): EnterpriseLoginResult {
+        logger.d("Get SSO code by email")
+        return when (val ssoCodeLoginFlow = getSsoCodeLoginFlow(email)) {
+            is SSOCodeLoginFlowResult.Success -> ssoCodeLoginFlow.enterpriseLoginResult
+            SSOCodeLoginFlowResult.FallbackToDomainRegistration -> getDomainRegistrationLoginFlow(email)
+        }
+    }
+
+    private suspend fun getSsoCodeLoginFlow(email: String): SSOCodeLoginFlowResult =
+        when (val ssoCodeResult = ssoLoginRepository.getByEmail(email)) {
+            is Either.Right ->
+                ssoCodeResult.value
+                    ?.let { EnterpriseLoginResult.Success(LoginRedirectPath.SSO(it)) }
+                    ?.let { SSOCodeLoginFlowResult.Success(it) }
+                    ?: SSOCodeLoginFlowResult.FallbackToDomainRegistration
+
+            is Either.Left -> if (ssoCodeResult.value.shouldFallbackToDomainRegistration()) {
+                SSOCodeLoginFlowResult.FallbackToDomainRegistration
+            } else {
+                SSOCodeLoginFlowResult.Success(
+                    ssoCodeResult.value.mapFailure().also { failure ->
+                        logger.logStructuredJson(
+                            level = KaliumLogLevel.ERROR,
+                            leadingMessage = "Get SSO code by email",
+                            jsonStringKeyValues = mapOf("error" to failure.toLogString())
+                        )
+                    }
+                )
+            }
+        }
+
+    private suspend fun getDomainRegistrationLoginFlow(email: String): EnterpriseLoginResult {
         logger.d("Get domain registration")
         return loginRepository.getDomainRegistration(email)
             .handleEnterpriseServiceNotEnabled()
@@ -121,6 +155,19 @@ internal fun GetLoginFlowForDomainUseCase(
             is NetworkFailure.FeatureNotSupported -> EnterpriseLoginResult.Failure.NotSupported
             else -> EnterpriseLoginResult.Failure.Generic(this)
         }
+
+    private fun NetworkFailure.shouldFallbackToDomainRegistration(): Boolean =
+        this is NetworkFailure.FeatureNotSupported ||
+                (this as? NetworkFailure.ServerMiscommunication)
+                    ?.kaliumException
+                    ?.let { it as? KaliumException.InvalidRequestError }
+                    ?.isNotFound() == true
+
+}
+
+private sealed interface SSOCodeLoginFlowResult {
+    data class Success(val enterpriseLoginResult: EnterpriseLoginResult) : SSOCodeLoginFlowResult
+    data object FallbackToDomainRegistration : SSOCodeLoginFlowResult
 }
 
 /**
@@ -128,7 +175,7 @@ internal fun GetLoginFlowForDomainUseCase(
  * Indicating error cases or the actual login path for the domain.
  */
 public sealed interface EnterpriseLoginResult {
-   public sealed class Failure : EnterpriseLoginResult {
+    public sealed class Failure : EnterpriseLoginResult {
 
         public abstract fun toLogString(): String
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/auth/login/SSOLoginRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/auth/login/SSOLoginRepositoryTest.kt
@@ -26,6 +26,7 @@ import com.wire.kalium.network.api.base.unauthenticated.domainLookup.DomainLooku
 import com.wire.kalium.network.api.base.unauthenticated.sso.SSOLoginApi
 import com.wire.kalium.network.api.unauthenticated.domainLookup.DomainLookupResponse
 import com.wire.kalium.network.api.unauthenticated.sso.InitiateParam
+import com.wire.kalium.network.api.unauthenticated.sso.SSOCodeResponse
 import com.wire.kalium.network.api.unauthenticated.sso.SSOSettingsResponse
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
@@ -191,6 +192,36 @@ class SSOLoginRepositoryTest {
     }
 
     @Test
+    fun givenApiRequestSuccess_whenGettingSsoCodeByEmail_thenSuccessIsPropagated() = runTest {
+        everySuspend {
+            ssoLogin.getByEmail(TEST_EMAIL)
+        }.returns(NetworkResponse.Success(SSOCodeResponse(TEST_CODE), mapOf(), 200))
+
+        val actual = ssoLoginRepository.getByEmail(TEST_EMAIL)
+
+        assertIs<Either.Right<String?>>(actual)
+        assertEquals(TEST_CODE, actual.value)
+        verifySuspend(VerifyMode.exactly(1)) {
+            ssoLogin.getByEmail(TEST_EMAIL)
+        }
+    }
+
+    @Test
+    fun givenApiRequestFail_whenGettingSsoCodeByEmail_thenNetworkFailureIsPropagated() = runTest {
+        everySuspend {
+            ssoLogin.getByEmail(TEST_EMAIL)
+        }.returns(NetworkResponse.Error(TestNetworkException.generic))
+
+        val actual = ssoLoginRepository.getByEmail(TEST_EMAIL)
+
+        assertIs<Either.Left<NetworkFailure.ServerMiscommunication>>(actual)
+        assertEquals(TestNetworkException.generic, actual.value.kaliumException)
+        verifySuspend(VerifyMode.exactly(1)) {
+            ssoLogin.getByEmail(TEST_EMAIL)
+        }
+    }
+
+    @Test
     fun givenDomainLookupSuccess_thenSuccesIsPropagated() = runTest {
         val domain = "test.com"
         val networkResponse = DomainLookupResponse(
@@ -236,6 +267,7 @@ class SSOLoginRepositoryTest {
     private companion object {
         const val TEST_CODE = "code"
         const val TEST_COOKIE = "cookie"
+        const val TEST_EMAIL = "user@example.com"
         const val TEST_SUCCESS = "wire/success"
         const val TEST_ERROR = "wire/error"
         val TEST_SERVER_CONFIG = newServerConfig(1)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/GetLoginFlowForDomainUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/GetLoginFlowForDomainUseCaseTest.kt
@@ -26,6 +26,7 @@ import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.data.auth.LoginDomainPath
 import com.wire.kalium.logic.data.auth.login.DomainLookupResult
 import com.wire.kalium.logic.data.auth.login.LoginRepository
+import com.wire.kalium.logic.data.auth.login.SSOLoginRepository
 import com.wire.kalium.network.api.model.ErrorResponse
 import com.wire.kalium.network.exceptions.KaliumException
 import dev.mokkery.MockMode
@@ -33,6 +34,7 @@ import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -50,6 +52,47 @@ class GetLoginFlowForDomainUseCaseTest {
 
         verifySuspend { arrangement.loginRepository.getDomainRegistration(Arrangement.EMAIL) }
         assertEquals(EnterpriseLoginResult.Success(LoginRedirectPath.Default), result)
+    }
+
+    @Test
+    fun givenEmail_whenSsoCodeByEmailExists_thenReturnSsoPath() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withSsoCodeByEmailResult(Arrangement.SSO_CODE.right())
+            .arrange()
+
+        val result = useCase(Arrangement.EMAIL)
+
+        verifySuspend { arrangement.ssoLoginRepository.getByEmail(Arrangement.EMAIL) }
+        verifySuspend(VerifyMode.exactly(0)) { arrangement.loginRepository.getDomainRegistration(any()) }
+        assertEquals(EnterpriseLoginResult.Success(LoginRedirectPath.SSO(Arrangement.SSO_CODE)), result)
+    }
+
+    @Test
+    fun givenEmail_whenSsoCodeByEmailReturnsNotFound_thenFallbackToDomainRegistration() = runTest {
+        val notFoundError = KaliumException.InvalidRequestError(ErrorResponse(404, "", "not-found"))
+        val (arrangement, useCase) = Arrangement()
+            .withSsoCodeByEmailResult(NetworkFailure.ServerMiscommunication(notFoundError).left())
+            .withDomainRegistrationResult(LoginDomainPath.Default.right())
+            .arrange()
+
+        val result = useCase(Arrangement.EMAIL)
+
+        verifySuspend { arrangement.ssoLoginRepository.getByEmail(Arrangement.EMAIL) }
+        verifySuspend { arrangement.loginRepository.getDomainRegistration(Arrangement.EMAIL) }
+        assertEquals(EnterpriseLoginResult.Success(LoginRedirectPath.Default), result)
+    }
+
+    @Test
+    fun givenEmail_whenSsoCodeByEmailReturnsGenericError_thenDoNotFallbackToDomainRegistration() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withSsoCodeByEmailResult(NetworkFailure.ServerMiscommunication(RuntimeException()).left())
+            .arrange()
+
+        val result = useCase(Arrangement.EMAIL)
+
+        verifySuspend { arrangement.ssoLoginRepository.getByEmail(Arrangement.EMAIL) }
+        verifySuspend(VerifyMode.exactly(0)) { arrangement.loginRepository.getDomainRegistration(any()) }
+        assertEquals(EnterpriseLoginResult.Failure.Generic::class, result::class)
     }
 
     @Test
@@ -113,7 +156,14 @@ class GetLoginFlowForDomainUseCaseTest {
     private class Arrangement {
 
         val loginRepository: LoginRepository = mock(mode = MockMode.autoUnit)
+        val ssoLoginRepository: SSOLoginRepository = mock(mode = MockMode.autoUnit)
         val customServerConfigRepository = mock<CustomServerConfigRepository>(mode = MockMode.autoUnit)
+        private var ssoCodeByEmailConfigured = false
+
+        suspend fun withSsoCodeByEmailResult(result: Either<NetworkFailure, String?>) = apply {
+            ssoCodeByEmailConfigured = true
+            everySuspend { ssoLoginRepository.getByEmail(any()) } returns result
+        }
 
         suspend fun withDomainRegistrationResult(result: Either<NetworkFailure, LoginDomainPath>) = apply {
             everySuspend { loginRepository.getDomainRegistration(any()) } returns result
@@ -127,10 +177,16 @@ class GetLoginFlowForDomainUseCaseTest {
             everySuspend { customServerConfigRepository.fetchRemoteConfig(any()) } returns result
         }
 
-        fun arrange() = this to GetLoginFlowForDomainUseCase(loginRepository, customServerConfigRepository)
+        suspend fun arrange(): Pair<Arrangement, GetLoginFlowForDomainUseCase> {
+            if (!ssoCodeByEmailConfigured) {
+                withSsoCodeByEmailResult(NetworkFailure.FeatureNotSupported.left())
+            }
+            return this to GetLoginFlowForDomainUseCase(loginRepository, ssoLoginRepository, customServerConfigRepository)
+        }
 
         companion object {
             const val EMAIL = "user@wire.com"
+            const val SSO_CODE = "99db9768-04e3-4b5d-9268-831b6a25c4ab"
         }
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-23280
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Implements the client-side support for multi-ingress SSO lookup by email.

Users on multi-domain backends should be able to enter their email and have the client resolve the correct team-specific SSO code through the backend, without manually entering an SSO code.

### Causes (Optional)

Multi-ingress deployments can expose several backend ingress domains. Manually entering an SSO code is error-prone, especially when many teams and ingress domains exist. The client needs to ask the backend for the correct SSO code based on the entered email and current ingress host before falling back to the existing domain-registration flow.

### Solutions

Added `POST /v15/sso/get-by-email` support in Kalium’s unauthenticated SSO API.

Updated the login flow resolution to first request an SSO code by email. When the backend returns a code, Kalium returns an SSO login path. When the endpoint is unsupported, disabled, or no SSO code is found, the existing domain-registration flow is preserved.

Added tests for the v15 network endpoint, repository mapping, and login-flow fallback/success behavior.