### PR TITLE
fix(sync): stop event batch after failure

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorker.kt
@@ -79,13 +79,13 @@ internal class IncrementalSyncWorkerImpl(
                     kaliumLogger.d("$TAG Received ${envelopes.size} events to process")
                     transactionProvider.transaction("processEvents") { context ->
                         databaseBuilder.dbInvalidationController.runMuted {
-                            envelopes.map { envelope -> eventProcessor.processEvent(context, envelope) }
-                                .foldToEitherWhileRight(mutableListOf<String>()) { eventEither, acc ->
-                                    eventEither.map { eventId ->
+                            envelopes.foldToEitherWhileRight(mutableListOf<String>()) { envelope, acc ->
+                                eventProcessor.processEvent(context, envelope)
+                                    .map { eventId ->
                                         eventId?.let(acc::add)
                                         acc
                                     }
-                                }
+                            }
                                 .flatMap { eventIds ->
                                     eventProcessor.flushPendingSideEffects().map { eventIds }
                                 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorkerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncWorkerTest.kt
@@ -147,6 +147,33 @@ class IncrementalSyncWorkerTest {
     }
 
     @Test
+    fun givenEventProcessingFails_whenPageContainsMoreEvents_thenLaterEventsAreNotProcessed() = runTest {
+        val failure = NetworkFailure.NoNetworkConnection(null)
+        val failingEnvelope = TestEvent.memberJoin("failing-event").wrapInEnvelope()
+        val laterEnvelope = TestEvent.memberJoin("later-event").wrapInEnvelope()
+        val (arrangement, worker) = Arrangement()
+            .withEventGathererReturning(flowOf(EventStreamData.NewEvents(listOf(failingEnvelope, laterEnvelope))))
+            .arrange {
+                everySuspend {
+                    eventProcessor.processEvent(any(), eq(failingEnvelope))
+                } returns Either.Left(failure)
+                everySuspend {
+                    eventProcessor.processEvent(any(), eq(laterEnvelope))
+                } returns Either.Right(laterEnvelope.event.id)
+            }
+
+        assertFailsWith<KaliumSyncException> {
+            worker.processEventsFlow().collect()
+        }
+
+        verifySuspend(VerifyMode.not) {
+            arrangement.eventProcessor.processEvent(any(), eq(laterEnvelope))
+            arrangement.eventProcessor.flushPendingSideEffects()
+            arrangement.eventRepository.setEventsAsProcessed(any())
+        }
+    }
+
+    @Test
     fun givenProcessorReturnsEventId_whenPerformingIncrementalSync_thenWorkerMarksEventAsProcessed() = runTest {
         val envelope = TestEvent.memberJoin().wrapInEnvelope()
         val eventId = envelope.event.id


### PR DESCRIPTION
## Intent

Prevent one failed event from amplifying side effects across the rest of an incremental-sync page.

## Root cause

The worker eagerly processed every envelope with `map` before folding the results. If an early event failed, later events still ran, but the transaction returned failure and no event IDs were marked processed. Those later events and their side effects were then replayed with the page.

## Reproduction

1. Return a page containing at least two events.
2. Make the first event fail.
3. Observe that the second event is still processed.
4. Observe that the page fails and no IDs are marked, causing the second event to run again on retry.

## Fix

Event processing now happens inside the existing `foldToEitherWhileRight`, which stops invoking processors after the first failure. The all-or-nothing transaction boundary is preserved, and pending side effects are not flushed on a failed page.

Regression coverage verifies that later events, side-effect flushing, and processed-ID marking do not run after an earlier failure.
