### PR TITLE
feat: add GetSelfTeamIdUseCase to retrieve current user's team ID from cache [WPB-25803]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/GetSelfTeamIdUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/GetSelfTeamIdUseCase.kt
@@ -1,0 +1,37 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.user
+
+import com.wire.kalium.common.functional.getOrNull
+import com.wire.kalium.logic.data.id.SelfTeamIdProvider
+import com.wire.kalium.logic.data.id.TeamId
+
+/**
+ * This use case is responsible for retrieving the current user's team ID.
+ * the team ID is cached in memory and is not expected to change during the app's lifecycle, so it is not wrapped in a Result.
+ */
+public interface GetSelfTeamIdUseCase {
+    public suspend operator fun invoke(): TeamId?
+}
+
+internal class GetSelfTeamIdUseCaseImpl internal constructor(
+    private val selfTeamIdProvider: SelfTeamIdProvider,
+) : GetSelfTeamIdUseCase {
+    override suspend operator fun invoke(): TeamId? = selfTeamIdProvider().getOrNull()
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/UserScope.kt
@@ -153,6 +153,7 @@ public class UserScope internal constructor(
 ) {
     private val validateUserHandleUseCase: ValidateUserHandleUseCase get() = ValidateUserHandleUseCaseImpl()
     public val getSelfUser: GetSelfUserUseCase get() = GetSelfUserUseCaseImpl(userRepository)
+    public val getSelfTeamId: GetSelfTeamIdUseCase get() = GetSelfTeamIdUseCaseImpl(selfTeamIdProvider)
     public val observeSelfUser: ObserveSelfUserUseCase get() = ObserveSelfUserUseCaseImpl(userRepository)
     public val observeSelfUserWithTeam: ObserveSelfUserWithTeamUseCase
         get() = ObserveSelfUserWithTeamUseCaseImpl(userRepository)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25803
<!--jira-description-action-hidden-marker-end-->
Avoid fetching the full self user from DB when only the current team id is needed. The team id is already cached in memory through Kalium, so these paths can use `GetSelfTeamIdUseCase` directly.

## What changed

- Added/provided `GetSelfTeamIdUseCase` through `UserScope` and Hilt.
- Switched conversation list/search and self profile team-id checks to the cached provider.
- Updated affected unit tests.