### PR TITLE
fix(sync): propagate conversation rename failures

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
@@ -111,10 +111,7 @@ internal class ConversationEventReceiverImpl(
                 Either.Right(Unit)
             }
 
-            is Event.Conversation.RenamedConversation -> {
-                renamedConversationHandler.handle(event)
-                Either.Right(Unit)
-            }
+            is Event.Conversation.RenamedConversation -> renamedConversationHandler.handle(event)
 
             is Event.Conversation.ConversationReceiptMode -> {
                 receiptModeUpdateEventHandler.handle(event)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/RenamedConversationEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/RenamedConversationEventHandler.kt
@@ -18,22 +18,25 @@
 
 package com.wire.kalium.logic.sync.receiver.conversation
 
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.wrapStorageRequest
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.common.functional.onFailure
+import com.wire.kalium.common.functional.onSuccess
+import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
-import com.wire.kalium.common.functional.onFailure
-import com.wire.kalium.common.functional.onSuccess
-import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.logic.util.createEventProcessingLogger
-import com.wire.kalium.common.error.wrapStorageRequest
 import com.wire.kalium.persistence.dao.conversation.ConversationDAO
 import kotlinx.datetime.Instant
 
 internal interface RenamedConversationEventHandler {
-    suspend fun handle(event: Event.Conversation.RenamedConversation)
+    suspend fun handle(event: Event.Conversation.RenamedConversation): Either<CoreFailure, Unit>
 }
 
 internal class RenamedConversationEventHandlerImpl(
@@ -41,10 +44,10 @@ internal class RenamedConversationEventHandlerImpl(
     private val persistMessage: PersistMessageUseCase,
 ) : RenamedConversationEventHandler {
 
-    override suspend fun handle(event: Event.Conversation.RenamedConversation) {
+    override suspend fun handle(event: Event.Conversation.RenamedConversation): Either<CoreFailure, Unit> {
         val logger = kaliumLogger.createEventProcessingLogger(event)
-        updateConversationName(event.conversationId, event.conversationName, event.dateTime)
-            .onSuccess {
+        return updateConversationName(event.conversationId, event.conversationName, event.dateTime)
+            .flatMap {
                 val message = Message.System(
                     id = event.id,
                     content = MessageContent.ConversationRenamed(event.conversationName),
@@ -55,8 +58,8 @@ internal class RenamedConversationEventHandlerImpl(
                     expirationData = null
                 )
                 persistMessage(message)
-                logger.logSuccess()
             }
+            .onSuccess { logger.logSuccess() }
             .onFailure(logger::logFailure)
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/RenameConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/RenameConversationUseCaseTest.kt
@@ -98,6 +98,9 @@ class RenameConversationUseCaseTest {
             everySuspend {
                 conversationRepository.changeConversationName(any(), any())
             } returns either
+            everySuspend {
+                renamedConversationEventHandler.handle(any())
+            } returns Either.Right(Unit)
         }
 
         fun arrange() = this to renameConversation

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
@@ -233,6 +233,22 @@ class ConversationEventReceiverTest {
     }
 
     @Test
+    fun givenRenamedConversationEvent_whenHandlerFails_thenFailureIsPropagated() = runTest {
+        val renamedConversationEvent = TestEvent.renamedConversation()
+        val (arrangement, conversationEventReceiver) = Arrangement().arrange {
+            withRenamedConversationEventResult(Either.Left(failure))
+        }
+
+        val result = conversationEventReceiver.onEvent(
+            arrangement.transactionContext,
+            renamedConversationEvent,
+            TestEvent.liveDeliveryInfo
+        )
+
+        result.shouldFail()
+    }
+
+    @Test
     fun givenConversationReceiptModeEvent_whenOnEventInvoked_thenReceiptModeUpdateEventHandlerShouldBeCalled() =
         runTest {
             val receiptModeUpdateEvent = TestEvent.receiptModeUpdate()
@@ -501,7 +517,7 @@ class ConversationEventReceiverTest {
             everySuspend { memberLeaveEventHandler.handle(any(), any()) } returns Either.Right(Unit)
             everySuspend { memberChangeEventHandler.handle(any(), any()) } returns Unit
             everySuspend { mlsWelcomeEventHandler.handle(any(), any()) } returns Either.Right(Unit)
-            everySuspend { renamedConversationEventHandler.handle(any()) } returns Unit
+            everySuspend { renamedConversationEventHandler.handle(any()) } returns Either.Right(Unit)
             everySuspend { receiptModeUpdateEventHandler.handle(any()) } returns Unit
             everySuspend { protocolUpdateEventHandler.handle(any(), any()) } returns Either.Right(Unit)
             everySuspend { channelAddPermissionUpdateEventHandler.handle(any()) } returns Either.Right(Unit)
@@ -512,6 +528,12 @@ class ConversationEventReceiverTest {
             everySuspend {
                 memberLeaveEventHandler.handle(any(), any())
             } returns Either.Right(Unit)
+        }
+
+        suspend fun withRenamedConversationEventResult(result: Either<CoreFailure, Unit>) = apply {
+            everySuspend {
+                renamedConversationEventHandler.handle(any())
+            } returns result
         }
 
         suspend fun withMemberJoinSucceeded() = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/RenamedConversationEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/RenamedConversationEventHandlerTest.kt
@@ -19,9 +19,11 @@
 package com.wire.kalium.logic.sync.receiver.conversation
 
 import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.framework.TestEvent
-import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.util.shouldFail
+import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.persistence.dao.conversation.ConversationDAO
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
@@ -44,7 +46,7 @@ class RenamedConversationEventHandlerTest {
             .withPersistingMessageReturning(Either.Right(Unit))
             .arrange()
 
-        eventHandler.handle(event)
+        eventHandler.handle(event).shouldSucceed()
 
         with(arrangement) {
             verifySuspend(VerifyMode.exactly(1)) {
@@ -58,6 +60,17 @@ class RenamedConversationEventHandlerTest {
     }
 
     @Test
+    fun givenSystemMessagePersistenceFails_whenHandlingRenameEvent_thenFailureIsPropagated() = runTest {
+        val event = TestEvent.renamedConversation()
+        val (arrangement, eventHandler) = Arrangement()
+            .withRenamingConversationSuccess()
+            .withPersistingMessageReturning(Either.Left(CoreFailure.Unknown(RuntimeException("message failed"))))
+            .arrange()
+
+        eventHandler.handle(event).shouldFail()
+    }
+
+    @Test
     fun givenAConversationEventRenamed_whenHandlingItFails_thenShouldNotUpdateTheConversation() = runTest {
         val event = TestEvent.renamedConversation()
         val (arrangement, eventHandler) = Arrangement()
@@ -65,7 +78,7 @@ class RenamedConversationEventHandlerTest {
             .withPersistingMessageReturning(Either.Right(Unit))
             .arrange()
 
-        eventHandler.handle(event)
+        eventHandler.handle(event).shouldFail()
 
         with(arrangement) {
             verifySuspend(VerifyMode.exactly(1)) {


### PR DESCRIPTION
## Intent

Prevent conversation rename events from being acknowledged when local persistence fails.

## Root cause

`RenamedConversationEventHandler` discarded the result of both the conversation-name update and the rename system-message persistence. The receiver always returned success.

## Reproduction

1. Deliver a `RenamedConversation` event.
2. Make either the conversation-name update or system-message persistence fail.
3. Observe the handler log the failure.
4. Observe the receiver still acknowledge the event.

## Fix

The handler now returns the combined persistence result, and the receiver returns it directly.

Regression coverage verifies name-update failure, system-message failure, receiver propagation, and the local rename use-case integration.
