### PR TITLE
fix(sync): skip failed stale session refresh events [WPB-27080]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiver.kt
@@ -83,7 +83,7 @@ internal class UserEventReceiverImpl internal constructor(
             is Event.User.LegalHoldRequest -> legalHoldRequestHandler.handle(event)
             is Event.User.LegalHoldEnabled -> legalHoldHandler.handleEnable(event)
             is Event.User.LegalHoldDisabled -> legalHoldHandler.handleDisable(event)
-            is Event.User.SessionRefreshSuggested -> handleSessionRefreshSuggested(event)
+            is Event.User.SessionRefreshSuggested -> handleSessionRefreshSuggested(event, deliveryInfo)
         }
     }
 
@@ -192,10 +192,21 @@ internal class UserEventReceiverImpl internal constructor(
         }
     }
 
-    private suspend fun handleSessionRefreshSuggested(event: Event.User.SessionRefreshSuggested): Either<CoreFailure, Unit> {
+    private suspend fun handleSessionRefreshSuggested(
+        event: Event.User.SessionRefreshSuggested,
+        deliveryInfo: EventDeliveryInfo
+    ): Either<CoreFailure, Unit> {
         val logger = kaliumLogger.createEventProcessingLogger(event)
         return sessionRefreshSuggestedEventHandler.handle(event)
             .onSuccess { logger.logSuccess() }
-            .onFailure { logger.logFailure(it) }
+            .onFailure {
+                logger.logComplete(
+                    if (deliveryInfo.source == EventSource.PENDING) EventLoggingStatus.SKIPPED else EventLoggingStatus.FAILURE,
+                    arrayOf("errorInfo" to it)
+                )
+            }
+            .flatMapLeft {
+                if (deliveryInfo.source == EventSource.PENDING) Either.Right(Unit) else Either.Left(it)
+            }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserEventReceiverTest.kt
@@ -210,6 +210,19 @@ class UserEventReceiverTest {
     }
 
     @Test
+    fun givenPendingSessionRefreshSuggestedEvent_whenRefreshFails_thenEventIsSkipped() = runTest {
+        val event = TestEvent.sessionRefreshSuggested(EVENT_ID)
+        val failure = StorageFailure.Generic(Throwable("refresh failed"))
+        val (arrangement, eventReceiver) = arrange {
+            withSessionRefreshSuggestedHandlerResult(Either.Left(failure))
+        }
+
+        val result = eventReceiver.onEvent(arrangement.transactionContext, event, TestEvent.nonLiveDeliveryInfo)
+
+        assertIs<Either.Right<Unit>>(result)
+    }
+
+    @Test
     fun givenNewConnectionEvent_thenConnectionIsPersisted() = runTest {
         val event = TestEvent.newConnection(status = ConnectionState.PENDING)
         val (arrangement, eventReceiver) = arrange {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-27080
<!--jira-description-action-hidden-marker-end-->
## Intent

Prevent an old `SessionRefreshSuggested` event from blocking incremental sync when replaying pending events.

## Root cause

Pending session-refresh events were handled like live events. If the refresh token was already missing or refreshing failed, the receiver returned a failure and kept the old event pending even though later authenticated requests can refresh the current session independently.

## Reproduction

1. Queue a `SessionRefreshSuggested` event while the client is offline.
2. Change or expire the stored session before incremental sync replays the event.
3. Let the refresh handler fail.
4. Observe that incremental sync fails on the stale event.

## Fix

The receiver now consumes failed refresh suggestions only when they came from the pending-event stream. Live refresh failures still propagate unchanged.

Regression coverage verifies both the pending-event skip and the existing live-event failure behavior.
