### PR TITLE
fix: proteus send recovery for locally invalid missing clients [WPB-26769]

### DIFF
--- a/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Clients.sq
+++ b/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Clients.sq
@@ -96,12 +96,10 @@ isClientMLSCapable:
 SELECT is_mls_capable FROM Client WHERE user_id = :user_id AND id = :client_id;
 
 tryMarkAsInvalid:
--- @NotifyCustomKey message_list
 -- @NotifyCustomKey Client
 UPDATE OR IGNORE Client SET is_valid = 0 WHERE user_id = :user_id AND  id IN :clientId_List;
 
 tryMarkAsValid:
--- @NotifyCustomKey message_list
 -- @NotifyCustomKey Client
 UPDATE OR IGNORE Client SET is_valid = 1 WHERE user_id = :user_id AND id IN :clientId_List;
 

--- a/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Clients.sq
+++ b/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Clients.sq
@@ -100,6 +100,11 @@ tryMarkAsInvalid:
 -- @NotifyCustomKey Client
 UPDATE OR IGNORE Client SET is_valid = 0 WHERE user_id = :user_id AND  id IN :clientId_List;
 
+tryMarkAsValid:
+-- @NotifyCustomKey message_list
+-- @NotifyCustomKey Client
+UPDATE OR IGNORE Client SET is_valid = 1 WHERE user_id = :user_id AND id IN :clientId_List;
+
 conversationRecipets:
 SELECT * FROM Client WHERE user_id IN (SELECT user FROM Member WHERE conversation = :conversation_id) AND is_valid = 1;
 

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAO.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAO.kt
@@ -83,6 +83,7 @@ interface ClientDAO {
     suspend fun conversationRecipient(ids: QualifiedIDEntity): Map<QualifiedIDEntity, List<Client>>
     suspend fun insertClientsAndRemoveRedundant(clients: List<InsertClientParam>)
     suspend fun tryMarkInvalid(invalidClientsList: List<Pair<QualifiedIDEntity, List<String>>>)
+    suspend fun tryMarkValid(validClientsList: List<Pair<QualifiedIDEntity, List<String>>>)
     suspend fun updateClientProteusVerificationStatus(userId: QualifiedIDEntity, clientId: String, verified: Boolean)
     fun observeClient(userId: QualifiedIDEntity, clientId: String): Flow<Client?>
 

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOImpl.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOImpl.kt
@@ -159,6 +159,16 @@ internal class ClientDAOImpl internal constructor(
         }
     }
 
