### PR TITLE
feat: use case for observing active calls [WPB-25067]

### DIFF
--- a/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Calls.sq
+++ b/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Calls.sq
@@ -25,6 +25,9 @@ VALUES (?, ?, ?, ?, ?, ?, ?);
 selectAllCalls:
 SELECT * FROM Call;
 
+selectActiveCalls:
+SELECT * FROM Call WHERE status IN ('STARTED', 'INCOMING', 'ANSWERED', 'ESTABLISHED', 'STILL_ONGOING');
+
 selectEstablishedCalls:
 SELECT * FROM Call WHERE status = 'ESTABLISHED' OR status = 'ANSWERED';
 

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/call/CallDAO.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/call/CallDAO.kt
@@ -57,6 +57,7 @@ interface CallDAO {
     fun observeIncomingCalls(): Flow<List<CallEntity>>
     fun observeOutgoingCalls(): Flow<List<CallEntity>>
     fun observeEstablishedCalls(): Flow<List<CallEntity>>
+    fun observeActiveCalls(): Flow<List<CallEntity>>
     suspend fun getEstablishedCall(): CallEntity
     fun observeOngoingCalls(): Flow<List<CallEntity>>
     suspend fun updateLastCallStatusByConversationId(status: CallEntity.Status, conversationId: QualifiedIDEntity)

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/call/CallDAOImpl.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/call/CallDAOImpl.kt
@@ -112,6 +112,12 @@ internal class CallDAOImpl(
             .mapToList()
             .flowOn(readDispatcher.value)
 
+    override fun observeActiveCalls(): Flow<List<CallEntity>> =
+        callsQueries.selectActiveCalls(mapper = mapper::fromCalls)
+            .asFlow()
+            .mapToList()
+            .flowOn(readDispatcher.value)
+
     override suspend fun getEstablishedCall(): CallEntity = withContext(readDispatcher.value) {
         callsQueries.selectEstablishedCalls(mapper = mapper::fromCalls).awaitAsOne()
     }

--- a/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/call/CallDAOTest.kt
+++ b/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/call/CallDAOTest.kt
@@ -22,9 +22,9 @@ import app.cash.turbine.test
 import com.wire.kalium.persistence.BaseDatabaseTest
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserIDEntity
+import com.wire.kalium.persistence.dao.call.CallDAOTest.Companion.callEntity
 import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -265,7 +265,7 @@ class CallDAOTest : BaseDatabaseTest() {
             CallEntity.Status.REJECTED,
             CallEntity.Status.MISSED,
             CallEntity.Status.CLOSED_INTERNALLY
-        ).map { status -> callEntity.copy(id = "id_${status.ordinal}", status = status) }
+        ).map(CallEntity.Status::createCallEntityFromStatus)
 
         val activeCalls = listOf(
             CallEntity.Status.STARTED,
@@ -273,6 +273,13 @@ class CallDAOTest : BaseDatabaseTest() {
             CallEntity.Status.ANSWERED,
             CallEntity.Status.ESTABLISHED,
             CallEntity.Status.STILL_ONGOING
-        ).map { status -> callEntity.copy(id = "id_${status.ordinal}", status = status) }
+        ).map(CallEntity.Status::createCallEntityFromStatus)
     }
 }
+
+private fun CallEntity.Status.createCallEntityFromStatus(): CallEntity = callEntity.copy(
+    id = "id_${this.ordinal}",
+    conversationId = QualifiedIDEntity("conversation_id_${this.ordinal}", "domain"),
+    status = this
+)
+

--- a/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/call/CallDAOTest.kt
+++ b/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/call/CallDAOTest.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -194,6 +195,55 @@ class CallDAOTest : BaseDatabaseTest() {
         }
     }
 
