### PR TITLE
fix: Maven publish for Apple AVS metadata [WPB-26486]

### DIFF
--- a/domain/calling/build.gradle.kts
+++ b/domain/calling/build.gradle.kts
@@ -65,11 +65,7 @@ kotlin {
                 implementation(libs.jna)
             }
         }
-        val appleMain by getting {
-            dependencies {
-                api(libs.avsKmp)
-            }
-        }
+        val appleMain by getting
 
         val commonTest by getting {
             dependencies { }

--- a/domain/calling/build.gradle.kts
+++ b/domain/calling/build.gradle.kts
@@ -66,6 +66,25 @@ kotlin {
             }
         }
         val appleMain by getting
+        val appleAvsMainSourceDir = "src/appleAvsMain/kotlin"
+        listOf(
+            getByName("iosArm64Main"),
+            getByName("iosSimulatorArm64Main"),
+            getByName("macosArm64Main")
+        ).forEach { appleTargetMain ->
+            appleTargetMain.kotlin.srcDir(appleAvsMainSourceDir)
+            appleTargetMain.dependencies {
+                implementation(libs.avsKmp)
+            }
+        }
+        val appleAvsIosMainSourceDir = "src/appleAvsIosMain/kotlin"
+        listOf(
+            getByName("iosArm64Main"),
+            getByName("iosSimulatorArm64Main")
+        ).forEach { iosTargetMain ->
+            iosTargetMain.kotlin.srcDir(appleAvsIosMainSourceDir)
+        }
+        getByName("macosArm64Main").kotlin.srcDir("src/appleAvsMacosMain/kotlin")
 
         val commonTest by getting {
             dependencies { }

--- a/domain/calling/src/appleAvsIosMain/kotlin/com/wire/kalium/calling/AppleAvsFlowManager.kt
+++ b/domain/calling/src/appleAvsIosMain/kotlin/com/wire/kalium/calling/AppleAvsFlowManager.kt
@@ -1,0 +1,52 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.calling
+
+import avs.AVSFlowManager
+import avs.AVSMediaManager
+import platform.UIKit.UIView
+
+actual class AppleAvsFlowManager actual constructor() {
+    private val mediaManager by lazy {
+        AVSMediaManager.defaultMediaManager() ?: AVSMediaManager()
+    }
+
+    private val flowManager by lazy {
+        AVSFlowManager(delegate = null, mediaManager = mediaManager).also {
+            it.setEnableLogging(true)
+        }
+    }
+
+    actual fun attachVideoView(view: Any?): Boolean {
+        val videoView = view as? UIView ?: return false
+        flowManager.attachVideoView(videoView)
+        return true
+    }
+
+    actual fun setVideoCaptureDevice(deviceId: String, forConversation: String) {
+        flowManager.setVideoCaptureDevice(deviceId = deviceId, forConversation = forConversation)
+    }
+
+    actual fun startAudio() {
+        mediaManager.startAudio()
+        flowManager
+    }
+
+    actual fun startIfAvailable(): Boolean = AppleAvs.bridge.startIfAvailable()
+}

--- a/domain/calling/src/appleAvsMacosMain/kotlin/com/wire/kalium/calling/AppleAvsFlowManager.kt
+++ b/domain/calling/src/appleAvsMacosMain/kotlin/com/wire/kalium/calling/AppleAvsFlowManager.kt
@@ -1,0 +1,52 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.calling
+
+import avs.AVSFlowManager
+import avs.AVSMediaManager
+import platform.AppKit.NSView
+
+actual class AppleAvsFlowManager actual constructor() {
+    private val mediaManager by lazy {
+        AVSMediaManager.defaultMediaManager() ?: AVSMediaManager()
+    }
+
+    private val flowManager by lazy {
+        AVSFlowManager(delegate = null, mediaManager = mediaManager).also {
+            it.setEnableLogging(true)
+        }
+    }
+
+    actual fun attachVideoView(view: Any?): Boolean {
+        val videoView = view as? NSView ?: return false
+        flowManager.attachVideoView(videoView)
+        return true
+    }
+
+    actual fun setVideoCaptureDevice(deviceId: String, forConversation: String) {
+        flowManager.setVideoCaptureDevice(deviceId = deviceId, forConversation = forConversation)
+    }
+
+    actual fun startAudio() {
+        mediaManager.startAudio()
+        flowManager
+    }
+
+    actual fun startIfAvailable(): Boolean = AppleAvs.bridge.startIfAvailable()
+}

--- a/domain/calling/src/appleAvsMain/kotlin/com/wire/kalium/calling/AppleAvs.kt
+++ b/domain/calling/src/appleAvsMain/kotlin/com/wire/kalium/calling/AppleAvs.kt
@@ -18,7 +18,7 @@
 
 @file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
 
-package com.wire.kalium.logic.feature.call
+package com.wire.kalium.calling
 
 import avs.wcall_answer
 import avs.wcall_config_update
@@ -46,7 +46,6 @@ import avs.wcall_set_video_send_state
 import avs.wcall_sft_resp
 import avs.wcall_setup
 import avs.wcall_start
-import com.wire.kalium.common.logger.kaliumLogger
 import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.COpaquePointer
 import kotlinx.cinterop.CPointer
@@ -60,53 +59,18 @@ import kotlinx.cinterop.staticCFunction
 import kotlinx.cinterop.toKString
 import kotlinx.cinterop.usePinned
 
-@Suppress("LongParameterList", "ReturnCount", "TooManyFunctions")
-internal object AppleAvsInterop {
-    interface Callbacks {
-        fun onReady(version: Int)
-        fun onSend(
-            context: COpaquePointer?,
-            conversationId: String?,
-            selfUserId: String?,
-            selfClientId: String?,
-            targetRecipientsJson: String?,
-            clientIdDestination: String?,
-            data: ByteArray,
-            transient: Boolean,
-            myClientsOnly: Boolean
-        ): Int
-        fun onSftRequest(context: COpaquePointer?, url: String?, data: ByteArray): Int
-        fun onIncomingCall(
-            conversationId: String?,
-            messageTime: UInt,
-            userId: String?,
-            clientId: String?,
-            video: Boolean,
-            shouldRing: Boolean,
-            conversationType: Int
-        )
-        fun onMissedCall(conversationId: String?, messageTime: UInt, userId: String?, video: Boolean)
-        fun onAnsweredCall(conversationId: String?)
-        fun onEstablishedCall(conversationId: String?, userId: String?, clientId: String?)
-        fun onClosedCall(reason: Int, conversationId: String?, messageTime: UInt, userId: String?, clientId: String?)
-        fun onMetrics(conversationId: String?, metricsJson: String?)
-        fun onConfigRequest(handle: UInt, context: COpaquePointer?): Int
-        fun onAudioCbrChanged(userId: String?, clientId: String?, enabled: Boolean)
-        fun onVideoStateChanged(conversationId: String?, userId: String?, clientId: String?, state: Int)
-        fun onParticipantChanged(conversationId: String?, data: String?)
-        fun onNetworkQualityChanged(conversationId: String?, userId: String?, clientId: String?, qualityInfoJson: String?)
-        fun onRequestNewEpoch(handle: UInt, conversationId: String?)
-        fun onClientsRequest(handle: UInt, conversationId: String?)
-        fun onActiveSpeakersChanged(handle: UInt, conversationId: String?, data: String?)
-        fun onMuteStateChanged(isMuted: Boolean)
-    }
+actual object AppleAvs {
+    actual val bridge: AppleAvsBridge = AppleAvsBridgeImpl
+}
 
-    data class CreatedHandle(val handle: UInt, val stableRef: StableRef<Callbacks>)
+@Suppress("LongParameterList", "ReturnCount", "TooManyFunctions")
+private object AppleAvsBridgeImpl : AppleAvsBridge {
+    data class CreatedHandle(val handle: UInt, val stableRef: StableRef<AppleAvsCallbacks>)
 
     private var isStarted = false
     private val handles = mutableMapOf<String, CreatedHandle>()
 
-    private fun callbacks(arg: COpaquePointer?): Callbacks? = arg?.asStableRef<Callbacks>()?.get()
+    private fun callbacks(arg: COpaquePointer?): AppleAvsCallbacks? = arg?.asStableRef<AppleAvsCallbacks>()?.get()
     private fun CPointer<ByteVar>?.string(): String? = this?.toKString()
     private fun CPointer<UByteVar>?.bytes(length: ULong): ByteArray = this?.readBytes(length.toInt()) ?: byteArrayOf()
 
@@ -137,7 +101,7 @@ internal object AppleAvsInterop {
             data = data.bytes(length),
             transient = transient != 0,
             myClientsOnly = myClientsOnly != 0
-        ) ?: AvsCallBackError.INVALID_ARGUMENT.value
+        ) ?: INVALID_ARGUMENT_ERROR
     }
 
     private val sftRequestHandler = staticCFunction {
@@ -146,7 +110,7 @@ internal object AppleAvsInterop {
             data: CPointer<UByteVar>?,
             length: ULong,
             arg: COpaquePointer? ->
-        callbacks(arg)?.onSftRequest(context, url.string(), data.bytes(length)) ?: AvsCallBackError.INVALID_ARGUMENT.value
+        callbacks(arg)?.onSftRequest(context, url.string(), data.bytes(length)) ?: INVALID_ARGUMENT_ERROR
     }
 
     private val incomingHandler = staticCFunction {
@@ -215,7 +179,7 @@ internal object AppleAvsInterop {
     }
 
     private val configRequestHandler = staticCFunction { handle: UInt, arg: COpaquePointer? ->
-        callbacks(arg)?.onConfigRequest(handle, arg) ?: AvsCallBackError.INVALID_ARGUMENT.value
+        callbacks(arg)?.onConfigRequest(handle, arg) ?: INVALID_ARGUMENT_ERROR
     }
 
     private val audioCbrHandler = staticCFunction {
@@ -279,22 +243,20 @@ internal object AppleAvsInterop {
         Unit
     }
 
-    fun startIfAvailable(): Boolean {
+    override fun startIfAvailable(): Boolean {
         if (isStarted) return true
 
         return runCatching {
-            val setupResult = wcall_setup()
-            val runResult = wcall_run()
+            wcall_setup()
+            wcall_run()
             isStarted = true
-            kaliumLogger.i("AVS iOS smoke: started AVS via cinterop (wcall_setup=$setupResult, wcall_run=$runResult)")
             true
-        }.getOrElse { error ->
-            kaliumLogger.w("AVS iOS smoke: failed to start AVS via cinterop (${error.message ?: error::class.simpleName})")
+        }.getOrElse {
             false
         }
     }
 
-    fun userHandle(selfUserId: String, selfClientId: String, callbacks: Callbacks): UInt? {
+    override fun userHandle(selfUserId: String, selfClientId: String, callbacks: AppleAvsCallbacks): UInt? {
         if (!startIfAvailable()) return null
 
         val key = "$selfUserId:$selfClientId"
@@ -322,10 +284,8 @@ internal object AppleAvsInterop {
             )
             registerAdditionalHandlers(handle, arg)
             handles[key] = CreatedHandle(handle, stableRef)
-            kaliumLogger.i("AVS iOS smoke: created wcall user handle=$handle for user=$selfUserId client=$selfClientId")
             handle
-        }.getOrElse { error ->
-            kaliumLogger.w("AVS iOS smoke: failed to create wcall user (${error.message ?: error::class.simpleName})")
+        }.getOrElse {
             null
         }
     }
@@ -340,7 +300,7 @@ internal object AppleAvsInterop {
         wcall_set_group_changed_handler(handle, null, arg)
     }
 
-    fun receiveCallingMessage(
+    override fun receiveCallingMessage(
         handle: UInt,
         payload: ByteArray,
         currentTimeSeconds: UInt,
@@ -354,7 +314,7 @@ internal object AppleAvsInterop {
         if (payload.isEmpty()) return false
 
         return runCatching {
-            val result = payload.usePinned { pinned ->
+            payload.usePinned { pinned ->
                 wcall_recv_msg(
                     wuser = handle,
                     buf = pinned.addressOf(0).reinterpret(),
@@ -368,85 +328,81 @@ internal object AppleAvsInterop {
                     meeting = 0
                 )
             }
-            kaliumLogger.i("AVS iOS smoke: wcall_recv_msg result=$result conversation=$conversationId")
             true
-        }.getOrElse { error ->
-            kaliumLogger.w("AVS iOS smoke: wcall_recv_msg failed (${error.message ?: error::class.simpleName})")
+        }.getOrElse {
             false
         }
     }
 
-    fun respondToSend(handle: UInt, status: Int, reason: String, context: COpaquePointer?) {
+    override fun respondToSend(handle: UInt, status: Int, reason: String, context: COpaquePointer?) {
         if (!startIfAvailable()) return
         wcall_resp(handle, status, reason, context)
     }
 
-    fun respondToSft(handle: UInt, error: Int, data: ByteArray, context: COpaquePointer?) {
+    override fun respondToSft(handle: UInt, error: Int, data: ByteArray, context: COpaquePointer?) {
         if (!startIfAvailable()) return
         data.usePinned { pinned ->
             wcall_sft_resp(handle, error, pinned.addressOf(0).reinterpret(), data.size.toULong(), context)
         }
     }
 
-    fun updateConfig(handle: UInt, error: Int, json: String) {
+    override fun updateConfig(handle: UInt, error: Int, json: String) {
         if (!startIfAvailable()) return
         wcall_config_update(handle, error, json)
     }
 
-    fun startCall(handle: UInt, conversationId: String, callType: Int, conversationType: Int, audioCbr: Boolean): Int =
+    override fun startCall(handle: UInt, conversationId: String, callType: Int, conversationType: Int, audioCbr: Boolean): Int =
         if (startIfAvailable()) wcall_start(handle, conversationId, callType, conversationType, audioCbr.toAvsInt(), 0) else -1
 
-    fun answerCall(handle: UInt, conversationId: String, callType: Int, audioCbr: Boolean): Int =
+    override fun answerCall(handle: UInt, conversationId: String, callType: Int, audioCbr: Boolean): Int =
         if (startIfAvailable()) wcall_answer(handle, conversationId, callType, audioCbr.toAvsInt()) else -1
 
-    fun endCall(handle: UInt, conversationId: String) {
+    override fun endCall(handle: UInt, conversationId: String) {
         if (!startIfAvailable()) return
         wcall_end(handle, conversationId)
     }
 
-    fun rejectCall(handle: UInt, conversationId: String): Int =
+    override fun rejectCall(handle: UInt, conversationId: String): Int =
         if (startIfAvailable()) wcall_reject(handle, conversationId) else -1
 
-    fun setMute(handle: UInt, muted: Boolean) {
+    override fun setMute(handle: UInt, muted: Boolean) {
         if (!startIfAvailable()) return
         wcall_set_mute(handle, muted.toAvsInt())
     }
 
-    fun setVideoSendState(handle: UInt, conversationId: String, state: Int) {
+    override fun setVideoSendState(handle: UInt, conversationId: String, state: Int) {
         if (!startIfAvailable()) return
         wcall_set_video_send_state(handle, conversationId, state)
     }
 
-    fun requestVideoStreams(handle: UInt, conversationId: String, mode: Int, json: String): Int =
+    override fun requestVideoStreams(handle: UInt, conversationId: String, mode: Int, json: String): Int =
         if (startIfAvailable()) wcall_request_video_streams(handle, conversationId, mode, json) else -1
 
-    fun setEpochInfo(handle: UInt, conversationId: String, epoch: UInt, clientsJson: String, keyBase64: String): Int =
+    override fun setEpochInfo(handle: UInt, conversationId: String, epoch: UInt, clientsJson: String, keyBase64: String): Int =
         if (startIfAvailable()) wcall_set_epoch_info(handle, conversationId, epoch, clientsJson, keyBase64) else -1
 
-    fun setClientsForConversation(handle: UInt, conversationId: String, clients: String): Int =
+    override fun setClientsForConversation(handle: UInt, conversationId: String, clients: String): Int =
         if (startIfAvailable()) wcall_set_clients_for_conv(handle, conversationId, clients) else -1
 
-    fun processNotifications(handle: UInt, isStarted: Boolean): Int =
+    override fun processNotifications(handle: UInt, isStarted: Boolean): Int =
         if (startIfAvailable()) wcall_process_notifications(handle, isStarted.toAvsInt()) else -1
 
-    fun setBackground(handle: UInt, background: Boolean): Int =
+    override fun setBackground(handle: UInt, background: Boolean): Int =
         if (startIfAvailable()) wcall_set_background(handle, background.toAvsInt()) else -1
 
-    fun setNetworkQualityInterval(handle: UInt, callbacks: Callbacks, intervalInSeconds: Int) {
+    override fun setNetworkQualityInterval(handle: UInt, callbacks: AppleAvsCallbacks, intervalInSeconds: Int) {
         if (!startIfAvailable()) return
         val arg = handles.values.firstOrNull { it.stableRef.get() === callbacks }?.stableRef?.asCPointer()
         wcall_set_network_quality_handler(handle, networkQualityHandler, intervalInSeconds, arg)
     }
 
-    fun notifyNetworkChangedIfAvailable(): Boolean {
+    override fun notifyNetworkChangedIfAvailable(): Boolean {
         if (!startIfAvailable()) return false
 
         return runCatching {
             wcall_network_changed()
-            kaliumLogger.i("AVS iOS smoke: networkChanged propagated to AVS via cinterop")
             true
-        }.getOrElse { error ->
-            kaliumLogger.w("AVS iOS smoke: failed to propagate networkChanged (${error.message ?: error::class.simpleName})")
+        }.getOrElse {
             false
         }
     }
@@ -454,4 +410,5 @@ internal object AppleAvsInterop {
     private fun Boolean.toAvsInt() = if (this) 1 else 0
 
     private const val DEFAULT_NETWORK_QUALITY_INTERVAL_SECONDS = 1
+    private const val INVALID_ARGUMENT_ERROR = 1
 }

--- a/domain/calling/src/appleMain/kotlin/com/wire/kalium/calling/AppleAvsBridge.kt
+++ b/domain/calling/src/appleMain/kotlin/com/wire/kalium/calling/AppleAvsBridge.kt
@@ -1,0 +1,98 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+@file:Suppress("LongParameterList", "TooManyFunctions")
+
+package com.wire.kalium.calling
+
+import kotlinx.cinterop.COpaquePointer
+
+@Suppress("TooManyFunctions")
+interface AppleAvsBridge {
+    fun startIfAvailable(): Boolean
+    fun userHandle(selfUserId: String, selfClientId: String, callbacks: AppleAvsCallbacks): UInt?
+    fun receiveCallingMessage(
+        handle: UInt,
+        payload: ByteArray,
+        currentTimeSeconds: UInt,
+        messageTimeSeconds: UInt,
+        conversationId: String,
+        senderUserId: String,
+        senderClientId: String,
+        conversationType: Int
+    ): Boolean
+    fun respondToSend(handle: UInt, status: Int, reason: String, context: COpaquePointer?)
+    fun respondToSft(handle: UInt, error: Int, data: ByteArray, context: COpaquePointer?)
+    fun updateConfig(handle: UInt, error: Int, json: String)
+    fun startCall(handle: UInt, conversationId: String, callType: Int, conversationType: Int, audioCbr: Boolean): Int
+    fun answerCall(handle: UInt, conversationId: String, callType: Int, audioCbr: Boolean): Int
+    fun endCall(handle: UInt, conversationId: String)
+    fun rejectCall(handle: UInt, conversationId: String): Int
+    fun setMute(handle: UInt, muted: Boolean)
+    fun setVideoSendState(handle: UInt, conversationId: String, state: Int)
+    fun requestVideoStreams(handle: UInt, conversationId: String, mode: Int, json: String): Int
+    fun setEpochInfo(handle: UInt, conversationId: String, epoch: UInt, clientsJson: String, keyBase64: String): Int
+    fun setClientsForConversation(handle: UInt, conversationId: String, clients: String): Int
+    fun processNotifications(handle: UInt, isStarted: Boolean): Int
+    fun setBackground(handle: UInt, background: Boolean): Int
+    fun setNetworkQualityInterval(handle: UInt, callbacks: AppleAvsCallbacks, intervalInSeconds: Int)
+    fun notifyNetworkChangedIfAvailable(): Boolean
+}
+
+interface AppleAvsCallbacks {
+    fun onReady(version: Int)
+    fun onSend(
+        context: COpaquePointer?,
+        conversationId: String?,
+        selfUserId: String?,
+        selfClientId: String?,
+        targetRecipientsJson: String?,
+        clientIdDestination: String?,
+        data: ByteArray,
+        transient: Boolean,
+        myClientsOnly: Boolean
+    ): Int
+    fun onSftRequest(context: COpaquePointer?, url: String?, data: ByteArray): Int
+    fun onIncomingCall(
+        conversationId: String?,
+        messageTime: UInt,
+        userId: String?,
+        clientId: String?,
+        video: Boolean,
+        shouldRing: Boolean,
+        conversationType: Int
+    )
+    fun onMissedCall(conversationId: String?, messageTime: UInt, userId: String?, video: Boolean)
+    fun onAnsweredCall(conversationId: String?)
+    fun onEstablishedCall(conversationId: String?, userId: String?, clientId: String?)
+    fun onClosedCall(reason: Int, conversationId: String?, messageTime: UInt, userId: String?, clientId: String?)
+    fun onMetrics(conversationId: String?, metricsJson: String?)
+    fun onConfigRequest(handle: UInt, context: COpaquePointer?): Int
+    fun onAudioCbrChanged(userId: String?, clientId: String?, enabled: Boolean)
+    fun onVideoStateChanged(conversationId: String?, userId: String?, clientId: String?, state: Int)
+    fun onParticipantChanged(conversationId: String?, data: String?)
+    fun onNetworkQualityChanged(conversationId: String?, userId: String?, clientId: String?, qualityInfoJson: String?)
+    fun onRequestNewEpoch(handle: UInt, conversationId: String?)
+    fun onClientsRequest(handle: UInt, conversationId: String?)
+    fun onActiveSpeakersChanged(handle: UInt, conversationId: String?, data: String?)
+    fun onMuteStateChanged(isMuted: Boolean)
+}
+
+expect object AppleAvs {
+    val bridge: AppleAvsBridge
+}

--- a/domain/calling/src/appleMain/kotlin/com/wire/kalium/calling/AppleAvsFlowManager.kt
+++ b/domain/calling/src/appleMain/kotlin/com/wire/kalium/calling/AppleAvsFlowManager.kt
@@ -16,10 +16,11 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.wire.kalium.logic.feature.call
+package com.wire.kalium.calling
 
-import com.wire.kalium.calling.AppleAvsFlowManager
-import com.wire.kalium.logic.util.PlatformView
-
-internal fun AppleAvsFlowManager.attachPlatformVideoView(view: PlatformView): Boolean =
-    attachVideoView(view.view)
+expect class AppleAvsFlowManager() {
+    fun attachVideoView(view: Any?): Boolean
+    fun setVideoCaptureDevice(deviceId: String, forConversation: String)
+    fun startAudio()
+    fun startIfAvailable(): Boolean
+}

--- a/logic/build.gradle.kts
+++ b/logic/build.gradle.kts
@@ -128,7 +128,20 @@ kotlin {
             kotlin.srcDir("src/commonJvmAndroid/kotlin")
         }
 
-        val appleMain by getting
+        val appleMain by getting {
+            kotlin.exclude("com/wire/kalium/logic/feature/call/**")
+        }
+        val appleCallSourceDir = "src/appleMain/kotlin/com/wire/kalium/logic/feature/call"
+        listOf(
+            getByName("iosArm64Main"),
+            getByName("iosSimulatorArm64Main"),
+            getByName("macosArm64Main")
+        ).forEach { appleTargetMain ->
+            appleTargetMain.kotlin.srcDir(appleCallSourceDir)
+            appleTargetMain.dependencies {
+                implementation(libs.avsKmp)
+            }
+        }
 
         val jvmMain by getting {
             addCommonKotlinJvmSourceDir()

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
@@ -81,9 +81,9 @@ public actual class CoreLogic(
 
     internal actual override val globalCallManager: GlobalCallManager by lazy {
         GlobalCallManager(
-            appContext = PlatformContext(appContext),
             scope = getGlobalScope(),
-            networkStateObserver = networkStateObserver
+            networkStateObserver = networkStateObserver,
+            platformContext = PlatformContext(appContext)
         )
     }
 

--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.network.NetworkStateObserverImpl
 import com.wire.kalium.logic.sync.WorkSchedulerProvider
 import com.wire.kalium.logic.sync.WorkSchedulerProviderImpl
+import com.wire.kalium.logic.util.PlatformContext
 import com.wire.kalium.network.NetworkStateObserver
 import com.wire.kalium.persistence.db.GlobalDatabaseBuilder
 import com.wire.kalium.persistence.db.PlatformDatabaseData
@@ -109,7 +110,7 @@ public actual class CoreLogic(
     actual override val workSchedulerProvider: WorkSchedulerProvider = WorkSchedulerProviderImpl()
     public actual override val audioNormalizedLoudnessBuilder: AudioNormalizedLoudnessBuilder = AudioNormalizedLoudnessBuilderImpl()
     actual override val globalCallManager: GlobalCallManager by lazy {
-        GlobalCallManager(getGlobalScope(), networkStateObserver)
+        GlobalCallManager(getGlobalScope(), networkStateObserver, PlatformContext())
     }
 }
 

--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -20,6 +20,8 @@
 
 package com.wire.kalium.logic.feature.call
 
+import com.wire.kalium.calling.AppleAvs
+import com.wire.kalium.calling.AppleAvsCallbacks
 import com.wire.kalium.calling.CallClosedReason
 import com.wire.kalium.calling.CallTypeCalling
 import com.wire.kalium.calling.ConversationTypeCalling
@@ -151,7 +153,7 @@ internal class CallManagerImpl internal constructor(
             flowManagerService.startFlowManager()
         }.join()
         callingLogger.i("$tagWithUserId: Creating iOS AVS Handle")
-        AppleAvsInterop.userHandle(
+        AppleAvs.bridge.userHandle(
             selfUserId = federatedIdMapper.parseToFederatedId(selfUserId),
             selfClientId = clientId.await().value,
             callbacks = callbacks
@@ -170,7 +172,7 @@ internal class CallManagerImpl internal constructor(
         }
         val callConversationType = getCallConversationType(targetConversationId)
         val type = callMapper.toConversationType(callConversationType)
-        val received = AppleAvsInterop.receiveCallingMessage(
+        val received = AppleAvs.bridge.receiveCallingMessage(
             handle = handle,
             payload = content.value.encodeToByteArray(),
             currentTimeSeconds = serverTimeHandler.toServerTimestamp().toUInt(),
@@ -206,7 +208,7 @@ internal class CallManagerImpl internal constructor(
         withCalling { handle ->
             val avsCallType = callMapper.toCallTypeCalling(callType)
             val startAvs = suspend {
-                AppleAvsInterop.startCall(
+                AppleAvs.bridge.startCall(
                     handle = handle,
                     conversationId = federatedIdMapper.parseToFederatedId(conversationId),
                     callType = avsCallType.avsValue,
@@ -232,7 +234,7 @@ internal class CallManagerImpl internal constructor(
         callingLogger.d("$tagWithUserId: answering call for conversationId: ${conversationId.toLogString()}..")
         val callType = if (isVideoCall) CallTypeCalling.VIDEO else CallTypeCalling.AUDIO
         val answerAvs = suspend {
-            AppleAvsInterop.answerCall(
+            AppleAvs.bridge.answerCall(
                 handle = handle,
                 conversationId = federatedIdMapper.parseToFederatedId(conversationId),
                 callType = callType.avsValue,
@@ -255,25 +257,25 @@ internal class CallManagerImpl internal constructor(
 
     override suspend fun endCall(conversationId: ConversationId) = withCalling { handle ->
         callingLogger.d("$tagWithUserId: endCall -> ${conversationId.toLogString()}")
-        AppleAvsInterop.endCall(handle, federatedIdMapper.parseToFederatedId(conversationId))
+        AppleAvs.bridge.endCall(handle, federatedIdMapper.parseToFederatedId(conversationId))
         Unit
     }
 
     override suspend fun rejectCall(conversationId: ConversationId) = withCalling { handle ->
         callingLogger.d("$tagWithUserId: rejectCall -> ${conversationId.toLogString()}")
-        AppleAvsInterop.rejectCall(handle, federatedIdMapper.parseToFederatedId(conversationId))
+        AppleAvs.bridge.rejectCall(handle, federatedIdMapper.parseToFederatedId(conversationId))
         Unit
     }
 
     override suspend fun muteCall(shouldMute: Boolean) = withCalling { handle ->
-        AppleAvsInterop.setMute(handle, shouldMute)
+        AppleAvs.bridge.setMute(handle, shouldMute)
         callingLogger.d("$tagWithUserId: wcall_set_mute() called")
         Unit
     }
 
     override suspend fun setVideoSendState(conversationId: ConversationId, videoState: VideoState) = withCalling { handle ->
         val videoStateCalling = callMapper.toVideoStateCalling(videoState)
-        AppleAvsInterop.setVideoSendState(handle, federatedIdMapper.parseToFederatedId(conversationId), videoStateCalling.avsValue)
+        AppleAvs.bridge.setVideoSendState(handle, federatedIdMapper.parseToFederatedId(conversationId), videoStateCalling.avsValue)
         Unit
     }
 
@@ -286,7 +288,7 @@ internal class CallManagerImpl internal constructor(
                 quality = callClient.quality
             )
         }
-        AppleAvsInterop.requestVideoStreams(
+        AppleAvs.bridge.requestVideoStreams(
             handle = handle,
             conversationId = federatedIdMapper.parseToFederatedId(conversationId),
             mode = DEFAULT_REQUEST_VIDEO_STREAMS_MODE,
@@ -297,7 +299,7 @@ internal class CallManagerImpl internal constructor(
 
     override suspend fun updateEpochInfo(conversationId: ConversationId, epochInfo: EpochInfo) = withCalling { handle ->
         callingLogger.d("$tagWithUserId: wcall_set_epoch_info() called -> ${conversationId.toLogString()} epoch=${epochInfo.epoch}")
-        AppleAvsInterop.setEpochInfo(
+        AppleAvs.bridge.setEpochInfo(
             handle = handle,
             conversationId = federatedIdMapper.parseToFederatedId(conversationId),
             epoch = epochInfo.epoch.toUInt(),
@@ -310,13 +312,13 @@ internal class CallManagerImpl internal constructor(
     override suspend fun updateConversationClients(conversationId: ConversationId, clients: String) {
         if (callRepository.getCallMetadata(conversationId)?.protocol is Conversation.ProtocolInfo.Proteus) {
             withCalling { handle ->
-                AppleAvsInterop.setClientsForConversation(handle, federatedIdMapper.parseToFederatedId(conversationId), clients)
+                AppleAvs.bridge.setClientsForConversation(handle, federatedIdMapper.parseToFederatedId(conversationId), clients)
             }
         }
     }
 
     override suspend fun reportProcessNotifications(isStarted: Boolean) = withCalling { handle ->
-        AppleAvsInterop.processNotifications(handle, isStarted)
+        AppleAvs.bridge.processNotifications(handle, isStarted)
         Unit
     }
 
@@ -333,12 +335,12 @@ internal class CallManagerImpl internal constructor(
     }
 
     override suspend fun setBackground(background: Boolean) = withCalling { handle ->
-        AppleAvsInterop.setBackground(handle, background)
+        AppleAvs.bridge.setBackground(handle, background)
         Unit
     }
 
     override suspend fun setNetworkQualityInterval(intervalInSeconds: Int) = withCalling { handle ->
-        AppleAvsInterop.setNetworkQualityInterval(handle, callbacks, intervalInSeconds)
+        AppleAvs.bridge.setNetworkQualityInterval(handle, callbacks, intervalInSeconds)
         Unit
     }
 
@@ -348,7 +350,7 @@ internal class CallManagerImpl internal constructor(
         job.cancel()
     }
 
-    private inner class AppleCallbacks : AppleAvsInterop.Callbacks {
+    private inner class AppleCallbacks : AppleAvsCallbacks {
         override fun onReady(version: Int) {
             callingLogger.i("$tagWithUserId: readyHandler; version=$version")
             onCallingReady()
@@ -398,7 +400,7 @@ internal class CallManagerImpl internal constructor(
                     networkStateObserver.observeNetworkState().firstOrNull { it is NetworkState.ConnectedWithInternet }
                 } != null
                 if (!connected) {
-                    AppleAvsInterop.respondToSft(deferredHandle.await(), AvsSFTError.NO_RESPONSE_DATA.value, byteArrayOf(), context)
+                    AppleAvs.bridge.respondToSft(deferredHandle.await(), AvsSFTError.NO_RESPONSE_DATA.value, byteArrayOf(), context)
                     return@launch
                 }
                 val dataString = data.decodeToString()
@@ -408,7 +410,7 @@ internal class CallManagerImpl internal constructor(
                         { it }
                     ) ?: byteArrayOf()
                 val error = if (responseData.isEmpty()) AvsSFTError.NO_RESPONSE_DATA.value else AvsSFTError.NONE.value
-                AppleAvsInterop.respondToSft(deferredHandle.await(), error, responseData, context)
+                AppleAvs.bridge.respondToSft(deferredHandle.await(), error, responseData, context)
             }
             return AvsCallBackError.NONE.value
         }
@@ -474,9 +476,9 @@ internal class CallManagerImpl internal constructor(
             scope.launch {
                 callRepository.getCallConfigResponse(limit = null).fold({
                     callingLogger.w("[OnConfigRequest/iOS] - Error: $it")
-                    AppleAvsInterop.updateConfig(handle, 1, "")
+                    AppleAvs.bridge.updateConfig(handle, 1, "")
                 }, { config ->
-                    AppleAvsInterop.updateConfig(handle, 0, kaliumConfigs.callConfigTransformer?.invoke(config) ?: config)
+                    AppleAvs.bridge.updateConfig(handle, 0, kaliumConfigs.callConfigTransformer?.invoke(config) ?: config)
                 })
             }
             return AvsCallBackError.NONE.value
@@ -565,7 +567,7 @@ internal class CallManagerImpl internal constructor(
                 is Either.Right -> AVS_SEND_SUCCESS_STATUS_CODE to ""
                 is Either.Left -> AVS_SEND_FAILURE_STATUS_CODE to "Couldn't send Calling Message"
             }
-            AppleAvsInterop.respondToSend(deferredHandle.await(), code, message, context)
+            AppleAvs.bridge.respondToSend(deferredHandle.await(), code, message, context)
         }
     }
 

--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/FlowManagerServiceImpl.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/FlowManagerServiceImpl.kt
@@ -18,8 +18,7 @@
 
 package com.wire.kalium.logic.feature.call
 
-import avs.AVSFlowManager
-import avs.AVSMediaManager
+import com.wire.kalium.calling.AppleAvsFlowManager
 import com.wire.kalium.common.logger.callingLogger
 import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.logic.data.id.ConversationId
@@ -30,14 +29,8 @@ import com.wire.kalium.logic.util.PlatformView
 internal actual open class FlowManagerServiceImpl(
     appContext: PlatformContext
 ) : FlowManagerService {
-    private val mediaManager by lazy {
-        AVSMediaManager.defaultMediaManager() ?: AVSMediaManager()
-    }
-
     private val flowManager by lazy {
-        AVSFlowManager(delegate = null, mediaManager = mediaManager).also {
-            it.setEnableLogging(true)
-        }
+        AppleAvsFlowManager()
     }
 
     actual override suspend fun setVideoPreview(conversationId: ConversationId, view: PlatformView) {
@@ -63,13 +56,10 @@ internal actual open class FlowManagerServiceImpl(
     }
 
     actual override suspend fun startFlowManager() {
-        if (!AppleAvsInterop.startIfAvailable()) {
+        if (!flowManager.startIfAvailable()) {
             kaliumLogger.w("AVS iOS smoke: startFlowManager could not start AVS")
             return
         }
-        mediaManager.startAudio()
-        flowManager
+        flowManager.startAudio()
     }
 }
-
-internal expect fun AVSFlowManager.attachPlatformVideoView(view: PlatformView): Boolean

--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -20,6 +20,7 @@
 
 package com.wire.kalium.logic.feature.call
 
+import com.wire.kalium.calling.AppleAvs
 import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.configuration.UserConfigRepository
@@ -43,12 +44,14 @@ import com.wire.kalium.logic.util.PlatformContext
 
 import kotlinx.coroutines.CoroutineScope
 
-internal actual class GlobalCallManager(
+internal actual class GlobalCallManager actual constructor(
     scope: CoroutineScope,
-    networkStateObserver: NetworkStateObserver
+    networkStateObserver: NetworkStateObserver,
+    platformContext: PlatformContext
 ) : CallNetworkChangeManager(scope, networkStateObserver) {
-    private val flowManagerService by lazy { FlowManagerServiceImpl(PlatformContext()) }
-    private val mediaManagerService by lazy { MediaManagerServiceImpl(PlatformContext()) }
+
+    private val flowManagerService by lazy { FlowManagerServiceImpl(platformContext) }
+    private val mediaManagerService by lazy { MediaManagerServiceImpl(platformContext) }
 
     @Suppress("LongParameterList")
     internal actual fun getCallManagerForClient(
@@ -105,7 +108,7 @@ internal actual class GlobalCallManager(
     }
 
     actual override fun networkChanged() {
-        if (!AppleAvsInterop.notifyNetworkChangedIfAvailable()) {
+        if (!AppleAvs.bridge.notifyNetworkChangedIfAvailable()) {
             kaliumLogger.w("AVS iOS smoke: networkChanged ignored because AVS is unavailable")
         }
     }

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -51,10 +51,10 @@ import kotlinx.coroutines.CoroutineScope
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
 
-internal actual class GlobalCallManager(
-    appContext: PlatformContext,
+internal actual class GlobalCallManager actual constructor(
     scope: CoroutineScope,
-    networkStateObserver: NetworkStateObserver
+    networkStateObserver: NetworkStateObserver,
+    platformContext: PlatformContext
 ) : CallNetworkChangeManager(scope, networkStateObserver) {
     private val callManagerHolder: ConcurrentMap<QualifiedID, CallManager> by lazy {
         ConcurrentHashMap()
@@ -134,12 +134,12 @@ internal actual class GlobalCallManager(
     }
 
     // Initialize it eagerly, so it's already initialized when `calling` is initialized
-    private val flowManager by lazy { FlowManagerServiceImpl(appContext, scope) }
+    private val flowManager by lazy { FlowManagerServiceImpl(platformContext, scope) }
 
     internal actual fun getFlowManager(): FlowManagerService = flowManager
 
     // Initialize it eagerly, so it's already initialized when `calling` is initialized
-    private val mediaManager by lazy { MediaManagerServiceImpl(appContext, scope) }
+    private val mediaManager by lazy { MediaManagerServiceImpl(platformContext, scope) }
 
     internal actual fun getMediaManager(): MediaManagerService = mediaManager
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -37,9 +37,15 @@ import com.wire.kalium.logic.feature.call.usecase.CreateAndPersistRecentlyEndedC
 import com.wire.kalium.logic.feature.call.usecase.EpochInfoUpdater
 import com.wire.kalium.messaging.sending.MessageSender
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
+import com.wire.kalium.logic.util.PlatformContext
 import com.wire.kalium.network.NetworkStateObserver
+import kotlinx.coroutines.CoroutineScope
 
-internal expect class GlobalCallManager : CallNetworkChangeManager {
+internal expect class GlobalCallManager(
+    scope: CoroutineScope,
+    networkStateObserver: NetworkStateObserver,
+    platformContext: PlatformContext
+) : CallNetworkChangeManager {
 
     @Suppress("LongParameterList")
     internal fun getCallManagerForClient(

--- a/logic/src/iosSimulatorArm64Main/kotlin/com/wire/kalium/logic/feature/call/AVSFlowManagerExtensions.kt
+++ b/logic/src/iosSimulatorArm64Main/kotlin/com/wire/kalium/logic/feature/call/AVSFlowManagerExtensions.kt
@@ -18,11 +18,8 @@
 
 package com.wire.kalium.logic.feature.call
 
-import avs.AVSFlowManager
+import com.wire.kalium.calling.AppleAvsFlowManager
 import com.wire.kalium.logic.util.PlatformView
 
-internal actual fun AVSFlowManager.attachPlatformVideoView(view: PlatformView): Boolean {
-    val videoView = view.view ?: return false
-    attachVideoView(videoView)
-    return true
-}
+internal fun AppleAvsFlowManager.attachPlatformVideoView(view: PlatformView): Boolean =
+    attachVideoView(view.view)

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
@@ -87,9 +87,9 @@ public actual class CoreLogic(
     public actual override val networkStateObserver: NetworkStateObserver =
         kaliumConfigs.mockNetworkStateObserver ?: NetworkStateObserverImpl()
     actual override val globalCallManager: GlobalCallManager = GlobalCallManager(
-        appContext = PlatformContext(),
         scope = CoroutineScope(KaliumDispatcherImpl.io),
         networkStateObserver = networkStateObserver,
+        platformContext = PlatformContext(),
     )
 
     actual override val workSchedulerProvider: WorkSchedulerProvider = WorkSchedulerProviderImpl()

--- a/logic/src/macosArm64Main/kotlin/com/wire/kalium/logic/feature/call/AVSFlowManagerExtensions.kt
+++ b/logic/src/macosArm64Main/kotlin/com/wire/kalium/logic/feature/call/AVSFlowManagerExtensions.kt
@@ -18,11 +18,8 @@
 
 package com.wire.kalium.logic.feature.call
 
-import avs.AVSFlowManager
+import com.wire.kalium.calling.AppleAvsFlowManager
 import com.wire.kalium.logic.util.PlatformView
 
-internal actual fun AVSFlowManager.attachPlatformVideoView(view: PlatformView): Boolean {
-    val videoView = view.view ?: return false
-    attachVideoView(videoView)
-    return true
-}
+internal fun AppleAvsFlowManager.attachPlatformVideoView(view: PlatformView): Boolean =
+    attachVideoView(view.view)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26486
<!--jira-description-action-hidden-marker-end-->
Fix Maven publish by moving Apple AVS code out of `:logic` and into `:domain:calling`.

- Moved the Apple AVS bridge to `:domain:calling`.
- Added small Apple AVS wrappers in `:domain:calling`.
- Updated `:logic` to call those wrappers instead of using `avs.*` directly.
- Kept AVS code out of Apple metadata compilation.
- Fixed `GlobalCallManager` constructor matching across platforms.

Why
Publishing failed because `:logic` used Apple AVS cinterop code from `appleMain`.

That code only exists for real Apple targets like iOS simulator or device builds, not for the shared Apple metadata task used during Maven publishing.
