### PR TITLE
fix: handle deleted one-on-one details [WPB-8645]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapper.kt
@@ -266,12 +266,12 @@ internal class ConversationMapperImpl(
                     ConversationDetails.OneOne(
                         conversation = fromConversationViewToEntity(daoModel),
                         otherUser = OtherUser(
-                            id = otherUserId.requireField("otherUserID in OneOnOne").toModel(),
+                            id = (otherUserId ?: id).toModel(),
                             name = name,
                             accentId = accentId ?: 0,
                             userType = domainUserTypeMapper.fromUserTypeEntity(userType),
                             availabilityStatus = userAvailabilityStatusMapper.fromDaoAvailabilityStatusToModel(userAvailabilityStatus),
-                            deleted = userDeleted ?: false,
+                            deleted = userDeleted ?: (otherUserId == null),
                             botService = botService?.let { BotService(it.id, it.provider) },
                             handle = null,
                             completePicture = previewAssetId?.toModel(),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
@@ -27,8 +27,12 @@ import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageMapper
 import com.wire.kalium.logic.data.message.MessagePreview
 import com.wire.kalium.logic.data.message.MessagePreviewContent
+import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.AvailabilityStatusMapper
 import com.wire.kalium.logic.data.user.type.DomainUserTypeMapper
+import com.wire.kalium.logic.data.user.type.UserType
+import com.wire.kalium.logic.data.user.type.UserTypeInfo
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.network.api.authenticated.conversation.ConvProtocol
@@ -82,6 +86,38 @@ internal class ConversationMapperTest {
             conversationMemberMapper,
             messageMapper,
         )
+    }
+
+    @Test
+    fun givenOneOnOneDaoModelWithoutOtherUserId_whenMappingToDetails_thenFallbackDeletedUserIsReturned() {
+        val conversation = TestConversation.VIEW_ONE_ON_ONE.copy(
+            name = null,
+            otherUserId = null,
+            userDeleted = null,
+        )
+        every {
+            protocolInfoMapper.fromEntity(any())
+        }.returns(Conversation.ProtocolInfo.Proteus)
+        every {
+            conversationStatusMapper.fromMutedStatusDaoModel(any())
+        }.returns(MutedConversationStatus.AllAllowed)
+        every {
+            domainUserTypeMapper.fromUserTypeEntity(any())
+        }.returns(UserTypeInfo.Regular(UserType.NONE))
+        every {
+            userAvailabilityStatusMapper.fromDaoAvailabilityStatusToModel(any())
+        }.returns(UserAvailabilityStatus.NONE)
+        every {
+            connectionStatusMapper.fromDaoModel(any())
+        }.returns(ConnectionState.NOT_CONNECTED)
+
+        val details = assertIs<ConversationDetails.OneOne>(
+            conversationMapper.fromDaoModelToDetails(conversation)
+        )
+
+        assertEquals(conversation.id.value, details.otherUser.id.value)
+        assertNull(details.otherUser.name)
+        assertTrue(details.otherUser.deleted)
     }
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationMapperTest.kt
@@ -60,6 +60,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 internal class ConversationMapperTest {
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8645
<!--jira-description-action-hidden-marker-end-->
## Summary
- tolerate one-on-one conversation rows where the other user id is missing
- mark that fallback user as deleted so clients can render the deleted account state instead of crashing
- add a mapper regression test for deleted 1:1 details

## Tests
- ./gradlew :kalium:logic:jvmTest --tests com.wire.kalium.logic.data.conversation.ConversationMapperTest