### PR TITLE
chore: use jdk 21 for android and kalium builds [WPB-25756]

### DIFF
--- a/.github/actions/setup-java-gradle/action.yml
+++ b/.github/actions/setup-java-gradle/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
 
     - name: Gradle Cache

--- a/buildSrc/src/main/kotlin/com/wire/kalium/plugins/CommonJvmConfig.kt
+++ b/buildSrc/src/main/kotlin/com/wire/kalium/plugins/CommonJvmConfig.kt
@@ -24,7 +24,7 @@ import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
 fun KotlinJvmTarget.commonJvmConfig(includeNativeInterop: Boolean, enableIntegrationTests: Boolean = false) {
     compilations.all {
         compileTaskProvider.configure {
-            compilerOptions.jvmTarget.set(JvmTarget.JVM_17)
+            compilerOptions.jvmTarget.set(JvmTarget.JVM_21)
         }
     }
     testRuns.getByName("test").executionTask.configure {

--- a/buildSrc/src/main/kotlin/com/wire/kalium/plugins/Multiplatform.kt
+++ b/buildSrc/src/main/kotlin/com/wire/kalium/plugins/Multiplatform.kt
@@ -55,7 +55,7 @@ internal fun Project.configureDefaultMultiplatform(
         }
 
         jvmToolchain {
-            languageVersion.set(JavaLanguageVersion.of(JavaVersion.VERSION_17.majorVersion))
+            languageVersion.set(JavaLanguageVersion.of(JavaVersion.VERSION_21.majorVersion))
         }
 
         applyDefaultHierarchyTemplate()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/asset/AssetRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/asset/AssetRepositoryTest.kt
@@ -399,7 +399,7 @@ internal class AssetRepositoryTest {
         val assetRawData = assetName.encodeToByteArray()
         val encryptedDataPath = encryptDataWithPath(assetRawData, assetEncryptionKey)
         val wrongAssetSha256 = calcFileSHA256(fakeKaliumFileSystem!!.source(encryptedDataPath))?.copyOf().apply {
-            this?.set(0, 99)
+            this?.set(0, this[0].inc())
         }
         val assetEncryptedData = fakeKaliumFileSystem!!.source(encryptedDataPath).buffer().use {
             it.readByteArray()

--- a/test/android-benchmarks/build.gradle.kts
+++ b/test/android-benchmarks/build.gradle.kts
@@ -47,8 +47,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
         isCoreLibraryDesugaringEnabled = true
     }
 
@@ -61,7 +61,7 @@ android {
 
 kotlin {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_17)
+        jvmTarget.set(JvmTarget.JVM_21)
     }
 }
 

--- a/test/benchmarks/build.gradle.kts
+++ b/test/benchmarks/build.gradle.kts
@@ -17,7 +17,7 @@ allOpen {
 
 kotlin {
     jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(JavaVersion.VERSION_17.majorVersion))
+        languageVersion.set(JavaLanguageVersion.of(JavaVersion.VERSION_21.majorVersion))
     }
 
     jvm()
@@ -85,5 +85,5 @@ jmhReport {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release.set(JavaVersion.VERSION_17.majorVersion.toInt())
+    options.release.set(JavaVersion.VERSION_21.majorVersion.toInt())
 }

--- a/tools/monkeys/docker/Dockerfile
+++ b/tools/monkeys/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17 AS jdk-build
+FROM eclipse-temurin:21 AS jdk-build
 
 COPY .. /kalium
 RUN cd /kalium && ./gradlew :monkeys:assembleDist

--- a/tools/protobuf-codegen/build.gradle.kts
+++ b/tools/protobuf-codegen/build.gradle.kts
@@ -63,6 +63,6 @@ tasks {
 
 kotlin {
     jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(JavaVersion.VERSION_17.majorVersion))
+        languageVersion.set(JavaLanguageVersion.of(JavaVersion.VERSION_21.majorVersion))
     }
 }

--- a/tools/testservice/Dockerfile
+++ b/tools/testservice/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jdk-noble
+FROM eclipse-temurin:21-jdk-noble
 
 # disable prompts from the txdata
 ENV DEBIAN_FRONTEND=noninteractive
@@ -20,7 +20,7 @@ COPY . .
 
 RUN ./gradlew :tools:testservice:shadowJar
 
-FROM eclipse-temurin:17-jdk-noble
+FROM eclipse-temurin:21-jdk-noble
 
 WORKDIR /app
 

--- a/tools/testservice/Jenkinsfile
+++ b/tools/testservice/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
                 }
             }
             steps {
-                withMaven(jdk: 'JDK17', maven: 'M3', mavenLocalRepo: '.repository') {
+                withMaven(jdk: 'JDK21', maven: 'M3', mavenLocalRepo: '.repository') {
                     sh 'PATH=$HOME/.cargo/bin:$PATH make'
                     sh 'sudo cp $WORKSPACE/native/libs/lib* /usr/lib/'
                     sh './gradlew clean'
@@ -25,7 +25,7 @@ pipeline {
         }
         stage('Build') {
             steps {
-                withMaven(jdk: 'JDK17', maven: 'M3', mavenLocalRepo: '.repository') {
+                withMaven(jdk: 'JDK21', maven: 'M3', mavenLocalRepo: '.repository') {
                     withCredentials([usernamePassword(credentialsId: 'READ_PACKAGES_GITHUB_TOKEN', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USER')]) {
                         sh './gradlew :tools:testservice:shadowJar'
                     }

--- a/tools/testservice/build.gradle.kts
+++ b/tools/testservice/build.gradle.kts
@@ -37,13 +37,13 @@ val mainFunctionClassName = "com.wire.kalium.testservice.TestserviceApplication"
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(JavaVersion.VERSION_17.majorVersion))
+        languageVersion.set(JavaLanguageVersion.of(JavaVersion.VERSION_21.majorVersion))
     }
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_17)
+        jvmTarget.set(JvmTarget.JVM_21)
     }
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25756
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Updates Kalium Gradle JVM/toolchain configuration from JDK 17 to JDK 21.
- Sets Kotlin JVM targets to `JVM_21` for shared JVM/KMP build configuration.
- Updates Kalium CI/helper setup to use Java 21 via the shared `setup-java-gradle` action.
- Updates Kalium Docker/Jenkins build environments that run Gradle to use JDK 21.

This keeps Kalium aligned with Android builds that now require a Java 21 runtime and avoids failures caused by running Gradle on Java 17.