### PR TITLE
feat: support message editing in offline (WPB-25295)

### DIFF
--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAO.kt
@@ -99,6 +99,12 @@ interface MessageDAO {
         newMessageId: String
     )
 
+    suspend fun updateTextMessageContent(
+        conversationId: QualifiedIDEntity,
+        messageId: String,
+        textContent: MessageEntityContent.Text,
+    )
+
     suspend fun updateLegalHoldMessageMembers(conversationId: QualifiedIDEntity, messageId: String, newMembers: List<QualifiedIDEntity>)
 
     fun observeMessageVisibility(messageUuid: String, conversationId: QualifiedIDEntity): Flow<MessageEntity.Visibility?>

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/MessageDAOImpl.kt
@@ -450,18 +450,36 @@ internal class MessageDAOImpl internal constructor(
         }
     }
 
+    override suspend fun updateTextMessageContent(
+        conversationId: QualifiedIDEntity,
+        messageId: String,
+        textContent: MessageEntityContent.Text,
+    ): Unit = withContext(writeDispatcher.value) {
+        queries.transaction {
+            updateTextMessageContentInDB(
+                conversationId = conversationId,
+                currentMessageId = messageId,
+                newTextContent = textContent,
+                newMessageId = messageId,
+                editInstant = null,
+            )
+        }
+    }
+
     /**
      * Be careful and run this operation in ONE wrapping transaction.
      */
     private suspend fun updateTextMessageContentInDB(
-        editInstant: Instant,
+        editInstant: Instant?,
         conversationId: QualifiedIDEntity,
         currentMessageId: String,
         newTextContent: MessageEntityContent.Text,
         newMessageId: String
     ) {
         // do not add withContext
-        queries.markMessageAsEdited(editInstant, currentMessageId, conversationId)
+        editInstant?.let {
+            queries.markMessageAsEdited(it, currentMessageId, conversationId)
+        }
         reactionsQueries.deleteAllReactionsForMessage(currentMessageId, conversationId)
         queries.deleteMessageMentions(currentMessageId, conversationId)
         queries.deleteMessageLinkPreviews(currentMessageId, conversationId)

--- a/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageTextEditTest.kt
+++ b/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageTextEditTest.kt
@@ -23,7 +23,6 @@ import com.wire.kalium.persistence.dao.receipt.ReceiptTypeEntity
 import com.wire.kalium.persistence.dao.unread.UnreadEventTypeEntity
 import com.wire.kalium.persistence.utils.stubs.newRegularMessageEntity
 import com.wire.kalium.util.time.UNIX_FIRST_DATE
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.runTest
@@ -187,6 +186,27 @@ class MessageTextEditTest : BaseMessageTest() {
         val editStatus = result.editStatus
         assertIs<MessageEntity.EditStatus.Edited>(editStatus)
         assertEquals(editDate, editStatus.lastDate)
+    }
+
+    @Test
+    fun givenTextWasInserted_whenUpdatingContentWithoutEditInstant_thenShouldNotMarkAsEdited() = runTest {
+        insertInitialData()
+
+        val newMessageBody = "newBody"
+        messageDAO.updateTextMessageContent(
+            conversationId = CONVERSATION_ID,
+            messageId = ORIGINAL_MESSAGE_ID,
+            textContent = ORIGINAL_CONTENT.copy(messageBody = newMessageBody),
+        )
+
+        val result = messageDAO.getMessageById(ORIGINAL_MESSAGE_ID, CONVERSATION_ID)!!
+
+        val content = result.content
+        assertIs<MessageEntityContent.Text>(content)
+        assertEquals(newMessageBody, content.messageBody)
+
+        assertIs<MessageEntity.Regular>(result)
+        assertIs<MessageEntity.EditStatus.NotEdited>(result.editStatus)
     }
 
     @Test

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/MessageRepository.kt
@@ -179,6 +179,12 @@ internal interface MessageRepository {
         editInstant: Instant
     ): Either<CoreFailure, Unit>
 
+    suspend fun updateTextMessage(
+        conversationId: ConversationId,
+        messageId: String,
+        messageContent: MessageContent.Text,
+    ): Either<CoreFailure, Unit>
+
     suspend fun updateLegalHoldMessageMembers(
         messageId: String,
         conversationId: ConversationId,
@@ -631,6 +637,24 @@ internal class MessageDataSource internal constructor(
                     messageContent.newMentions.map { messageMentionMapper.fromModelToDao(it) }
                 ),
                 newMessageId = newMessageId
+            )
+        }
+    }
+
+    override suspend fun updateTextMessage(
+        conversationId: ConversationId,
+        messageId: String,
+        messageContent: MessageContent.Text,
+    ): Either<CoreFailure, Unit> {
+        return wrapStorageRequest {
+            messageDAO.updateTextMessageContent(
+                conversationId = conversationId.toDao(),
+                messageId = messageId,
+                textContent = MessageEntityContent.Text(
+                    messageContent.value,
+                    messageContent.linkPreviews.map { linkPreviewMapper.fromModelToDao(it) },
+                    messageContent.mentions.map { messageMentionMapper.fromModelToDao(it) }
+                ),
             )
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -2279,6 +2279,7 @@ public class UserSessionScope internal constructor(
             messageSender = messages.messageSender,
             userId = userId,
             sendPendingAssetMessage = messages.sendPendingAssetMessage,
+            messageSendFailureHandler = messages.messageSendFailureHandler,
         )
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/EditMessageBuilder.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/EditMessageBuilder.kt
@@ -1,0 +1,47 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.message
+
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import kotlinx.datetime.Clock
+import kotlin.uuid.Uuid
+
+internal object EditMessageBuilder {
+    fun buildTextEditSignaling(
+        originalMessage: Message.Regular,
+        originalContent: MessageContent.Text,
+        editedMessageId: String = Uuid.random().toString(),
+        date: kotlinx.datetime.Instant = Clock.System.now(),
+    ): Message.Signaling = Message.Signaling(
+        id = editedMessageId,
+        content = MessageContent.TextEdited(
+            editMessageId = originalMessage.id,
+            newContent = originalContent.value,
+            newMentions = originalContent.mentions,
+        ),
+        conversationId = originalMessage.conversationId,
+        date = date,
+        senderUserId = originalMessage.senderUserId,
+        senderClientId = originalMessage.senderClientId,
+        status = Message.Status.Pending,
+        isSelfMessage = true,
+        expirationData = null,
+    )
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/RetryFailedMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/RetryFailedMessageUseCase.kt
@@ -54,8 +54,6 @@ import com.wire.kalium.persistence.dao.message.MessageEntity
 import com.wire.kalium.util.KaliumDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Clock
-import kotlin.uuid.Uuid
 
 // todo(interface). extract interface for use case
 @Suppress("LongParameterList")
@@ -139,27 +137,8 @@ public class RetryFailedMessageUseCase internal constructor(
 
     private suspend fun retrySendingEditMessage(message: Message.Regular): Either<CoreFailure, Unit> =
         when (val content = message.content) {
-            is MessageContent.Text -> {
-                val editContent = MessageContent.TextEdited(
-                    editMessageId = message.id,
-                    newContent = content.value,
-                    newMentions = content.mentions
-                )
-                // Create new unique message ID
-                val generatedMessageUuid = Uuid.random().toString()
-                val editMessage = Message.Signaling(
-                    id = generatedMessageUuid,
-                    content = editContent,
-                    conversationId = message.conversationId,
-                    date = Clock.System.now(),
-                    senderUserId = message.senderUserId,
-                    senderClientId = message.senderClientId,
-                    status = Message.Status.Pending,
-                    isSelfMessage = true,
-                    expirationData = null
-                )
-                retrySendingMessage(editMessage)
-            }
+            is MessageContent.Text ->
+                retrySendingMessage(EditMessageBuilder.buildTextEditSignaling(message, content))
 
             else -> handleError("Message edit with content of type ${content::class.simpleName} cannot be retried")
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendEditTextMessageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/SendEditTextMessageUseCase.kt
@@ -78,49 +78,85 @@ public class SendEditTextMessageUseCase internal constructor(
             it is SlowSyncStatus.Complete
         }
 
-        provideClientId().flatMap { clientId ->
-            val content = MessageContent.TextEdited(
-                editMessageId = originalMessageId,
-                newContent = text,
-                newMentions = mentions
-            )
-            val message = Message.Signaling(
-                id = editedMessageId,
-                content = content,
-                conversationId = conversationId,
-                date = Clock.System.now(),
-                senderUserId = selfUserId,
-                senderClientId = clientId,
-                status = Message.Status.Pending,
-                isSelfMessage = true,
-                expirationData = null
-            )
-            // until the edit send is completed and accepted by the backend, we don't change the message id to be able to handle any
-            // incoming edits from other clients that happened in the meantime and already changed the message id
-            messageRepository.updateTextMessage(
-                conversationId = message.conversationId,
-                messageContent = content,
-                newMessageId = originalMessageId,
-                editInstant = message.date
-            ).flatMap {
-                messageRepository.updateMessageStatus(
-                    messageStatus = MessageEntity.Status.PENDING,
-                    conversationId = message.conversationId,
-                    messageUuid = originalMessageId
-                )
-            }
-                .flatMap {
-                    messageSender.sendMessage(message)
-                }
-        }.fold(
+        messageRepository.getMessageById(conversationId, originalMessageId).fold(
             {
-                messageSendFailureHandler.handleFailureAndUpdateMessageStatus(it, conversationId, originalMessageId, TYPE)
                 MessageOperationResult.Failure(it)
             },
-            {
-                MessageOperationResult.Success
+            { originalMessage ->
+                if (originalMessage.status == Message.Status.Pending) {
+                    // Message is PENDING, so only update the text
+                    messageRepository.updateTextMessage(
+                        conversationId = conversationId,
+                        messageId = originalMessageId,
+                        messageContent = MessageContent.Text(
+                            value = text,
+                            mentions = mentions,
+                        ),
+                    ).fold(
+                        { MessageOperationResult.Failure(it) },
+                        { MessageOperationResult.Success }
+                    )
+                } else {
+                    val content = MessageContent.TextEdited(
+                        editMessageId = originalMessageId,
+                        newContent = text,
+                        newMentions = mentions
+                    )
+
+                    sendEditMessage(conversationId, originalMessageId, editedMessageId, content).fold(
+                        {
+                            messageSendFailureHandler.handleFailureAndUpdateMessageStatus(
+                                failure = it,
+                                conversationId = conversationId,
+                                messageId = originalMessageId,
+                                messageType = TYPE,
+                                scheduleResendIfNoNetwork = true
+                            )
+                            MessageOperationResult.Failure(it)
+                        },
+                        {
+                            MessageOperationResult.Success
+                        }
+                    )
+                }
             }
         )
+    }
+
+    private suspend fun sendEditMessage(
+        conversationId: ConversationId,
+        originalMessageId: String,
+        editedMessageId: String,
+        content: MessageContent.TextEdited
+    ) = provideClientId().flatMap { clientId ->
+        val message = Message.Signaling(
+            id = editedMessageId,
+            content = content,
+            conversationId = conversationId,
+            date = Clock.System.now(),
+            senderUserId = selfUserId,
+            senderClientId = clientId,
+            status = Message.Status.Pending,
+            isSelfMessage = true,
+            expirationData = null
+        )
+        // until the edit send is completed and accepted by the backend, we don't change the message id to be able to handle any
+        // incoming edits from other clients that happened in the meantime and already changed the message id
+        messageRepository.updateTextMessage(
+            conversationId = message.conversationId,
+            messageContent = content,
+            newMessageId = originalMessageId,
+            editInstant = message.date
+        ).flatMap {
+            messageRepository.updateMessageStatus(
+                messageStatus = MessageEntity.Status.PENDING,
+                conversationId = message.conversationId,
+                messageUuid = originalMessageId
+            )
+        }
+            .flatMap {
+                messageSender.sendMessage(message)
+            }
     }
 
     internal companion object {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/PendingMessagesSenderWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/PendingMessagesSenderWorker.kt
@@ -23,6 +23,8 @@ import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.message.EditMessageBuilder
+import com.wire.kalium.logic.feature.message.MessageSendFailureHandler
 import com.wire.kalium.messaging.sending.MessageSender
 import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.common.functional.onSuccess
@@ -37,6 +39,7 @@ internal class PendingMessagesSenderWorker(
     private val messageSender: MessageSender,
     private val userId: UserId,
     private val sendPendingAssetMessage: SendPendingAssetMessageUseCase,
+    private val messageSendFailureHandler: MessageSendFailureHandler,
 ) : DefaultWorker {
 
     /**
@@ -56,6 +59,12 @@ internal class PendingMessagesSenderWorker(
                     when {
                         message is Message.Regular && message.content is MessageContent.Asset ->
                             sendPendingAssetMessage(message)
+
+                        message is Message.Regular &&
+                                message.content is MessageContent.Text &&
+                                message.editStatus is Message.EditStatus.Edited ->
+                            resendPendingTextEdit(message, message.content as MessageContent.Text)
+
                         else ->
                             messageSender.sendPendingMessage(message.conversationId, message.id)
                     }
@@ -68,7 +77,27 @@ internal class PendingMessagesSenderWorker(
         return Result.Success
     }
 
+    private suspend fun resendPendingTextEdit(
+        originalMessage: Message.Regular,
+        originalContent: MessageContent.Text,
+    ) {
+        val signaling = EditMessageBuilder.buildTextEditSignaling(originalMessage, originalContent)
+        messageSender.sendMessage(signaling)
+            .onFailure { failure ->
+                kaliumLogger.withFeatureId(SYNC)
+                    .i("Failed to resend pending text edit for message ${originalMessage.id}. Failure = $failure")
+                messageSendFailureHandler.handleFailureAndUpdateMessageStatus(
+                    failure = failure,
+                    conversationId = originalMessage.conversationId,
+                    messageId = originalMessage.id,
+                    messageType = TEXT_EDITED_TYPE,
+                    scheduleResendIfNoNetwork = false,
+                )
+            }
+    }
+
     companion object {
         const val NAME_PREFIX = "scheduled-message-"
+        private const val TEXT_EDITED_TYPE = "TextEdited"
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/fakes/FakeMessageRepository.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/fakes/FakeMessageRepository.kt
@@ -148,6 +148,12 @@ internal open class FakeMessageRepository : MessageRepository {
         editInstant: Instant
     ): Either<CoreFailure, Unit> = Unit.right()
 
+    override suspend fun updateTextMessage(
+        conversationId: ConversationId,
+        messageId: String,
+        messageContent: MessageContent.Text,
+    ): Either<CoreFailure, Unit> = Unit.right()
+
     override suspend fun updateLegalHoldMessageMembers(
         messageId: String,
         conversationId: ConversationId,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendEditTextMessageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/SendEditTextMessageUseCaseTest.kt
@@ -22,11 +22,14 @@ import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestMessage
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import com.wire.kalium.logic.test_util.testKaliumDispatcher
@@ -38,6 +41,7 @@ import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
+import dev.mokkery.matcher.eq
 import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
@@ -54,6 +58,7 @@ class SendEditTextMessageUseCaseTest {
         // Given
         val (arrangement, sendEditTextMessage) = Arrangement(testKaliumDispatcher)
             .withSlowSyncStatusComplete()
+            .withGetMessageByIdSuccess(Message.Status.Sent)
             .withCurrentClientProviderSuccess()
             .withUpdateTextMessageSuccess()
             .withUpdateMessageStatusSuccess()
@@ -87,6 +92,7 @@ class SendEditTextMessageUseCaseTest {
         // Given
         val (arrangement, sendEditTextMessage) = Arrangement(testKaliumDispatcher)
             .withSlowSyncStatusComplete()
+            .withGetMessageByIdSuccess(Message.Status.Sent)
             .withCurrentClientProviderSuccess()
             .withUpdateTextMessageSuccess()
             .withUpdateMessageStatusSuccess()
@@ -118,6 +124,37 @@ class SendEditTextMessageUseCaseTest {
         }
     }
 
+    @Test
+    fun givenMessageIsPending_whenSendingEditText_thenUpdateContentOnlyAndReturnSuccess() = runTest {
+        // Given
+        val (arrangement, sendEditTextMessage) = Arrangement(testKaliumDispatcher)
+            .withSlowSyncStatusComplete()
+            .withGetMessageByIdSuccess(Message.Status.Pending)
+            .withUpdateTextMessageSuccess()
+            .arrange()
+        val originalMessageId = "message id"
+        val editedMessageId = "edited message id"
+        val editedMessageText = "text"
+
+        // When
+        val result = sendEditTextMessage(TestConversation.ID, originalMessageId, editedMessageText, listOf(), editedMessageId)
+
+        // Then
+        assertIs<MessageOperationResult.Success>(result)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.messageRepository.updateTextMessage(any(), eq(originalMessageId), any<MessageContent.Text>())
+        }
+        verifySuspend(VerifyMode.not) {
+            arrangement.messageRepository.updateMessageStatus(any(), any(), any())
+        }
+        verifySuspend(VerifyMode.not) {
+            arrangement.messageSendFailureHandler.handleFailureAndUpdateMessageStatus(any(), any(), any(), any(), any())
+        }
+        verifySuspend(VerifyMode.not) {
+            arrangement.messageSender.sendMessage(any(), any())
+        }
+    }
+
     private class Arrangement(var dispatcher: KaliumDispatcher = TestKaliumDispatcher) {
         val messageRepository = mock<MessageRepository>(mode = MockMode.autoUnit)
         val currentClientIdProvider = mock<CurrentClientIdProvider>(mode = MockMode.autoUnit)
@@ -137,6 +174,12 @@ class SendEditTextMessageUseCaseTest {
             } returns Either.Left(NetworkFailure.NoNetworkConnection(null))
         }
 
+        suspend fun withGetMessageByIdSuccess(status: Message.Status) = apply {
+            everySuspend {
+                messageRepository.getMessageById(any(), any())
+            } returns Either.Right(TestMessage.TEXT_MESSAGE.copy(status = status))
+        }
+
         fun withSlowSyncStatusComplete() = apply {
             val stateFlow = MutableStateFlow<SlowSyncStatus>(SlowSyncStatus.Complete).asStateFlow()
             every {
@@ -152,7 +195,10 @@ class SendEditTextMessageUseCaseTest {
 
         suspend fun withUpdateTextMessageSuccess() = apply {
             everySuspend {
-                messageRepository.updateTextMessage(any(), any(), any(), any())
+                messageRepository.updateTextMessage(any(), any<MessageContent.TextEdited>(), any(), any())
+            } returns Either.Right(Unit)
+            everySuspend {
+                messageRepository.updateTextMessage(any(), any<String>(), any<MessageContent.Text>())
             } returns Either.Right(Unit)
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/PendingMessagesSenderWorkerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/PendingMessagesSenderWorkerTest.kt
@@ -20,8 +20,11 @@ package com.wire.kalium.logic.sync
 
 import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageRepository
+import com.wire.kalium.logic.feature.message.MessageSendFailureHandler
 import com.wire.kalium.logic.framework.TestMessage
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.messaging.sending.MessageSender
@@ -30,10 +33,12 @@ import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.matcher.eq
+import dev.mokkery.matcher.matching
 import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 
@@ -42,6 +47,7 @@ class PendingMessagesSenderWorkerTest {
     private val messageRepository = mock<MessageRepository>()
     private val messageSender = mock<MessageSender>()
     private val sendPendingAssetMessage = mock<SendPendingAssetMessageUseCase>(mode = MockMode.autoUnit)
+    private val messageSendFailureHandler = mock<MessageSendFailureHandler>(mode = MockMode.autoUnit)
 
     private lateinit var pendingMessagesSenderWorker: PendingMessagesSenderWorker
 
@@ -52,6 +58,7 @@ class PendingMessagesSenderWorkerTest {
             messageSender,
             TestUser.USER_ID,
             sendPendingAssetMessage,
+            messageSendFailureHandler,
         )
     }
 
@@ -72,6 +79,9 @@ class PendingMessagesSenderWorkerTest {
         }
         verifySuspend(VerifyMode.not) {
             sendPendingAssetMessage.invoke(any<Message.Regular>())
+        }
+        verifySuspend(VerifyMode.not) {
+            messageSender.sendMessage(any(), any())
         }
     }
 
@@ -109,6 +119,63 @@ class PendingMessagesSenderWorkerTest {
         }
         verifySuspend(VerifyMode.not) {
             sendPendingAssetMessage.invoke(any<Message.Regular>())
+        }
+    }
+
+    @Test
+    fun givenPendingTextMessageWithEditedStatus_whenExecutingWorker_thenTextEditedSignalingIsSent() = runTest {
+        val editedMessage = TestMessage.TEXT_MESSAGE.copy(
+            editStatus = Message.EditStatus.Edited(Instant.fromEpochMilliseconds(123L))
+        )
+        everySuspend {
+            messageRepository.getAllPendingMessagesFromUser(eq(TestUser.USER_ID))
+        } returns Either.Right(listOf(editedMessage))
+        everySuspend {
+            messageSender.sendMessage(any(), any())
+        } returns Either.Right(Unit)
+
+        pendingMessagesSenderWorker.doWork()
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            messageSender.sendMessage(
+                matching { signaling ->
+                    signaling is Message.Signaling &&
+                            signaling.content is MessageContent.TextEdited &&
+                            (signaling.content as MessageContent.TextEdited).editMessageId == editedMessage.id &&
+                            (signaling.content as MessageContent.TextEdited).newContent ==
+                            (editedMessage.content as MessageContent.Text).value
+                },
+                any()
+            )
+        }
+        verifySuspend(VerifyMode.not) {
+            messageSender.sendPendingMessage(any(), any())
+        }
+    }
+
+    @Test
+    fun givenPendingEditedMessageFailsWithNoNetwork_whenExecutingWorker_thenFailureHandlerCalledWithoutReschedule() = runTest {
+        val editedMessage = TestMessage.TEXT_MESSAGE.copy(
+            editStatus = Message.EditStatus.Edited(Instant.fromEpochMilliseconds(123L))
+        )
+        val failure = NetworkFailure.NoNetworkConnection(null)
+        everySuspend {
+            messageRepository.getAllPendingMessagesFromUser(eq(TestUser.USER_ID))
+        } returns Either.Right(listOf(editedMessage))
+        everySuspend {
+            messageSender.sendMessage(any(), any())
+        } returns Either.Left(failure)
+
+        pendingMessagesSenderWorker.doWork()
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            messageSendFailureHandler.handleFailureAndUpdateMessageStatus(
+                failure = eq(failure),
+                conversationId = eq(editedMessage.conversationId),
+                messageId = eq(editedMessage.id),
+                messageType = eq("TextEdited"),
+                scheduleResendIfNoNetwork = eq(false),
+            )
         }
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25295
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-25295
----

# What's new in this PR?

Allow editing messages when no Internet connection is available.
The following scenarios are covered:
1. Online, message status = sent: no changes, current edit feature.
2. Online, message status = pending: edit not allowed to avoid race conditions, message is supposed to be sent shortly.
3. Offline, message status = sent: editing already sent message. Edit will be sent once connected.
4. Offline, message status = pending: editing pending message, only update the message content, message will be sent as regular message once connected.


Key changes in app code:
Enable "Edit" menu for pending messages

Key changes in kalium code:
SendEditTextMessageUseCase - support Pending and Regular message edit flows.
EditMessageBuilder - reuse TextEdited message builder between use case and worker.
MessageDAO \ Repository - new updateTextMessage() function to update only the contents without edit status for pending message editing.