+    @Test
+    fun givenNoActiveCalls_whenObservingActiveCalls_thenReturnEmptyList() = runTest {
+        // given
+        nonActiveCalls.forEach {
+            callDAO.insertCall(it)
+        }
+
+        // when
+        callDAO.observeActiveCalls().test {
+            // then
+            assertEquals(emptyList(), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun givenNonActiveAndActiveCalls_whenObservingActiveCalls_thenReturnOnlyActiveCalls() = runTest {
+        // given
+        (nonActiveCalls + activeCalls).forEach {
+            callDAO.insertCall(it)
+        }
+
+        // when
+        callDAO.observeActiveCalls().test {
+            // then
+            assertEquals(activeCalls.toSet(), awaitItem().toSet())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun givenNonActiveAndActiveCalls_andSomeCallIsUpdated_whenObservingActiveCalls_thenReturnUpdatedActiveCalls() = runTest {
+        // given
+        val callToUpdate = callEntity.copy(id = "id_to_update", status = CallEntity.Status.ESTABLISHED) // now it's active
+        (nonActiveCalls + activeCalls + callToUpdate).forEach {
+            callDAO.insertCall(it)
+        }
+
+        // when
+        callDAO.observeActiveCalls().test {
+            // then
+            assertEquals((activeCalls + callToUpdate).toSet(), awaitItem().toSet())
+
+            callDAO.updateLastCallStatusByConversationId(CallEntity.Status.CLOSED, callToUpdate.conversationId) // now it's not active
+            assertEquals(activeCalls.toSet(), awaitItem().toSet())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
     companion object {
         // given
         val convId = QualifiedIDEntity(
@@ -209,5 +259,20 @@ class CallDAOTest : BaseDatabaseTest() {
             conversationType = ConversationEntity.Type.GROUP,
             type = CallEntity.Type.CONFERENCE
         )
+
+        val nonActiveCalls = listOf(
+            CallEntity.Status.CLOSED,
+            CallEntity.Status.REJECTED,
+            CallEntity.Status.MISSED,
+            CallEntity.Status.CLOSED_INTERNALLY
+        ).map { status -> callEntity.copy(id = "id_${status.ordinal}", status = status) }
+
+        val activeCalls = listOf(
+            CallEntity.Status.STARTED,
+            CallEntity.Status.INCOMING,
+            CallEntity.Status.ANSWERED,
+            CallEntity.Status.ESTABLISHED,
+            CallEntity.Status.STILL_ONGOING
+        ).map { status -> callEntity.copy(id = "id_${status.ordinal}", status = status) }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
@@ -111,6 +111,7 @@ internal interface CallRepository {
     fun outgoingCallsFlow(): Flow<List<Call>>
     fun ongoingCallsFlow(): Flow<List<Call>>
     fun establishedCallsFlow(): Flow<List<Call>>
+    fun activeCallsFlow(): Flow<List<Call>>
     suspend fun establishedCallConversationId(): ConversationId?
     fun observeLastActiveCallByConversationId(conversationId: ConversationId): Flow<Call?>
 
@@ -216,6 +217,8 @@ internal class CallDataSource(
     override fun ongoingCallsFlow(): Flow<List<Call>> = callDAO.observeOngoingCalls().combineWithCallsMetadata()
 
     override fun establishedCallsFlow(): Flow<List<Call>> = callDAO.observeEstablishedCalls().combineWithCallsMetadata()
+
+    override fun activeCallsFlow(): Flow<List<Call>> = callDAO.observeActiveCalls().combineWithCallsMetadata()
 
     private val mutexProvider = MutexProvider<ConversationId>()
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallsScope.kt
@@ -51,6 +51,8 @@ import com.wire.kalium.logic.feature.call.usecase.IsLastCallClosedUseCase
 import com.wire.kalium.logic.feature.call.usecase.IsLastCallClosedUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.MuteCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.MuteCallUseCaseImpl
+import com.wire.kalium.logic.feature.call.usecase.ObserveActiveCallsUseCase
+import com.wire.kalium.logic.feature.call.usecase.ObserveActiveCallsUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.ObserveAskCallFeedbackUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveCallModerationActionsUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveCallModerationActionsUseCaseImpl
@@ -166,6 +168,11 @@ public class CallsScope internal constructor(
         get() = ObserveEstablishedCallWithSortedParticipantsUseCaseImpl(
             callRepository = callRepository,
             callingParticipantsOrder = callingParticipantsOrder
+        )
+
+    public val observeActiveCalls: ObserveActiveCallsUseCase
+        get() = ObserveActiveCallsUseCaseImpl(
+            callRepository = callRepository
         )
 
     public val startCall: StartCallUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/ObserveActiveCallsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/ObserveActiveCallsUseCase.kt
@@ -1,0 +1,35 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.call.usecase
+
+import com.wire.kalium.logic.data.call.Call
+import com.wire.kalium.logic.data.call.CallRepository
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * This use case is responsible for observing the active calls.
+ * Active calls are the calls that are either outgoing, ongoing or incoming, so one of these states:
+ * STARTED, INCOMING, ANSWERED, ESTABLISHED, STILL_ONGOING
+ */
+public interface ObserveActiveCallsUseCase {
+    public operator fun invoke(): Flow<List<Call>>
+}
+
+internal class ObserveActiveCallsUseCaseImpl(private val callRepository: CallRepository) : ObserveActiveCallsUseCase {
+    override fun invoke(): Flow<List<Call>> = callRepository.activeCallsFlow()
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
@@ -43,6 +43,7 @@ import com.wire.kalium.logic.data.id.QualifiedClientID
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.id.toDao
+import com.wire.kalium.logic.data.id.toModel
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.data.mls.CipherSuite
 import com.wire.kalium.logic.data.session.SessionRepository
@@ -127,6 +128,7 @@ class CallRepositoryTest {
     fun breakDown() {
         Dispatchers.resetMain()
     }
+
     @Test
     fun whenRequestingCallConfig_withNoLimitParam_ThenAResultIsReturned() = runTest {
         val (_, callRepository) = Arrangement(testDispatcher.testKaliumDispatcher())
@@ -1939,6 +1941,61 @@ class CallRepositoryTest {
     }
 
     @Test
+    fun givenNoActiveCalls_whenObservingActiveCalls_thenReturnEmptyList() = runTest {
+        // given
+        val (_, callRepository) = Arrangement(testDispatcher.testKaliumDispatcher())
+            .withObserveActiveCallsReturning(flowOf(emptyList()))
+            .withInitialCallMetadataProfile(CallMetadataProfile(emptyMap()))
+            .arrange()
+        // when
+        callRepository.activeCallsFlow().test {
+            // then
+            assertEquals(emptyList(), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun givenActiveCall_whenObservingActiveCalls_thenReturnActiveCall() = runTest {
+        // given
+        val activeCallEntity = createCallEntity().copy(status = CallEntity.Status.ESTABLISHED)
+        val activeCallMetadata = createCallMetadata().copy(callStatus = CallStatus.ESTABLISHED)
+        val (arrangement, callRepository) = Arrangement(testDispatcher.testKaliumDispatcher())
+            .withObserveActiveCallsReturning(flowOf(listOf(activeCallEntity)))
+            .withInitialCallMetadataProfile(CallMetadataProfile(mapOf(activeCallEntity.conversationId.toModel() to activeCallMetadata)))
+            .arrange()
+        // when
+        callRepository.activeCallsFlow().test {
+            // then
+            assertEquals(listOf(arrangement.callMapper.toCall(activeCallEntity, activeCallMetadata)), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun givenActiveCallIsUpdated_whenObservingActiveCalls_thenReturnUpdatedList() = runTest {
+        // given
+        val activeCallEntity = createCallEntity().copy(status = CallEntity.Status.ESTABLISHED) // not it's active
+        val activeCallMetadata = createCallMetadata().copy(callStatus = CallStatus.ESTABLISHED)
+        val activeCallsFlow = MutableStateFlow(listOf(activeCallEntity))
+        val (arrangement, callRepository) = Arrangement(testDispatcher.testKaliumDispatcher())
+            .withObserveActiveCallsReturning(activeCallsFlow)
+            .withInitialCallMetadataProfile(CallMetadataProfile(mapOf(activeCallEntity.conversationId.toModel() to activeCallMetadata)))
+            .arrange()
+        // when
+        callRepository.activeCallsFlow().test {
+            // then
+            assertEquals(listOf(arrangement.callMapper.toCall(activeCallEntity, activeCallMetadata)), awaitItem())
+
+            activeCallsFlow.emit(emptyList())
+            callRepository.updateCallStatusById(activeCallEntity.conversationId.toModel(), CallStatus.CLOSED) // now it's not active
+            advanceUntilIdle()
+            assertEquals(emptyList(), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun givenACall_whenUpdatingCallQualityData_thenCallQualityDataIsUpdatedCorrectlyAndCallQualityDataObserverEmitsData() = runTest {
         // given
         val conversationId = Arrangement.randomConversationId
@@ -2027,7 +2084,7 @@ class CallRepositoryTest {
         val callDAO = mock<CallDAO>(mode = MockMode.autoUnit)
         val serverTimeApi: ServerTimeApi = mock<ServerTimeApi>()
 
-        private val callMapper = CallMapperImpl(qualifiedIdMapper)
+        val callMapper = CallMapperImpl(qualifiedIdMapper)
         private val federatedIdMapper = FederatedIdMapperImpl(TestUser.SELF.id, qualifiedIdMapper, sessionRepository)
         private var initialCallMetadataProfile: CallMetadataProfile = CallMetadataProfile()
 
@@ -2238,6 +2295,12 @@ class CallRepositoryTest {
         fun withObserveLastActiveCallReturning(result: Flow<CallEntity?>) = apply {
             every {
                 callDAO.observeLastActiveCallByConversationId(any())
+            } returns result
+        }
+
+        fun withObserveActiveCallsReturning(result: Flow<List<CallEntity>>) = apply {
+            every {
+                callDAO.observeActiveCalls()
             } returns result
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/ObserveActiveCallsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/ObserveActiveCallsUseCaseTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.call.usecase
+
+import app.cash.turbine.test
+import com.wire.kalium.logic.data.call.Call
+import com.wire.kalium.logic.data.call.CallRepository
+import com.wire.kalium.logic.framework.TestCall
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class ObserveActiveCallsUseCaseTest {
+
+    @Test
+    fun givenAnEmptyCallList_whenInvoking_thenEmitsAnEmptyListOfCalls() = runTest {
+        val (_, useCase) = Arrangement()
+            .withActiveCallsFlow(flowOf(listOf()))
+            .arrange()
+
+        useCase().test {
+            assertEquals(listOf(), awaitItem())
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun givenAnActiveCall_whenInvoking_thenEmitsListWithThatActiveCall() = runTest {
+        val (_, useCase) = Arrangement()
+            .withActiveCallsFlow(flowOf(listOf(activeCall)))
+            .arrange()
+
+        useCase().test {
+            assertEquals(listOf(activeCall), awaitItem())
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun givenAnEmptyCallList_whenInvoking_andActiveCallAppears_thenEmitsThatChange() = runTest {
+        val activeCall = TestCall.oneOnOneEstablishedCall()
+        val activeCallsFlow = MutableStateFlow<List<Call>>(listOf())
+        val (_, useCase) = Arrangement()
+            .withActiveCallsFlow(activeCallsFlow)
+            .arrange()
+
+        useCase().test {
+            assertEquals(listOf(), awaitItem())
+
+            activeCallsFlow.emit(listOf(activeCall))
+            assertEquals(listOf(activeCall), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    inner class Arrangement {
+
+        val callRepository = mock<CallRepository>(mode = MockMode.autoUnit)
+
+        fun arrange() = this to ObserveActiveCallsUseCaseImpl(callRepository)
+
+        fun withActiveCallsFlow(calls: Flow<List<Call>>) = apply {
+            everySuspend { callRepository.activeCallsFlow() } returns calls
+        }
+    }
+
+    companion object {
+        val activeCall = TestCall.oneOnOneEstablishedCall()
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25067
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Use case to observe active calls, so the ones that are either outgoing, ongoing or incoming, so all not yet closed.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
