### PR TITLE
fix: persist database keys durably [WPB-26997]

### DIFF
--- a/data/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
+++ b/data/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmmSettings/EncryptedSettingsHolder.kt
@@ -37,13 +37,17 @@ private val lock = Object()
 internal actual fun buildSettings(
     options: SettingOptions,
     param: EncryptedSettingsPlatformParam
-): Settings = synchronized(lock) {
-    val settings = if (options.shouldEncryptData) {
+): Settings = SharedPreferencesSettings(buildSharedPreferences(options, param), false)
+
+internal fun buildSharedPreferences(
+    options: SettingOptions,
+    param: EncryptedSettingsPlatformParam
+): SharedPreferences = synchronized(lock) {
+    if (options.shouldEncryptData) {
         encryptedSharedPref(options, param, false)
     } else {
         param.appContext.getSharedPreferences(options.fileName, Context.MODE_PRIVATE)
     }
-    SharedPreferencesSettings(settings, false)
 }
 
 private fun getOrCreateMasterKey(

--- a/data/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmmSettings/GlobalPrefProvider.kt
+++ b/data/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/kmmSettings/GlobalPrefProvider.kt
@@ -25,17 +25,27 @@ import com.wire.kalium.persistence.client.TokenStorage
 import com.wire.kalium.persistence.client.TokenStorageImpl
 import com.wire.kalium.persistence.dbPassphrase.PassphraseStorage
 import com.wire.kalium.persistence.dbPassphrase.PassphraseStorageImpl
+import com.russhwolf.settings.SharedPreferencesSettings
 
 actual class GlobalPrefProvider(context: Context, shouldEncryptData: Boolean = true) {
 
+    private val settingsOptions = SettingOptions.AppSettings(shouldEncryptData)
+    private val platformParam = EncryptedSettingsPlatformParam(context)
+    private val encryptedSharedPreferences = buildSharedPreferences(settingsOptions, platformParam)
+
     private val encryptedSettingsHolder: KaliumPreferences = KaliumPreferencesSettings(
-        buildSettings(SettingOptions.AppSettings(shouldEncryptData), EncryptedSettingsPlatformParam(context))
+        SharedPreferencesSettings(encryptedSharedPreferences, commit = false)
+    )
+
+    // Database creation/rekey must not commit before its key alias has reached durable storage.
+    private val durablePassphraseSettingsHolder: KaliumPreferences = KaliumPreferencesSettings(
+        SharedPreferencesSettings(encryptedSharedPreferences, commit = true)
     )
 
     actual val authTokenStorage: AuthTokenStorage
         get() = AuthTokenStorageImpl(encryptedSettingsHolder)
     actual val passphraseStorage: PassphraseStorage
-        get() = PassphraseStorageImpl(encryptedSettingsHolder)
+        get() = PassphraseStorageImpl(durablePassphraseSettingsHolder)
     actual val tokenStorage: TokenStorage
         get() = TokenStorageImpl(encryptedSettingsHolder)
 }

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/util/DatabaseKeyLock.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/util/DatabaseKeyLock.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.util
+
+/** Serializes database-key state transitions across SDK instances in this process. */
+internal object DatabaseKeyLock {
+    private val monitor = Any()
+
+    fun <T> withLock(block: () -> T): T = synchronized(monitor, block)
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26997
<!--jira-description-action-hidden-marker-end-->
## Summary

- reuse one encrypted `SharedPreferences` delegate for all global settings views
- use synchronous commits only for database passphrase writes that must be durable before database creation or rekey
- serialize multi-step database-key state transitions within the process

## Stack

1. **This PR:** durable database-key storage infrastructure
2. Raw SQLCipher V2 keys for new user databases
3. Eager global database migration to a fresh raw V2 key
