### PR TITLE
fix: wipe 1:1 conversation when other user deleted (WPB-23377)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1423,7 +1423,9 @@ public class UserSessionScope internal constructor(
             oneOnOneProtocolSelector,
             oneOnOneMigrator,
             incrementalSyncRepository,
-            pendingActionsRepository
+            pendingActionsRepository,
+            conversationRepository,
+            mlsConversationRepository,
         )
 
     private val recoverPendingOneOnOneResolutionsUseCase: RecoverPendingOneOnOneResolutionsUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolver.kt
@@ -30,6 +30,10 @@ import com.wire.kalium.common.functional.left
 import com.wire.kalium.common.functional.map
 import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.cryptography.CryptoTransactionContext
+import com.wire.kalium.logic.data.client.wrapInMLSContext
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.conversation.mls.PendingActionsRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
@@ -102,6 +106,8 @@ internal class OneOnOneResolverImpl(
     private val oneOnOneMigrator: OneOnOneMigrator,
     private val incrementalSyncRepository: IncrementalSyncRepository,
     private val pendingActionsRepository: PendingActionsRepository,
+    private val conversationRepository: ConversationRepository,
+    private val mlsConversationRepository: MLSConversationRepository,
     private val maxConcurrentResolutions: Int = DEFAULT_MAX_CONCURRENT_RESOLUTIONS,
     private val maxThrottleRetries: Int = DEFAULT_MAX_THROTTLE_RETRIES,
     private val throttleRetryDelayMs: Long = DEFAULT_THROTTLE_RETRY_DELAY_MS,
@@ -286,6 +292,9 @@ internal class OneOnOneResolverImpl(
         invalidateCurrentKnownProtocols: Boolean,
         allowJoinByExternalCommit: Boolean,
     ): Either<CoreFailure, ConversationId> {
+        if (user.deleted) {
+            return cleanupDeletedPeerMlsGroup(transactionContext, user.id)
+        }
         kaliumLogger.i("Resolving one-on-one protocol for ${user.id.toLogString()}")
         if (invalidateCurrentKnownProtocols) {
             userRepository.fetchUsersByIds(setOf(user.id))
@@ -307,6 +316,29 @@ internal class OneOnOneResolverImpl(
                 )
             }
         })
+    }
+
+    private suspend fun cleanupDeletedPeerMlsGroup(
+        transactionContext: CryptoTransactionContext,
+        userId: UserId,
+    ): Either<CoreFailure, ConversationId> {
+        kaliumLogger.i("Peer ${userId.toLogString()} is deleted — wiping 1:1 MLS group from CoreCrypto if any")
+        return userRepository.getOneOnOnConversationId(userId).flatMap { conversationId ->
+            conversationRepository.getConversationProtocolInfo(conversationId).flatMap { protocolInfo ->
+                when (protocolInfo) {
+                    is Conversation.ProtocolInfo.MLSCapable -> transactionContext.wrapInMLSContext { mlsContext ->
+                        mlsConversationRepository.leaveGroup(mlsContext, protocolInfo.groupId)
+                    }.flatMapLeft {
+                        kaliumLogger.i(
+                            "Wipe of 1:1 MLS group for deleted peer ${userId.toLogString()} returned $it — " +
+                                "treating as already wiped"
+                        )
+                        Either.Right(Unit)
+                    }
+                    is Conversation.ProtocolInfo.Proteus -> Either.Right(Unit)
+                }
+            }.map { conversationId }
+        }
     }
 
     private companion object {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolverTest.kt
@@ -18,10 +18,16 @@
 package com.wire.kalium.logic.feature.conversation.mls
 
 import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.MLSFailure
 import com.wire.kalium.common.error.NetworkFailure
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.data.conversation.mls.PendingActionsRepository
+import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.data.user.UserId
@@ -317,6 +323,106 @@ class OneOnOneResolverTest {
         }
     }
 
