### PR TITLE
fix: call updates resetting conversation paging [WPB-22834] [WPB-26730]

### DIFF
--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationExtensions.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationExtensions.kt
@@ -19,12 +19,19 @@ package com.wire.kalium.persistence.dao.conversation
 
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
+import androidx.paging.PagingSource
 import com.wire.kalium.persistence.ConversationDetailsWithEventsQueries
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.conversation.ConversationExtensions.QueryConfig
 import com.wire.kalium.persistence.dao.message.AsyncQueryPagingSource
 import com.wire.kalium.persistence.dao.message.KaliumPager
 import com.wire.kalium.persistence.db.ReadDispatcher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.dropWhile
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.onEach
 
 interface ConversationExtensions {
     fun getPagerForConversationDetailsWithEventsSearch(
@@ -39,6 +46,7 @@ interface ConversationExtensions {
         val onlyInteractionEnabled: Boolean = false,
         val newActivitiesOnTop: Boolean = false,
         val ongoingCallConversationIds: List<QualifiedIDEntity> = emptyList(),
+        val ongoingCallConversationIdsFlow: Flow<List<QualifiedIDEntity>> = flowOf(ongoingCallConversationIds),
         val conversationFilter: ConversationFilterEntity = ConversationFilterEntity.ALL,
         val strictMlsFilter: Boolean = true,
     )
@@ -53,15 +61,33 @@ internal class ConversationExtensionsImpl internal constructor(
         queryConfig: QueryConfig,
         pagingConfig: PagingConfig,
         startingOffset: Long
-    ): KaliumPager<ConversationDetailsWithEventsEntity> =
-        KaliumPager(
+    ): KaliumPager<ConversationDetailsWithEventsEntity> {
+        val ongoingCallConversationIds = MutableStateFlow(queryConfig.ongoingCallConversationIds)
+        val pagingSourceFactory = InvalidatingPagingSourceFactory {
+            pagingSource(
+                queryConfig = queryConfig,
+                initialOffset = startingOffset,
+                ongoingCallConversationIds = { ongoingCallConversationIds.value }
+            )
+        }
+        return KaliumPager(
             // We could return a Flow directly, but having the PagingSource is the only way to test this
             pager = Pager(pagingConfig) {
-                pagingSource(queryConfig, startingOffset)
+                pagingSourceFactory()
             },
-            pagingSource = pagingSource(queryConfig, startingOffset),
+            pagingSource = pagingSource(
+                queryConfig = queryConfig,
+                initialOffset = startingOffset,
+                ongoingCallConversationIds = { ongoingCallConversationIds.value }
+            ),
             readDispatcher = readDispatcher,
+            invalidateOn = queryConfig.ongoingCallConversationIdsFlow
+                .distinctUntilChanged()
+                .onEach { ongoingCallConversationIds.value = it }
+                .dropWhile { it == queryConfig.ongoingCallConversationIds },
+            invalidatePagingSource = pagingSourceFactory::invalidate
         )
+    }
 
     /**
      * Uses lightweight COUNT when `searchQuery` is empty.
@@ -74,7 +100,11 @@ internal class ConversationExtensionsImpl internal constructor(
      * - Only used when search is empty
      * - SELECT still uses full ConversationDetails rules (COUNT can be a superset)
      */
-    private fun pagingSource(queryConfig: QueryConfig, initialOffset: Long) = with(queryConfig) {
+    private fun pagingSource(
+        queryConfig: QueryConfig,
+        initialOffset: Long,
+        ongoingCallConversationIds: () -> List<QualifiedIDEntity>
+    ) = with(queryConfig) {
         AsyncQueryPagingSource(
             countQuery =
                 if (searchQuery.isBlank()) {
@@ -101,7 +131,7 @@ internal class ConversationExtensionsImpl internal constructor(
                         onlyInteractionsEnabled = onlyInteractionEnabled,
                         conversationFilter = conversationFilter.name,
                         newActivitiesOnTop = newActivitiesOnTop,
-                        ongoingCallConversationIds = ongoingCallConversationIds,
+                        ongoingCallConversationIds = ongoingCallConversationIds(),
                         limit = limit,
                         offset = offset,
                         strict_mls = if (queryConfig.strictMlsFilter) 1 else 0,
@@ -114,7 +144,7 @@ internal class ConversationExtensionsImpl internal constructor(
                         conversationFilter = conversationFilter.name,
                         searchQuery = searchQuery,
                         newActivitiesOnTop = newActivitiesOnTop,
-                        ongoingCallConversationIds = ongoingCallConversationIds,
+                        ongoingCallConversationIds = ongoingCallConversationIds(),
                         limit = limit,
                         offset = offset,
                         strict_mls = if (queryConfig.strictMlsFilter) 1 else 0,
@@ -123,5 +153,25 @@ internal class ConversationExtensionsImpl internal constructor(
                 }
             }
         )
+    }
+
+    private class InvalidatingPagingSourceFactory<Value : Any>(
+        private val pagingSourceFactory: () -> PagingSource<Int, Value>
+    ) {
+        private var currentPagingSource: PagingSource<Int, Value>? = null
+
+        operator fun invoke(): PagingSource<Int, Value> =
+            pagingSourceFactory().also { pagingSource ->
+                currentPagingSource = pagingSource
+                pagingSource.registerInvalidatedCallback {
+                    if (currentPagingSource === pagingSource) {
+                        currentPagingSource = null
+                    }
+                }
+            }
+
+        fun invalidate() {
+            currentPagingSource?.invalidate()
+        }
     }
 }

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationExtensions.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationExtensions.kt
@@ -17,9 +17,9 @@
  */
 package com.wire.kalium.persistence.dao.conversation
 
+import androidx.paging.InvalidatingPagingSourceFactory
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
-import androidx.paging.PagingSource
 import com.wire.kalium.persistence.ConversationDetailsWithEventsQueries
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.conversation.ConversationExtensions.QueryConfig
@@ -153,25 +153,5 @@ internal class ConversationExtensionsImpl internal constructor(
                 }
             }
         )
-    }
-
-    private class InvalidatingPagingSourceFactory<Value : Any>(
-        private val pagingSourceFactory: () -> PagingSource<Int, Value>
-    ) {
-        private var currentPagingSource: PagingSource<Int, Value>? = null
-
-        operator fun invoke(): PagingSource<Int, Value> =
-            pagingSourceFactory().also { pagingSource ->
-                currentPagingSource = pagingSource
-                pagingSource.registerInvalidatedCallback {
-                    if (currentPagingSource === pagingSource) {
-                        currentPagingSource = null
-                    }
-                }
-            }
-
-        fun invalidate() {
-            currentPagingSource?.invalidate()
-        }
     }
 }

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/KaliumPager.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/message/KaliumPager.kt
@@ -23,7 +23,9 @@ import androidx.paging.PagingData
 import androidx.paging.PagingSource
 import com.wire.kalium.persistence.db.ReadDispatcher
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.launch
 
 /**
  * Exposes a [pagingDataFlow] that can be used in Android UI components to display paginated data.
@@ -31,8 +33,26 @@ import kotlinx.coroutines.flow.flowOn
 class KaliumPager<EntityType : Any>(
     private val pager: Pager<Int, EntityType>,
     internal val pagingSource: PagingSource<Int, EntityType>,
-    private val readDispatcher: ReadDispatcher
+    private val readDispatcher: ReadDispatcher,
+    private val invalidateOn: Flow<*>? = null,
+    private val invalidatePagingSource: (() -> Unit)? = null,
 ) {
     val pagingDataFlow: Flow<PagingData<EntityType>>
-        get() = pager.flow.flowOn(readDispatcher.value)
+        get() {
+            val invalidationFlow = invalidateOn
+            val invalidate = invalidatePagingSource
+            return when {
+                invalidationFlow == null || invalidate == null -> pager.flow.flowOn(readDispatcher.value)
+                else -> channelFlow {
+                    val invalidationJob = launch {
+                        invalidationFlow.collect { invalidate() }
+                    }
+                    try {
+                        pager.flow.collect { send(it) }
+                    } finally {
+                        invalidationJob.cancel()
+                    }
+                }.flowOn(readDispatcher.value)
+            }
+        }
 }

--- a/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/conversation/ConversationExtensionsTest.kt
+++ b/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/conversation/ConversationExtensionsTest.kt
@@ -19,6 +19,8 @@
 package com.wire.kalium.persistence.conversation
 
 import androidx.paging.PagingConfig
+import androidx.paging.PagingDataEvent
+import androidx.paging.PagingDataPresenter
 import androidx.paging.PagingSource
 import com.wire.kalium.persistence.BaseDatabaseTest
 import com.wire.kalium.persistence.dao.ConnectionDAO
@@ -45,6 +47,10 @@ import com.wire.kalium.persistence.utils.stubs.newConversationEntity
 import com.wire.kalium.persistence.utils.stubs.newDraftMessageEntity
 import com.wire.kalium.persistence.utils.stubs.newRegularMessageEntity
 import com.wire.kalium.persistence.utils.stubs.newUserEntity
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
 import kotlin.test.AfterTest
@@ -125,6 +131,40 @@ class ConversationExtensionsTest : BaseDatabaseTest() {
             assertEquals("$CONVERSATION_ID_PREFIX$index", conversation.conversationViewEntity.id.value)
             assertEquals(false, conversation.conversationViewEntity.archived)
         }
+    }
+
+    @Test
+    fun givenOngoingCallConversationIdsChange_whenCollectingPagingData_thenReloadUsesLatestIds() = runTest(dispatcher) {
+        populateData(count = 2, isChannel = false)
+        val ongoingCallConversationIds = MutableStateFlow(emptyList<ConversationIDEntity>())
+        val pager = conversationExtensions.getPagerForConversationDetailsWithEventsSearch(
+            pagingConfig = PagingConfig(PAGE_SIZE),
+            queryConfig = ConversationExtensions.QueryConfig(
+                newActivitiesOnTop = true,
+                ongoingCallConversationIds = ongoingCallConversationIds.value,
+                ongoingCallConversationIdsFlow = ongoingCallConversationIds,
+            ),
+        )
+        var refreshCount = 0
+        val presenter = object : PagingDataPresenter<ConversationDetailsWithEventsEntity>(dispatcher) {
+            override suspend fun presentPagingDataEvent(event: PagingDataEvent<ConversationDetailsWithEventsEntity>) {
+                if (event is PagingDataEvent.Refresh) refreshCount++
+            }
+        }
+        val collectionJob = launch {
+            pager.pagingDataFlow.collectLatest(presenter::collectFrom)
+        }
+
+        advanceUntilIdle()
+        assertEquals(1, refreshCount)
+        assertEquals("${CONVERSATION_ID_PREFIX}0", presenter.snapshot().items.first().conversationViewEntity.id.value)
+
+        ongoingCallConversationIds.value = listOf(ConversationIDEntity("${CONVERSATION_ID_PREFIX}1", "domain"))
+        advanceUntilIdle()
+
+        assertEquals(2, refreshCount)
+        assertEquals("${CONVERSATION_ID_PREFIX}1", presenter.snapshot().items.first().conversationViewEntity.id.value)
+        collectionJob.cancel()
     }
 
     @Test

--- a/logic/src/androidHostTest/kotlin/com/wire/kalium/logic/feature/conversation/GetPaginatedFlowOfConversationDetailsWithEventsBySearchQueryUseCaseTest.kt
+++ b/logic/src/androidHostTest/kotlin/com/wire/kalium/logic/feature/conversation/GetPaginatedFlowOfConversationDetailsWithEventsBySearchQueryUseCaseTest.kt
@@ -65,14 +65,15 @@ internal class GetPaginatedFlowOfConversationDetailsWithEventsBySearchQueryUseCa
                         pagingConfig,
                         startingOffset,
                         false,
-                        emptyList()
+                        emptyList(),
+                        any()
                     )
             }
         }
     }
 
     @Test
-    fun givenJoinableCalls_whenGettingPaginatedList_thenCallUseCaseWithJoinableConversationIds() =
+    fun givenJoinableCalls_whenGettingPaginatedList_thenPassInitialCallIdsToRepository() =
         runTest(dispatcher.default) {
             // Given
             val joinableCallConversationId = ConversationId("joinable", "domain")
@@ -99,14 +100,15 @@ internal class GetPaginatedFlowOfConversationDetailsWithEventsBySearchQueryUseCa
                         pagingConfig,
                         startingOffset,
                         false,
-                        listOf(joinableCallConversationId)
+                        listOf(joinableCallConversationId),
+                        any()
                     )
                 }
             }
         }
 
     @Test
-    fun givenJoinableCallIdsChange_whenGettingPaginatedList_thenPagerIsRecreated() =
+    fun givenJoinableCallIdsChange_whenGettingPaginatedList_thenRepositoryPagerIsCreatedOnce() =
         runTest(dispatcher.default) {
             // Given
             val joinableCallConversationId = ConversationId("joinable", "domain")
@@ -132,64 +134,14 @@ internal class GetPaginatedFlowOfConversationDetailsWithEventsBySearchQueryUseCa
                 // Then
                 verifySuspend(VerifyMode.exactly(1)) {
                     conversationRepository.extensions.getPaginatedConversationDetailsWithEventsBySearchQuery(
-                        queryConfig,
-                        pagingConfig,
-                        startingOffset,
-                        false,
-                        emptyList()
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any()
                     )
                 }
-                verifySuspend(VerifyMode.exactly(1)) {
-                    conversationRepository.extensions.getPaginatedConversationDetailsWithEventsBySearchQuery(
-                        queryConfig,
-                        pagingConfig,
-                        startingOffset,
-                        false,
-                        listOf(joinableCallConversationId)
-                    )
-                }
-            }
-        }
-
-    @Test
-    fun givenSameJoinableCallIdsInDifferentOrder_whenGettingPaginatedList_thenPagerIsNotRecreated() =
-        runTest(dispatcher.default) {
-            // Given
-            val firstJoinableCallConversationId = ConversationId("joinable-1", "domain")
-            val secondJoinableCallConversationId = ConversationId("joinable-2", "domain")
-            val (arrangement, useCase) = Arrangement()
-                .withJoinableCallsFlow(
-                    flowOf(
-                        linkedMapOf(
-                            firstJoinableCallConversationId to TestCall.groupIncomingCall(firstJoinableCallConversationId),
-                            secondJoinableCallConversationId to TestCall.groupIncomingCall(secondJoinableCallConversationId)
-                        ),
-                        linkedMapOf(
-                            secondJoinableCallConversationId to TestCall.groupIncomingCall(secondJoinableCallConversationId),
-                            firstJoinableCallConversationId to TestCall.groupIncomingCall(firstJoinableCallConversationId)
-                        )
-                    )
-                )
-                .withPaginatedConversationResult(flowOf(PagingData.empty()))
-                .arrange()
-
-            // When
-            useCase(
-                queryConfig = arrangement.queryConfig,
-                pagingConfig = arrangement.pagingConfig,
-                startingOffset = arrangement.startingOffset,
-                strictMlsFilter = false
-            ).toList()
-
-            // Then
-            verifySuspend(VerifyMode.exactly(1)) {
-                arrangement.conversationRepository.extensions.getPaginatedConversationDetailsWithEventsBySearchQuery(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any()
-                )
             }
         }
 
@@ -220,6 +172,7 @@ internal class GetPaginatedFlowOfConversationDetailsWithEventsBySearchQueryUseCa
         suspend fun withPaginatedConversationResult(result: Flow<PagingData<ConversationDetailsWithEvents>>) = apply {
             everySuspend {
                 conversationRepositoryExtensions.getPaginatedConversationDetailsWithEventsBySearchQuery(
+                    any(),
                     any(),
                     any(),
                     any(),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryExtensions.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryExtensions.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.persistence.dao.message.KaliumPager
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.toDao
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 
 internal interface ConversationRepositoryExtensions {
@@ -36,6 +37,7 @@ internal interface ConversationRepositoryExtensions {
         startingOffset: Long,
         strictMlsFilter: Boolean,
         ongoingCallConversationIds: List<ConversationId> = emptyList(),
+        ongoingCallConversationIdsFlow: Flow<List<ConversationId>> = flowOf(ongoingCallConversationIds),
     ): Flow<PagingData<ConversationDetailsWithEvents>>
 }
 
@@ -49,6 +51,7 @@ internal class ConversationRepositoryExtensionsImpl internal constructor(
         startingOffset: Long,
         strictMlsFilter: Boolean,
         ongoingCallConversationIds: List<ConversationId>,
+        ongoingCallConversationIdsFlow: Flow<List<ConversationId>>,
     ): Flow<PagingData<ConversationDetailsWithEvents>> {
         val pager: KaliumPager<ConversationDetailsWithEventsEntity> = with(queryConfig) {
             conversationDAO.platformExtensions.getPagerForConversationDetailsWithEventsSearch(
@@ -58,6 +61,7 @@ internal class ConversationRepositoryExtensionsImpl internal constructor(
                     onlyInteractionEnabled = onlyInteractionEnabled,
                     newActivitiesOnTop = newActivitiesOnTop,
                     ongoingCallConversationIds = ongoingCallConversationIds.map { it.toDao() },
+                    ongoingCallConversationIdsFlow = ongoingCallConversationIdsFlow.map { ids -> ids.map { it.toDao() } },
                     conversationFilter = conversationFilter.toDao(),
                     strictMlsFilter = strictMlsFilter
                 ),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetPaginatedFlowOfConversationDetailsWithEventsBySearchQueryUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetPaginatedFlowOfConversationDetailsWithEventsBySearchQueryUseCase.kt
@@ -24,10 +24,9 @@ import com.wire.kalium.logic.data.conversation.ConversationDetailsWithEvents
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.ConversationQueryConfig
 import com.wire.kalium.util.KaliumDispatcher
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 
@@ -42,24 +41,26 @@ public class GetPaginatedFlowOfConversationDetailsWithEventsBySearchQueryUseCase
     private val conversationRepository: ConversationRepository,
     private val callRepository: CallRepository,
 ) {
-    @OptIn(ExperimentalCoroutinesApi::class)
     public suspend operator fun invoke(
         queryConfig: ConversationQueryConfig,
         pagingConfig: PagingConfig,
         startingOffset: Long,
         strictMlsFilter: Boolean
-    ): Flow<PagingData<ConversationDetailsWithEvents>> = callRepository.joinableCallsByConversationIdFlow()
-        .map { joinableCallsByConversationId -> joinableCallsByConversationId.keys }
-        .distinctUntilChanged()
-        .flatMapLatest { joinableCallConversationIds ->
-            conversationRepository.extensions
-                .getPaginatedConversationDetailsWithEventsBySearchQuery(
-                    queryConfig = queryConfig,
-                    pagingConfig = pagingConfig,
-                    startingOffset = startingOffset,
-                    strictMlsFilter = strictMlsFilter,
-                    ongoingCallConversationIds = joinableCallConversationIds.toList()
-                )
-        }
-        .flowOn(dispatcher.io)
+    ): Flow<PagingData<ConversationDetailsWithEvents>> {
+        val joinableCallConversationIdsFlow = callRepository.joinableCallsByConversationIdFlow()
+            .map { joinableCallsByConversationId -> joinableCallsByConversationId.keys.toSet() }
+            .distinctUntilChanged()
+            .map { joinableCallConversationIds -> joinableCallConversationIds.toList() }
+        val initialJoinableCallConversationIds = joinableCallConversationIdsFlow.first()
+
+        return conversationRepository.extensions.getPaginatedConversationDetailsWithEventsBySearchQuery(
+            queryConfig = queryConfig,
+            pagingConfig = pagingConfig,
+            startingOffset = startingOffset,
+            strictMlsFilter = strictMlsFilter,
+            ongoingCallConversationIds = initialJoinableCallConversationIds,
+            ongoingCallConversationIdsFlow = joinableCallConversationIdsFlow
+        )
+            .flowOn(dispatcher.io)
+    }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-22834
<!--jira-description-action-hidden-marker-end-->
update conversation list pagination so call status changes refresh the
current paging source instead of recreating the whole Pager.

Previously, joinable-call changes could cause the use case to emit a new Pager,
which risked disrupting scroll position and paging state. Removing the call flow
entirely would keep the Pager stable, but would also make the conversation list
stale when new calls started or ended.

The new approach keeps one Pager for the current query/filter and passes the
ongoing-call ID flow into the paging layer. When that flow emits a new value, the
active PagingSource is invalidated and the next load reads the latest call IDs.

## Changes

- Added optional invalidation support to `KaliumPager`.
- Passed `ongoingCallConversationIdsFlow` through repository extensions into DAO paging config.
- Updated conversation paging source creation to read latest ongoing-call IDs on invalidation.
- Removed Pager recreation on call status changes from the search pagination use case.
- Added/updated tests for initial call IDs and call-flow updates.