### PR TITLE
fix(sync): propagate member change event failures

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
@@ -101,10 +101,7 @@ internal class ConversationEventReceiverImpl(
 
             is Event.Conversation.MemberLeave -> memberLeaveHandler.handle(transactionContext, event)
 
-            is Event.Conversation.MemberChanged -> {
-                memberChangeHandler.handle(transactionContext, event)
-                Either.Right(Unit)
-            }
+            is Event.Conversation.MemberChanged -> memberChangeHandler.handle(transactionContext, event)
 
             is Event.Conversation.MLSWelcome -> {
                 mlsWelcomeHandler.handle(transactionContext, event)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandler.kt
@@ -18,6 +18,8 @@
 
 package com.wire.kalium.logic.sync.receiver.conversation
 
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.getOrNull
 import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.common.functional.onSuccess
@@ -40,7 +42,10 @@ import com.wire.kalium.util.serialization.toJsonElement
 import kotlinx.datetime.Instant
 
 internal interface MemberChangeEventHandler {
-    suspend fun handle(transactionContext: CryptoTransactionContext, event: Event.Conversation.MemberChanged)
+    suspend fun handle(
+        transactionContext: CryptoTransactionContext,
+        event: Event.Conversation.MemberChanged
+    ): Either<CoreFailure, Unit>
 }
 
 internal class MemberChangeEventHandlerImpl(
@@ -51,16 +56,20 @@ internal class MemberChangeEventHandlerImpl(
 ) : MemberChangeEventHandler {
     private val logger by lazy { kaliumLogger.withFeatureId(KaliumLogger.Companion.ApplicationFlow.EVENT_RECEIVER) }
 
-    override suspend fun handle(transactionContext: CryptoTransactionContext, event: Event.Conversation.MemberChanged) {
+    override suspend fun handle(
+        transactionContext: CryptoTransactionContext,
+        event: Event.Conversation.MemberChanged
+    ): Either<CoreFailure, Unit> {
         val eventLogger = kaliumLogger.createEventProcessingLogger(event)
-        when (event) {
+        return when (event) {
             is Event.Conversation.MemberChanged.MemberMutedStatusChanged -> {
                 conversationRepository.updateMutedStatusLocally(
                     event.conversationId,
                     event.mutedConversationStatus,
                     DateTimeUtil.currentInstant().toEpochMilliseconds()
                 )
-                eventLogger.logSuccess()
+                    .onSuccess { eventLogger.logSuccess() }
+                    .onFailure { eventLogger.logFailure(it) }
             }
 
             is Event.Conversation.MemberChanged.MemberArchivedStatusChanged -> {
@@ -69,7 +78,8 @@ internal class MemberChangeEventHandlerImpl(
                     event.isArchiving,
                     DateTimeUtil.currentInstant().toEpochMilliseconds()
                 )
-                eventLogger.logSuccess()
+                    .onSuccess { eventLogger.logSuccess() }
+                    .onFailure { eventLogger.logFailure(it) }
             }
 
             is Event.Conversation.MemberChanged.MemberChangedRole -> {
@@ -81,6 +91,7 @@ internal class MemberChangeEventHandlerImpl(
                     EventLoggingStatus.SKIPPED,
                     arrayOf("info" to "Ignoring 'conversation.member-update' event, not handled yet")
                 )
+                Either.Right(Unit)
             }
         }
     }
@@ -88,13 +99,20 @@ internal class MemberChangeEventHandlerImpl(
     private suspend fun handleMemberChangedRoleEvent(
         transactionContext: CryptoTransactionContext,
         event: Event.Conversation.MemberChanged.MemberChangedRole
-    ) {
+    ): Either<CoreFailure, Unit> {
         val eventLogger = kaliumLogger.createEventProcessingLogger(event)
+        val updatedMember = event.member ?: run {
+            eventLogger.logComplete(
+                EventLoggingStatus.SKIPPED,
+                arrayOf("info" to "Ignoring member role update without member data")
+            )
+            return Either.Right(Unit)
+        }
         val currentRole = event.member?.id?.let {
             conversationRepository.getConversationMemberRole(event.conversationId, it).getOrNull()
         }
         // Attempt to fetch conversation details if needed, as this might be an unknown conversation
-        fetchConversationIfUnknown(transactionContext, event.conversationId)
+        return fetchConversationIfUnknown(transactionContext, event.conversationId)
             .run {
                 onSuccess {
                     val logMap = mapOf("event" to event.toLogMap())
@@ -108,7 +126,7 @@ internal class MemberChangeEventHandlerImpl(
                     logger.w("Failure fetching conversation details on MemberChange Event: ${logMap.toJsonElement()}")
                 }
                 // Even if unable to fetch conversation details, at least attempt updating the member
-                conversationRepository.updateMemberFromEvent(event.member!!, event.conversationId)
+                conversationRepository.updateMemberFromEvent(updatedMember, event.conversationId)
             }
             .onFailure { eventLogger.logFailure(it) }
             .onSuccess {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
@@ -195,6 +195,23 @@ class ConversationEventReceiverTest {
     }
 
     @Test
+    fun givenMemberChangeEvent_whenHandlerFails_thenFailureIsPropagated() = runTest {
+        val memberChangeEvent =
+            TestEvent.memberChange(member = Conversation.Member(TestUser.USER_ID, Conversation.Member.Role.Admin))
+        val (arrangement, conversationEventReceiver) = Arrangement().arrange {
+            withMemberChangeEventResult(Either.Left(failure))
+        }
+
+        val result = conversationEventReceiver.onEvent(
+            arrangement.transactionContext,
+            memberChangeEvent,
+            TestEvent.liveDeliveryInfo
+        )
+
+        result.shouldFail()
+    }
+
+    @Test
     fun givenMLSWelcomeEvent_whenOnEventInvoked_thenMlsWelcomeHandlerShouldBeCalled() = runTest {
         val mlsWelcomeEvent = TestEvent.newMLSWelcomeEvent()
 
@@ -499,7 +516,7 @@ class ConversationEventReceiverTest {
             everySuspend { deletedConversationEventHandler.handle(any(), any()) } returns Unit
             everySuspend { memberJoinEventHandler.handle(any(), any()) } returns Either.Right(Unit)
             everySuspend { memberLeaveEventHandler.handle(any(), any()) } returns Either.Right(Unit)
-            everySuspend { memberChangeEventHandler.handle(any(), any()) } returns Unit
+            everySuspend { memberChangeEventHandler.handle(any(), any()) } returns Either.Right(Unit)
             everySuspend { mlsWelcomeEventHandler.handle(any(), any()) } returns Either.Right(Unit)
             everySuspend { renamedConversationEventHandler.handle(any()) } returns Unit
             everySuspend { receiptModeUpdateEventHandler.handle(any()) } returns Unit
@@ -512,6 +529,12 @@ class ConversationEventReceiverTest {
             everySuspend {
                 memberLeaveEventHandler.handle(any(), any())
             } returns Either.Right(Unit)
+        }
+
+        suspend fun withMemberChangeEventResult(result: Either<CoreFailure, Unit>) = apply {
+            everySuspend {
+                memberChangeEventHandler.handle(any(), any())
+            } returns result
         }
 
         suspend fun withMemberJoinSucceeded() = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandlerTest.kt
@@ -33,6 +33,7 @@ import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMokkeryImpl
+import com.wire.kalium.logic.util.shouldFail
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
@@ -45,6 +46,28 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 
 class MemberChangeEventHandlerTest {
+
+    @Test
+    fun givenMutedStatusUpdateFails_whenHandlingEvent_thenFailureIsPropagated() = runTest {
+        val event = TestEvent.memberChangeMutedStatus()
+        val (arrangement, eventHandler) = Arrangement()
+            .withUpdateMutedStatusLocally(Either.Left(StorageFailure.Generic(RuntimeException("update failed"))))
+            .arrange()
+
+        eventHandler.handle(arrangement.transactionContext, event).shouldFail()
+    }
+
+    @Test
+    fun givenMemberUpdateFails_whenHandlingRoleEvent_thenFailureIsPropagated() = runTest {
+        val event = TestEvent.memberChange(member = Member(TestUser.USER_ID, Member.Role.Admin))
+        val (arrangement, eventHandler) = Arrangement()
+            .withFetchConversationIfUnknownSucceeding()
+            .withConversationMemberRole(Member.Role.Member)
+            .withUpdateMemberResult(Either.Left(StorageFailure.Generic(RuntimeException("update failed"))))
+            .arrange()
+
+        eventHandler.handle(arrangement.transactionContext, event).shouldFail()
+    }
 
     @Test
     fun givenMemberChangeEvent_whenHandlingIt_thenShouldFetchConversationIfUnknown() = runTest {
@@ -279,9 +302,13 @@ class MemberChangeEventHandlerTest {
         }
 
         suspend fun withUpdateMemberSucceeding() = apply {
+            withUpdateMemberResult(Either.Right(Unit))
+        }
+
+        suspend fun withUpdateMemberResult(result: Either<CoreFailure, Unit>) = apply {
             everySuspend {
                 conversationRepository.updateMemberFromEvent(any(), any())
-            } returns Either.Right(Unit)
+            } returns result
         }
 
         suspend fun withConversationMemberRole(role: Member.Role?) = apply {


### PR DESCRIPTION
## Intent

Prevent member-change persistence failures from being silently acknowledged.

## Root cause

`MemberChangeEventHandler` discarded failures while updating muted state, archived state, and member roles. `ConversationEventReceiver` then always returned success.

## Reproduction

1. Deliver a conversation member-update event.
2. Make the corresponding local repository update fail.
3. Observe the handler log or ignore the failure.
4. Observe the receiver still acknowledge the event.

## Fix

The handler now returns the repository result for supported member-change events, and the receiver returns it directly. Ignored event shapes remain successful skips, and role changes still attempt their local update if fetching unknown conversation details fails.

Regression coverage verifies muted-state failure, member-role failure, and receiver propagation.
