### PR TITLE
feat: retry sending text, location and asset messages (WPB-25291)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -2278,6 +2278,7 @@ public class UserSessionScope internal constructor(
             messageRepository = messageRepository,
             messageSender = messages.messageSender,
             userId = userId,
+            sendPendingAssetMessage = messages.sendPendingAssetMessage,
         )
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/upload/ScheduleNewAssetMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/upload/ScheduleNewAssetMessageUseCase.kt
@@ -107,7 +107,11 @@ internal class ScheduleNewAssetMessageUseCaseImpl(
                         launch { uploadAsset(message, currentAssetMessageContent) }.invokeOnCompletion { reason ->
                             if (reason is CancellationException) {
                                 scope.launch(NonCancellable) {
-                                    updateAssetMessageTransferStatus(AssetTransferStatus.FAILED_UPLOAD, message.conversationId, message.id)
+                                    updateAssetMessageTransferStatus(
+                                        AssetTransferStatus.FAILED_UPLOAD,
+                                        message.conversationId,
+                                        message.id
+                                    )
                                 }
                             }
                         }
@@ -115,7 +119,13 @@ internal class ScheduleNewAssetMessageUseCaseImpl(
                 }
                 .onFailure {
                     updateAssetMessageTransferStatus(AssetTransferStatus.FAILED_UPLOAD, asset.conversationId, messageId)
-                    messageSendFailureHandler.handleFailureAndUpdateMessageStatus(it, asset.conversationId, messageId, TYPE)
+                    messageSendFailureHandler.handleFailureAndUpdateMessageStatus(
+                        failure = it,
+                        conversationId = asset.conversationId,
+                        messageId = messageId,
+                        messageType = TYPE,
+                        scheduleResendIfNoNetwork = true
+                    )
                 }
         }.fold({
             Failure.Generic(it)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/upload/UploadAssetUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/asset/upload/UploadAssetUseCase.kt
@@ -32,6 +32,7 @@ import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.feature.asset.AudioNormalizedLoudnessBuilder
 import com.wire.kalium.logic.feature.asset.UpdateAssetMessageTransferStatusUseCase
+import com.wire.kalium.logic.feature.asset.UpdateAudioMessageNormalizedLoudnessUseCase
 import com.wire.kalium.logic.feature.message.MessageSendFailureHandler
 import com.wire.kalium.logic.util.fileExtension
 import com.wire.kalium.messaging.sending.MessageSender
@@ -49,6 +50,7 @@ internal class UploadAssetUseCaseImpl(
     private val messageSender: MessageSender,
     private val messageSendFailureHandler: MessageSendFailureHandler,
     private val updateAssetMessageTransferStatus: UpdateAssetMessageTransferStatusUseCase,
+    private val updateAudioNormalizedLoudness: UpdateAudioMessageNormalizedLoudnessUseCase,
     private val persistMessage: PersistMessageUseCase,
     private val audioNormalizedLoudnessBuilder: AudioNormalizedLoudnessBuilder,
     private val dispatcher: KaliumDispatcher
@@ -76,7 +78,22 @@ internal class UploadAssetUseCaseImpl(
             filetype = metadata.mimeType,
         ).onFailure {
             updateAssetMessageTransferStatus(AssetTransferStatus.FAILED_UPLOAD, message.conversationId, message.id)
-            messageSendFailureHandler.handleFailureAndUpdateMessageStatus(it, message.conversationId, message.id, TYPE)
+            messageSendFailureHandler.handleFailureAndUpdateMessageStatus(
+                failure = it,
+                conversationId = message.conversationId,
+                messageId = message.id,
+                messageType = TYPE,
+                scheduleResendIfNoNetwork = true
+            )
+
+            audioNormalizedLoudnessDeferred.await()?.let { normalizedLoudness ->
+                updateAudioNormalizedLoudness(
+                    conversationId = message.conversationId,
+                    messageId = message.id,
+                    normalizedLoudness = normalizedLoudness
+                )
+            }
+
         }.flatMap { (assetId, sha256) ->
             // We update the message with the remote data (assetId & sha256 key) obtained by the successful asset upload,
             // we also update the generated audio normalized loudness if applicable,
@@ -103,7 +120,13 @@ internal class UploadAssetUseCaseImpl(
                     assetDataSource.deleteAssetLocally(metadata.assetId.key)
                     // Finally we try to send the Asset Message to the recipients of the given conversation
                     messageSender.sendMessage(updatedMessage).onFailure {
-                        messageSendFailureHandler.handleFailureAndUpdateMessageStatus(it, message.conversationId, message.id, TYPE)
+                        messageSendFailureHandler.handleFailureAndUpdateMessageStatus(
+                            failure = it,
+                            conversationId = message.conversationId,
+                            messageId = message.id,
+                            messageType = TYPE,
+                            scheduleResendIfNoNetwork = true
+                        )
                     }
                 }
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageScope.kt
@@ -106,6 +106,8 @@ import com.wire.kalium.logic.feature.selfDeletingMessages.ObserveSelfDeletionTim
 import com.wire.kalium.logic.feature.sessionreset.ResetSessionUseCase
 import com.wire.kalium.logic.feature.sessionreset.ResetSessionUseCaseImpl
 import com.wire.kalium.logic.feature.user.ObserveFileSharingStatusUseCase
+import com.wire.kalium.logic.sync.SendPendingAssetMessageUseCase
+import com.wire.kalium.logic.sync.SendPendingAssetMessageUseCaseImpl
 import com.wire.kalium.logic.sync.SyncManager
 import com.wire.kalium.logic.sync.receiver.asset.AudioNormalizedLoudnessScheduler
 import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldHandler
@@ -164,7 +166,7 @@ public class MessageScope internal constructor(
     private val legalHoldStatusMapper: LegalHoldStatusMapper = LegalHoldStatusMapperImpl
 ) {
 
-    private val messageSendFailureHandler: MessageSendFailureHandler
+    internal val messageSendFailureHandler: MessageSendFailureHandler
         get() = MessageSendFailureHandlerImpl(
             userRepository,
             clientRepository,
@@ -315,10 +317,21 @@ public class MessageScope internal constructor(
             getMessageAttachments = getMessageAttachmentsUseCase.value,
         )
 
-    private val getAssetMessageTransferStatus: GetAssetMessageTransferStatusUseCase
+    internal val getAssetMessageTransferStatus: GetAssetMessageTransferStatusUseCase
         get() = GetAssetMessageTransferStatusUseCaseImpl(
             messageRepository,
             dispatcher
+        )
+
+    internal val sendPendingAssetMessage: SendPendingAssetMessageUseCase
+        get() = SendPendingAssetMessageUseCaseImpl(
+            assetRepository,
+            persistMessage,
+            updateAssetMessageTransferStatus,
+            getAssetMessageTransferStatus,
+            messageSender,
+            messageSendFailureHandler,
+            audioNormalizedLoudnessBuilder,
         )
 
     public val retryFailedMessage: RetryFailedMessageUseCase
@@ -359,6 +372,7 @@ public class MessageScope internal constructor(
             messageSender,
             messageSendFailureHandler,
             updateAssetMessageTransferStatus,
+            updateAudioMessageNormalizedLoudnessUseCase,
             persistMessage,
             audioNormalizedLoudnessBuilder,
             dispatcher,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendLocationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendLocationUseCase.kt
@@ -103,7 +103,13 @@ public class SendLocationUseCase internal constructor(
                 .flatMap { messageSender.sendMessage(message) }
         }.fold(
             {
-                messageSendFailureHandler.handleFailureAndUpdateMessageStatus(it, conversationId, generatedMessageUuid, TYPE)
+                messageSendFailureHandler.handleFailureAndUpdateMessageStatus(
+                    failure = it,
+                    conversationId = conversationId,
+                    messageId = generatedMessageUuid,
+                    messageType = TYPE,
+                    scheduleResendIfNoNetwork = true,
+                )
                 MessageOperationResult.Failure(it)
             },
             {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendTextMessageUseCase.kt
@@ -121,7 +121,8 @@ public class SendTextMessageUseCase internal constructor(
                 failure = it,
                 conversationId = conversationId,
                 messageId = generatedMessageUuid,
-                messageType = TYPE
+                messageType = TYPE,
+                scheduleResendIfNoNetwork = true,
             )
         }.fold(
             { MessageOperationResult.Failure(it) },

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/PendingMessagesSenderWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/PendingMessagesSenderWorker.kt
@@ -19,6 +19,8 @@
 package com.wire.kalium.logic.sync
 
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.SYNC
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.messaging.sending.MessageSender
@@ -33,7 +35,8 @@ import com.wire.kalium.common.logger.kaliumLogger
 internal class PendingMessagesSenderWorker(
     private val messageRepository: MessageRepository,
     private val messageSender: MessageSender,
-    private val userId: UserId
+    private val userId: UserId,
+    private val sendPendingAssetMessage: SendPendingAssetMessageUseCase,
 ) : DefaultWorker {
 
     /**
@@ -50,7 +53,12 @@ internal class PendingMessagesSenderWorker(
             .onSuccess { pendingMessages ->
                 pendingMessages.forEach { message ->
                     kaliumLogger.withFeatureId(SYNC).i("Attempting scheduled sending of message $message")
-                    messageSender.sendPendingMessage(message.conversationId, message.id)
+                    when {
+                        message is Message.Regular && message.content is MessageContent.Asset ->
+                            sendPendingAssetMessage(message)
+                        else ->
+                            messageSender.sendPendingMessage(message.conversationId, message.id)
+                    }
                 }
             }.onFailure {
                 kaliumLogger.withFeatureId(SYNC).w("Failed to fetch and attempt retry of pending messages: $it")

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SendPendingAssetMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SendPendingAssetMessageUseCase.kt
@@ -45,7 +45,6 @@ import com.wire.kalium.logic.util.fileExtension
 import com.wire.kalium.messaging.sending.MessageSender
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
-import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
 
 /**
@@ -136,12 +135,10 @@ internal class SendPendingAssetMessageUseCaseImpl(
                 downloadIfNeeded = false
             ).flatMap { fetchAssetResult ->
 
-                val updatedMetadata = async {
-                    metadata.withAudioNormalizedLoudnessIfNeeded(
-                        mimeType = mimeType,
-                        assetDataPath = fetchAssetResult.path.toString()
-                    )
-                }
+                val updatedMetadata = metadata.withAudioNormalizedLoudnessIfNeeded(
+                    mimeType = mimeType,
+                    assetDataPath = fetchAssetResult.path.toString()
+                )
 
                 assetRepository.uploadAndPersistPrivateAsset(
                     mimeType = mimeType,
@@ -156,7 +153,7 @@ internal class SendPendingAssetMessageUseCaseImpl(
                     val (uploadedAssetId, sha256Key) = uploadResult
 
                     assetContent.copy(
-                        metadata = updatedMetadata.await(),
+                        metadata = updatedMetadata,
                         remoteData = remoteData.copy(
                             sha256 = sha256Key.data,
                             assetId = uploadedAssetId.key,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SendPendingAssetMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SendPendingAssetMessageUseCase.kt
@@ -1,0 +1,179 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.sync
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.common.functional.map
+import com.wire.kalium.common.functional.onFailure
+import com.wire.kalium.common.functional.onSuccess
+import com.wire.kalium.common.functional.right
+import com.wire.kalium.common.logger.kaliumLogger
+import com.wire.kalium.cryptography.utils.AES256Key
+import com.wire.kalium.cryptography.utils.SHA256Key
+import com.wire.kalium.logic.data.asset.AssetRepository
+import com.wire.kalium.logic.data.asset.AssetTransferStatus
+import com.wire.kalium.logic.data.asset.isAudioMimeType
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.toApi
+import com.wire.kalium.logic.data.message.AssetContent
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.message.PersistMessageUseCase
+import com.wire.kalium.logic.feature.asset.AudioNormalizedLoudnessBuilder
+import com.wire.kalium.logic.feature.asset.GetAssetMessageTransferStatusUseCase
+import com.wire.kalium.logic.feature.asset.UpdateAssetMessageTransferStatusUseCase
+import com.wire.kalium.logic.feature.message.MessageSendFailureHandler
+import com.wire.kalium.logic.util.fileExtension
+import com.wire.kalium.messaging.sending.MessageSender
+
+/**
+ * Handles sending a pending asset message, retrying the upload if the previous attempt failed due to
+ * no network connectivity. This is called by [PendingMessagesSenderWorker] when network is restored.
+ *
+ * Unlike [com.wire.kalium.logic.feature.message.RetryFailedMessageUseCase] which operates on
+ * messages with [Message.Status.Failed] status, this use case operates on messages that remain
+ * in [Message.Status.Pending] state after an upload failure caused by [com.wire.kalium.common.error.NetworkFailure.NoNetworkConnection].
+ */
+internal interface SendPendingAssetMessageUseCase {
+    suspend operator fun invoke(message: Message.Regular): Either<CoreFailure, Unit>
+}
+
+@Suppress("LongParameterList")
+internal class SendPendingAssetMessageUseCaseImpl(
+    private val assetRepository: AssetRepository,
+    private val persistMessage: PersistMessageUseCase,
+    private val updateAssetMessageTransferStatus: UpdateAssetMessageTransferStatusUseCase,
+    private val getAssetMessageTransferStatus: GetAssetMessageTransferStatusUseCase,
+    private val messageSender: MessageSender,
+    private val messageSendFailureHandler: MessageSendFailureHandler,
+    private val audioNormalizedLoudnessBuilder: AudioNormalizedLoudnessBuilder,
+) : SendPendingAssetMessageUseCase {
+
+    override suspend fun invoke(message: Message.Regular): Either<CoreFailure, Unit> {
+        val content = message.content as? MessageContent.Asset
+            ?: return Either.Left(CoreFailure.Unknown(IllegalStateException("Not an asset message: ${message.id}")))
+
+        return when (val status = getAssetMessageTransferStatus(message.conversationId, message.id)) {
+            AssetTransferStatus.FAILED_UPLOAD -> reuploadAndSend(message, content.value)
+            AssetTransferStatus.UPLOADED -> messageSender.sendPendingMessage(message.conversationId, message.id)
+            else -> {
+                kaliumLogger.i("Skipping pending asset message ${message.id} with transfer status $status")
+                Either.Right(Unit)
+            }
+        }
+    }
+
+    private suspend fun reuploadAndSend(message: Message.Regular, content: AssetContent): Either<CoreFailure, Unit> {
+        updateAssetMessageTransferStatus(AssetTransferStatus.UPLOAD_IN_PROGRESS, message.conversationId, message.id)
+        return uploadAsset(message.conversationId, content)
+            .flatMap { uploadedContent ->
+                val updatedMessage = message.copy(content = MessageContent.Asset(uploadedContent))
+                persistMessage(updatedMessage).map { updatedMessage }
+            }
+            .onSuccess { updatedMessage ->
+                updateAssetMessageTransferStatus(AssetTransferStatus.UPLOADED, message.conversationId, message.id)
+                assetRepository.deleteAssetLocally(content.remoteData.assetId)
+                messageSender.sendMessage(updatedMessage).onFailure {
+                    messageSendFailureHandler.handleFailureAndUpdateMessageStatus(
+                        failure = it,
+                        conversationId = message.conversationId,
+                        messageId = message.id,
+                        messageType = TYPE,
+                        scheduleResendIfNoNetwork = true
+                    )
+                }
+            }
+            .onFailure {
+                updateAssetMessageTransferStatus(AssetTransferStatus.FAILED_UPLOAD, message.conversationId, message.id)
+                messageSendFailureHandler.handleFailureAndUpdateMessageStatus(
+                    failure = it,
+                    conversationId = message.conversationId,
+                    messageId = message.id,
+                    messageType = TYPE,
+                    scheduleResendIfNoNetwork = true
+                )
+            }
+            .map { }
+    }
+
+    private suspend fun uploadAsset(
+        conversationId: ConversationId,
+        assetContent: AssetContent,
+    ): Either<CoreFailure, AssetContent> = with(assetContent) {
+
+        assetRepository.fetchPrivateDecodedAsset(
+            assetId = remoteData.assetId,
+            assetDomain = remoteData.assetDomain,
+            assetName = name ?: "",
+            assetToken = remoteData.assetToken,
+            encryptionKey = AES256Key(remoteData.otrKey),
+            assetSHA256Key = SHA256Key(remoteData.sha256),
+            mimeType = mimeType,
+            downloadIfNeeded = false
+        ).flatMap { fetchAssetResult ->
+
+            val updatedMetadata = metadata.withAudioNormalizedLoudnessIfNeeded(
+                mimeType = mimeType,
+                assetDataPath = fetchAssetResult.path.toString()
+            )
+
+            assetRepository.uploadAndPersistPrivateAsset(
+                mimeType = mimeType,
+                assetDataPath = fetchAssetResult.path,
+                otrKey = AES256Key(remoteData.otrKey),
+                extension = name?.fileExtension() ?: "",
+                conversationId = conversationId.toApi(),
+                filename = name,
+                filetype = mimeType,
+            ).flatMap { uploadResult ->
+
+                val (uploadedAssetId, sha256Key) = uploadResult
+
+                assetContent.copy(
+                    metadata = updatedMetadata,
+                    remoteData = remoteData.copy(
+                        sha256 = sha256Key.data,
+                        assetId = uploadedAssetId.key,
+                        assetDomain = uploadedAssetId.domain,
+                        assetToken = uploadedAssetId.assetToken
+                    )
+                ).right()
+            }
+        }
+    }
+
+    private suspend fun AssetContent.AssetMetadata?.withAudioNormalizedLoudnessIfNeeded(
+        mimeType: String,
+        assetDataPath: String,
+    ): AssetContent.AssetMetadata? = when {
+        !isAudioMimeType(mimeType) -> this
+        this !is AssetContent.AssetMetadata.Audio -> this
+        normalizedLoudness != null -> this
+        else -> {
+            val normalizedLoudness = audioNormalizedLoudnessBuilder(assetDataPath)
+            copy(normalizedLoudness = normalizedLoudness)
+        }
+    }
+
+    private companion object {
+        const val TYPE = "Asset"
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SendPendingAssetMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SendPendingAssetMessageUseCase.kt
@@ -43,6 +43,10 @@ import com.wire.kalium.logic.feature.asset.UpdateAssetMessageTransferStatusUseCa
 import com.wire.kalium.logic.feature.message.MessageSendFailureHandler
 import com.wire.kalium.logic.util.fileExtension
 import com.wire.kalium.messaging.sending.MessageSender
+import com.wire.kalium.util.KaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcherImpl
+import kotlinx.coroutines.async
+import kotlinx.coroutines.withContext
 
 /**
  * Handles sending a pending asset message, retrying the upload if the previous attempt failed due to
@@ -65,6 +69,7 @@ internal class SendPendingAssetMessageUseCaseImpl(
     private val messageSender: MessageSender,
     private val messageSendFailureHandler: MessageSendFailureHandler,
     private val audioNormalizedLoudnessBuilder: AudioNormalizedLoudnessBuilder,
+    private val dispatchers: KaliumDispatcher = KaliumDispatcherImpl,
 ) : SendPendingAssetMessageUseCase {
 
     override suspend fun invoke(message: Message.Regular): Either<CoreFailure, Unit> {
@@ -117,45 +122,49 @@ internal class SendPendingAssetMessageUseCaseImpl(
     private suspend fun uploadAsset(
         conversationId: ConversationId,
         assetContent: AssetContent,
-    ): Either<CoreFailure, AssetContent> = with(assetContent) {
+    ): Either<CoreFailure, AssetContent> = withContext(dispatchers.io) {
+        with(assetContent) {
 
-        assetRepository.fetchPrivateDecodedAsset(
-            assetId = remoteData.assetId,
-            assetDomain = remoteData.assetDomain,
-            assetName = name ?: "",
-            assetToken = remoteData.assetToken,
-            encryptionKey = AES256Key(remoteData.otrKey),
-            assetSHA256Key = SHA256Key(remoteData.sha256),
-            mimeType = mimeType,
-            downloadIfNeeded = false
-        ).flatMap { fetchAssetResult ->
-
-            val updatedMetadata = metadata.withAudioNormalizedLoudnessIfNeeded(
+            assetRepository.fetchPrivateDecodedAsset(
+                assetId = remoteData.assetId,
+                assetDomain = remoteData.assetDomain,
+                assetName = name ?: "",
+                assetToken = remoteData.assetToken,
+                encryptionKey = AES256Key(remoteData.otrKey),
+                assetSHA256Key = SHA256Key(remoteData.sha256),
                 mimeType = mimeType,
-                assetDataPath = fetchAssetResult.path.toString()
-            )
+                downloadIfNeeded = false
+            ).flatMap { fetchAssetResult ->
 
-            assetRepository.uploadAndPersistPrivateAsset(
-                mimeType = mimeType,
-                assetDataPath = fetchAssetResult.path,
-                otrKey = AES256Key(remoteData.otrKey),
-                extension = name?.fileExtension() ?: "",
-                conversationId = conversationId.toApi(),
-                filename = name,
-                filetype = mimeType,
-            ).flatMap { uploadResult ->
-
-                val (uploadedAssetId, sha256Key) = uploadResult
-
-                assetContent.copy(
-                    metadata = updatedMetadata,
-                    remoteData = remoteData.copy(
-                        sha256 = sha256Key.data,
-                        assetId = uploadedAssetId.key,
-                        assetDomain = uploadedAssetId.domain,
-                        assetToken = uploadedAssetId.assetToken
+                val updatedMetadata = async {
+                    metadata.withAudioNormalizedLoudnessIfNeeded(
+                        mimeType = mimeType,
+                        assetDataPath = fetchAssetResult.path.toString()
                     )
-                ).right()
+                }
+
+                assetRepository.uploadAndPersistPrivateAsset(
+                    mimeType = mimeType,
+                    assetDataPath = fetchAssetResult.path,
+                    otrKey = AES256Key(remoteData.otrKey),
+                    extension = name?.fileExtension() ?: "",
+                    conversationId = conversationId.toApi(),
+                    filename = name,
+                    filetype = mimeType,
+                ).flatMap { uploadResult ->
+
+                    val (uploadedAssetId, sha256Key) = uploadResult
+
+                    assetContent.copy(
+                        metadata = updatedMetadata.await(),
+                        remoteData = remoteData.copy(
+                            sha256 = sha256Key.data,
+                            assetId = uploadedAssetId.key,
+                            assetDomain = uploadedAssetId.domain,
+                            assetToken = uploadedAssetId.assetToken
+                        )
+                    ).right()
+                }
             }
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/AudioNormalizedLoudnessBuilderMock.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/AudioNormalizedLoudnessBuilderMock.kt
@@ -18,8 +18,12 @@
 package com.wire.kalium.logic.feature.asset
 
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
-class AudioNormalizedLoudnessBuilderMock(private val defaultResult: ByteArray? = null) : AudioNormalizedLoudnessBuilder {
+class AudioNormalizedLoudnessBuilderMock(
+    private val defaultResult: ByteArray? = null,
+    private val canReadFile: (String) -> Boolean = { true },
+) : AudioNormalizedLoudnessBuilder {
     private val results = mutableMapOf<String, Pair<ByteArray?, Int>>()
 
     fun every(filePath: String, result: ByteArray?) { results[filePath] = result to 0 }
@@ -33,7 +37,10 @@ class AudioNormalizedLoudnessBuilderMock(private val defaultResult: ByteArray? =
         )
     }
 
-    override suspend fun invoke(filePath: String): ByteArray? = (results[filePath]?.first ?: defaultResult).also { result ->
-        results[filePath] = result to (results[filePath]?.second ?: 0) + 1 // increment call count
+    override suspend fun invoke(filePath: String): ByteArray? {
+        assertTrue(canReadFile(filePath), "AudioNormalizedLoudnessBuilderMock could not read $filePath")
+        return (results[filePath]?.first ?: defaultResult).also { result ->
+            results[filePath] = result to (results[filePath]?.second ?: 0) + 1 // increment call count
+        }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/upload/UploadAssetUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/asset/upload/UploadAssetUseCaseTest.kt
@@ -30,6 +30,7 @@ import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.feature.asset.AudioNormalizedLoudnessBuilderMock
 import com.wire.kalium.logic.feature.asset.UpdateAssetMessageTransferStatusUseCase
+import com.wire.kalium.logic.feature.asset.UpdateAudioMessageNormalizedLoudnessUseCase
 import com.wire.kalium.logic.feature.asset.UpdateTransferStatusResult
 import com.wire.kalium.logic.feature.message.MessageSendFailureHandler
 import com.wire.kalium.logic.framework.TestMessage.assetMessage
@@ -233,6 +234,7 @@ class UploadAssetUseCaseTest {
         val persistMessage: PersistMessageUseCase = mock(mode = MockMode.autoUnit)
         val audioNormalizedLoudnessBuilder = AudioNormalizedLoudnessBuilderMock()
         var persistMessageResult: Either<CoreFailure, Unit> = Unit.right()
+        var updateAudioNormalizedLoudness: UpdateAudioMessageNormalizedLoudnessUseCase = mock(mode = MockMode.autoUnit)
 
         suspend fun arrange(block: suspend Arrangement.() -> Unit): Pair<Arrangement, UploadAssetUseCaseImpl> {
             block()
@@ -258,6 +260,7 @@ class UploadAssetUseCaseTest {
                 messageSender,
                 messageSendFailureHandler,
                 updateAssetMessageTransferStatus,
+                updateAudioNormalizedLoudness,
                 persistMessage,
                 audioNormalizedLoudnessBuilder,
                 testDispatcher

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/PendingMessagesSenderWorkerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/PendingMessagesSenderWorkerTest.kt
@@ -19,11 +19,13 @@
 package com.wire.kalium.logic.sync
 
 import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageRepository
-import com.wire.kalium.messaging.sending.MessageSender
 import com.wire.kalium.logic.framework.TestMessage
 import com.wire.kalium.logic.framework.TestUser
-import com.wire.kalium.common.functional.Either
+import com.wire.kalium.messaging.sending.MessageSender
+import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
@@ -39,16 +41,22 @@ class PendingMessagesSenderWorkerTest {
 
     private val messageRepository = mock<MessageRepository>()
     private val messageSender = mock<MessageSender>()
+    private val sendPendingAssetMessage = mock<SendPendingAssetMessageUseCase>(mode = MockMode.autoUnit)
 
     private lateinit var pendingMessagesSenderWorker: PendingMessagesSenderWorker
 
     @BeforeTest
     fun setup() {
-        pendingMessagesSenderWorker = PendingMessagesSenderWorker(messageRepository, messageSender, TestUser.USER_ID)
+        pendingMessagesSenderWorker = PendingMessagesSenderWorker(
+            messageRepository,
+            messageSender,
+            TestUser.USER_ID,
+            sendPendingAssetMessage,
+        )
     }
 
     @Test
-    fun givenPendingMessagesAreFetched_whenExecutingAWorker_thenScheduleSendingOfMessages() = runTest {
+    fun givenPendingTextMessage_whenExecutingAWorker_thenSendPendingMessageIsCalled() = runTest {
         val message = TestMessage.TEXT_MESSAGE
         everySuspend {
             messageRepository.getAllPendingMessagesFromUser(eq(TestUser.USER_ID))
@@ -61,6 +69,29 @@ class PendingMessagesSenderWorkerTest {
 
         verifySuspend(VerifyMode.exactly(1)) {
             messageSender.sendPendingMessage(eq(message.conversationId), eq(message.id))
+        }
+        verifySuspend(VerifyMode.not) {
+            sendPendingAssetMessage.invoke(any<Message.Regular>())
+        }
+    }
+
+    @Test
+    fun givenPendingAssetMessage_whenExecutingAWorker_thenSendPendingAssetMessageIsCalled() = runTest {
+        val message = TestMessage.assetMessage()
+        everySuspend {
+            messageRepository.getAllPendingMessagesFromUser(eq(TestUser.USER_ID))
+        } returns Either.Right(listOf(message))
+        everySuspend {
+            sendPendingAssetMessage.invoke(eq(message))
+        } returns Either.Right(Unit)
+
+        pendingMessagesSenderWorker.doWork()
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            sendPendingAssetMessage.invoke(eq(message))
+        }
+        verifySuspend(VerifyMode.not) {
+            messageSender.sendPendingMessage(any(), any())
         }
     }
 
@@ -75,6 +106,9 @@ class PendingMessagesSenderWorkerTest {
 
         verifySuspend(VerifyMode.not) {
             messageSender.sendPendingMessage(any(), any())
+        }
+        verifySuspend(VerifyMode.not) {
+            sendPendingAssetMessage.invoke(any<Message.Regular>())
         }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/SendPendingAssetMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/SendPendingAssetMessageUseCaseTest.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.map
+import com.wire.kalium.common.functional.right
 import com.wire.kalium.cryptography.utils.SHA256Key
 import com.wire.kalium.logic.data.asset.AssetRepository
 import com.wire.kalium.logic.data.asset.AssetTransferStatus
@@ -29,7 +30,6 @@ import com.wire.kalium.logic.data.asset.FakeKaliumFileSystem
 import com.wire.kalium.logic.data.asset.FetchedAssetData
 import com.wire.kalium.logic.data.asset.UploadedAssetId
 import com.wire.kalium.logic.data.message.AssetContent
-import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.feature.asset.AudioNormalizedLoudnessBuilderMock
@@ -37,9 +37,9 @@ import com.wire.kalium.logic.feature.asset.GetAssetMessageTransferStatusUseCase
 import com.wire.kalium.logic.feature.asset.UpdateAssetMessageTransferStatusUseCase
 import com.wire.kalium.logic.feature.asset.UpdateTransferStatusResult
 import com.wire.kalium.logic.feature.message.MessageSendFailureHandler
+import com.wire.kalium.logic.framework.TestAsset.mockedLongAssetData
 import com.wire.kalium.logic.framework.TestMessage.ASSET_CONTENT
 import com.wire.kalium.logic.framework.TestMessage.assetMessage
-import com.wire.kalium.logic.framework.TestAsset.mockedLongAssetData
 import com.wire.kalium.logic.test_util.TestNetworkException
 import com.wire.kalium.logic.util.fileExtension
 import com.wire.kalium.messaging.sending.MessageSender
@@ -343,6 +343,10 @@ class SendPendingAssetMessageUseCaseTest {
         val audioNormalizedLoudnessBuilder = AudioNormalizedLoudnessBuilderMock(
             canReadFile = { fakeKaliumFileSystem.exists(it.toPath()) }
         )
+
+        init {
+            everySuspend { assetRepository.deleteAssetLocally(any()) } returns Unit.right()
+        }
 
         suspend fun withGetAssetMessageTransferStatus(status: AssetTransferStatus) = apply {
             everySuspend { getAssetMessageTransferStatus.invoke(any(), any()) } returns status

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/SendPendingAssetMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/SendPendingAssetMessageUseCaseTest.kt
@@ -1,0 +1,432 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.sync
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.NetworkFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.map
+import com.wire.kalium.cryptography.utils.SHA256Key
+import com.wire.kalium.logic.data.asset.AssetRepository
+import com.wire.kalium.logic.data.asset.AssetTransferStatus
+import com.wire.kalium.logic.data.asset.FakeKaliumFileSystem
+import com.wire.kalium.logic.data.asset.FetchedAssetData
+import com.wire.kalium.logic.data.asset.UploadedAssetId
+import com.wire.kalium.logic.data.message.AssetContent
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.message.PersistMessageUseCase
+import com.wire.kalium.logic.feature.asset.AudioNormalizedLoudnessBuilderMock
+import com.wire.kalium.logic.feature.asset.GetAssetMessageTransferStatusUseCase
+import com.wire.kalium.logic.feature.asset.UpdateAssetMessageTransferStatusUseCase
+import com.wire.kalium.logic.feature.asset.UpdateTransferStatusResult
+import com.wire.kalium.logic.feature.message.MessageSendFailureHandler
+import com.wire.kalium.logic.framework.TestMessage.ASSET_CONTENT
+import com.wire.kalium.logic.framework.TestMessage.assetMessage
+import com.wire.kalium.logic.framework.TestAsset.mockedLongAssetData
+import com.wire.kalium.logic.test_util.TestNetworkException
+import com.wire.kalium.logic.util.fileExtension
+import com.wire.kalium.messaging.sending.MessageSender
+import dev.mokkery.MockMode
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.matcher.matching
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import okio.Path
+import okio.Path.Companion.toPath
+import okio.buffer
+import okio.use
+import kotlin.test.Test
+
+class SendPendingAssetMessageUseCaseTest {
+
+    @Test
+    fun givenFailedUploadStatus_whenInvoked_thenFetchesLocalAssetAndUploads() = runTest {
+        val name = "photo.jpg"
+        val content = MessageContent.Asset(ASSET_CONTENT.value.copy(name = name))
+        val path = fakeKaliumFileSystem.providePersistentAssetPath(name)
+        val message = assetMessage().copy(content = content)
+        val uploadedAssetId = UploadedAssetId("remote_key", "remote_domain", "remote_token")
+        val uploadedSha = SHA256Key(byteArrayOf())
+
+        val (arrangement, useCase) = Arrangement()
+            .withGetAssetMessageTransferStatus(AssetTransferStatus.FAILED_UPLOAD)
+            .withUpdateAssetMessageTransferStatus(UpdateTransferStatusResult.Success)
+            .withFetchPrivateDecodedAsset(Either.Right(path))
+            .withStoredData(mockedLongAssetData(), path)
+            .withUploadAndPersistPrivateAsset(Either.Right(uploadedAssetId to uploadedSha))
+            .withPersistMessage(Either.Right(Unit))
+            .withSendMessage(Either.Right(Unit))
+            .arrange()
+
+        useCase(message)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.assetRepository.uploadAndPersistPrivateAsset(
+                mimeType = any(),
+                assetDataPath = path,
+                otrKey = any(),
+                extension = name.fileExtension(),
+                conversationId = any(),
+                filename = any(),
+                filetype = any()
+            )
+        }
+    }
+
+    @Test
+    fun givenFailedUploadStatus_whenUploadSucceeds_thenPersistsUpdatedMessageAndSends() = runTest {
+        val name = "photo.jpg"
+        val content = MessageContent.Asset(ASSET_CONTENT.value.copy(name = name))
+        val path = fakeKaliumFileSystem.providePersistentAssetPath(name)
+        val message = assetMessage().copy(content = content)
+        val uploadedAssetId = UploadedAssetId("remote_key", "remote_domain", "remote_token")
+        val uploadedSha = SHA256Key(byteArrayOf())
+
+        val (arrangement, useCase) = Arrangement()
+            .withGetAssetMessageTransferStatus(AssetTransferStatus.FAILED_UPLOAD)
+            .withUpdateAssetMessageTransferStatus(UpdateTransferStatusResult.Success)
+            .withFetchPrivateDecodedAsset(Either.Right(path))
+            .withStoredData(mockedLongAssetData(), path)
+            .withUploadAndPersistPrivateAsset(Either.Right(uploadedAssetId to uploadedSha))
+            .withPersistMessage(Either.Right(Unit))
+            .withSendMessage(Either.Right(Unit))
+            .arrange()
+
+        useCase(message)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.persistMessage.invoke(
+                matching {
+                    it.id == message.id && it.content is MessageContent.Asset
+                            && (it.content as MessageContent.Asset).value.remoteData.assetId == uploadedAssetId.key
+                            && (it.content as MessageContent.Asset).value.remoteData.assetDomain == uploadedAssetId.domain
+                }
+            )
+        }
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.messageSender.sendMessage(
+                matching { m ->
+                    m.id == message.id && m.content is MessageContent.Asset
+                            && (m.content as MessageContent.Asset).value.remoteData.assetId == uploadedAssetId.key
+                },
+                any()
+            )
+        }
+    }
+
+    @Test
+    fun givenAudioAssetWithoutNormalizedLoudness_whenUploadSucceeds_thenBuildsAndPersistsNormalizedLoudness() = runTest {
+        val name = "audio.wav"
+        val path = fakeKaliumFileSystem.providePersistentAssetPath(name)
+        val normalizedLoudness = byteArrayOf(1, 2, 3)
+        val content = MessageContent.Asset(
+            ASSET_CONTENT.value.copy(
+                name = name,
+                mimeType = "audio/wav",
+                metadata = AssetContent.AssetMetadata.Audio(durationMs = 1_000L, normalizedLoudness = null)
+            )
+        )
+        val message = assetMessage().copy(content = content)
+        val uploadedAssetId = UploadedAssetId("remote_key", "remote_domain", "remote_token")
+        val uploadedSha = SHA256Key(byteArrayOf())
+
+        val (arrangement, useCase) = Arrangement()
+            .withGetAssetMessageTransferStatus(AssetTransferStatus.FAILED_UPLOAD)
+            .withUpdateAssetMessageTransferStatus(UpdateTransferStatusResult.Success)
+            .withFetchPrivateDecodedAsset(Either.Right(path))
+            .withStoredData(mockedLongAssetData(), path)
+            .withAudioNormalizedLoudnessBuilderResult(path.toString(), normalizedLoudness)
+            .withUploadAndPersistPrivateAssetDeletingSourcePath(Either.Right(uploadedAssetId to uploadedSha))
+            .withPersistMessage(Either.Right(Unit))
+            .withSendMessage(Either.Right(Unit))
+            .arrange()
+
+        useCase(message)
+
+        arrangement.audioNormalizedLoudnessBuilder.assertInvoked(path.toString())
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.persistMessage.invoke(
+                matching {
+                    val assetContent = (it.content as? MessageContent.Asset)?.value
+                    val metadata = assetContent?.metadata as? AssetContent.AssetMetadata.Audio
+                    it.id == message.id &&
+                            assetContent?.remoteData?.assetId == uploadedAssetId.key &&
+                            metadata != null &&
+                            metadata.durationMs == 1_000L &&
+                            metadata.normalizedLoudness.contentEquals(normalizedLoudness)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun givenAudioAssetAlreadyWithNormalizedLoudness_whenUploadSucceeds_thenPreservesItWithoutBuilding() = runTest {
+        val name = "audio.wav"
+        val path = fakeKaliumFileSystem.providePersistentAssetPath(name)
+        val existingLoudness = byteArrayOf(4, 5, 6)
+        val content = MessageContent.Asset(
+            ASSET_CONTENT.value.copy(
+                name = name,
+                mimeType = "audio/wav",
+                metadata = AssetContent.AssetMetadata.Audio(durationMs = 2_000L, normalizedLoudness = existingLoudness)
+            )
+        )
+        val message = assetMessage().copy(content = content)
+        val uploadedAssetId = UploadedAssetId("remote_key", "remote_domain", "remote_token")
+        val uploadedSha = SHA256Key(byteArrayOf())
+
+        val (arrangement, useCase) = Arrangement()
+            .withGetAssetMessageTransferStatus(AssetTransferStatus.FAILED_UPLOAD)
+            .withUpdateAssetMessageTransferStatus(UpdateTransferStatusResult.Success)
+            .withFetchPrivateDecodedAsset(Either.Right(path))
+            .withStoredData(mockedLongAssetData(), path)
+            .withUploadAndPersistPrivateAsset(Either.Right(uploadedAssetId to uploadedSha))
+            .withPersistMessage(Either.Right(Unit))
+            .withSendMessage(Either.Right(Unit))
+            .arrange()
+
+        useCase(message)
+
+        arrangement.audioNormalizedLoudnessBuilder.assertInvoked(path.toString(), 0)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.persistMessage.invoke(
+                matching {
+                    val metadata = ((it.content as? MessageContent.Asset)?.value?.metadata as? AssetContent.AssetMetadata.Audio)
+                    metadata != null &&
+                            metadata.durationMs == 2_000L &&
+                            metadata.normalizedLoudness.contentEquals(existingLoudness)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun givenNonAudioAsset_whenUploadSucceeds_thenDoesNotBuildNormalizedLoudness() = runTest {
+        val name = "photo.jpg"
+        val path = fakeKaliumFileSystem.providePersistentAssetPath(name)
+        val content = MessageContent.Asset(
+            ASSET_CONTENT.value.copy(
+                name = name,
+                mimeType = "image/jpeg",
+                metadata = AssetContent.AssetMetadata.Image(width = 100, height = 100)
+            )
+        )
+        val message = assetMessage().copy(content = content)
+        val uploadedAssetId = UploadedAssetId("remote_key", "remote_domain", "remote_token")
+        val uploadedSha = SHA256Key(byteArrayOf())
+
+        val (arrangement, useCase) = Arrangement()
+            .withGetAssetMessageTransferStatus(AssetTransferStatus.FAILED_UPLOAD)
+            .withUpdateAssetMessageTransferStatus(UpdateTransferStatusResult.Success)
+            .withFetchPrivateDecodedAsset(Either.Right(path))
+            .withStoredData(mockedLongAssetData(), path)
+            .withUploadAndPersistPrivateAsset(Either.Right(uploadedAssetId to uploadedSha))
+            .withPersistMessage(Either.Right(Unit))
+            .withSendMessage(Either.Right(Unit))
+            .arrange()
+
+        useCase(message)
+
+        arrangement.audioNormalizedLoudnessBuilder.assertInvoked(path.toString(), 0)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.persistMessage.invoke(
+                matching {
+                    val metadata = ((it.content as? MessageContent.Asset)?.value?.metadata as? AssetContent.AssetMetadata.Image)
+                    metadata != null && metadata.width == 100 && metadata.height == 100
+                }
+            )
+        }
+    }
+
+    @Test
+    fun givenFailedUploadStatus_whenUploadFails_thenSetsFailedUploadAndFailedStatus() = runTest {
+        val name = "photo.jpg"
+        val content = MessageContent.Asset(ASSET_CONTENT.value.copy(name = name))
+        val path = fakeKaliumFileSystem.providePersistentAssetPath(name)
+        val message = assetMessage().copy(content = content)
+
+        val (arrangement, useCase) = Arrangement()
+            .withGetAssetMessageTransferStatus(AssetTransferStatus.FAILED_UPLOAD)
+            .withUpdateAssetMessageTransferStatus(UpdateTransferStatusResult.Success)
+            .withFetchPrivateDecodedAsset(Either.Right(path))
+            .withStoredData(mockedLongAssetData(), path)
+            .withUploadAndPersistPrivateAsset(Either.Left(NetworkFailure.ServerMiscommunication(TestNetworkException.missingAuth)))
+            .arrange()
+
+        useCase(message)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.updateAssetMessageTransferStatus.invoke(
+                AssetTransferStatus.FAILED_UPLOAD,
+                message.conversationId,
+                message.id
+            )
+        }
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.messageSendFailureHandler.handleFailureAndUpdateMessageStatus(
+                failure = any(),
+                conversationId = message.conversationId,
+                messageId = message.id,
+                messageType = any(),
+                scheduleResendIfNoNetwork = true
+            )
+        }
+        arrangement.audioNormalizedLoudnessBuilder.assertInvoked(path.toString(), 0)
+    }
+
+    @Test
+    fun givenUploadedStatus_whenInvoked_thenCallsSendPendingMessageDirectly() = runTest {
+        val message = assetMessage()
+
+        val (arrangement, useCase) = Arrangement()
+            .withGetAssetMessageTransferStatus(AssetTransferStatus.UPLOADED)
+            .withSendPendingMessage(Either.Right(Unit))
+            .arrange()
+
+        useCase(message)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.messageSender.sendPendingMessage(message.conversationId, message.id)
+        }
+        verifySuspend(VerifyMode.not) {
+            arrangement.assetRepository.uploadAndPersistPrivateAsset(any(), any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun givenUploadInProgressStatus_whenInvoked_thenSkipsWithoutSendingOrUploading() = runTest {
+        val message = assetMessage()
+
+        val (arrangement, useCase) = Arrangement()
+            .withGetAssetMessageTransferStatus(AssetTransferStatus.UPLOAD_IN_PROGRESS)
+            .arrange()
+
+        useCase(message)
+
+        verifySuspend(VerifyMode.not) {
+            arrangement.messageSender.sendPendingMessage(any(), any())
+        }
+        verifySuspend(VerifyMode.not) {
+            arrangement.assetRepository.uploadAndPersistPrivateAsset(any(), any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    private inner class Arrangement {
+        val assetRepository = mock<AssetRepository>(mode = MockMode.autoUnit)
+        val persistMessage = mock<PersistMessageUseCase>(mode = MockMode.autoUnit)
+        val updateAssetMessageTransferStatus = mock<UpdateAssetMessageTransferStatusUseCase>(mode = MockMode.autoUnit)
+        val getAssetMessageTransferStatus = mock<GetAssetMessageTransferStatusUseCase>(mode = MockMode.autoUnit)
+        val messageSender = mock<MessageSender>(mode = MockMode.autoUnit)
+        val messageSendFailureHandler = mock<MessageSendFailureHandler>(mode = MockMode.autoUnit)
+        val audioNormalizedLoudnessBuilder = AudioNormalizedLoudnessBuilderMock(
+            canReadFile = { fakeKaliumFileSystem.exists(it.toPath()) }
+        )
+
+        suspend fun withGetAssetMessageTransferStatus(status: AssetTransferStatus) = apply {
+            everySuspend { getAssetMessageTransferStatus.invoke(any(), any()) } returns status
+        }
+
+        suspend fun withUpdateAssetMessageTransferStatus(result: UpdateTransferStatusResult) = apply {
+            everySuspend { updateAssetMessageTransferStatus.invoke(any(), any(), any()) } returns result
+        }
+
+        suspend fun withFetchPrivateDecodedAsset(result: Either<CoreFailure, Path>) = apply {
+            everySuspend {
+                assetRepository.fetchPrivateDecodedAsset(any(), any(), any(), any(), any(), any(), any(), any())
+            } returns result.map { FetchedAssetData(it, true) }
+        }
+
+        fun withStoredData(data: ByteArray, dataPath: Path) = apply {
+            fakeKaliumFileSystem.sink(dataPath).buffer().use {
+                it.write(data)
+                it.flush()
+            }
+        }
+
+        fun withAudioNormalizedLoudnessBuilderResult(filePath: String, result: ByteArray?) = apply {
+            audioNormalizedLoudnessBuilder.every(filePath, result)
+        }
+
+        suspend fun withUploadAndPersistPrivateAsset(result: Either<CoreFailure, Pair<UploadedAssetId, SHA256Key>>) = apply {
+            everySuspend {
+                assetRepository.uploadAndPersistPrivateAsset(
+                    mimeType = any(),
+                    assetDataPath = any(),
+                    otrKey = any(),
+                    extension = any(),
+                    conversationId = any(),
+                    filename = any(),
+                    filetype = any()
+                )
+            } returns result
+        }
+
+        suspend fun withUploadAndPersistPrivateAssetDeletingSourcePath(
+            result: Either<CoreFailure, Pair<UploadedAssetId, SHA256Key>>
+        ) = apply {
+            everySuspend {
+                assetRepository.uploadAndPersistPrivateAsset(
+                    mimeType = any(),
+                    assetDataPath = any(),
+                    otrKey = any(),
+                    extension = any(),
+                    conversationId = any(),
+                    filename = any(),
+                    filetype = any()
+                )
+            } calls { invocation ->
+                val assetDataPath = invocation.args[1] as Path
+                fakeKaliumFileSystem.delete(assetDataPath)
+                result
+            }
+        }
+
+        suspend fun withPersistMessage(result: Either<CoreFailure, Unit>) = apply {
+            everySuspend { persistMessage.invoke(any()) } returns result
+        }
+
+        suspend fun withSendMessage(result: Either<CoreFailure, Unit>) = apply {
+            everySuspend { messageSender.sendMessage(any(), any()) } returns result
+        }
+
+        suspend fun withSendPendingMessage(result: Either<CoreFailure, Unit>) = apply {
+            everySuspend { messageSender.sendPendingMessage(any(), any()) } returns result
+        }
+
+        fun arrange() = this to SendPendingAssetMessageUseCaseImpl(
+            assetRepository = assetRepository,
+            persistMessage = persistMessage,
+            updateAssetMessageTransferStatus = updateAssetMessageTransferStatus,
+            getAssetMessageTransferStatus = getAssetMessageTransferStatus,
+            messageSender = messageSender,
+            messageSendFailureHandler = messageSendFailureHandler,
+            audioNormalizedLoudnessBuilder = audioNormalizedLoudnessBuilder,
+        )
+    }
+
+    companion object {
+        val fakeKaliumFileSystem = FakeKaliumFileSystem()
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25291
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-25291
----

# What's new in this PR?

### Issues

- Text, location, and asset messages that fail to send because of a transient network outage are not retried when connectivity returns; the user must manually re-send each one.
- For asset messages, retry was particularly broken: the local file was deleted on first attempt, so even manual retry could not re-upload the original bytes, and audio waveform (normalized loudness) was recomputed (or lost) on retry.

### Solutions

- Flip `scheduleResendIfNoNetwork = true` for `SendTextMessageUseCase`, `SendLocationUseCase`, and both failure branches in `ScheduleNewAssetMessageUseCase` / `UploadAssetUseCase`, so transient network failures enqueue the message for the pending-messages worker.
- Introduce `SendPendingAssetMessageUseCase`, which on retry: re-fetches the local asset, recomputes audio normalized loudness only if it's missing, re-uploads, updates the message with the new remote data, persists, deletes the local copy, and dispatches via `MessageSender`.
- `PendingMessagesSenderWorker` now branches: regular asset messages go through `SendPendingAssetMessageUseCase`; everything else stays on `messageSender.sendPendingMessage`.
- On upload failure, `UploadAssetUseCase` now persists any already-computed audio loudness so retry doesn't recompute (or lose) it.
- `MessageScope` exposes `sendPendingAssetMessage` and the worker is wired up via `UserSessionScope`.
