### PR TITLE
ci: migrate GitHub Actions updates to Renovate [WPB-26656]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,16 +20,6 @@ updates:
     commit-message:
       prefix: "chore(deps): [WPB-9777] "
 
-  - package-ecosystem: "github-actions"
-    open-pull-requests-limit: 2
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore(deps): [WPB-9777] "
-    cooldown:
-      default-days: 14
-
   # Pinned, hash-locked SBOM toolchain for scripts/generate-sbom.sh.
   # Dependabot bumps the pins and regenerates the --hash lines automatically,
   # so the lockfile stays current without losing supply-chain integrity.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,8 @@ updates:
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
-      interval: "cron"
-      cronjob: "0 8,14 * * *"
+      interval: "daily"
+      time: "08:00"
       timezone: "Europe/Berlin"
     allow:
       - dependency-name: "com.wire:avs"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,29 +6,16 @@
 version: 2
 updates:
   - package-ecosystem: "gradle"
-    open-pull-requests-limit: 5
     directory: "/"
     schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 14
-      exclude:
-        - "com.wire:avs"
-        - "com.wire:core-crypto-android"
-        - "com.wire:core-crypto-jvm"
-        - "io.github.mohamadjaara:core-crypto-kmp"
-    commit-message:
-      prefix: "chore(deps): [WPB-9777] "
-
-  # Pinned, hash-locked SBOM toolchain for scripts/generate-sbom.sh.
-  # Dependabot bumps the pins and regenerates the --hash lines automatically,
-  # so the lockfile stays current without losing supply-chain integrity.
-  - package-ecosystem: "pip"
-    open-pull-requests-limit: 2
-    directory: "/scripts"
-    schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 14
+      interval: "cron"
+      cronjob: "0 8,14 * * *"
+      timezone: "Europe/Berlin"
+    allow:
+      - dependency-name: "com.wire:avs"
+      - dependency-name: "com.wire:avs-kmp"
+      - dependency-name: "com.wire:core-crypto-android"
+      - dependency-name: "com.wire:core-crypto-jvm"
+      - dependency-name: "io.github.mohamadjaara:core-crypto-kmp"
     commit-message:
       prefix: "chore(deps): [WPB-9777] "

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "enabledManagers": [
+    "github-actions"
+  ],
+  "schedule": [
+    "before 5am on monday"
+  ],
+  "prConcurrentLimit": 2,
+  "commitMessagePrefix": "chore(deps): [WPB-9777]"
+}

--- a/renovate.json
+++ b/renovate.json
@@ -5,11 +5,47 @@
     "helpers:pinGitHubActionDigests"
   ],
   "enabledManagers": [
-    "github-actions"
+    "github-actions",
+    "gradle",
+    "gradle-wrapper",
+    "pip_requirements"
   ],
   "schedule": [
     "before 5am on monday"
   ],
-  "prConcurrentLimit": 2,
-  "commitMessagePrefix": "chore(deps): [WPB-9777]"
+  "prConcurrentLimit": 5,
+  "commitMessagePrefix": "chore(deps): [WPB-9777]",
+  "packageRules": [
+    {
+      "description": "Match Dependabot's 14 day cooldown for Gradle and pip updates.",
+      "matchManagers": [
+        "gradle",
+        "gradle-wrapper",
+        "pip_requirements"
+      ],
+      "minimumReleaseAge": "14 days"
+    },
+    {
+      "description": "Group SBOM Python toolchain updates into a single PR.",
+      "matchManagers": [
+        "pip_requirements"
+      ],
+      "groupName": "SBOM Python toolchain",
+      "groupSlug": "sbom-python-toolchain"
+    },
+    {
+      "description": "Leave Wire crypto and AVS updates to Dependabot so they do not consume Renovate PR slots.",
+      "matchManagers": [
+        "gradle"
+      ],
+      "matchPackageNames": [
+        "com.wire:avs",
+        "com.wire:avs-kmp",
+        "com.wire:core-crypto-android",
+        "com.wire:core-crypto-jvm",
+        "io.github.mohamadjaara:core-crypto-kmp"
+      ],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26656
<!--jira-description-action-hidden-marker-end-->
## Summary

This migrates GitHub Actions dependency updates from Dependabot to Renovate while keeping Dependabot responsible for the existing Gradle and pip update flows.

## Why

Renovate is nicer and better suited for this use case because its GitHub Actions manager natively understands SHA-pinned uses entries with trailing version comments, such as actions/checkout@<sha> # v6. That means it can update the pinned digest and keep the human-readable version comment in sync in the same PR.

Dependabot updates the pinned hash, but it treats the trailing version marker as plain YAML comment text, so the comment can drift from the actual pinned Action version. Renovate's helpers:pinGitHubActionDigests preset is built for exactly this supply-chain pattern.

## Changes

- Remove the github-actions ecosystem from .github/dependabot.yml.
- Add renovate.json scoped to the github-actions manager.
- Enable helpers:pinGitHubActionDigests so Actions stay SHA-pinned while Renovate manages version-aware updates.
- Keep the weekly schedule, PR concurrency limit, and Wire commit prefix style.