+    override suspend fun tryMarkValid(
+        validClientsList: List<Pair<QualifiedIDEntity, List<String>>>
+    ) = withContext(writeDispatcher.value) {
+        clientsQueries.transaction {
+            validClientsList.forEach { (userId, clientIdList) ->
+                clientsQueries.tryMarkAsValid(userId, clientIdList)
+            }
+        }
+    }
+
     override suspend fun updateClientProteusVerificationStatus(userId: QualifiedIDEntity, clientId: String, verified: Boolean) {
         withContext(writeDispatcher.value) {
             clientsQueries.updateClientProteusVerificationStatus(verified, userId, clientId)

--- a/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOTest.kt
+++ b/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/client/ClientDAOTest.kt
@@ -261,6 +261,23 @@ class ClientDAOTest : BaseDatabaseTest() {
     }
 
     @Test
+    fun givenInvalidUserClient_whenMarkingAsValid_thenConversationRecipientsIncludeItAgain() = runTest {
+        val user = user
+        val expected: Map<QualifiedIDEntity, List<Client>> = mapOf(user.id to listOf(client, client1))
+        userDAO.upsertUser(user)
+        clientDAO.insertClient(insertedClient)
+        clientDAO.insertClient(insertedClient1)
+        clientDAO.tryMarkInvalid(listOf(insertedClient.userId to listOf(insertedClient.id)))
+        conversationDAO.insertConversations(listOf(conversationEntity1))
+        memberDAO.insertMember(MemberEntity(user.id, MemberEntity.Role.Admin), conversationEntity1.id)
+
+        clientDAO.tryMarkValid(listOf(insertedClient.userId to listOf(insertedClient.id)))
+
+        val actual = clientDAO.conversationRecipient(conversationEntity1.id)
+        assertEquals(expected, actual)
+    }
+
+    @Test
     fun givenNewClientAdded_thenItIsMarkedAsNotVerified() = runTest {
         val user = user
         userDAO.upsertUser(user)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/ClientRepository.kt
@@ -94,6 +94,7 @@ internal interface ClientRepository {
     ): Either<StorageFailure, Unit>
 
     suspend fun storeMapOfUserToClientId(userToClientMap: Map<UserId, List<ClientId>>): Either<StorageFailure, Unit>
+    suspend fun tryMarkClientsAsValid(userToClientMap: Map<UserId, List<ClientId>>): Either<StorageFailure, Unit>
     suspend fun removeClientsAndReturnUsersWithNoClients(
         redundantClientsOfUsers: Map<UserId, List<ClientId>>
     ): Either<StorageFailure, List<UserId>>
@@ -284,6 +285,15 @@ internal class ClientDataSource(
             clientMapper.toInsertClientParam(userId, clients)
         }.let { insertClientParamList ->
             wrapStorageRequest { clientDAO.insertClients(insertClientParamList) }
+        }
+
+    override suspend fun tryMarkClientsAsValid(
+        userToClientMap: Map<UserId, List<ClientId>>
+    ): Either<StorageFailure, Unit> =
+        userToClientMap.map { (userId, clients) ->
+            userId.toDao() to clients.map { it.value }
+        }.let { validClients ->
+            wrapStorageRequest { clientDAO.tryMarkValid(validClients) }
         }
 
     override suspend fun removeClientsAndReturnUsersWithNoClients(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSendFailureHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSendFailureHandler.kt
@@ -121,11 +121,14 @@ internal class MessageSendFailureHandlerImpl internal constructor(
     private suspend fun addMissingClients(missingClients: Map<UserId, List<ClientId>>): Either<CoreFailure, Unit> =
         if (missingClients.isEmpty()) Either.Right(Unit)
         else clientRemoteRepository.fetchOtherUserClients(missingClients.keys.toList())
-            .flatMap {
-                it.map { (userId, clientList) -> clientMapper.toInsertClientParam(clientList, userId) }
-                    .flatten().let { insertClientParamList ->
+            .flatMap { fetchedClients ->
+                fetchedClients.map { (userId, clientList) -> clientMapper.toInsertClientParam(clientList, userId) }
+                    .flatten()
+                    .let { insertClientParamList ->
                         if (insertClientParamList.isEmpty()) Either.Right(Unit)
                         else clientRepository.storeUserClientListAndRemoveRedundantClients(insertClientParamList)
+                    }.flatMap {
+                        clientRepository.tryMarkClientsAsValid(missingClients)
                     }
             }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/ClientRepositoryTest.kt
@@ -466,6 +466,23 @@ class ClientRepositoryTest {
         }
     }
 
+    @Test
+    fun givenUserClientMap_whenMarkingClientsAsValid_thenDaoIsCalledWithMappedValues() = runTest {
+        val userId = UserId("user-id", "domain")
+        val clients = listOf(ClientId("client-id-1"), ClientId("client-id-2"))
+        val (arrangement, clientRepository) = Arrangement()
+            .withTryMarkValid()
+            .arrange()
+
+        clientRepository.tryMarkClientsAsValid(mapOf(userId to clients)).shouldSucceed()
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.clientDAO.tryMarkValid(
+                eq(listOf(userId.toDao() to clients.map { it.value }))
+            )
+        }
+    }
+
     private companion object {
         val selfUserId = UserId("self-user-id", "domain")
         const val SECOND_FACTOR_CODE = "123456"
@@ -571,6 +588,12 @@ class ClientRepositoryTest {
         suspend fun withDeleteClientLocally() = apply {
             everySuspend {
                 clientDAO.deleteClient(any(), any())
+            }.returns(Unit)
+        }
+
+        suspend fun withTryMarkValid() = apply {
+            everySuspend {
+                clientDAO.tryMarkValid(any())
             }.returns(Unit)
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/prekey/MessageSendFailureHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/prekey/MessageSendFailureHandlerTest.kt
@@ -68,6 +68,7 @@ internal class MessageSendFailureHandlerTest {
                 withFetchUsersByIdSuccess()
                 withFetchOtherUserClients(Either.Right(emptyMap()))
                 withStoreUserClientListAndRemoveRedundantClients(Either.Right(Unit))
+                withTryMarkClientsAsValid(Either.Right(Unit))
             }
         val failureData =
             ProteusSendMessageFailure(mapOf(arrangement.userOne, arrangement.userTwo), mapOf(), mapOf(), null)
@@ -86,6 +87,7 @@ internal class MessageSendFailureHandlerTest {
                 withFetchUsersByIdSuccess()
                 withFetchOtherUserClients(Either.Right(mapOf(userOneDTO, userTwoDTO)))
                 withStoreUserClientListAndRemoveRedundantClients(Either.Right(Unit))
+                withTryMarkClientsAsValid(Either.Right(Unit))
             }
 
         val failureData =
@@ -99,6 +101,11 @@ internal class MessageSendFailureHandlerTest {
         verifySuspend(VerifyMode.exactly(1)) {
             arrangement.clientRepository.storeUserClientListAndRemoveRedundantClients(
                 eq(arrangement.userOneInsertClientParams + arrangement.userTwoInsertClientParams)
+            )
+        }
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.clientRepository.tryMarkClientsAsValid(
+                eq(mapOf(arrangement.userOne.first to arrangement.userOne.second, arrangement.userTwo.first to arrangement.userTwo.second))
             )
         }
     }
@@ -276,6 +283,7 @@ internal class MessageSendFailureHandlerTest {
                 withFetchUsersByIdSuccess()
                 withFetchOtherUserClients(Either.Right(mapOf(userOneDTO)))
                 withStoreUserClientListAndRemoveRedundantClients(Either.Right(Unit))
+                withTryMarkClientsAsValid(Either.Right(Unit))
             }
 
         val failure = ProteusSendMessageFailure(
@@ -312,6 +320,7 @@ internal class MessageSendFailureHandlerTest {
             .arrange {
                 withFetchOtherUserClients(Either.Right(emptyMap()))
                 withStoreUserClientListAndRemoveRedundantClients(Either.Right(Unit))
+                withTryMarkClientsAsValid(Either.Right(Unit))
                 withFetchUsersByIdSuccess()
                 withFetchConversationSucceeding()
             }
@@ -334,6 +343,7 @@ internal class MessageSendFailureHandlerTest {
             .arrange {
                 withFetchOtherUserClients(Either.Right(emptyMap()))
                 withStoreUserClientListAndRemoveRedundantClients(Either.Right(Unit))
+                withTryMarkClientsAsValid(Either.Right(Unit))
                 withFetchUsersByIdSuccess()
             }
         val failureData = ProteusSendMessageFailure(mapOf(arrangement.userOne, arrangement.userTwo), mapOf(), mapOf(), null)
@@ -433,6 +443,14 @@ internal class MessageSendFailureHandlerTest {
         ) = apply {
             everySuspend {
                 clientRepository.storeUserClientListAndRemoveRedundantClients(any())
+            }.returns(result)
+        }
+
+        suspend fun withTryMarkClientsAsValid(
+            result: Either<StorageFailure, Unit>
+        ) = apply {
+            everySuspend {
+                clientRepository.tryMarkClientsAsValid(any())
             }.returns(result)
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26769
<!--jira-description-action-hidden-marker-end-->
Proteus send recovery could fail to recover when the backend reported a missing client that already existed locally but had `Client.is_valid = 0`.

The send retry refreshed users, conversation info, and client lists, but storing the refreshed client list did not make the client valid again. This is intentional for normal `insertClient`, which preserves `is_valid` on conflict. Because recipient selection filters with `is_valid = 1`, the missing client stayed excluded from the retry payload, so the next send hit the same `412` again.

**Fix**
Add an explicit revalidation path for Proteus send recovery:

- Add DAO support to mark clients valid again.
- Expose it through `ClientRepository`.
- In `MessageSendFailureHandler.addMissingClients`, keep the existing fetch/store flow, then mark the clients reported by the `412` missing-client response as valid.
- Keep normal `insertClient` behavior unchanged, so ordinary re-inserts still do not accidentally reset invalid clients.

This keeps the fix scoped to send recovery: if the backend says these clients are missing, recovery refreshes client state and makes those exact reported clients eligible for recipient selection again on retry.