### PR TITLE
fix(sync): propagate new conversation event failures

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
@@ -87,10 +87,7 @@ internal class ConversationEventReceiverImpl(
                 Either.Right(Unit)
             }
 
-            is Event.Conversation.NewConversation -> {
-                newConversationHandler.handle(transactionContext, event)
-                Either.Right(Unit)
-            }
+            is Event.Conversation.NewConversation -> newConversationHandler.handle(transactionContext, event)
 
             is Event.Conversation.DeletedConversation -> {
                 deletedConversationHandler.handle(transactionContext, event)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandler.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.logic.sync.receiver.conversation
 
+import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
 import com.wire.kalium.common.functional.getOrNull
@@ -43,7 +44,10 @@ import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 import com.wire.kalium.util.DateTimeUtil
 
 internal interface NewConversationEventHandler {
-    suspend fun handle(transactionContext: CryptoTransactionContext, event: Event.Conversation.NewConversation)
+    suspend fun handle(
+        transactionContext: CryptoTransactionContext,
+        event: Event.Conversation.NewConversation
+    ): Either<CoreFailure, Unit>
 }
 
 internal class NewConversationEventHandlerImpl(
@@ -55,10 +59,13 @@ internal class NewConversationEventHandlerImpl(
     private val persistConversation: PersistConversationUseCase,
 ) : NewConversationEventHandler {
 
-    override suspend fun handle(transactionContext: CryptoTransactionContext, event: Event.Conversation.NewConversation) {
+    override suspend fun handle(
+        transactionContext: CryptoTransactionContext,
+        event: Event.Conversation.NewConversation
+    ): Either<CoreFailure, Unit> {
         val eventLogger = kaliumLogger.createEventProcessingLogger(event)
         val selfUserTeamId = selfTeamIdProvider().getOrNull()
-        persistConversation(transactionContext, event.conversation, reason = ConversationSyncReason.Event)
+        return persistConversation(transactionContext, event.conversation, reason = ConversationSyncReason.Event)
             .flatMap { isNewUnhandledConversation ->
                 resolveConversationIfOneOnOne(transactionContext, selfUserTeamId, event)
                     .flatMap {
@@ -81,6 +88,7 @@ internal class NewConversationEventHandlerImpl(
             }.onFailure {
                 eventLogger.logFailure(it)
             }
+            .map { Unit }
     }
 
     private suspend fun resolveConversationIfOneOnOne(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
@@ -115,6 +115,22 @@ class ConversationEventReceiverTest {
     }
 
     @Test
+    fun givenNewConversationEvent_whenHandlerFails_thenFailureIsPropagated() = runTest {
+        val newConversationEvent = TestEvent.newConversationEvent()
+        val (arrangement, conversationEventReceiver) = Arrangement().arrange {
+            withNewConversationEventResult(Either.Left(failure))
+        }
+
+        val result = conversationEventReceiver.onEvent(
+            arrangement.transactionContext,
+            newConversationEvent,
+            TestEvent.liveDeliveryInfo
+        )
+
+        result.shouldFail()
+    }
+
+    @Test
     fun givenDeletedConversationEvent_whenOnEventInvoked_thenDeletedConversationHandlerShouldBeCalled() = runTest {
         val deletedConversationEvent = TestEvent.deletedConversation()
 
@@ -495,7 +511,7 @@ class ConversationEventReceiverTest {
         private suspend fun withDefaultSuccessfulHandlers() {
             everySuspend { newMessageEventHandler.handleNewProteusMessage(any(), any(), any()) } returns Unit
             everySuspend { newMessageEventHandler.handleNewMLSMessage(any(), any(), any()) } returns Unit
-            everySuspend { newConversationEventHandler.handle(any(), any()) } returns Unit
+            everySuspend { newConversationEventHandler.handle(any(), any()) } returns Either.Right(Unit)
             everySuspend { deletedConversationEventHandler.handle(any(), any()) } returns Unit
             everySuspend { memberJoinEventHandler.handle(any(), any()) } returns Either.Right(Unit)
             everySuspend { memberLeaveEventHandler.handle(any(), any()) } returns Either.Right(Unit)
@@ -512,6 +528,12 @@ class ConversationEventReceiverTest {
             everySuspend {
                 memberLeaveEventHandler.handle(any(), any())
             } returns Either.Right(Unit)
+        }
+
+        suspend fun withNewConversationEventResult(result: Either<CoreFailure, Unit>) = apply {
+            everySuspend {
+                newConversationEventHandler.handle(any(), any())
+            } returns result
         }
 
         suspend fun withMemberJoinSucceeded() = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/NewConversationEventHandlerTest.kt
@@ -44,6 +44,7 @@ import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.test_util.wasInTheLastSecond
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMokkeryImpl
+import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.network.api.authenticated.conversation.ConversationResponse
 import com.wire.kalium.network.api.authenticated.conversation.ReceiptMode
 import com.wire.kalium.persistence.dao.conversation.ConversationEntity
@@ -62,6 +63,18 @@ import kotlinx.datetime.Instant
 import kotlin.test.Test
 
 class NewConversationEventHandlerTest {
+
+    @Test
+    fun givenConversationPersistenceFails_whenHandlingEvent_thenFailureIsPropagated() = runTest {
+        val failure = StorageFailure.Generic(RuntimeException("persistence failed"))
+        val event = testNewConversationEvent()
+        val (arrangement, eventHandler) = Arrangement()
+            .withSelfUserTeamId(Either.Right(TestTeam.TEAM_ID))
+            .withPersistingConversations(Either.Left(failure))
+            .arrange()
+
+        eventHandler.handle(arrangement.transactionContext, event).shouldFail()
+    }
 
     @Test
     fun givenNewConversationOriginatedFromEvent_whenHandlingIt_thenPersistConversationShouldBeCalled() = runTest {


### PR DESCRIPTION
## Intent

Prevent new-conversation event failures from being silently marked as processed.

## Root cause

`NewConversationEventHandler` logged failures from conversation persistence, one-on-one resolution, modified-date updates, and user fetching but returned no result. `ConversationEventReceiver` therefore always acknowledged the event.

## Reproduction

1. Deliver a `NewConversation` event.
2. Make conversation persistence fail.
3. Observe the handler log the failure.
4. Observe the receiver still return success and allow the event to be marked processed.

## Fix

The handler now returns `Either<CoreFailure, Unit>`, and the receiver returns that result directly. Existing best-effort system-message behavior remains unchanged.

Regression coverage verifies failure propagation at both handler and receiver boundaries.
