### PR TITLE
feat: add NotifyCustomKey annotations for message-related operations [WPB-26678]

### DIFF
--- a/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/CellFiles.sq
+++ b/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/CellFiles.sq
@@ -62,6 +62,8 @@ SET assetTransferStatus = ?
 WHERE uuid = ?;
 
 upsertAttachmentFile:
+-- @NotifyCustomKey message_list_:conversationId
+-- @NotifyCustomKey CellFile
 INSERT INTO CellFile(
     uuid,
     conversationId,
@@ -103,4 +105,3 @@ ON CONFLICT(uuid) DO UPDATE SET
     assetTransferStatus = COALESCE(excluded.assetTransferStatus, assetTransferStatus),
     contentUrlExpiresAt = COALESCE(excluded.contentUrlExpiresAt, contentUrlExpiresAt),
     editSupported = excluded.editSupported;
-

--- a/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Clients.sq
+++ b/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Clients.sq
@@ -44,6 +44,8 @@ deleteClientsOfUser:
 DELETE FROM Client WHERE user_id = ?;
 
 insertClient:
+-- @NotifyCustomKey message_list
+-- @NotifyCustomKey Client
 INSERT INTO Client(user_id, id, device_type, client_type, is_valid, registration_date, label, model, last_active, mls_public_keys, is_mls_capable, is_async_notifications_capable)
 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id, user_id) DO UPDATE SET
@@ -94,12 +96,16 @@ isClientMLSCapable:
 SELECT is_mls_capable FROM Client WHERE user_id = :user_id AND id = :client_id;
 
 tryMarkAsInvalid:
+-- @NotifyCustomKey message_list
+-- @NotifyCustomKey Client
 UPDATE OR IGNORE Client SET is_valid = 0 WHERE user_id = :user_id AND  id IN :clientId_List;
 
 conversationRecipets:
 SELECT * FROM Client WHERE user_id IN (SELECT user FROM Member WHERE conversation = :conversation_id) AND is_valid = 1;
 
 updateClientProteusVerificationStatus:
+-- @NotifyCustomKey message_list
+-- @NotifyCustomKey Client
 UPDATE Client SET is_verified = :is_verified WHERE user_id = :user_id AND id = :client_id;
 
 selectRecipientsByConversationAndUserId:

