### PR TITLE
feat: migrate global database to a raw SQLCipher key [WPB-27002]

### DIFF
--- a/data/persistence/src/androidDeviceTest/kotlin/com/wire/kalium/persistence/db/support/GlobalDatabaseRawKeyMigrationTest.kt
+++ b/data/persistence/src/androidDeviceTest/kotlin/com/wire/kalium/persistence/db/support/GlobalDatabaseRawKeyMigrationTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.persistence.db.support
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import net.zetetic.database.sqlcipher.SQLiteDatabase
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class GlobalDatabaseRawKeyMigrationTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val databaseFile: File
+        get() = context.getDatabasePath(DATABASE_NAME)
+
+    @BeforeTest
+    fun setUp() {
+        System.loadLibrary("sqlcipher")
+        deleteDatabase()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        deleteDatabase()
+    }
+
+    @Test
+    fun given32ByteSecret_whenConvertingToRawKey_thenSqlCipherBlobFormatIsReturned() {
+        val rawKey = SECRET.toSqlCipherRawKey()
+
+        assertEquals(67, rawKey.size)
+        assertEquals(
+            "x'000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'",
+            rawKey.decodeToString()
+        )
+    }
+
+    @Test
+    fun givenHistoricalGlobalKey_whenMigrating_thenDatabaseUsesFreshRawKey() {
+        val rawKey = V2_SECRET.toSqlCipherRawKey()
+        var migrationCompleted = false
+        createDatabase(HISTORICAL_V1_SECRET)
+
+        assertContentEquals(
+            rawKey,
+            globalDatabaseKey(databaseFile, HISTORICAL_V1_SECRET, rawKey) { migrationCompleted = true }
+        )
+        assertTrue(migrationCompleted)
+        assertTrue(canOpenDatabase(databaseFile, rawKey, verifyIntegrity = true))
+        assertFalse(canOpenDatabase(databaseFile, HISTORICAL_V1_SECRET))
+    }
+
+    @Test
+    fun givenRekeyCompletedBeforeV2AliasWasStored_whenMigratingAgain_thenRawKeyIsRecovered() {
+        val rawKey = V2_SECRET.toSqlCipherRawKey()
+        var migrationCompleted = false
+        createDatabase(rawKey)
+
+        assertContentEquals(
+            rawKey,
+            globalDatabaseKey(databaseFile, HISTORICAL_V1_SECRET, rawKey) { migrationCompleted = true }
+        )
+        assertTrue(migrationCompleted)
+        assertTrue(canOpenDatabase(databaseFile, rawKey, verifyIntegrity = true))
+    }
+
+    private fun createDatabase(key: ByteArray) {
+        databaseFile.parentFile?.mkdirs()
+        val database = SQLiteDatabase.openDatabase(
+            databaseFile.absolutePath,
+            key,
+            null,
+            SQLiteDatabase.CREATE_IF_NECESSARY,
+            null
+        )
+        try {
+            database.execSQL("CREATE TABLE migration_test(id INTEGER PRIMARY KEY)")
+        } finally {
+            database.close()
+        }
+    }
+
+    private fun deleteDatabase() {
+        context.deleteDatabase(DATABASE_NAME)
+    }
+
+    private companion object {
+        const val DATABASE_NAME = "sqlcipher-global-key-test.db"
+        val SECRET = ByteArray(32) { index -> index.toByte() }
+        val V2_SECRET = ByteArray(32) { index -> (index + 1).toByte() }
+        val HISTORICAL_V1_SECRET = "historical-v1-secret".encodeToByteArray()
+    }
+}

--- a/data/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/GlobalDatabase.kt
+++ b/data/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/GlobalDatabase.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.persistence.db
 
 import app.cash.sqldelight.async.coroutines.synchronous
 import com.wire.kalium.persistence.GlobalDatabase
+import com.wire.kalium.persistence.db.support.globalDatabaseKey
 import com.wire.kalium.persistence.util.FileNameUtil
 import kotlinx.coroutines.CoroutineDispatcher
 
