### PR TITLE
fix(sync): handle stale connection events [WPB-27079]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.logic.sync.receiver
 
 import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
@@ -49,6 +50,8 @@ import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldHandler
 import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldRequestHandler
 import com.wire.kalium.logic.util.EventLoggingStatus
 import com.wire.kalium.logic.util.createEventProcessingLogger
+import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.network.exceptions.isNotFound
 import kotlin.time.Duration.Companion.ZERO
 import kotlin.time.Duration.Companion.seconds
 
@@ -115,6 +118,14 @@ internal class UserEventReceiverImpl internal constructor(
     ): Either<CoreFailure, Unit> {
         val logger = kaliumLogger.createEventProcessingLogger(event)
         return userRepository.fetchUserInfo(event.connection.qualifiedToId)
+            .flatMapLeft { failure ->
+                if (failure.isUserNotFoundFailure()) {
+                    kaliumLogger.w("Ignoring missing user details while processing a connection event")
+                    Either.Right(Unit)
+                } else {
+                    Either.Left(failure)
+                }
+            }
             .flatMap {
                 val previousStatus = connectionRepository.getConnection(event.connection.qualifiedConversationId)
                     .map { it.connection.status }.getOrNull()
@@ -199,3 +210,7 @@ internal class UserEventReceiverImpl internal constructor(
             .onFailure { logger.logFailure(it) }
     }
 }
+
+private fun CoreFailure.isUserNotFoundFailure(): Boolean =
+    ((this as? NetworkFailure.ServerMiscommunication)?.kaliumException as? KaliumException.InvalidRequestError)
+        ?.isNotFound() == true

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiverTest.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.logic.sync.receiver
 
 import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.client.ClientRepository
@@ -40,6 +41,7 @@ import com.wire.kalium.logic.sync.receiver.handler.SessionRefreshSuggestedEventH
 import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldHandler
 import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldRequestHandler
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
+import com.wire.kalium.logic.test_util.TestNetworkException
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMokkeryImpl
 import dev.mokkery.answering.returns
@@ -221,6 +223,39 @@ class UserEventReceiverTest {
         eventReceiver.onEvent(arrangement.transactionContext, event, TestEvent.liveDeliveryInfo)
 
         verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.connectionRepository.insertConnectionFromEvent(any(), any())
+        }
+    }
+
+    @Test
+    fun givenStaleNewConnectionEvent_whenUserDetailsReturnNotFound_thenConnectionIsPersisted() = runTest {
+        val event = TestEvent.newConnection(status = ConnectionState.PENDING)
+        val failure = NetworkFailure.ServerMiscommunication(TestNetworkException.notFound)
+        val (arrangement, eventReceiver) = arrange {
+            withFetchUserInfoReturning(Either.Left(failure))
+            withInsertConnectionFromEventSucceeding()
+        }
+
+        val result = eventReceiver.onEvent(arrangement.transactionContext, event, TestEvent.nonLiveDeliveryInfo)
+
+        assertIs<Either.Right<Unit>>(result)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.connectionRepository.insertConnectionFromEvent(any(), eq(event))
+        }
+    }
+
+    @Test
+    fun givenNewConnectionEvent_whenFetchingUserDetailsFails_thenFailureIsPropagated() = runTest {
+        val event = TestEvent.newConnection(status = ConnectionState.PENDING)
+        val failure = NetworkFailure.ServerMiscommunication(TestNetworkException.generic)
+        val (arrangement, eventReceiver) = arrange {
+            withFetchUserInfoReturning(Either.Left(failure))
+        }
+
+        val result = eventReceiver.onEvent(arrangement.transactionContext, event, TestEvent.nonLiveDeliveryInfo)
+
+        assertIs<Either.Left<NetworkFailure.ServerMiscommunication>>(result)
+        verifySuspend(VerifyMode.not) {
             arrangement.connectionRepository.insertConnectionFromEvent(any(), any())
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-27079
<!--jira-description-action-hidden-marker-end-->
## Intent

Allow incremental sync to consume stale connection events when the referenced user is no longer available.

## Root cause

`User.NewConnection` fetches current user details before persisting the connection state embedded in the event. If an offline client replays the event after that user becomes unavailable, the terminal 404 is propagated and the pending-event batch retries indefinitely.

## Reproduction

1. Keep a client offline while it receives a connection event.
2. Make the referenced user unavailable before the client resumes.
3. Resume the client and replay pending events.
4. Observe the user-details 404 preventing the embedded connection state from being persisted.

## Change

Continue processing the connection event when the user-details request returns 404. The user repository already persists an incomplete user placeholder for failed lookups, so the connection state can be stored safely. Other failures continue to propagate.

## Test coverage

Regression coverage verifies that a 404 still persists the connection event and that unrelated server errors remain retryable.