--- a/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -540,6 +540,7 @@ SELECT degraded_conversation_notified FROM Conversation
 WHERE qualified_id = :conversationId;
 
 clearContent {
+-- @NotifyCustomKey message_list_:conversationId
 -- @NotifyCustomKey conversation_list_last_message
 -- @NotifyCustomKey Asset
 -- @NotifyCustomKey Message

--- a/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/MessageAttachments.sq
+++ b/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/MessageAttachments.sq
@@ -14,6 +14,8 @@ CREATE TABLE MessageAttachments (
 CREATE INDEX IF NOT EXISTS message_attachments_asset_id_idx ON MessageAttachments(asset_id);
 
 insertCellAttachment:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey MessageAttachments
 INSERT INTO MessageAttachments (
     asset_id,
     message_id,

--- a/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/MessageDrafts.sq
+++ b/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/MessageDrafts.sq
@@ -16,13 +16,9 @@ CREATE TABLE MessageDraft (
 );
 
 deleteDraft:
--- @NotifyCustomKey conversation_list_draft
--- @NotifyCustomKey MessageDraft
 DELETE FROM MessageDraft WHERE conversation_id = ?;
 
 upsertDraft:
--- @NotifyCustomKey conversation_list_draft
--- @NotifyCustomKey MessageDraft
 INSERT INTO MessageDraft(conversation_id, text, edit_message_id, quoted_message_id, mention_list)
 VALUES( ?, ?, ?, ?, ?)
 ON CONFLICT(conversation_id) DO UPDATE SET

--- a/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/MessageDrafts.sq
+++ b/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/MessageDrafts.sq
@@ -16,9 +16,13 @@ CREATE TABLE MessageDraft (
 );
 
 deleteDraft:
+-- @NotifyCustomKey conversation_list_draft
+-- @NotifyCustomKey MessageDraft
 DELETE FROM MessageDraft WHERE conversation_id = ?;
 
 upsertDraft:
+-- @NotifyCustomKey conversation_list_draft
+-- @NotifyCustomKey MessageDraft
 INSERT INTO MessageDraft(conversation_id, text, edit_message_id, quoted_message_id, mention_list)
 VALUES( ?, ?, ?, ?, ?)
 ON CONFLICT(conversation_id) DO UPDATE SET

--- a/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -236,11 +236,13 @@ AND content_type IN ('TEXT', 'ASSET', 'KNOCK', 'MISSED_CALL')
 GROUP BY conversation_id;
 
 deleteAllMessages:
+-- @NotifyCustomKey message_list
 -- @NotifyCustomKey conversation_list_last_message
 -- @NotifyCustomKey Message
 DELETE FROM Message;
 
 deleteMessage:
+-- @NotifyCustomKey message_list_:conversation_id
 -- @NotifyCustomKey conversation_list_last_message
 -- @NotifyCustomKey Message
 DELETE FROM Message WHERE id = ? AND conversation_id = ?;
@@ -249,16 +251,19 @@ deleteMessageLinkPreviews:
 DELETE FROM MessageLinkPreview WHERE message_id = ? AND conversation_id = ?;
 
 deleteMessageMentions:
+-- @NotifyCustomKey message_list_:conversation_id
 -- @NotifyCustomKey conversation_list_last_message
 -- @NotifyCustomKey MessageMention
 DELETE FROM MessageMention WHERE message_id = ? AND conversation_id = ?;
 
 deleteMessageById:
+-- @NotifyCustomKey message_list
 -- @NotifyCustomKey conversation_list_last_message
 -- @NotifyCustomKey Message
 DELETE FROM Message WHERE id = ?;
 
 markMessageAsDeleted {
+-- @NotifyCustomKey message_list_:conversation_id
 -- @NotifyCustomKey conversation_list_last_message
 -- @NotifyCustomKey Message
 -- @NotifyCustomKey MessageTextContent
@@ -281,6 +286,8 @@ markMessageAsDeleted {
 }
 
 markMessageAsEdited:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey Message
 UPDATE Message
 SET last_edit_date = ?
 WHERE id = ? AND conversation_id = ?;
@@ -292,18 +299,21 @@ selectChanges:
 SELECT changes();
 
 insertOrIgnoreMessage:
+-- @NotifyCustomKey message_list_:conversation_id
 -- @NotifyCustomKey conversation_list_last_message
 -- @NotifyCustomKey Message
 INSERT OR IGNORE INTO Message(id, content_type, conversation_id, creation_date, sender_user_id, sender_client_id, status, last_edit_date, visibility, expects_read_confirmation, expire_after_millis, self_deletion_end_date)
 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 insertMessage:
+-- @NotifyCustomKey message_list_:conversation_id
 -- @NotifyCustomKey conversation_list_last_message
 -- @NotifyCustomKey Message
 INSERT INTO Message(id, content_type, conversation_id, creation_date, sender_user_id, sender_client_id, status, last_edit_date, visibility, expects_read_confirmation, expire_after_millis, self_deletion_end_date)
 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 insertOrIgnoreBulkSystemMessage:
+-- @NotifyCustomKey message_list
 -- @NotifyCustomKey conversation_list_last_message
 -- @NotifyCustomKey Message
 INSERT OR IGNORE INTO Message(id, content_type, conversation_id, creation_date, sender_user_id, sender_client_id, status, visibility, expects_read_confirmation)
@@ -314,12 +324,14 @@ INSERT OR IGNORE INTO MessageLinkPreview(message_id, conversation_id, url, url_o
 VALUES (?, ?, ?, ?, ?, ?, ?);
 
 insertMessageMention:
+-- @NotifyCustomKey message_list_:conversation_id
 -- @NotifyCustomKey conversation_list_last_message
 -- @NotifyCustomKey MessageMention
 INSERT OR IGNORE INTO MessageMention(message_id, conversation_id, start, length, user_id)
 VALUES (?, ?, ?, ?, ?);
 
 insertMessageTextContent:
+-- @NotifyCustomKey message_list_:conversation_id
 -- @NotifyCustomKey conversation_list_last_message
 -- @NotifyCustomKey MessageTextContent
 INSERT OR IGNORE INTO MessageTextContent(message_id, conversation_id, text_body, quoted_message_id, is_quote_verified, is_quoting_self)
@@ -338,84 +350,116 @@ CASE WHEN
                         0 ))END);
 
 insertMessageRestrictedAssetContent:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey MessageRestrictedAssetContent
 INSERT OR IGNORE INTO MessageRestrictedAssetContent(message_id, conversation_id, asset_mime_type,asset_size,asset_name)
 VALUES(?, ?, ?,?,?);
 
 insertMessageAssetContent:
+-- @NotifyCustomKey message_list_:conversation_id
 -- @NotifyCustomKey conversation_list_last_message
 -- @NotifyCustomKey MessageAssetContent
 INSERT OR IGNORE INTO MessageAssetContent(message_id, conversation_id, asset_size, asset_name, asset_mime_type, asset_otr_key, asset_sha256, asset_id, asset_token, asset_domain, asset_encryption_algorithm, asset_width, asset_height, asset_duration_ms, asset_normalized_loudness)
 VALUES(?, ?, ?, ?, ?, ? ,?, ?, ?, ?, ?, ?, ?,  ?, ?);
 
 insertMessageUnknownContent:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey MessageUnknownContent
 INSERT OR IGNORE INTO MessageUnknownContent(message_id, conversation_id, unknown_type_name, unknown_encoded_data)
 VALUES(?, ?, ?, ?);
 
 insertMissedCallMessage:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey MessageMissedCallContent
 INSERT OR IGNORE INTO MessageMissedCallContent(message_id, conversation_id, caller_id)
 VALUES(?, ?, ?);
 
 insertLocationMessageContent:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey MessageConversationLocationContent
 INSERT OR IGNORE INTO MessageConversationLocationContent(message_id, conversation_id, latitude, longitude, name, zoom)
 VALUES(?, ?, ?, ?, ?, ?);
 
 insertSystemMessageContent:
+-- @NotifyCustomKey message_list_:conversation_id
 -- @NotifyCustomKey conversation_list_last_message
 -- @NotifyCustomKey MessageSystemContent
 INSERT OR IGNORE INTO MessageSystemContent(message_id, conversation_id, content_type, text_1, integer_1, boolean_1, list_1, enum_1, blob_1)
 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 insertSystemMemberChange:
+-- @NotifyCustomKey message_list_:conversation_id
 -- @NotifyCustomKey conversation_list_last_message
 -- @NotifyCustomKey MessageSystemContent
 INSERT OR IGNORE INTO MessageSystemContent(message_id, conversation_id, content_type, list_1, enum_1)
 VALUES(?, ?, 'MEMBER_CHANGE', :member_change_list, :member_change_type);
 
 insertSystemFailedDecryption:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey MessageSystemContent
 INSERT OR IGNORE INTO MessageSystemContent(message_id, conversation_id, content_type, blob_1, boolean_1, integer_1)
 VALUES(?, ?, 'FAILED_DECRYPT', :unknown_encoded_data, 0, :error_code);
 
 insertSystemConversationRenamed:
+-- @NotifyCustomKey message_list_:conversation_id
 -- @NotifyCustomKey conversation_list_last_message
 -- @NotifyCustomKey MessageSystemContent
 INSERT OR IGNORE INTO MessageSystemContent(message_id, conversation_id, content_type, text_1)
 VALUES(:message_id, :conversation_id, 'CONVERSATION_RENAMED', :conversation_name);
 
 insertSystemNewConversationReceiptMode:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey MessageSystemContent
 INSERT OR IGNORE INTO MessageSystemContent(message_id, conversation_id, content_type, boolean_1)
 VALUES(?, ?, 'NEW_CONVERSATION_RECEIPT_MODE', :receipt_mode);
 
 insertSystemConversationReceiptModeChanged:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey MessageSystemContent
 INSERT OR IGNORE INTO MessageSystemContent(message_id, conversation_id, content_type, boolean_1)
 VALUES(?, ?, 'CONVERSATION_RECEIPT_MODE_CHANGED', :receipt_mode);
 
 insertSystemConversationAppsEnabledChanged:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey MessageSystemContent
 INSERT OR IGNORE INTO MessageSystemContent(message_id, conversation_id, content_type, boolean_1)
 VALUES(?, ?, 'CONVERSATION_APPS_ENABLED_CHANGED', :is_apps_enabled);
 
 insertSystemConversationTimerChanged:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey MessageSystemContent
 INSERT OR IGNORE INTO MessageSystemContent(message_id, conversation_id, content_type, integer_1)
 VALUES(:message_id, :conversation_id, 'CONVERSATION_TIMER_CHANGED', :message_timer);
 
 insertSystemFederationTerminated:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey MessageSystemContent
 INSERT OR IGNORE INTO MessageSystemContent(message_id, conversation_id, content_type, list_1, enum_1)
 VALUES(:message_id, :conversation_id, 'FEDERATION_TERMINATED', :domain_list, :federation_type);
 
 insertSystemConversationProtocolChanged:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey MessageSystemContent
 INSERT OR IGNORE INTO MessageSystemContent(message_id, conversation_id, content_type, enum_1)
 VALUES(:message_id, :conversation_id, 'CONVERSATION_PROTOCOL_CHANGED', :protocol);
 
 insertSystemLegalHold:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey MessageSystemContent
 INSERT OR IGNORE INTO MessageSystemContent(message_id, conversation_id, content_type, list_1, enum_1)
 VALUES(?, ?, 'LEGAL_HOLD', :legal_hold_member_list, :legal_hold_type);
 
 -- Update query for system content
 updateSystemMessageLegalHoldMembers:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey MessageSystemContent
 UPDATE MessageSystemContent
 SET list_1 = :user_id_list
 WHERE message_id = :message_id AND conversation_id = :conversation_id AND content_type = 'LEGAL_HOLD';
 
 updateSystemMessageDecryptionResolved:
+-- @NotifyCustomKey message_list
+-- @NotifyCustomKey MessageSystemContent
 UPDATE MessageSystemContent
 SET boolean_1 = 1
 WHERE message_id IN (
@@ -427,11 +471,15 @@ WHERE message_id IN (
 );
 
 updateMessageStatus:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey Message
 UPDATE Message
 SET status = ?
 WHERE id = ? AND conversation_id = ?;
 
 updateMessagesStatusIfNotRead:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey Message
 UPDATE Message
 SET status = ?
 WHERE id IN ?
@@ -439,6 +487,8 @@ AND conversation_id = ?
 AND status != 'READ';
 
 updateQuotedMessageId:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey MessageTextContent
 UPDATE MessageTextContent
 SET quoted_message_id = ?
 WHERE quoted_message_id = ? AND conversation_id = ?;
@@ -447,6 +497,7 @@ selectMessageVisibility:
 SELECT visibility FROM Message WHERE id = ? AND conversation_id = ?;
 
 updateAssetContent {
+-- @NotifyCustomKey message_list_:conversationId
 -- @NotifyCustomKey conversation_list_last_message
 -- @NotifyCustomKey Message
 -- @NotifyCustomKey MessageAssetContent
@@ -460,6 +511,7 @@ updateAssetContent {
 }
 
 updateMessageTextContent:
+-- @NotifyCustomKey message_list_:conversation_id
 -- @NotifyCustomKey conversation_list_last_message
 -- @NotifyCustomKey MessageTextContent
 UPDATE MessageTextContent
@@ -467,6 +519,7 @@ SET text_body = ?
 WHERE message_id = ? AND conversation_id = ?;
 
 updateMessageId:
+-- @NotifyCustomKey message_list_:conversationId
 -- @NotifyCustomKey conversation_list_last_message
 -- @NotifyCustomKey Message
 UPDATE Message
@@ -480,18 +533,26 @@ selectById:
 SELECT * FROM MessageDetailsView WHERE id = ? AND conversationId = ?;
 
 countByConversationIdAndVisibility:
+-- @CustomKey message_list_:conversation_id
+-- @CustomKey message_list
 SELECT count(*) FROM Message WHERE conversation_id = ? AND visibility IN ?;
 
 countPendingByConversationIdAndVisibility:
+-- @CustomKey message_list_:conversation_id
+-- @CustomKey message_list
 SELECT count(*) FROM Message WHERE conversation_id = ? AND visibility IN ? AND status = 'PENDING';
 
 selectOldestVisibleMessageTimestampByConversationId:
 SELECT MIN(creation_date) FROM Message WHERE conversation_id = ? AND visibility = "VISIBLE";
 
 selectByConversationIdAndVisibility:
+-- @CustomKey message_list_:conversationId
+-- @CustomKey message_list
 SELECT * FROM MessageDetailsView WHERE conversationId = :conversationId AND visibility IN :visibility ORDER BY date DESC LIMIT :limit OFFSET :offset;
 
 selectPendingByConversationIdAndVisibility:
+-- @CustomKey message_list_:conversationId
+-- @CustomKey message_list
 SELECT *
 FROM MessageDetailsView
 WHERE conversationId = :conversationId
@@ -501,6 +562,8 @@ ORDER BY date DESC
 LIMIT :limit OFFSET :offset;
 
 selectNonPendingByConversationIdAndVisibility:
+-- @CustomKey message_list_:conversationId
+-- @CustomKey message_list
 SELECT *
 FROM MessageDetailsView
 WHERE conversationId = :conversationId
@@ -529,6 +592,8 @@ ON MessageDetailsView.conversationId = LastMessage.conversation_id AND MessageDe
 WHERE LastMessage.conversation_id IN :conversationIds;
 
 selectMessagesByConversationIdAndVisibilityAfterDate:
+-- @CustomKey message_list_:conversationId
+-- @CustomKey message_list
 SELECT * FROM MessageDetailsView WHERE MessageDetailsView.conversationId = ? AND visibility IN ? AND date > ? ORDER BY date DESC;
 
 selectMessagesFromUserByStatus:
@@ -556,6 +621,7 @@ ORDER BY
     Message.creation_date DESC;
 
 promoteMessageToSentUpdatingServerTime {
+-- @NotifyCustomKey message_list_:conversation_id
 -- @NotifyCustomKey conversation_list_last_message
 -- @NotifyCustomKey Message
 UPDATE Message
@@ -584,15 +650,21 @@ AND visibility = "VISIBLE"
 AND selfDeletionEndDate <= STRFTIME('%s', 'now') * 1000; -- Checks if message end date is lower than current time in millis
 
 markSelfDeletionEndDate:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey Message
 UPDATE Message
 SET self_deletion_end_date = ?
 WHERE conversation_id = ? AND id = ?;
 
 insertMessageRecipientsFailure:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey MessageRecipientFailure
 INSERT OR IGNORE INTO MessageRecipientFailure(message_id, conversation_id, recipient_failure_list, recipient_failure_type)
 VALUES(?, ?, ?, ?);
 
 moveMessages:
+-- @NotifyCustomKey message_list_:to
+-- @NotifyCustomKey message_list_:from
 -- @NotifyCustomKey conversation_list_last_message
 -- @NotifyCustomKey Message
 UPDATE OR REPLACE Message
@@ -600,6 +672,8 @@ SET conversation_id = :to
 WHERE conversation_id = :from;
 
 selectConversationMessagesFromSearch:
+-- @CustomKey message_list_:conversationId
+-- @CustomKey message_list
 SELECT MessageDetailsView.*
 FROM MessageTextContent AS TextContent
 JOIN MessageDetailsView
@@ -625,6 +699,8 @@ LIMIT :limit
 OFFSET :offset;
 
 countBySearchedMessageAndConversationId:
+-- @CustomKey message_list_:conversationId
+-- @CustomKey message_list
 SELECT COUNT(*)
 FROM MessageTextContent AS TextContent
 JOIN Message
@@ -651,6 +727,8 @@ ORDER BY Message.creation_date ASC
 LIMIT 1;
 
 updateAudioMessageNormalizedLoudness:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey MessageAssetContent
 UPDATE MessageAssetContent
 SET asset_normalized_loudness = ?
 WHERE message_id = ? AND conversation_id = ?;

--- a/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Reactions.sq
+++ b/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Reactions.sq
@@ -16,16 +16,24 @@ doesMessageExist:
 SELECT 1 FROM Message WHERE id = :message_id AND conversation_id = :conversation_id;
 
 deleteAllReactionsOnMessageFromUser:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey Reaction
 DELETE FROM Reaction WHERE message_id = ? AND conversation_id = ? AND sender_id = ?;
 
 deleteReaction:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey Reaction
 DELETE FROM Reaction WHERE message_id = ? AND conversation_id = ? AND sender_id = ? AND emoji = ?;
 
 insertReaction:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey Reaction
 INSERT INTO Reaction(message_id, conversation_id, sender_id, emoji, date)
 VALUES(?, ?, ?, ?, ?);
 
 deleteAllReactionsForMessage:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey Reaction
 DELETE FROM Reaction WHERE message_id = ? AND conversation_id = ?;
 
 selectByMessageIdAndConversationIdAndSenderId:

--- a/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Receipts.sq
+++ b/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Receipts.sq
@@ -16,6 +16,8 @@ CREATE INDEX receipt_msg_type ON Receipt(message_id, type);
 
 -- TODO: Cast to proper types when/if SQLDelight supports it:
 insertReceipt:
+-- @NotifyCustomKey message_list_:value_
+-- @NotifyCustomKey Receipt
 WITH insertion(message_id, conversation_id, user_id, type, date) AS(
     VALUES (CAST(? AS TEXT), CAST(? AS TEXT), CAST(? AS TEXT), CAST(? AS TEXT), CAST(? AS TEXT))
 )

--- a/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/content/ButtonContent.sq
+++ b/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/content/ButtonContent.sq
@@ -14,10 +14,14 @@ CREATE TABLE ButtonContent (
 );
 
 insertButton:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey ButtonContent
 INSERT INTO ButtonContent (message_id, conversation_id, id, text)
 VALUES (:message_id, :conversation_id, :id, :text);
 
 markSelected {
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey ButtonContent
     UPDATE ButtonContent
     SET is_selected = 0
     WHERE conversation_id = :conversation_id AND
@@ -31,7 +35,11 @@ markSelected {
 }
 
 removeAllSelection:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey ButtonContent
 UPDATE ButtonContent SET is_selected = 0 WHERE conversation_id = :conversation_id AND message_id = :message_id;
 
 deleteAllButtons:
+-- @NotifyCustomKey message_list_:conversation_id
+-- @NotifyCustomKey ButtonContent
 DELETE FROM ButtonContent WHERE conversation_id = :conversation_id AND message_id = :message_id;

--- a/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/message/MessageExtensionsTest.kt
+++ b/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/message/MessageExtensionsTest.kt
@@ -33,6 +33,8 @@ import com.wire.kalium.persistence.dao.message.MessageExtensions
 import com.wire.kalium.persistence.dao.message.MessageExtensionsImpl
 import com.wire.kalium.persistence.dao.message.MessageMapper
 import com.wire.kalium.persistence.dao.message.attachment.MessageAttachmentEntity
+import com.wire.kalium.persistence.dao.receipt.ReceiptDAO
+import com.wire.kalium.persistence.dao.receipt.ReceiptTypeEntity
 import com.wire.kalium.persistence.db.ReadDispatcher
 import com.wire.kalium.persistence.utils.stubs.newConversationEntity
 import com.wire.kalium.persistence.utils.stubs.newRegularMessageEntity
@@ -59,6 +61,7 @@ class MessageExtensionsTest : BaseDatabaseTest() {
     private lateinit var messageDAO: MessageDAO
     private lateinit var conversationDAO: ConversationDAO
     private lateinit var userDAO: UserDAO
+    private lateinit var receiptDAO: ReceiptDAO
     private val selfUserId = UserIDEntity("selfValue", "selfDomain")
 
     @BeforeTest
@@ -73,6 +76,7 @@ class MessageExtensionsTest : BaseDatabaseTest() {
         messageDAO = db.messageDAO
         conversationDAO = db.conversationDAO
         userDAO = db.userDAO
+        receiptDAO = db.receiptDAO
         messageExtensions = MessageExtensionsImpl(
             messagesQueries = messagesQueries,
             messageAttachmentsQueries = messageAttachmentsQueries,
@@ -289,6 +293,114 @@ class MessageExtensionsTest : BaseDatabaseTest() {
         assertEquals(attachmentId, multipartContent.attachments.single().assetId)
     }
 
+    @Test
+    fun givenMessageListPageLoaded_whenMessageIsInsertedInSameConversation_thenPagingSourceShouldBeInvalidated() = runTest {
+        populateMessageData()
+        val pagingSource = getPager().pagingSource
+
+        pagingSource.refresh().also { result ->
+            assertIs<PagingSource.LoadResult.Page<Int, MessageEntity>>(result)
+        }
+        assertFalse { pagingSource.invalid }
+
+        messageDAO.insertOrIgnoreMessage(
+            newRegularMessageEntity(
+                id = "new-message",
+                conversationId = CONVERSATION_ID,
+                senderUserId = USER_ID
+            )
+        )
+
+        assertTrue { pagingSource.invalid }
+    }
+
+    @Test
+    fun givenMessageListPageLoaded_whenMessageIsInsertedInDifferentConversation_thenPagingSourceShouldNotBeInvalidated() = runTest {
+        populateMessageData()
+        conversationDAO.insertConversation(newConversationEntity(id = OTHER_CONVERSATION_ID))
+        val pagingSource = getPager().pagingSource
+
+        pagingSource.refresh().also { result ->
+            assertIs<PagingSource.LoadResult.Page<Int, MessageEntity>>(result)
+        }
+        assertFalse { pagingSource.invalid }
+
+        messageDAO.insertOrIgnoreMessage(
+            newRegularMessageEntity(
+                id = "other-new-message",
+                conversationId = OTHER_CONVERSATION_ID,
+                senderUserId = USER_ID
+            )
+        )
+
+        assertFalse { pagingSource.invalid }
+    }
+
+    @Test
+    fun givenMessageListPageLoaded_whenReceiptIsInsertedInSameConversation_thenPagingSourceShouldBeInvalidated() = runTest {
+        populateMessageData()
+        val pagingSource = getPager().pagingSource
+
+        pagingSource.refresh().also { result ->
+            assertIs<PagingSource.LoadResult.Page<Int, MessageEntity>>(result)
+        }
+        assertFalse { pagingSource.invalid }
+
+        receiptDAO.insertReceipts(
+            userId = USER_ID,
+            conversationId = CONVERSATION_ID,
+            date = Instant.fromEpochSeconds(1),
+            type = ReceiptTypeEntity.DELIVERY,
+            messageIds = listOf("0")
+        )
+
+        assertTrue { pagingSource.invalid }
+    }
+
+    @Test
+    fun givenMessageListPageLoaded_whenReceiptIsInsertedInDifferentConversation_thenPagingSourceShouldNotBeInvalidated() = runTest {
+        populateMessageData()
+        conversationDAO.insertConversation(newConversationEntity(id = OTHER_CONVERSATION_ID))
+        messageDAO.insertOrIgnoreMessage(
+            newRegularMessageEntity(
+                id = "other-message",
+                conversationId = OTHER_CONVERSATION_ID,
+                senderUserId = USER_ID
+            )
+        )
+        val pagingSource = getPager().pagingSource
+
+        pagingSource.refresh().also { result ->
+            assertIs<PagingSource.LoadResult.Page<Int, MessageEntity>>(result)
+        }
+        assertFalse { pagingSource.invalid }
+
+        receiptDAO.insertReceipts(
+            userId = USER_ID,
+            conversationId = OTHER_CONVERSATION_ID,
+            date = Instant.fromEpochSeconds(1),
+            type = ReceiptTypeEntity.DELIVERY,
+            messageIds = listOf("other-message")
+        )
+
+        assertFalse { pagingSource.invalid }
+    }
+
+    @Test
+    fun givenMessageListPageLoaded_whenSenderNameIsUpdated_thenPagingSourceShouldNotBeInvalidated() = runTest {
+        populateMessageData()
+        val pagingSource = getPager().pagingSource
+
+        pagingSource.refresh().also { result ->
+            assertIs<PagingSource.LoadResult.Page<Int, MessageEntity>>(result)
+        }
+        assertFalse { pagingSource.invalid }
+
+        userDAO.updateUserDisplayName(USER_ID, "Updated User")
+
+        assertFalse { pagingSource.invalid }
+    }
+
     private fun getPager(): KaliumPager<MessageEntity> = messageExtensions.getPagerForConversation(
         conversationId = CONVERSATION_ID,
         visibilities = MessageEntity.Visibility.entries.toList(),
@@ -312,8 +424,7 @@ class MessageExtensionsTest : BaseDatabaseTest() {
     )
 
     private suspend fun populateMessageData(prefix: String = "") {
-        val userId = UserIDEntity("user", "domain")
-        userDAO.upsertUser(newUserEntity(qualifiedID = userId))
+        userDAO.upsertUser(newUserEntity(qualifiedID = USER_ID))
         conversationDAO.insertConversation(newConversationEntity(id = CONVERSATION_ID))
         val messages = buildList<MessageEntity> {
             repeat(MESSAGE_COUNT) {
@@ -321,7 +432,7 @@ class MessageExtensionsTest : BaseDatabaseTest() {
                     newRegularMessageEntity(
                         id = it.toString(),
                         conversationId = CONVERSATION_ID,
-                        senderUserId = userId,
+                        senderUserId = USER_ID,
                         content = MessageEntityContent.Text("message $it"),
                         // Ordered by date - Inserting with decreasing date is important to assert pagination
                         date = Instant.fromEpochSeconds(MESSAGE_COUNT - it.toLong())
@@ -333,8 +444,7 @@ class MessageExtensionsTest : BaseDatabaseTest() {
     }
 
     private suspend fun populatePendingAndNonPendingMessageData() {
-        val userId = UserIDEntity("user", "domain")
-        userDAO.upsertUser(newUserEntity(qualifiedID = userId))
+        userDAO.upsertUser(newUserEntity(qualifiedID = USER_ID))
         conversationDAO.insertConversation(newConversationEntity(id = CONVERSATION_ID))
         val messages = buildList<MessageEntity> {
             repeat(PENDING_MESSAGE_COUNT) {
@@ -342,7 +452,7 @@ class MessageExtensionsTest : BaseDatabaseTest() {
                     newRegularMessageEntity(
                         id = "pending-$it",
                         conversationId = CONVERSATION_ID,
-                        senderUserId = userId,
+                        senderUserId = USER_ID,
                         status = MessageEntity.Status.PENDING,
                         content = MessageEntityContent.Text("pending message $it"),
                         date = Instant.fromEpochSeconds(PENDING_MESSAGE_COUNT - it.toLong())
@@ -354,7 +464,7 @@ class MessageExtensionsTest : BaseDatabaseTest() {
                     newRegularMessageEntity(
                         id = "non-pending-$it",
                         conversationId = CONVERSATION_ID,
-                        senderUserId = userId,
+                        senderUserId = USER_ID,
                         status = MessageEntity.Status.SENT,
                         content = MessageEntityContent.Text("non-pending message $it"),
                         date = Instant.fromEpochSeconds(NON_PENDING_MESSAGE_COUNT - it.toLong())
@@ -371,6 +481,8 @@ class MessageExtensionsTest : BaseDatabaseTest() {
         const val PENDING_MESSAGE_COUNT = 25
         const val NON_PENDING_MESSAGE_COUNT = 40
         const val MIXED_MESSAGE_COUNT = PENDING_MESSAGE_COUNT + NON_PENDING_MESSAGE_COUNT
+        val USER_ID = UserIDEntity("user", "domain")
         val CONVERSATION_ID = ConversationIDEntity("conversation", "domain")
+        val OTHER_CONVERSATION_ID = ConversationIDEntity("otherConversation", "domain")
     }
 }


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26678
<!--jira-description-action-hidden-marker-end-->

----

make messages list update per conversaion 
before 
self message from same device in any conversation will cause 6 refreshes 
self message from another device in any conversation will cause 4 refreshes
other message in any conversation 1 refresh 

after 
any message in not the open conv 0 udpate 
self message from same device will cause 2 refreshes
self message from another device 2 refreshes
other message 1 refresh 