+    @Test
+    fun givenPeerIsDeletedAndOneOnOneIsMls_whenResolving_thenWipesMlsGroupAndKeepsLocalConversation() = runTest {
+        val deletedPeer = TestUser.OTHER.copy(deleted = true)
+        val convId = TestConversation.ID
+        val (arrangement, resolver) = arrange {
+            withGetOneOnOnConversationIdReturning(Either.Right(convId))
+            withGetConversationProtocolInfoReturning(Either.Right(TestConversation.MLS_PROTOCOL_INFO))
+            withLeaveGroupReturning(Either.Right(Unit))
+        }
+
+        resolver.resolveOneOnOneConversationWithUser(arrangement.transactionContext, deletedPeer, false).shouldSucceed {
+            kotlin.test.assertEquals(convId, it)
+        }
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.mlsConversationRepository.leaveGroup(mokkeryAny(), mokkeryEq(TestConversation.MLS_PROTOCOL_INFO.groupId))
+        }
+        verifySuspend(VerifyMode.not) { arrangement.conversationRepository.deleteConversationLocally(mokkeryAny()) }
+        verifySuspend(VerifyMode.not) { arrangement.oneOnOneProtocolSelector.getProtocolForUser(mokkeryAny()) }
+        verifySuspend(VerifyMode.not) { arrangement.oneOnOneMigrator.migrateToMLS(mokkeryAny(), mokkeryAny(), mokkeryAny()) }
+        verifySuspend(VerifyMode.not) { arrangement.oneOnOneMigrator.migrateToProteus(mokkeryAny()) }
+        verifySuspend(VerifyMode.not) { arrangement.userRepository.fetchUsersByIds(mokkeryAny()) }
+    }
+
+    @Test
+    fun givenPeerIsDeletedAndOneOnOneIsProteus_whenResolving_thenDoesNotTouchCryptoAndKeepsLocalConversation() = runTest {
+        val deletedPeer = TestUser.OTHER.copy(deleted = true)
+        val convId = TestConversation.ID
+        val (arrangement, resolver) = arrange {
+            withGetOneOnOnConversationIdReturning(Either.Right(convId))
+            withGetConversationProtocolInfoReturning(Either.Right(TestConversation.PROTEUS_PROTOCOL_INFO))
+        }
+
+        resolver.resolveOneOnOneConversationWithUser(arrangement.transactionContext, deletedPeer, false).shouldSucceed {
+            kotlin.test.assertEquals(convId, it)
+        }
+
+        verifySuspend(VerifyMode.not) {
+            arrangement.mlsConversationRepository.leaveGroup(mokkeryAny(), mokkeryAny())
+        }
+        verifySuspend(VerifyMode.not) { arrangement.conversationRepository.deleteConversationLocally(mokkeryAny()) }
+        verifySuspend(VerifyMode.not) { arrangement.oneOnOneMigrator.migrateToMLS(mokkeryAny(), mokkeryAny(), mokkeryAny()) }
+    }
+
+    @Test
+    fun givenPeerIsDeletedAndNoActive1on1_whenResolving_thenReturnsLeftAndDoesNothing() = runTest {
+        val deletedPeer = TestUser.OTHER.copy(deleted = true)
+        val (arrangement, resolver) = arrange {
+            withGetOneOnOnConversationIdReturning(Either.Left(StorageFailure.DataNotFound))
+        }
+
+        resolver.resolveOneOnOneConversationWithUser(arrangement.transactionContext, deletedPeer, false).shouldFail()
+
+        verifySuspend(VerifyMode.not) {
+            arrangement.mlsConversationRepository.leaveGroup(mokkeryAny(), mokkeryAny())
+        }
+        verifySuspend(VerifyMode.not) { arrangement.oneOnOneProtocolSelector.getProtocolForUser(mokkeryAny()) }
+        verifySuspend(VerifyMode.not) { arrangement.oneOnOneMigrator.migrateToMLS(mokkeryAny(), mokkeryAny(), mokkeryAny()) }
+    }
+
+    @Test
+    fun givenPeerIsDeletedAndMlsGroupAlreadyWiped_whenResolving_thenStillReturnsSuccess() = runTest {
+        val deletedPeer = TestUser.OTHER.copy(deleted = true)
+        val convId = TestConversation.ID
+        val (arrangement, resolver) = arrange {
+            withGetOneOnOnConversationIdReturning(Either.Right(convId))
+            withGetConversationProtocolInfoReturning(Either.Right(TestConversation.MLS_PROTOCOL_INFO))
+            withLeaveGroupReturning(Either.Left(MLSFailure.Generic(IllegalStateException("group not found"))))
+        }
+
+        resolver.resolveOneOnOneConversationWithUser(arrangement.transactionContext, deletedPeer, false).shouldSucceed {
+            kotlin.test.assertEquals(convId, it)
+        }
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.mlsConversationRepository.leaveGroup(mokkeryAny(), mokkeryAny())
+        }
+        verifySuspend(VerifyMode.not) { arrangement.oneOnOneMigrator.migrateToMLS(mokkeryAny(), mokkeryAny(), mokkeryAny()) }
+    }
+
+    @Test
+    fun givenPeerIsDeletedAndScheduledResolveById_whenResolving_thenShortCircuitsViaCleanupPath() = runTest {
+        val deletedPeer = TestUser.OTHER.copy(deleted = true)
+        val convId = TestConversation.ID
+        val (arrangement, resolver) = arrange {
+            withGetKnownUserReturning(flowOf(deletedPeer))
+            withFetchUsersByIdReturning(Either.Right(true))
+            withGetOneOnOnConversationIdReturning(Either.Right(convId))
+            withGetConversationProtocolInfoReturning(Either.Right(TestConversation.MLS_PROTOCOL_INFO))
+            withLeaveGroupReturning(Either.Right(Unit))
+        }
+
+        resolver.resolveOneOnOneConversationWithUserId(arrangement.transactionContext, deletedPeer.id, true).shouldSucceed()
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.mlsConversationRepository.leaveGroup(mokkeryAny(), mokkeryAny())
+        }
+        verifySuspend(VerifyMode.not) { arrangement.oneOnOneProtocolSelector.getProtocolForUser(mokkeryAny()) }
+    }
+
     private class Arrangement(
         private val maxConcurrentResolutions: Int = 4,
         private val maxThrottleRetries: Int = 3,
@@ -329,6 +435,8 @@ class OneOnOneResolverTest {
         val oneOnOneMigrator = mock<OneOnOneMigrator>(mode = MockMode.autoUnit)
         val incrementalSyncRepository = mock<IncrementalSyncRepository>(mode = MockMode.autoUnit)
         val pendingActionsRepository = mock<PendingActionsRepository>(mode = MockMode.autoUnit)
+        val conversationRepository = mock<ConversationRepository>(mode = MockMode.autoUnit)
+        val mlsConversationRepository = mock<MLSConversationRepository>(mode = MockMode.autoUnit)
         fun arrange() = run {
             runBlocking {
                 everySuspend { pendingActionsRepository.enqueuePendingOneOnOneResolution(mokkeryAny()) } returns Unit
@@ -340,10 +448,24 @@ class OneOnOneResolverTest {
                 oneOnOneMigrator = oneOnOneMigrator,
                 incrementalSyncRepository = incrementalSyncRepository,
                 pendingActionsRepository = pendingActionsRepository,
+                conversationRepository = conversationRepository,
+                mlsConversationRepository = mlsConversationRepository,
                 maxConcurrentResolutions = maxConcurrentResolutions,
                 maxThrottleRetries = maxThrottleRetries,
                 throttleRetryDelayMs = throttleRetryDelayMs,
             )
+        }
+
+        suspend fun withGetOneOnOnConversationIdReturning(result: Either<StorageFailure, ConversationId>) {
+            everySuspend { userRepository.getOneOnOnConversationId(mokkeryAny()) } returns result
+        }
+
+        suspend fun withGetConversationProtocolInfoReturning(result: Either<StorageFailure, Conversation.ProtocolInfo>) {
+            everySuspend { conversationRepository.getConversationProtocolInfo(mokkeryAny()) } returns result
+        }
+
+        suspend fun withLeaveGroupReturning(result: Either<CoreFailure, Unit>) {
+            everySuspend { mlsConversationRepository.leaveGroup(mokkeryAny(), mokkeryAny()) } returns result
         }
 
         suspend fun withGetUsersWithOneOnOneConversationReturning(result: List<OtherUser>) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-23377
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-23377
----

# What's new in this PR?

### Issues
App was trying to resolve 1:1 conversation with deleted user.

### Solutions
Update OneOnOneResolver to wipe MLS conversation from CC if other user is deleted.