### PR TITLE
feat: add debug CRL expiration controls [WPB-24945]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/e2ei/CertificateRevocationListRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/e2ei/CertificateRevocationListRepository.kt
@@ -27,6 +27,11 @@ import com.wire.kalium.network.api.base.unbound.acme.ACMEApi
 import com.wire.kalium.persistence.config.CRLUrlExpirationList
 import com.wire.kalium.persistence.config.CRLWithExpiration
 import com.wire.kalium.persistence.dao.MetadataDAO
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.datetime.Clock
+import kotlinx.serialization.builtins.serializer
+import kotlin.time.Duration.Companion.minutes
 
 internal interface CertificateRevocationListRepository {
 
@@ -37,7 +42,10 @@ internal interface CertificateRevocationListRepository {
      */
     suspend fun getCRLs(): CRLUrlExpirationList?
     suspend fun addOrUpdateCRL(url: String, timestamp: ULong)
+    suspend fun clearCRLExpirationDates()
     suspend fun getClientDomainCRL(url: String): Either<CoreFailure, ByteArray>
+    fun observeShouldForceCRLExpirationAfterOneMinute(): Flow<Boolean>
+    suspend fun setShouldForceCRLExpirationAfterOneMinute(enabled: Boolean)
 }
 
 internal class CertificateRevocationListRepositoryDataSource(
@@ -49,6 +57,11 @@ internal class CertificateRevocationListRepositoryDataSource(
         metadataDAO.getSerializable(CRL_LIST_KEY, CRLUrlExpirationList.serializer())
 
     override suspend fun addOrUpdateCRL(url: String, timestamp: ULong) {
+        val expirationTimestamp = if (shouldForceCRLExpirationAfterOneMinute()) {
+            (Clock.System.now() + 1.minutes).epochSeconds.toULong()
+        } else {
+            timestamp
+        }
         val newCRLUrls = metadataDAO.getSerializable(CRL_LIST_KEY, CRLUrlExpirationList.serializer())
             ?.let { crlExpirationList ->
                 val crlWithExpiration = crlExpirationList.cRLWithExpirationList.find {
@@ -57,7 +70,7 @@ internal class CertificateRevocationListRepositoryDataSource(
                 crlWithExpiration?.let { item ->
                     crlExpirationList.cRLWithExpirationList.map { current ->
                         if (current.url == url) {
-                            return@map item.copy(expiration = timestamp)
+                            return@map item.copy(expiration = expirationTimestamp)
                         } else {
                             return@map current
                         }
@@ -65,17 +78,26 @@ internal class CertificateRevocationListRepositoryDataSource(
                 } ?: run {
                     // add new CRL
                     crlExpirationList.cRLWithExpirationList.plus(
-                        CRLWithExpiration(url, timestamp)
+                        CRLWithExpiration(url, expirationTimestamp)
                     )
                 }
 
             } ?: run {
             // add new CRL
-            listOf(CRLWithExpiration(url, timestamp))
+            listOf(CRLWithExpiration(url, expirationTimestamp))
         }
         metadataDAO.putSerializable(
             CRL_LIST_KEY,
             CRLUrlExpirationList(newCRLUrls),
+            CRLUrlExpirationList.serializer()
+        )
+    }
+
+    override suspend fun clearCRLExpirationDates() {
+        val currentCRLs = metadataDAO.getSerializable(CRL_LIST_KEY, CRLUrlExpirationList.serializer()) ?: return
+        metadataDAO.putSerializable(
+            CRL_LIST_KEY,
+            CRLUrlExpirationList(currentCRLs.cRLWithExpirationList.map { it.copy(expiration = 0UL) }),
             CRLUrlExpirationList.serializer()
         )
     }
@@ -89,7 +111,19 @@ internal class CertificateRevocationListRepositoryDataSource(
             acmeApi.getClientDomainCRL(url, proxyUrl)
         }
 
+    override fun observeShouldForceCRLExpirationAfterOneMinute(): Flow<Boolean> =
+        metadataDAO.observeSerializable(CRL_FORCE_EXPIRATION_AFTER_ONE_MINUTE_KEY, Boolean.serializer())
+            .map { it ?: false }
+
+    override suspend fun setShouldForceCRLExpirationAfterOneMinute(enabled: Boolean) {
+        metadataDAO.putSerializable(CRL_FORCE_EXPIRATION_AFTER_ONE_MINUTE_KEY, enabled, Boolean.serializer())
+    }
+
+    private suspend fun shouldForceCRLExpirationAfterOneMinute(): Boolean =
+        metadataDAO.getSerializable(CRL_FORCE_EXPIRATION_AFTER_ONE_MINUTE_KEY, Boolean.serializer()) ?: false
+
     companion object {
         const val CRL_LIST_KEY = "crl_list_key"
+        const val CRL_FORCE_EXPIRATION_AFTER_ONE_MINUTE_KEY = "crl_force_expiration_after_one_minute"
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -2457,6 +2457,7 @@ public class UserSessionScope internal constructor(
             resetMlsConversation,
             cryptoTransactionProvider,
             client.refillKeyPackages,
+            certificateRevocationListRepository,
             userScopedLogger,
         )
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugCRLExpirationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugCRLExpirationUseCase.kt
@@ -1,0 +1,55 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.debug
+
+import com.wire.kalium.logic.data.e2ei.CertificateRevocationListRepository
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Observes whether debug CRL expiration override is enabled.
+ */
+public interface ObserveDebugCRLExpirationAfterOneMinuteUseCase {
+    public operator fun invoke(): Flow<Boolean>
+}
+
+/**
+ * Enables or disables debug CRL expiration override.
+ *
+ * When enabled, stored CRL expiration dates are cleared so CRLs can be refetched using the debug expiration interval.
+ */
+public interface SetDebugCRLExpirationAfterOneMinuteUseCase {
+    public suspend operator fun invoke(enabled: Boolean)
+}
+
+internal class ObserveDebugCRLExpirationAfterOneMinuteUseCaseImpl(
+    private val certificateRevocationListRepository: CertificateRevocationListRepository
+) : ObserveDebugCRLExpirationAfterOneMinuteUseCase {
+    override fun invoke(): Flow<Boolean> =
+        certificateRevocationListRepository.observeShouldForceCRLExpirationAfterOneMinute()
+}
+
+internal class SetDebugCRLExpirationAfterOneMinuteUseCaseImpl(
+    private val certificateRevocationListRepository: CertificateRevocationListRepository
+) : SetDebugCRLExpirationAfterOneMinuteUseCase {
+    override suspend fun invoke(enabled: Boolean) {
+        certificateRevocationListRepository.setShouldForceCRLExpirationAfterOneMinute(enabled)
+        if (enabled) {
+            certificateRevocationListRepository.clearCRLExpirationDates()
+        }
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
@@ -38,6 +38,7 @@ import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCas
 import com.wire.kalium.logic.data.conversation.LegalHoldStatusMapperImpl
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.conversation.ResetMLSConversationUseCase
+import com.wire.kalium.logic.data.e2ei.CertificateRevocationListRepository
 import com.wire.kalium.logic.data.event.EventGenerator
 import com.wire.kalium.logic.data.event.EventRepository
 import com.wire.kalium.logic.data.featureConfig.FeatureConfigRepository
@@ -124,6 +125,7 @@ public class DebugScope internal constructor(
     private val resetMLSConversationUseCase: ResetMLSConversationUseCase,
     private val transactionProvider: CryptoTransactionProvider,
     private val refillKeyPackagesUseCase: RefillKeyPackagesUseCase,
+    private val certificateRevocationListRepository: CertificateRevocationListRepository,
     logger: KaliumLogger,
     internal val dispatcher: KaliumDispatcher = KaliumDispatcherImpl,
 ) {
@@ -298,6 +300,12 @@ public class DebugScope internal constructor(
 
     public val setDebugE2EICertificateExpiration: SetDebugE2EICertificateExpirationUseCase
         get() = SetDebugE2EICertificateExpirationUseCaseImpl(e2EIClientProvider)
+
+    public val observeDebugCRLExpirationAfterOneMinute: ObserveDebugCRLExpirationAfterOneMinuteUseCase
+        get() = ObserveDebugCRLExpirationAfterOneMinuteUseCaseImpl(certificateRevocationListRepository)
+
+    public val setDebugCRLExpirationAfterOneMinute: SetDebugCRLExpirationAfterOneMinuteUseCase
+        get() = SetDebugCRLExpirationAfterOneMinuteUseCaseImpl(certificateRevocationListRepository)
 
     public val repairFaultyRemovalKeysUseCase: RepairFaultyRemovalKeysUseCase by lazy {
         RepairFaultyRemovalKeysUseCaseImpl(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/e2ei/CertificateRevocationListRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/e2ei/CertificateRevocationListRepositoryTest.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.common.functional.right
 import com.wire.kalium.logic.configuration.E2EISettings
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.e2ei.CertificateRevocationListRepositoryDataSource.Companion.CRL_LIST_KEY
+import com.wire.kalium.logic.data.e2ei.CertificateRevocationListRepositoryDataSource.Companion.CRL_FORCE_EXPIRATION_AFTER_ONE_MINUTE_KEY
 import com.wire.kalium.network.api.base.unbound.acme.ACMEApi
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.config.CRLUrlExpirationList
@@ -32,8 +33,11 @@ import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
+import dev.mokkery.matcher.matches
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
+import kotlinx.datetime.Clock
+import kotlinx.serialization.builtins.serializer
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 
@@ -113,6 +117,45 @@ class CertificateRevocationListRepositoryTest {
     }
 
     @Test
+    fun givenForceExpirationAfterOneMinute_whenUpdatingCRLs_thenExpirationIsOverridden() = runTest {
+        val now = Clock.System.now().epochSeconds.toULong()
+        val (arrangement, crlRepository) = Arrangement()
+            .withEmptyList()
+            .withForceExpirationAfterOneMinute(true)
+            .arrange()
+
+        crlRepository.addOrUpdateCRL(DUMMY_URL, TIMESTAMP)
+
+        verifySuspend {
+            arrangement.metadataDAO.putSerializable(
+                CRL_LIST_KEY,
+                matches {
+                    val expiration = it.cRLWithExpirationList.single().expiration
+                    expiration >= now && expiration != TIMESTAMP
+                },
+                CRLUrlExpirationList.serializer()
+            )
+        }
+    }
+
+    @Test
+    fun givenStoredCRLs_whenClearingExpirationDates_thenStoredUrlsRemainWithExpiredDates() = runTest {
+        val (arrangement, crlRepository) = Arrangement()
+            .withCRLs()
+            .arrange()
+
+        crlRepository.clearCRLExpirationDates()
+
+        verifySuspend {
+            arrangement.metadataDAO.putSerializable(
+                CRL_LIST_KEY,
+                CRLUrlExpirationList(listOf(CRLWithExpiration(DUMMY_URL, 0UL))),
+                CRLUrlExpirationList.serializer()
+            )
+        }
+    }
+
+    @Test
     fun givenCRLUrlProxyRequired_whenClientDomainCRLRequested_thenProxyIsApplied() = runTest {
         val (arrangement, crlRepository) = Arrangement()
             .withClientDomainCRL()
@@ -164,6 +207,10 @@ class CertificateRevocationListRepositoryTest {
         val metadataDAO = mock<MetadataDAO>(mode = MockMode.autoUnit)
         val userConfigRepository = mock<UserConfigRepository>()
 
+        init {
+            withForceExpirationAfterOneMinute(false)
+        }
+
         fun arrange() = this to CertificateRevocationListRepositoryDataSource(acmeApi, metadataDAO, userConfigRepository)
 
         fun withEmptyList() = apply {
@@ -191,6 +238,15 @@ class CertificateRevocationListRepositoryTest {
                     CRLUrlExpirationList.serializer()
                 )
             } returns CRLUrlExpirationList(listOf(CRLWithExpiration(DUMMY_URL, TIMESTAMP)))
+        }
+
+        fun withForceExpirationAfterOneMinute(enabled: Boolean) = apply {
+            everySuspend {
+                metadataDAO.getSerializable(
+                    CRL_FORCE_EXPIRATION_AFTER_ONE_MINUTE_KEY,
+                    Boolean.serializer()
+                )
+            } returns enabled
         }
 
         fun withE2EISettings(result: Either<StorageFailure, E2EISettings> = E2EI_SETTINGS.right()) = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/debug/DebugCRLExpirationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/debug/DebugCRLExpirationUseCaseTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.debug
+
+import com.wire.kalium.logic.data.e2ei.CertificateRevocationListRepository
+import dev.mokkery.MockMode
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class DebugCRLExpirationUseCaseTest {
+
+    private val certificateRevocationListRepository = mock<CertificateRevocationListRepository>(mode = MockMode.autoUnit)
+
+    @Test
+    fun givenForceExpirationIsEnabled_whenSettingDebugCRLExpiration_thenExpirationDatesAreCleared() = runTest {
+        val useCase = SetDebugCRLExpirationAfterOneMinuteUseCaseImpl(certificateRevocationListRepository)
+
+        useCase(true)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            certificateRevocationListRepository.setShouldForceCRLExpirationAfterOneMinute(true)
+            certificateRevocationListRepository.clearCRLExpirationDates()
+        }
+    }
+
+    @Test
+    fun givenForceExpirationIsDisabled_whenSettingDebugCRLExpiration_thenExpirationDatesAreNotCleared() = runTest {
+        val useCase = SetDebugCRLExpirationAfterOneMinuteUseCaseImpl(certificateRevocationListRepository)
+
+        useCase(false)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            certificateRevocationListRepository.setShouldForceCRLExpirationAfterOneMinute(false)
+        }
+        verifySuspend(VerifyMode.not) {
+            certificateRevocationListRepository.clearCRLExpirationDates()
+        }
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24945
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Adds debug support for forcing E2EI CRLs to expire after 1 minute.

This allows clients to test certificate revocation flows without waiting for the normal CRL expiration period.

### Causes (Optional)

CRL expiration is normally based on the expiry returned by CoreCrypto/backend data, which can make revocation testing slow.

### Solutions

Adds debug use cases to observe and set a `Force CRL expiry after 1 minute` flag.

When the flag is enabled:
- existing stored CRL expiration dates are cleared
- newly stored CRLs receive a local expiration timestamp of `now + 1 minute`

When the flag is disabled, stored CRLs go back to using the normal expiration timestamp provided by the CRL flow.