### PR TITLE
refactor: use snapshot reads for correctness paths

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
@@ -30,7 +30,6 @@ import com.wire.kalium.common.functional.getOrNull
 import com.wire.kalium.common.functional.map
 import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.common.functional.onSuccess
-import com.wire.kalium.common.functional.onlyRight
 import com.wire.kalium.common.functional.right
 import com.wire.kalium.common.logger.callingLogger
 import com.wire.kalium.common.logger.logStructuredJson
@@ -44,7 +43,6 @@ import com.wire.kalium.logic.data.client.CryptoTransactionProvider
 import com.wire.kalium.logic.data.client.wrapInMLSContext
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Conversation
-import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.EpochChangesObserver
 import com.wire.kalium.logic.data.conversation.JoinSubconversationUseCase
@@ -238,8 +236,10 @@ internal class CallDataSource(
             )
         }
     ) {
-        val conversation: ConversationDetails =
-            conversationRepository.observeConversationDetailsById(conversationId).onlyRight().first()
+        val conversation = conversationRepository.getConversationById(conversationId).getOrNull() ?: run {
+            callingLogger.w("[CallRepository][createCall] -> Conversation not found: ${conversationId.toLogString()}")
+            return@withLock
+        }
 
         val caller = userRepository.getKnownUser(callerId).first()
         val team = caller?.teamId?.let { teamId -> teamRepository.getTeam(teamId).first() }
@@ -249,14 +249,14 @@ internal class CallDataSource(
             id = Uuid.random().toString(),
             type = type,
             status = status,
-            conversationType = conversation.conversation.type,
+            conversationType = conversation.type,
             callerId = callerId
         )
 
         val metadata = CallMetadata(
             callerId = callerId,
-            conversationName = conversation.conversation.name,
-            conversationType = conversation.conversation.type,
+            conversationName = conversation.name,
+            conversationType = conversation.type,
             callerName = caller?.name,
             callerTeamName = team?.name,
             isMuted = isMuted,
@@ -264,7 +264,7 @@ internal class CallDataSource(
             isCbrEnabled = isCbrEnabled,
             establishedTime = null,
             callStatus = status,
-            protocol = conversation.conversation.protocol,
+            protocol = conversation.protocol,
             activeSpeakers = mapOf()
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -74,10 +74,16 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.datetime.Instant
+
+internal data class ConversationMemberCounts(
+    val conversationSize: Int,
+    val servicesCount: Int,
+    val guestsCount: Int,
+    val guestsProCount: Int
+)
 
 @Suppress("TooManyFunctions")
 internal interface ConversationRepository {
@@ -88,6 +94,7 @@ internal interface ConversationRepository {
     suspend fun observeConversationById(conversationId: ConversationId): Flow<Either<StorageFailure, Conversation>>
     suspend fun observeConversationDetailsById(conversationID: ConversationId): Flow<Either<StorageFailure, ConversationDetails>>
     suspend fun getConversationById(conversationId: ConversationId): Either<StorageFailure, Conversation>
+    suspend fun getConversationLastReadDate(conversationId: ConversationId): Either<StorageFailure, Instant>
     suspend fun getNonDeletedConversationById(conversationId: ConversationId): Either<StorageFailure, Conversation>
 
     // endregion
@@ -145,6 +152,8 @@ internal interface ConversationRepository {
     suspend fun getConversationRecipientsForCalling(conversationId: ConversationId): Either<CoreFailure, List<Recipient>>
     suspend fun getConversationProtocolInfo(conversationId: ConversationId): Either<StorageFailure, Conversation.ProtocolInfo>
     suspend fun observeConversationMembers(conversationID: ConversationId): Flow<List<Conversation.Member>>
+    suspend fun isConversationMemberAdmin(conversationId: ConversationId, userId: UserId): Either<StorageFailure, Boolean>
+    suspend fun getConversationMemberCounts(conversationId: ConversationId): Either<StorageFailure, ConversationMemberCounts>
 
     /**
      * Fetches a list of all members' IDs or a given conversation including self user
@@ -407,6 +416,10 @@ internal class ConversationDataSource internal constructor(
         }
     }
 
+    override suspend fun getConversationLastReadDate(conversationId: ConversationId): Either<StorageFailure, Instant> = wrapStorageRequest {
+        conversationDAO.getConversationLastReadDate(conversationId.toDao())
+    }
+
     override suspend fun getNonDeletedConversationById(
         conversationId: ConversationId
     ): Either<StorageFailure, Conversation> = wrapStorageRequest {
@@ -594,8 +607,27 @@ internal class ConversationDataSource internal constructor(
             members.map(memberMapper::fromDaoModel)
         }
 
+    override suspend fun isConversationMemberAdmin(
+        conversationId: ConversationId,
+        userId: UserId
+    ): Either<StorageFailure, Boolean> = wrapStorageRequest {
+        memberDAO.isMemberAdmin(conversationId.toDao(), userId.toDao())
+    }
+
+    override suspend fun getConversationMemberCounts(conversationId: ConversationId): Either<StorageFailure, ConversationMemberCounts> =
+        wrapStorageRequest {
+            memberDAO.getConversationMemberCounts(conversationId.toDao()).let {
+                ConversationMemberCounts(
+                    conversationSize = it.conversationSize,
+                    servicesCount = it.servicesCount,
+                    guestsCount = it.guestsCount,
+                    guestsProCount = it.guestsProCount
+                )
+            }
+        }
+
     override suspend fun getConversationMembers(conversationId: ConversationId): Either<StorageFailure, List<UserId>> = wrapStorageRequest {
-        memberDAO.observeConversationMembers(conversationId.toDao()).first().map { it.user.toModel() }
+        memberDAO.getConversationMembers(conversationId.toDao()).map { it.toModel() }
     }
 
     override suspend fun persistMembers(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -584,7 +584,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -732,10 +731,10 @@ public class UserSessionScope internal constructor(
         // this can depend directly on DAO it will make it easier to user
         // and remove any circular dependency when using this inside user repository
         wrapStorageNullableRequest {
-            userStorage.database.userDAO.observeUserDetailsByQualifiedID(userId.toDao()).firstOrNull()
-        }.map { userDetailsEntity ->
-            _teamId = Either.Right(userDetailsEntity?.team?.let { TeamId(it) })
-            userDetailsEntity?.team?.let { TeamId(it) }
+            userStorage.database.userDAO.getTeamIdByQualifiedID(userId.toDao())
+        }.map { teamId ->
+            _teamId = Either.Right(teamId?.let { TeamId(it) })
+            teamId?.let { TeamId(it) }
         }
     }
 
@@ -2800,7 +2799,7 @@ public class UserSessionScope internal constructor(
     private val createAndPersistRecentlyEndedCallMetadata: CreateAndPersistRecentlyEndedCallMetadataUseCase
         get() = CreateAndPersistRecentlyEndedCallMetadataUseCaseImpl(
             callRepository = callRepository,
-            observeConversationMembers = conversations.observeConversationMembers,
+            conversationRepository = conversationRepository,
             selfTeamIdProvider = selfTeamId
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/ShouldRemoteMuteChecker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/ShouldRemoteMuteChecker.kt
@@ -17,7 +17,6 @@
  */
 package com.wire.kalium.logic.feature.call
 
-import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserId
 
@@ -28,28 +27,20 @@ import com.wire.kalium.logic.data.user.UserId
  */
 internal interface ShouldRemoteMuteChecker {
     fun check(
-        senderUserId: UserId,
+        isSenderAdmin: Boolean,
         selfUserId: UserId,
         selfClientId: String,
-        targets: MessageContent.Calling.Targets?,
-        conversationMembers: List<Conversation.Member>
+        targets: MessageContent.Calling.Targets?
     ): Boolean
 }
 
 internal class ShouldRemoteMuteCheckerImpl : ShouldRemoteMuteChecker {
     override fun check(
-        senderUserId: UserId,
+        isSenderAdmin: Boolean,
         selfUserId: UserId,
         selfClientId: String,
-        targets: MessageContent.Calling.Targets?,
-        conversationMembers: List<Conversation.Member>
-    ): Boolean = isSenderAnAdmin(senderUserId, conversationMembers) && isCurrentClientTargeted(selfUserId, selfClientId, targets)
-
-    // Only admins can remotely mute other participants, so we need to check if the sender is an admin or not.
-    private fun isSenderAnAdmin(senderUserId: UserId, conversationMembers: List<Conversation.Member>): Boolean =
-        conversationMembers.any { member ->
-            member.id == senderUserId && member.role == Conversation.Member.Role.Admin
-        }
+        targets: MessageContent.Calling.Targets?
+    ): Boolean = isSenderAdmin && isCurrentClientTargeted(selfUserId, selfClientId, targets)
 
     // Because of the nature of MLS (where all the MLS group members always receive a message),
     // we need to check if the current client is a target of the remote mute or not.

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/CreateAndPersistRecentlyEndedCallMetadataUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/CreateAndPersistRecentlyEndedCallMetadataUseCase.kt
@@ -23,14 +23,11 @@ import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.CallScreenSharingMetadata
 import com.wire.kalium.logic.data.call.CallStatus
 import com.wire.kalium.logic.data.call.RecentlyEndedCallMetadata
+import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.SelfTeamIdProvider
-import com.wire.kalium.logic.data.user.type.isAppOrBot
-import com.wire.kalium.logic.data.user.type.isGuest
 import com.wire.kalium.logic.data.user.type.isOwner
-import com.wire.kalium.logic.feature.conversation.ObserveConversationMembersUseCase
 import com.wire.kalium.util.DateTimeUtil
-import kotlinx.coroutines.flow.first
 
 /**
  * Given a call and raw call end reason create metadata containing all information regarding
@@ -42,7 +39,7 @@ internal interface CreateAndPersistRecentlyEndedCallMetadataUseCase {
 
 internal class CreateAndPersistRecentlyEndedCallMetadataUseCaseImpl internal constructor(
     private val callRepository: CallRepository,
-    private val observeConversationMembers: ObserveConversationMembersUseCase,
+    private val conversationRepository: ConversationRepository,
     private val selfTeamIdProvider: SelfTeamIdProvider,
 ) : CreateAndPersistRecentlyEndedCallMetadataUseCase {
     override suspend fun invoke(conversationId: ConversationId, callEndedReason: Int) {
@@ -54,12 +51,9 @@ internal class CreateAndPersistRecentlyEndedCallMetadataUseCaseImpl internal con
         }
     }
 
-    private suspend fun CallMetadata.createMetadata(conversationId: ConversationId, callEndedReason: Int): RecentlyEndedCallMetadata {
+    private suspend fun CallMetadata.createMetadata(conversationId: ConversationId, callEndedReason: Int): RecentlyEndedCallMetadata? {
         val selfCallUser = getFullParticipants().firstOrNull { participant -> participant.userType.isOwner() }
-        val conversationMembers = observeConversationMembers(conversationId).first()
-        val conversationServicesCount = conversationMembers.count { member -> member.user.userType.isAppOrBot() }
-        val guestsCount = conversationMembers.count { member -> member.user.userType.isGuest() }
-        val guestsProCount = conversationMembers.count { member -> member.user.userType.isGuest() && member.user.teamId != null }
+        val memberCounts = conversationRepository.getConversationMemberCounts(conversationId).getOrNull() ?: return null
         val isOutgoingCall = callStatus == CallStatus.STARTED
         val callDurationInSeconds = establishedTime?.let {
             DateTimeUtil.calculateMillisDifference(it, DateTimeUtil.currentIsoDateTimeString()) / MILLIS_IN_SECOND
@@ -74,15 +68,15 @@ internal class CreateAndPersistRecentlyEndedCallMetadataUseCaseImpl internal con
                 isOutgoingCall = isOutgoingCall,
                 callDurationInSeconds = callDurationInSeconds,
                 callParticipantsCount = participants.size,
-                conversationServices = conversationServicesCount,
+                conversationServices = memberCounts.servicesCount,
                 callAVSwitchToggle = selfCallUser?.isCameraOn ?: false,
                 callVideoEnabled = isCameraOn
             ),
             conversationDetails = RecentlyEndedCallMetadata.ConversationDetails(
                 conversationType = conversationType,
-                conversationSize = conversationMembers.size,
-                conversationGuests = guestsCount,
-                conversationGuestsPro = guestsProCount
+                conversationSize = memberCounts.conversationSize,
+                conversationGuests = memberCounts.guestsCount,
+                conversationGuestsPro = memberCounts.guestsProCount
             ),
             isTeamMember = selfTeamIdProvider().getOrNull() != null
         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
@@ -43,7 +43,6 @@ import com.wire.kalium.messaging.hooks.ConversationLastReadEventData
 import com.wire.kalium.messaging.hooks.PersistenceEventHookNotifier
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
@@ -95,13 +94,13 @@ public class UpdateConversationReadDateUseCase internal constructor(
 
     private suspend fun doWork(conversationId: QualifiedID, time: Instant) {
         coroutineScope {
-            conversationRepository.observeConversationById(conversationId).first().onFailure {
+            conversationRepository.getConversationLastReadDate(conversationId).onFailure {
                 logger.w("Failed to update conversation read date; StorageFailure $it")
-            }.onSuccess { conversation ->
-                if (conversation.lastReadDate >= time) {
+            }.onSuccess { lastReadDate ->
+                if (lastReadDate >= time) {
                     logger.d(
                         "Skipping last-read update for '${conversationId.toLogString()}': " +
-                            "stored=${conversation.lastReadDate} >= requested=$time"
+                            "stored=$lastReadDate >= requested=$time"
                     )
                     // Skipping, as current lastRead is already newer than the scheduled one
                     return@onSuccess
@@ -111,7 +110,7 @@ public class UpdateConversationReadDateUseCase internal constructor(
 
                 if (shouldRunOptionalSideEffects) {
                     launch {
-                        sendConfirmation(conversationId, conversation.lastReadDate, time)
+                        sendConfirmation(conversationId, lastReadDate, time)
                     }
                 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/confirmation/ConfirmationDeliveryHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/confirmation/ConfirmationDeliveryHandler.kt
@@ -35,7 +35,6 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.first
 
 /**
  * Internal: Handles the send of delivery confirmation of messages.
@@ -81,7 +80,7 @@ internal class ConfirmationDeliveryHandlerImpl(
             kaliumLogger.d("Started collecting pending messages for delivery confirmation")
             val messagesToSend = pendingConfirmationMessages.block { it.toMap() }
             messagesToSend.forEach { (conversationId, messages) ->
-                conversationRepository.observeConversationById(conversationId).first().flatMap { conversation ->
+                conversationRepository.getConversationById(conversationId).flatMap { conversation ->
                     if (conversation.type == Conversation.Type.OneOnOne) {
                         sendDeliverSignalUseCase(
                             conversation = conversation,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/CallingMessageHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/CallingMessageHandler.kt
@@ -32,7 +32,6 @@ import com.wire.kalium.logic.feature.call.CallManager
 import com.wire.kalium.logic.feature.call.ShouldRemoteMuteChecker
 import com.wire.kalium.logic.feature.call.ShouldRemoteMuteCheckerImpl
 import com.wire.kalium.logic.feature.call.usecase.MuteCallUseCase
-import kotlinx.coroutines.flow.first
 import kotlinx.serialization.json.Json
 
 internal interface CallingMessageHandler {
@@ -81,13 +80,14 @@ internal class CallingMessageHandlerImpl internal constructor(
             return
         }
 
-        val conversationMembers = conversationRepository.observeConversationMembers(targetConversationId).first()
+        val isSenderAdmin = conversationRepository
+            .isConversationMemberAdmin(targetConversationId, message.senderUserId)
+            .getOrNull() ?: false
         val shouldRemoteMute = shouldRemoteMuteChecker.check(
-            senderUserId = message.senderUserId,
+            isSenderAdmin = isSenderAdmin,
             selfUserId = selfUserId,
             selfClientId = clientId.value,
-            targets = callingValue.targets,
-            conversationMembers = conversationMembers
+            targets = callingValue.targets
         )
         callingLogger.i("$tagWithUserId: Calling $REMOTE_MUTE_TYPE message received for conversationId: $targetConversationId.")
         if (shouldRemoteMute) {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
@@ -90,6 +90,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
@@ -2126,9 +2127,13 @@ class CallRepositoryTest {
         }
 
         suspend fun givenObserveConversationDetailsByIdReturns(flow: Flow<Either<StorageFailure, ConversationDetails>>) = apply {
+            val result = when (val details = flow.first()) {
+                is Either.Left -> Either.Left(details.value)
+                is Either.Right -> Either.Right(details.value.conversation)
+            }
             everySuspend {
-                conversationRepository.observeConversationDetailsById(any())
-            } returns flow
+                conversationRepository.getConversationById(any())
+            } returns result
         }
 
         suspend fun givenGetKnownUserSucceeds() = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/ShouldRemoteMuteCheckerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/ShouldRemoteMuteCheckerTest.kt
@@ -17,7 +17,6 @@
  */
 package com.wire.kalium.logic.feature.call
 
-import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserId
 import kotlin.test.Test
@@ -31,11 +30,10 @@ class ShouldRemoteMuteCheckerTest {
             .arrange()
 
         val shouldRemoteMute = checker.check(
-            senderUserId = OTHER_USER_ID,
+            isSenderAdmin = false,
             selfUserId = SELF_USER_ID,
             selfClientId = SELF_CLIENT_ID,
-            targets = null,
-            conversationMembers = listOf(conversationMember.copy(role = Conversation.Member.Role.Member))
+            targets = null
         )
 
         assertEquals(false, shouldRemoteMute)
@@ -47,11 +45,10 @@ class ShouldRemoteMuteCheckerTest {
             .arrange()
 
         val shouldRemoteMute = checker.check(
-            senderUserId = OTHER_USER_ID,
+            isSenderAdmin = true,
             selfUserId = SELF_USER_ID,
             selfClientId = SELF_CLIENT_ID,
-            targets = null,
-            conversationMembers = listOf(conversationMember)
+            targets = null
         )
 
         assertEquals(false, shouldRemoteMute)
@@ -63,11 +60,10 @@ class ShouldRemoteMuteCheckerTest {
             .arrange()
 
         val shouldRemoteMute = checker.check(
-            senderUserId = OTHER_USER_ID,
+            isSenderAdmin = true,
             selfUserId = SELF_USER_ID,
             selfClientId = SELF_CLIENT_ID,
-            targets = targetsWithoutCurrentUser,
-            conversationMembers = listOf(conversationMember)
+            targets = targetsWithoutCurrentUser
         )
 
         assertEquals(false, shouldRemoteMute)
@@ -79,11 +75,10 @@ class ShouldRemoteMuteCheckerTest {
             .arrange()
 
         val shouldRemoteMute = checker.check(
-            senderUserId = OTHER_USER_ID,
+            isSenderAdmin = true,
             selfUserId = SELF_USER_ID,
             selfClientId = SELF_CLIENT_ID,
-            targets = targetsWithCurrentUserButDifferentClient,
-            conversationMembers = listOf(conversationMember)
+            targets = targetsWithCurrentUserButDifferentClient
         )
 
         assertEquals(false, shouldRemoteMute)
@@ -95,11 +90,10 @@ class ShouldRemoteMuteCheckerTest {
             .arrange()
 
         val shouldRemoteMute = checker.check(
-            senderUserId = OTHER_USER_ID,
+            isSenderAdmin = true,
             selfUserId = SELF_USER_ID,
             selfClientId = SELF_CLIENT_ID,
-            targets = targetsWithCurrentUserAndCurrentClient,
-            conversationMembers = listOf(conversationMember)
+            targets = targetsWithCurrentUserAndCurrentClient
         )
 
         assertEquals(true, shouldRemoteMute)
@@ -144,10 +138,6 @@ class ShouldRemoteMuteCheckerTest {
                     OTHER_USER_ID.value to listOf(OTHER_CLIENT_ID, OTHER_CLIENT_ID)
                 ),
             )
-        )
-
-        val conversationMember = Conversation.Member(
-            OTHER_USER_ID, Conversation.Member.Role.Admin
         )
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/CreateAndPersistRecentlyEndedCallMetadataUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/CreateAndPersistRecentlyEndedCallMetadataUseCaseTest.kt
@@ -24,12 +24,12 @@ import com.wire.kalium.logic.data.call.CallStatus
 import com.wire.kalium.logic.data.call.ParticipantMinimized
 import com.wire.kalium.logic.data.call.RecentlyEndedCallMetadata
 import com.wire.kalium.logic.data.conversation.Conversation
-import com.wire.kalium.logic.data.conversation.MemberDetails
+import com.wire.kalium.logic.data.conversation.ConversationMemberCounts
+import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.SelfTeamIdProvider
 import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.logic.data.user.type.UserTypeInfo
-import com.wire.kalium.logic.feature.conversation.ObserveConversationMembersUseCase
 import com.wire.kalium.logic.framework.TestCall.CALLER_ID
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.framework.TestUser.OTHER_MINIMIZED
@@ -41,7 +41,6 @@ import dev.mokkery.everySuspend
 import dev.mokkery.verifySuspend
 import dev.mokkery.every
 import dev.mokkery.mock
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 
@@ -53,7 +52,7 @@ class CreateAndPersistRecentlyEndedCallMetadataUseCaseTest {
         val (arrangement, useCase) = Arrangement()
             .withOutgoingCall()
             .withSelfTeamIdPresent()
-            .withConversationMembers()
+            .withConversationMemberCounts()
             .arrange()
 
         // when
@@ -74,7 +73,7 @@ class CreateAndPersistRecentlyEndedCallMetadataUseCaseTest {
         val (arrangement, useCase) = Arrangement()
             .withOutgoingCall()
             .withSelfTeamIdPresent()
-            .withConversationGuests()
+            .withConversationMemberCounts(guestsCount = 1)
             .arrange()
 
         // when
@@ -101,7 +100,7 @@ class CreateAndPersistRecentlyEndedCallMetadataUseCaseTest {
         val (arrangement, useCase) = Arrangement()
             .withOutgoingCall()
             .withSelfTeamIdPresent()
-            .withConversationGuestsPro()
+            .withConversationMemberCounts(guestsCount = 1, guestsProCount = 1)
             .arrange()
 
         // when
@@ -129,7 +128,7 @@ class CreateAndPersistRecentlyEndedCallMetadataUseCaseTest {
         val (arrangement, useCase) = Arrangement()
             .withIncomingCall()
             .withSelfTeamIdPresent()
-            .withConversationMembers()
+            .withConversationMemberCounts()
             .arrange()
 
         // when
@@ -152,7 +151,7 @@ class CreateAndPersistRecentlyEndedCallMetadataUseCaseTest {
 
     private class Arrangement {
 
-        val observeConversationMembers = mock<ObserveConversationMembersUseCase>(mode = MockMode.autoUnit)
+        val conversationRepository = mock<ConversationRepository>(mode = MockMode.autoUnit)
         val selfTeamIdProvider = mock<SelfTeamIdProvider>(mode = MockMode.autoUnit)
         val callRepository = mock<CallRepository>(mode = MockMode.autoUnit)
 
@@ -168,37 +167,19 @@ class CreateAndPersistRecentlyEndedCallMetadataUseCaseTest {
             )
         }
 
-        suspend fun withConversationMembers() = apply {
-            everySuspend { observeConversationMembers(any()) } returns (
-                flowOf(
-                    listOf(
-                        MemberDetails(TestUser.SELF, Conversation.Member.Role.Admin),
-                        MemberDetails(TestUser.OTHER, Conversation.Member.Role.Member)
-                    )
-                )
-            )
-        }
-
-        suspend fun withConversationGuests() = apply {
-            everySuspend { observeConversationMembers(any()) } returns (
-                flowOf(
-                    listOf(
-                        MemberDetails(TestUser.SELF, Conversation.Member.Role.Admin),
-                        MemberDetails(
-                            TestUser.OTHER.copy(userType = UserTypeInfo.Regular(UserType.GUEST), teamId = null),
-                            Conversation.Member.Role.Member
-                        )
-                    )
-                )
-            )
-        }
-
-        suspend fun withConversationGuestsPro() = apply {
-            everySuspend { observeConversationMembers(any()) } returns (
-                flowOf(
-                    listOf(
-                        MemberDetails(TestUser.SELF, Conversation.Member.Role.Admin),
-                        MemberDetails(TestUser.OTHER.copy(userType = UserTypeInfo.Regular(UserType.GUEST)), Conversation.Member.Role.Member)
+        suspend fun withConversationMemberCounts(
+            conversationSize: Int = 2,
+            servicesCount: Int = 0,
+            guestsCount: Int = 0,
+            guestsProCount: Int = 0
+        ) = apply {
+            everySuspend { conversationRepository.getConversationMemberCounts(any()) } returns (
+                Either.Right(
+                    ConversationMemberCounts(
+                        conversationSize = conversationSize,
+                        servicesCount = servicesCount,
+                        guestsCount = guestsCount,
+                        guestsProCount = guestsProCount
                     )
                 )
             )
@@ -211,7 +192,7 @@ class CreateAndPersistRecentlyEndedCallMetadataUseCaseTest {
         fun arrange(): Pair<Arrangement, CreateAndPersistRecentlyEndedCallMetadataUseCase> =
             this to CreateAndPersistRecentlyEndedCallMetadataUseCaseImpl(
                 callRepository = callRepository,
-                observeConversationMembers = observeConversationMembers,
+                conversationRepository = conversationRepository,
                 selfTeamIdProvider = selfTeamIdProvider
             )
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCaseTest.kt
@@ -19,7 +19,6 @@ package com.wire.kalium.logic.feature.conversation
 
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.cache.SelfConversationIdProvider
-import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.MessageContent
@@ -45,7 +44,6 @@ import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -65,9 +63,7 @@ class UpdateConversationReadDateUseCaseTest {
         val persistedLastRead = Clock.System.now()
         val conversationId = TestConversation.CONVERSATION.id
         val (arrangement, updateConversationReadDateUseCase) = arrange {
-            withObserveByIdReturning(
-                TestConversation.CONVERSATION.copy(lastReadDate = persistedLastRead)
-            )
+            withLastReadDateReturning(conversationId, persistedLastRead)
         }
 
         updateConversationReadDateUseCase(conversationId, persistedLastRead - 1.seconds)
@@ -89,9 +85,7 @@ class UpdateConversationReadDateUseCaseTest {
         val newLastRead = persistedLastRead + 1.seconds
         val conversationId = TestConversation.CONVERSATION.id
         val (arrangement, updateConversationReadDateUseCase) = arrange {
-            withObserveByIdReturning(
-                TestConversation.CONVERSATION.copy(lastReadDate = persistedLastRead)
-            )
+            withLastReadDateReturning(conversationId, persistedLastRead)
         }
 
         updateConversationReadDateUseCase(conversationId, newLastRead)
@@ -107,9 +101,7 @@ class UpdateConversationReadDateUseCaseTest {
         val newLastRead = persistedLastRead + 1.seconds
         val conversationId = TestConversation.CONVERSATION.id
         val (arrangement, updateConversationReadDateUseCase) = arrange {
-            withObserveByIdReturning(
-                TestConversation.CONVERSATION.copy(lastReadDate = persistedLastRead)
-            )
+            withLastReadDateReturning(conversationId, persistedLastRead)
         }
 
         updateConversationReadDateUseCase(conversationId, newLastRead)
@@ -125,9 +117,7 @@ class UpdateConversationReadDateUseCaseTest {
         val newLastRead = persistedLastRead + 1.seconds
         val conversationId = TestConversation.CONVERSATION.id
         val (arrangement, updateConversationReadDateUseCase) = arrange {
-            withObserveByIdReturning(
-                TestConversation.CONVERSATION.copy(lastReadDate = persistedLastRead)
-            )
+            withLastReadDateReturning(conversationId, persistedLastRead)
         }
 
         updateConversationReadDateUseCase(conversationId, newLastRead)
@@ -141,9 +131,7 @@ class UpdateConversationReadDateUseCaseTest {
         val newLastRead = persistedLastRead + 1.seconds
         val conversationId = TestConversation.CONVERSATION.id
         val (arrangement, updateConversationReadDateUseCase) = arrange {
-            withObserveByIdReturning(
-                TestConversation.CONVERSATION.copy(lastReadDate = persistedLastRead)
-            )
+            withLastReadDateReturning(conversationId, persistedLastRead)
         }
 
         updateConversationReadDateUseCase(conversationId, newLastRead)
@@ -172,9 +160,7 @@ class UpdateConversationReadDateUseCaseTest {
         val newLastRead = persistedLastRead + 1.seconds
         val conversationId = TestConversation.CONVERSATION.id
         val (arrangement, updateConversationReadDateUseCase) = arrange {
-            withObserveByIdReturning(
-                TestConversation.CONVERSATION.copy(lastReadDate = persistedLastRead)
-            )
+            withLastReadDateReturning(conversationId, persistedLastRead)
         }
 
         updateConversationReadDateUseCase(conversationId, newLastRead, invokeImmediately = true)
@@ -189,9 +175,7 @@ class UpdateConversationReadDateUseCaseTest {
         val persistedLastRead = Clock.System.now()
         val conversationId = TestConversation.CONVERSATION.id
         val (arrangement, updateConversationReadDateUseCase) = arrange {
-            withObserveByIdReturning(
-                TestConversation.CONVERSATION.copy(lastReadDate = persistedLastRead)
-            )
+            withLastReadDateReturning(conversationId, persistedLastRead)
         }
 
         updateConversationReadDateUseCase(conversationId, persistedLastRead - 1.seconds, invokeImmediately = true)
@@ -232,9 +216,7 @@ class UpdateConversationReadDateUseCaseTest {
         val conversationId = TestConversation.CONVERSATION.id
         val workQueue = ParallelConversationWorkQueue(backgroundScope, kaliumLogger, StandardTestDispatcher(testScheduler))
         val (arrangement, updateConversationReadDateUseCase) = arrange {
-            withObserveByIdReturning(
-                TestConversation.CONVERSATION.copy(lastReadDate = persistedLastRead)
-            )
+            withLastReadDateReturning(conversationId, persistedLastRead)
             this.workQueue = workQueue
         }
 
@@ -292,10 +274,10 @@ class UpdateConversationReadDateUseCaseTest {
             )
         }
 
-        suspend fun withObserveByIdReturning(conversation: Conversation) {
+        suspend fun withLastReadDateReturning(conversationId: ConversationId, lastReadDate: Instant) {
             everySuspend {
-                conversationRepository.observeConversationById(eq(conversation.id))
-            } returns flowOf(Either.Right(conversation))
+                conversationRepository.getConversationLastReadDate(eq(conversationId))
+            } returns Either.Right(lastReadDate)
         }
 
         suspend fun withSelfConversationIds(conversationIds: List<ConversationId>) {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/confirmation/ConfirmationDeliveryHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/confirmation/ConfirmationDeliveryHandlerTest.kt
@@ -41,8 +41,6 @@ import dev.mokkery.verifySuspend
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -82,7 +80,7 @@ class ConfirmationDeliveryHandlerTest {
     @Test
     fun givenMessagesEnqueued_whenCollectingThem_thenShouldSendOnlyForOneToOneConversations() = runTest {
         val (arrangement, sut) = Arrangement()
-            .withConversationDetailsResult(flowOf(TestConversation.CONVERSATION.right()))
+            .withConversationResult(TestConversation.CONVERSATION.right())
             .withSendDeliverSignalResult()
             .arrange()
 
@@ -93,7 +91,7 @@ class ConfirmationDeliveryHandlerTest {
         advanceUntilIdle()
         job.cancel()
 
-        verifySuspend(VerifyMode.atLeast(1)) { arrangement.conversationRepository.observeConversationById(any()) }
+        verifySuspend(VerifyMode.atLeast(1)) { arrangement.conversationRepository.getConversationById(any()) }
         verifySuspend(VerifyMode.atLeast(1)) { arrangement.sendDeliverSignal(any(), any()) }
         assertTrue(arrangement.pendingConfirmationMessages.isEmpty())
     }
@@ -102,7 +100,7 @@ class ConfirmationDeliveryHandlerTest {
     @Test
     fun givenMessagesEnqueued_whenCollectingThemAndNoSession_thenShouldStopCollecting() = runTest {
         val (arrangement, sut) = Arrangement()
-            .withConversationDetailsResult(flowOf(TestConversation.CONVERSATION.right()))
+            .withConversationResult(TestConversation.CONVERSATION.right())
             .withSendDeliverSignalResult()
             .arrange()
 
@@ -114,7 +112,7 @@ class ConfirmationDeliveryHandlerTest {
         sut.enqueueConfirmationDelivery(TestConversation.ID, TestMessage.TEST_MESSAGE_ID)
         advanceUntilIdle()
 
-        verifySuspend(VerifyMode.not) { arrangement.conversationRepository.observeConversationById(any()) }
+        verifySuspend(VerifyMode.not) { arrangement.conversationRepository.getConversationById(any()) }
         verifySuspend(VerifyMode.not) { arrangement.sendDeliverSignal(any(), any()) }
     }
 
@@ -122,7 +120,7 @@ class ConfirmationDeliveryHandlerTest {
     @Test
     fun givenMessagesEnqueued_whenSendingConfirmationsAndError_thenMessagesShouldPersist() = runTest {
         val (arrangement, sut) = Arrangement()
-            .withConversationDetailsResult(flowOf(TestConversation.CONVERSATION.right()))
+            .withConversationResult(TestConversation.CONVERSATION.right())
             .withSendDeliverSignalResult(
                 MessageOperationResult.Failure(
                     CoreFailure.Unknown(
@@ -140,7 +138,7 @@ class ConfirmationDeliveryHandlerTest {
 
         job.cancel()
 
-        verifySuspend(VerifyMode.atLeast(1)) { arrangement.conversationRepository.observeConversationById(any()) }
+        verifySuspend(VerifyMode.atLeast(1)) { arrangement.conversationRepository.getConversationById(any()) }
         verifySuspend(VerifyMode.atLeast(1)) { arrangement.sendDeliverSignal(any(), any()) }
         assertTrue(arrangement.pendingConfirmationMessages.isNotEmpty())
     }
@@ -149,7 +147,7 @@ class ConfirmationDeliveryHandlerTest {
     @Test
     fun givenABigLoadOfMessagesEnqueued_whenSendingConfirmations_thenShouldAddAndRemoveSecurely() = runTest {
         val (arrangement, sut) = Arrangement()
-            .withConversationDetailsResult(flowOf(TestConversation.CONVERSATION.right()))
+            .withConversationResult(TestConversation.CONVERSATION.right())
             .withSendDeliverSignalResult()
             .arrange()
 
@@ -169,7 +167,7 @@ class ConfirmationDeliveryHandlerTest {
         advanceTimeBy(2000L)
         job.cancel()
 
-        verifySuspend(VerifyMode.atLeast(1)) { arrangement.conversationRepository.observeConversationById(any()) }
+        verifySuspend(VerifyMode.atLeast(1)) { arrangement.conversationRepository.getConversationById(any()) }
         verifySuspend(VerifyMode.exactly(1)) { arrangement.sendDeliverSignal(any(), any()) }
         assertTrue(arrangement.pendingConfirmationMessages.isEmpty())
     }
@@ -179,7 +177,7 @@ class ConfirmationDeliveryHandlerTest {
     @Test
     fun givenMultipleEnqueues_whenSendingConfirmations_thenShouldOnlySendOnce() = runTest {
         val (arrangement, sut) = Arrangement()
-            .withConversationDetailsResult(flowOf(TestConversation.CONVERSATION.right()))
+            .withConversationResult(TestConversation.CONVERSATION.right())
             .withSendDeliverSignalResult()
             .arrange()
 
@@ -192,7 +190,7 @@ class ConfirmationDeliveryHandlerTest {
         advanceUntilIdle()
         job.cancel()
 
-        verifySuspend(VerifyMode.atLeast(1)) { arrangement.conversationRepository.observeConversationById(any()) }
+        verifySuspend(VerifyMode.atLeast(1)) { arrangement.conversationRepository.getConversationById(any()) }
         verifySuspend(VerifyMode.exactly(1)) { arrangement.sendDeliverSignal(any(), any()) }
         assertTrue(arrangement.pendingConfirmationMessages.isEmpty())
     }
@@ -200,7 +198,7 @@ class ConfirmationDeliveryHandlerTest {
     @Test
     fun givenSyncIsOngoing_whenItTakesLongTimeToExecute_thenShouldReturnAnyway() = runTest {
         val (arrangement, handler) = Arrangement()
-            .withConversationDetailsResult(flowOf(TestConversation.CONVERSATION.right()))
+            .withConversationResult(TestConversation.CONVERSATION.right())
             .withSendDeliverSignalResult()
             .arrange()
 
@@ -228,7 +226,7 @@ class ConfirmationDeliveryHandlerTest {
     @Test
     fun givenMessagesSent_whenCleared_thenShouldRemoveMessagesFromPendingConfirmation() = runTest {
         val (arrangement, handler) = Arrangement()
-            .withConversationDetailsResult(flowOf(TestConversation.CONVERSATION.right()))
+            .withConversationResult(TestConversation.CONVERSATION.right())
             .withSendDeliverSignalResult()
             .arrange()
 
@@ -239,7 +237,7 @@ class ConfirmationDeliveryHandlerTest {
         advanceUntilIdle()
         job.cancel()
 
-        verifySuspend(VerifyMode.atLeast(1)) { arrangement.conversationRepository.observeConversationById(any()) }
+        verifySuspend(VerifyMode.atLeast(1)) { arrangement.conversationRepository.getConversationById(any()) }
         verifySuspend(VerifyMode.atLeast(1)) { arrangement.sendDeliverSignal(any(), any()) }
         assertTrue(arrangement.pendingConfirmationMessages[TestConversation.ID]?.isEmpty() ?: true)
     }
@@ -252,8 +250,8 @@ class ConfirmationDeliveryHandlerTest {
 
         val pendingConfirmationMessages: ConcurrentMutableMap<ConversationId, MutableSet<String>> = ConcurrentMutableMap()
 
-        suspend fun withConversationDetailsResult(result: Flow<Either<StorageFailure, Conversation>>) = apply {
-            everySuspend { conversationRepository.observeConversationById(any()) } returns result
+        suspend fun withConversationResult(result: Either<StorageFailure, Conversation>) = apply {
+            everySuspend { conversationRepository.getConversationById(any()) } returns result
         }
 
         suspend fun withSendDeliverSignalResult(result: MessageOperationResult = MessageOperationResult.Success) = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/CallingMessageHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/CallingMessageHandlerTest.kt
@@ -21,7 +21,6 @@ import com.wire.kalium.common.functional.right
 import com.wire.kalium.logic.data.call.CallModerationAction
 import com.wire.kalium.logic.data.call.CallModerationActionsRepository
 import com.wire.kalium.logic.data.conversation.ClientId
-import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.message.Message
@@ -39,7 +38,6 @@ import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import kotlin.test.Test
@@ -115,7 +113,7 @@ class CallingMessageHandlerTest {
 
         fun withShouldRemoteMuteCheckerReturning(shouldRemoteMute: Boolean) = apply {
             everySuspend {
-                shouldRemoteMuteChecker.check(any(), any(), any(), any(), any())
+                shouldRemoteMuteChecker.check(any(), any(), any(), any())
             } returns shouldRemoteMute
         }
 
@@ -125,15 +123,15 @@ class CallingMessageHandlerTest {
             } returns clientId.right()
         }
 
-        fun withObserveConversationMembersReturning(members: List<Conversation.Member>) = apply {
+        fun withIsConversationMemberAdminReturning(isAdmin: Boolean) = apply {
             everySuspend {
-                conversationRepository.observeConversationMembers(any())
-            } returns flowOf(members)
+                conversationRepository.isConversationMemberAdmin(any(), any())
+            } returns isAdmin.right()
         }
 
         init {
             withCurrentClientIdProviderReturning(TestClient.CLIENT_ID)
-            withObserveConversationMembersReturning(emptyList())
+            withIsConversationMemberAdminReturning(false)
         }
 
         fun arrange() = this to CallingMessageHandlerImpl(

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCaseIntegrationTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCaseIntegrationTest.kt
@@ -22,7 +22,6 @@ import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.logic.cache.SelfConversationIdProvider
-import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDataSource
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
@@ -54,8 +53,6 @@ import com.wire.kalium.userstorage.di.PlatformUserStorageProperties
 import com.wire.kalium.userstorage.di.UserStorage
 import com.wire.kalium.userstorage.di.UserStorageProvider
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.TestScope
@@ -189,10 +186,9 @@ class UpdateConversationReadDateUseCaseIntegrationTest {
             clientApi = ClientApiStub(),
             conversationMetaDataDAO = database.builder.conversationMetaDataDAO,
         )
-        val observedConversation = TestConversation.GROUP().copy(lastReadDate = persistedLastRead)
         return object : ConversationRepository by delegate {
-            override suspend fun observeConversationById(conversationId: ConversationId): Flow<Either<StorageFailure, Conversation>> =
-                flowOf(Either.Right(observedConversation))
+            override suspend fun getConversationLastReadDate(conversationId: ConversationId): Either<StorageFailure, Instant> =
+                Either.Right(persistedLastRead)
         }
     }
 


### PR DESCRIPTION
## Why
After removing the persistence FlowCache, correctness-sensitive logic should avoid collecting observation flows just to make one decision. This PR switches those paths to direct snapshot reads so they use fresh, narrow database state.

## What changed
- Read-date updates use a last-read snapshot.
- Delivery confirmations and call creation use direct conversation reads.
- Remote mute checks use a narrow sender-admin lookup.
- Recently-ended call metadata uses aggregate member counts instead of collecting members.
- Session team lookup uses a team-id-only DAO read.

## Validation
- ./gradlew :logic:jvmTest --tests "*CallRepositoryTest" --tests "*ShouldRemoteMuteCheckerTest" --tests "*CreateAndPersistRecentlyEndedCallMetadataUseCaseTest" --tests "*UpdateConversationReadDateUseCaseTest" --tests "*ConfirmationDeliveryHandlerTest" --tests "*CallingMessageHandlerTest" --tests "*UpdateConversationReadDateUseCaseIntegrationTest" -Djava.library.path=./native/libs
- ./gradlew detekt