### PR TITLE
fix(calling): honor disabled calling on Apple [WPB-8645]

### DIFF
--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -21,17 +21,27 @@
 package com.wire.kalium.logic.feature.call
 
 import com.wire.kalium.calling.AppleAvs
+import com.wire.kalium.calling.ConversationTypeCalling
 import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.logic.cache.SelfConversationIdProvider
 import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.data.call.CallClientList
 import com.wire.kalium.logic.data.call.CallRepository
+import com.wire.kalium.logic.data.call.CallType
+import com.wire.kalium.logic.data.call.EpochInfo
+import com.wire.kalium.logic.data.call.Participant
+import com.wire.kalium.logic.data.call.TestVideoType
+import com.wire.kalium.logic.data.call.VideoState
 import com.wire.kalium.logic.data.call.VideoStateChecker
 import com.wire.kalium.logic.data.call.mapper.CallMapper
 import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.id.FederatedIdMapper
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.call.usecase.ConversationClientsInCallUpdater
 import com.wire.kalium.logic.feature.call.usecase.GetCallConversationTypeProvider
@@ -52,6 +62,7 @@ internal actual class GlobalCallManager actual constructor(
 
     private val flowManagerService by lazy { FlowManagerServiceImpl(platformContext) }
     private val mediaManagerService by lazy { MediaManagerServiceImpl(platformContext) }
+    private var hasEnabledCallingClient = false
 
     @Suppress("LongParameterList")
     internal actual fun getCallManagerForClient(
@@ -73,6 +84,12 @@ internal actual class GlobalCallManager actual constructor(
         kaliumConfigs: KaliumConfigs,
         createAndPersistRecentlyEndedCallMetadata: CreateAndPersistRecentlyEndedCallMetadataUseCase
     ): CallManager {
+        if (!kaliumConfigs.enableCalling) {
+            kaliumLogger.w("Calls disabled by KaliumConfigs.enableCalling=false: using Apple no-op CallManager")
+            return DisabledAppleCallManager
+        }
+
+        hasEnabledCallingClient = true
         return CallManagerImpl(
             callRepository = callRepository,
             currentClientIdProvider = currentClientIdProvider,
@@ -108,8 +125,41 @@ internal actual class GlobalCallManager actual constructor(
     }
 
     actual override fun networkChanged() {
+        if (!hasEnabledCallingClient) {
+            kaliumLogger.w("Calls disabled by KaliumConfigs.enableCalling=false: networkChanged ignored")
+            return
+        }
+
         if (!AppleAvs.bridge.notifyNetworkChangedIfAvailable()) {
             kaliumLogger.w("AVS iOS smoke: networkChanged ignored because AVS is unavailable")
         }
     }
+}
+
+@Suppress("TooManyFunctions")
+private object DisabledAppleCallManager : CallManager {
+    override suspend fun onCallingMessageReceived(message: Message.Signaling, content: MessageContent.Calling) = Unit
+
+    override suspend fun startCall(
+        conversationId: ConversationId,
+        callType: CallType,
+        conversationTypeCalling: ConversationTypeCalling,
+        isAudioCbr: Boolean,
+    ) = Unit
+
+    override suspend fun answerCall(conversationId: ConversationId, isAudioCbr: Boolean, isVideoCall: Boolean) = Unit
+    override suspend fun endCall(conversationId: ConversationId) = Unit
+    override suspend fun rejectCall(conversationId: ConversationId) = Unit
+    override suspend fun muteCall(shouldMute: Boolean) = Unit
+    override suspend fun setVideoSendState(conversationId: ConversationId, videoState: VideoState) = Unit
+    override suspend fun requestVideoStreams(conversationId: ConversationId, callClients: CallClientList) = Unit
+    override suspend fun updateEpochInfo(conversationId: ConversationId, epochInfo: EpochInfo) = Unit
+    override suspend fun updateConversationClients(conversationId: ConversationId, clients: String) = Unit
+    override suspend fun reportProcessNotifications(isStarted: Boolean) = Unit
+    override suspend fun setTestVideoType(testVideoType: TestVideoType) = Unit
+    override suspend fun setTestPreviewActive(shouldEnable: Boolean) = Unit
+    override suspend fun setTestRemoteVideoStates(conversationId: ConversationId, participants: List<Participant>) = Unit
+    override suspend fun setBackground(background: Boolean) = Unit
+    override suspend fun setNetworkQualityInterval(intervalInSeconds: Int) = Unit
+    override suspend fun cancelJobs() = Unit
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8645
<!--jira-description-action-hidden-marker-end-->
## Summary
- return a no-op Apple CallManager when KaliumConfigs.enableCalling is false
- skip Apple AVS network change notifications until an enabled calling client exists
- prevents no-AVS builds from trying to create AVS handles for clients with calling disabled

## Validation
- ./gradlew detekt -Pkalium.providerCacheScope=LOCAL
- Wire TUI composite validation: ./gradlew fatJar -Pkalium.providerCacheScope=LOCAL
- Wire TUI composite validation: ./gradlew linkReleaseExecutableMacosArm64 -PUSE_UNIFIED_CORE_CRYPTO=true -Pkalium.providerCacheScope=LOCAL
- Wire TUI native smoke restored stored sessions without new AVS handle errors