@@ -31,10 +32,21 @@ actual fun globalDatabaseProvider(
 ): GlobalDatabaseBuilder {
     val schema = GlobalDatabase.Schema.synchronous()
     val dbName = FileNameUtil.globalDBName()
+    if (passphrase != null) {
+        System.loadLibrary("sqlcipher")
+    }
+    val databaseKey = passphrase?.value?.let {
+        globalDatabaseKey(
+            databaseFile = platformDatabaseData.context.getDatabasePath(dbName),
+            secret = it,
+            migrationRawKey = platformDatabaseData.globalDatabaseMigrationRawKey,
+            onMigrationComplete = platformDatabaseData.onGlobalDatabaseMigratedToRawKey
+        )
+    }
     val driver = databaseDriver(
         platformDatabaseData.context,
         dbName,
-        passphrase?.value,
+        databaseKey,
         schema
     ) {
         isWALEnabled = enableWAL

--- a/data/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/PlatformDatabaseData.kt
+++ b/data/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/PlatformDatabaseData.kt
@@ -31,7 +31,9 @@ import com.wire.kalium.persistence.db.support.SupportOpenHelperFactory
  * in the future like [nuke]
  */
 actual class PlatformDatabaseData(
-    val context: Context
+    val context: Context,
+    internal val globalDatabaseMigrationRawKey: ByteArray? = null,
+    internal val onGlobalDatabaseMigratedToRawKey: () -> Unit = {}
 )
 
 @Suppress("LongParameterList")

--- a/data/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/support/SqlCipherKey.kt
+++ b/data/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/support/SqlCipherKey.kt
@@ -1,0 +1,161 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.persistence.db.support
+
+import android.database.sqlite.SQLiteException
+import com.wire.kalium.persistence.kaliumLogger
+import net.zetetic.database.sqlcipher.SQLiteDatabase
+import java.io.File
+
+private const val SQLCIPHER_RAW_KEY_BYTES = 32
+private const val SQLCIPHER_RAW_KEY_PAYLOAD_BYTES = 67
+private const val RAW_KEY_PREFIX_LENGTH = 2
+private const val HEX_CHARS_PER_BYTE = 2
+private const val NIBBLE_BITS = 4
+private const val LOW_NIBBLE_MASK = 0x0F
+private const val UNSIGNED_BYTE_MASK = 0xFF
+private val hexDigits = "0123456789abcdef".encodeToByteArray()
+
+/**
+ * Converts 32 bytes of random key material to SQLCipher's raw-key BLOB representation.
+ *
+ * The returned payload is `x'<64 hex characters>'`. SQLCipher uses those 32 bytes directly
+ * instead of applying its password KDF.
+ */
+internal fun ByteArray.toSqlCipherRawKey(): ByteArray {
+    require(size == SQLCIPHER_RAW_KEY_BYTES) {
+        "SQLCipher raw keys must contain exactly $SQLCIPHER_RAW_KEY_BYTES bytes"
+    }
+
+    return ByteArray(SQLCIPHER_RAW_KEY_PAYLOAD_BYTES).also { result ->
+        result[0] = 'x'.code.toByte()
+        result[1] = '\''.code.toByte()
+        forEachIndexed { index, byte ->
+        val unsignedByte = byte.toInt() and UNSIGNED_BYTE_MASK
+        result[RAW_KEY_PREFIX_LENGTH + index * HEX_CHARS_PER_BYTE] = hexDigits[unsignedByte ushr NIBBLE_BITS]
+        result[RAW_KEY_PREFIX_LENGTH + index * HEX_CHARS_PER_BYTE + 1] = hexDigits[unsignedByte and LOW_NIBBLE_MASK]
+        }
+        result[result.lastIndex] = '\''.code.toByte()
+    }
+}
+
+/**
+ * Selects the key representation for the global database and eagerly rekeys a legacy database.
+ *
+ * If migration fails but the legacy database is still readable, availability wins and the legacy
+ * representation is returned. A later process start will retry the migration.
+ */
+@Suppress("TooGenericExceptionCaught")
+internal fun globalDatabaseKey(
+    databaseFile: File,
+    secret: ByteArray,
+    migrationRawKey: ByteArray?,
+    onMigrationComplete: () -> Unit
+): ByteArray {
+    if (migrationRawKey == null || !databaseFile.exists()) return secret
+
+    val selectedKey = try {
+        rekeyDatabase(databaseFile, secret, migrationRawKey)
+        check(canOpenDatabase(databaseFile, migrationRawKey, verifyIntegrity = true)) {
+            "Global database could not be validated after raw-key migration"
+        }
+        onMigrationComplete()
+        migrationRawKey
+    } catch (migrationFailure: RuntimeException) {
+        when {
+            canOpenDatabase(databaseFile, migrationRawKey, verifyIntegrity = true) -> {
+                onMigrationComplete()
+                migrationRawKey
+            }
+
+            canOpenDatabase(databaseFile, secret) -> {
+                val message = "Failed to migrate the global database to a SQLCipher raw key; continuing with its legacy key"
+                kaliumLogger.w(message, migrationFailure)
+                secret
+            }
+
+            else -> throw migrationFailure
+        }
+    }
+    return selectedKey
+}
+
+private fun rekeyDatabase(databaseFile: File, legacyKey: ByteArray, rawKey: ByteArray) {
+    val database = SQLiteDatabase.openDatabase(
+        databaseFile.absolutePath,
+        legacyKey,
+        null,
+        SQLiteDatabase.OPEN_READWRITE,
+        null
+    )
+    try {
+        database.rawQuery("PRAGMA wal_checkpoint(TRUNCATE)", emptyArray()).use { cursor ->
+            check(cursor.moveToFirst() && cursor.getInt(0) == 0) {
+                "Could not checkpoint the global database before raw-key migration"
+            }
+        }
+        database.rawQuery("PRAGMA journal_mode=DELETE", emptyArray()).use { cursor ->
+            check(cursor.moveToFirst() && cursor.getString(0).equals("delete", ignoreCase = true)) {
+                "Could not leave WAL mode before global database raw-key migration"
+            }
+        }
+        database.changePassword(rawKey)
+    } finally {
+        database.close()
+    }
+}
+
+internal fun canOpenDatabase(
+    databaseFile: File,
+    key: ByteArray,
+    verifyIntegrity: Boolean = false
+): Boolean {
+    var database: SQLiteDatabase? = null
+    return try {
+        database = SQLiteDatabase.openDatabase(
+            databaseFile.absolutePath,
+            key,
+            null,
+            SQLiteDatabase.OPEN_READWRITE,
+            null
+        )
+        hasReadableSchema(database) &&
+                hasActiveCipher(database) &&
+                (!verifyIntegrity || hasValidCipherIntegrity(database))
+    } catch (_: SQLiteException) {
+        false
+    } finally {
+        database?.close()
+    }
+}
+
+private fun hasReadableSchema(database: SQLiteDatabase): Boolean =
+    database.rawQuery("SELECT COUNT(*) FROM sqlite_schema", emptyArray()).use { cursor ->
+        cursor.moveToFirst()
+    }
+
+private fun hasActiveCipher(database: SQLiteDatabase): Boolean =
+    database.rawQuery("PRAGMA cipher_status", emptyArray()).use { cursor ->
+        cursor.moveToFirst() && cursor.getInt(0) == 1
+    }
+
+private fun hasValidCipherIntegrity(database: SQLiteDatabase): Boolean =
+    database.rawQuery("PRAGMA cipher_integrity_check", emptyArray()).use { cursor ->
+        !cursor.moveToFirst()
+    }

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/CoreLogic.kt
@@ -32,12 +32,14 @@ import com.wire.kalium.logic.network.NetworkStateObserverImpl
 import com.wire.kalium.logic.sync.WorkSchedulerProvider
 import com.wire.kalium.logic.sync.WorkSchedulerProviderImpl
 import com.wire.kalium.logic.util.PlatformContext
+import com.wire.kalium.logic.util.DatabaseKeyLock
 import com.wire.kalium.logic.util.SecurityHelperImpl
 import com.wire.kalium.network.NetworkStateObserver
 import com.wire.kalium.persistence.db.GlobalDatabaseBuilder
 import com.wire.kalium.persistence.db.PlatformDatabaseData
 import com.wire.kalium.persistence.db.globalDatabaseProvider
 import com.wire.kalium.persistence.kmmSettings.GlobalPrefProvider
+import com.wire.kalium.persistence.util.FileNameUtil
 import com.wire.kalium.usernetwork.di.PlatformUserAuthenticatedNetworkProvider
 import com.wire.kalium.usernetwork.di.UserAuthenticatedNetworkProvider
 import com.wire.kalium.util.KaliumDispatcherImpl
@@ -60,14 +62,27 @@ public actual class CoreLogic(
         kaliumConfigs.shouldEncryptData()
     )
 
+    private val securityHelper = SecurityHelperImpl(globalPreferences.passphraseStorage)
+    private val globalDBKeyMaterial = if (kaliumConfigs.shouldEncryptData()) {
+        DatabaseKeyLock.withLock {
+            securityHelper.globalDBKeyMaterial(
+                databaseExists = appContext.getDatabasePath(FileNameUtil.globalDBName()).exists()
+            )
+        }
+    } else {
+        null
+    }
+
     actual override val globalDatabaseBuilder: GlobalDatabaseBuilder = globalDatabaseProvider(
-        platformDatabaseData = PlatformDatabaseData(appContext),
+        platformDatabaseData = PlatformDatabaseData(
+            context = appContext,
+            globalDatabaseMigrationRawKey = globalDBKeyMaterial?.migrationRawKey,
+            onGlobalDatabaseMigratedToRawKey = {
+                DatabaseKeyLock.withLock(securityHelper::markGlobalDBSecretAsV2)
+            }
+        ),
         queriesContext = KaliumDispatcherImpl.io,
-        passphrase = if (kaliumConfigs.shouldEncryptData()) {
-            SecurityHelperImpl(globalPreferences.passphraseStorage).globalDBSecret()
-        } else {
-            null
-        },
+        passphrase = globalDBKeyMaterial?.currentSecret,
         enableWAL = true
     )
 


### PR DESCRIPTION
## Summary

- eagerly rekey the small global database from its legacy V1 password to a fresh 32-byte raw V2 key
- checkpoint and leave WAL mode before rekeying
- validate the migrated database before promoting the pending V2 alias
- recover safely if the process stops after rekeying but before alias promotion, while retaining the legacy key when migration fails before rekey
- cover migration and recovery with Android device tests

## Stack

1. [Durable database-key storage infrastructure](https://github.com/wireapp/kalium/pull/4281)
2. [Raw SQLCipher V2 keys for new user databases](https://github.com/wireapp/kalium/pull/4282)
3. **This PR:** eager global database migration to a fresh raw V2 key

Existing user databases remain on V1; their migration is deferred.
