### PR TITLE
fix(sync): skip stale protocol events [WPB-27064]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ProtocolUpdateEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ProtocolUpdateEventHandler.kt
@@ -19,7 +19,9 @@
 package com.wire.kalium.logic.sync.receiver.conversation
 
 import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.flatMapLeft
 import com.wire.kalium.common.functional.map
 import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.common.functional.onSuccess
@@ -32,6 +34,8 @@ import com.wire.kalium.logic.data.conversation.UpdateConversationProtocolUseCase
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.message.SystemMessageInserter
 import com.wire.kalium.logic.util.createEventProcessingLogger
+import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.network.exceptions.isConversationNotFound
 import kotlinx.coroutines.flow.first
 
 internal interface ProtocolUpdateEventHandler {
@@ -55,6 +59,14 @@ internal class ProtocolUpdateEventHandlerImpl(
     ): Either<CoreFailure, Unit> {
         val eventLogger = logger.createEventProcessingLogger(event)
         return updateConversationProtocol(transactionContext, event.conversationId, event.protocol, localOnly = true)
+            .flatMapLeft { failure ->
+                if (failure.isNoConversationFailure()) {
+                    logger.i("Ignoring protocol update event for a deleted conversation")
+                    Either.Right(false)
+                } else {
+                    Either.Left(failure)
+                }
+            }
             .onSuccess { updated ->
                 if (updated) {
                     systemMessageInserter.insertProtocolChangedSystemMessage(
@@ -77,3 +89,7 @@ internal class ProtocolUpdateEventHandlerImpl(
             .map { }
     }
 }
+
+private fun CoreFailure.isNoConversationFailure(): Boolean =
+    ((this as? NetworkFailure.ServerMiscommunication)?.kaliumException as? KaliumException.InvalidRequestError)
+        ?.isConversationNotFound() == true

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ProtocolUpdateEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ProtocolUpdateEventHandlerTest.kt
@@ -26,6 +26,7 @@ import com.wire.kalium.logic.data.message.SystemMessageInserter
 import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.logic.sync.receiver.conversation.ProtocolUpdateEventHandler
 import com.wire.kalium.logic.sync.receiver.conversation.ProtocolUpdateEventHandlerImpl
+import com.wire.kalium.logic.test_util.TestNetworkException
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMokkeryImpl
 import com.wire.kalium.logic.util.shouldFail
@@ -108,6 +109,36 @@ class ProtocolUpdateEventHandlerTest {
 
         verifySuspend(VerifyMode.exactly(1)) {
             arrangement.updateConversationProtocol(any(), eq(event.conversationId), eq(event.protocol), eq(true))
+        }
+    }
+
+    @Test
+    fun givenStaleProtocolEventForDeletedConversation_whenBackendReturnsNoConversation_thenEventIsSkipped() = runTest {
+        val event = TestEvent.newConversationProtocolEvent()
+        val failure = NetworkFailure.ServerMiscommunication(TestNetworkException.noConversation)
+
+        val (arrangement, useCase) = arrange {
+            withUpdateProtocolUpdateReturns(Either.Left(failure))
+        }
+
+        useCase.handle(arrangement.transactionContext, event).shouldSucceed()
+
+        verifySuspend(VerifyMode.not) {
+            arrangement.systemMessageInserter.insertProtocolChangedSystemMessage(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun givenProtocolEvent_whenBackendReturnsOtherServerError_thenErrorIsPropagated() = runTest {
+        val event = TestEvent.newConversationProtocolEvent()
+        val failure = NetworkFailure.ServerMiscommunication(TestNetworkException.generic)
+
+        val (arrangement, useCase) = arrange {
+            withUpdateProtocolUpdateReturns(Either.Left(failure))
+        }
+
+        useCase.handle(arrangement.transactionContext, event).shouldFail {
+            assertEquals(failure, it)
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-27064
<!--jira-description-action-hidden-marker-end-->
## Intent

Prevent incremental sync from repeatedly failing when it replays a protocol update for a conversation that has already been deleted.

## Root cause

Protocol update events refresh conversation details before updating the local protocol. When an offline client replays an old event after the conversation was deleted, the backend returns `404 no-conversation`. The handler propagated that terminal response, causing the entire pending-event batch to fail and replay indefinitely.

## Reproduction

1. Keep a client offline while another client creates and migrates a conversation to MLS.
2. Delete the conversation before the offline client resumes.
3. Resume the offline client and process its pending protocol update events.
4. Observe `no-conversation` aborting incremental sync and the same event batch retrying.

## Change

Treat only `no-conversation` responses as a successfully consumed protocol event. Do not insert a protocol-change system message for the skipped event. All other failures continue to propagate.

## Test coverage

Regression coverage verifies that deleted-conversation protocol events are skipped and unrelated server failures remain retryable.
