### PR TITLE
fix(sync): propagate receipt mode event failures

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiver.kt
@@ -116,10 +116,7 @@ internal class ConversationEventReceiverImpl(
                 Either.Right(Unit)
             }
 
-            is Event.Conversation.ConversationReceiptMode -> {
-                receiptModeUpdateEventHandler.handle(event)
-                Either.Right(Unit)
-            }
+            is Event.Conversation.ConversationReceiptMode -> receiptModeUpdateEventHandler.handle(event)
 
             is Event.Conversation.MLSReset -> {
                 mlsResetConversationEventHandler.handle(transactionContext, event)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ReceiptModeUpdateEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ReceiptModeUpdateEventHandler.kt
@@ -18,7 +18,13 @@
 
 package com.wire.kalium.logic.sync.receiver.conversation
 
-import kotlin.uuid.Uuid
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.wrapStorageRequest
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.common.functional.onFailure
+import com.wire.kalium.common.functional.onSuccess
+import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ReceiptModeMapper
 import com.wire.kalium.logic.data.event.Event
@@ -27,16 +33,13 @@ import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.di.MapperProvider
-import com.wire.kalium.common.functional.onFailure
-import com.wire.kalium.common.functional.onSuccess
-import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.logic.util.createEventProcessingLogger
-import com.wire.kalium.common.error.wrapStorageRequest
 import com.wire.kalium.persistence.dao.conversation.ConversationDAO
 import kotlinx.datetime.Clock
+import kotlin.uuid.Uuid
 
 internal interface ReceiptModeUpdateEventHandler {
-    suspend fun handle(event: Event.Conversation.ConversationReceiptMode)
+    suspend fun handle(event: Event.Conversation.ConversationReceiptMode): Either<CoreFailure, Unit>
 }
 
 internal class ReceiptModeUpdateEventHandlerImpl(
@@ -45,10 +48,10 @@ internal class ReceiptModeUpdateEventHandlerImpl(
     private val receiptModeMapper: ReceiptModeMapper = MapperProvider.receiptModeMapper()
 ) : ReceiptModeUpdateEventHandler {
 
-    override suspend fun handle(event: Event.Conversation.ConversationReceiptMode) {
+    override suspend fun handle(event: Event.Conversation.ConversationReceiptMode): Either<CoreFailure, Unit> {
         val eventLogger = kaliumLogger.createEventProcessingLogger(event)
-        updateReceiptMode(event)
-            .onSuccess {
+        return updateReceiptMode(event)
+            .flatMap {
                 val message = Message.System(
                     Uuid.random().toString(),
                     MessageContent.ConversationReceiptModeChanged(
@@ -63,8 +66,8 @@ internal class ReceiptModeUpdateEventHandlerImpl(
                 )
 
                 persistMessage(message)
-                eventLogger.logSuccess()
             }
+            .onSuccess { eventLogger.logSuccess() }
             .onFailure { eventLogger.logFailure(it) }
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
@@ -252,6 +252,22 @@ class ConversationEventReceiverTest {
         }
 
     @Test
+    fun givenConversationReceiptModeEvent_whenHandlerFails_thenFailureIsPropagated() = runTest {
+        val receiptModeUpdateEvent = TestEvent.receiptModeUpdate()
+        val (arrangement, conversationEventReceiver) = Arrangement().arrange {
+            withReceiptModeEventResult(Either.Left(failure))
+        }
+
+        val result = conversationEventReceiver.onEvent(
+            arrangement.transactionContext,
+            receiptModeUpdateEvent,
+            TestEvent.liveDeliveryInfo
+        )
+
+        result.shouldFail()
+    }
+
+    @Test
     fun givenConversationMessageTimerEvent_whenOnEventInvoked_thenPropagateConversationMessageTimerEventHandlerResult() =
         runTest {
             val conversationMessageTimerEvent = TestEvent.timerChanged()
@@ -502,7 +518,7 @@ class ConversationEventReceiverTest {
             everySuspend { memberChangeEventHandler.handle(any(), any()) } returns Unit
             everySuspend { mlsWelcomeEventHandler.handle(any(), any()) } returns Either.Right(Unit)
             everySuspend { renamedConversationEventHandler.handle(any()) } returns Unit
-            everySuspend { receiptModeUpdateEventHandler.handle(any()) } returns Unit
+            everySuspend { receiptModeUpdateEventHandler.handle(any()) } returns Either.Right(Unit)
             everySuspend { protocolUpdateEventHandler.handle(any(), any()) } returns Either.Right(Unit)
             everySuspend { channelAddPermissionUpdateEventHandler.handle(any()) } returns Either.Right(Unit)
             everySuspend { mlsResetConversationEventHandler.handle(any(), any()) } returns Unit
@@ -512,6 +528,12 @@ class ConversationEventReceiverTest {
             everySuspend {
                 memberLeaveEventHandler.handle(any(), any())
             } returns Either.Right(Unit)
+        }
+
+        suspend fun withReceiptModeEventResult(result: Either<CoreFailure, Unit>) = apply {
+            everySuspend {
+                receiptModeUpdateEventHandler.handle(any())
+            } returns result
         }
 
         suspend fun withMemberJoinSucceeded() = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ReceiptModeUpdateEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/ReceiptModeUpdateEventHandlerTest.kt
@@ -18,15 +18,18 @@
 
 package com.wire.kalium.logic.sync.receiver.conversation
 
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.framework.TestEvent
-import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.persistence.dao.conversation.ConversationDAO
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.matcher.matches
@@ -37,6 +40,27 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 
 class ReceiptModeUpdateEventHandlerTest {
+
+    @Test
+    fun givenReceiptModeUpdateFails_whenHandlingEvent_thenFailureIsPropagated() = runTest {
+        val event = TestEvent.receiptModeUpdate()
+        val (_, eventHandler) = Arrangement()
+            .withUpdateReceiptModeFailure()
+            .arrange()
+
+        eventHandler.handle(event).shouldFail()
+    }
+
+    @Test
+    fun givenSystemMessagePersistenceFails_whenHandlingEvent_thenFailureIsPropagated() = runTest {
+        val event = TestEvent.receiptModeUpdate()
+        val (_, eventHandler) = Arrangement()
+            .withUpdateReceiptModeSuccess()
+            .withPersistingSystemMessage(Either.Left(CoreFailure.Unknown(RuntimeException("message failed"))))
+            .arrange()
+
+        eventHandler.handle(event).shouldFail()
+    }
 
     @Test
     fun givenAConversationEventReceiptMode_whenHandlingIt_thenShouldUpdateTheConversation() = runTest {
@@ -122,10 +146,16 @@ class ReceiptModeUpdateEventHandlerTest {
             } returns Unit
         }
 
-        suspend fun withPersistingSystemMessage() = apply {
+        suspend fun withUpdateReceiptModeFailure() = apply {
+            everySuspend {
+                conversationDAO.updateConversationReceiptMode(any(), any())
+            } throws RuntimeException("update failed")
+        }
+
+        suspend fun withPersistingSystemMessage(result: Either<CoreFailure, Unit> = Either.Right(Unit)) = apply {
             everySuspend {
                 persistMessage.invoke(any())
-            } returns Either.Right(Unit)
+            } returns result
         }
 
         fun arrange() = this to receiptModeUpdateEventHandler


### PR DESCRIPTION
## Intent

Prevent receipt-mode events from being acknowledged when local persistence fails.

## Root cause

`ReceiptModeUpdateEventHandler` discarded failures from the receipt-mode update and from system-message persistence. The receiver always returned success.

## Reproduction

1. Deliver a `ConversationReceiptMode` event.
2. Make either the conversation update or system-message persistence fail.
3. Observe the handler log the failure.
4. Observe the receiver still acknowledge the event.

## Fix

The handler now returns the combined persistence result, and the receiver returns it directly.

Regression coverage verifies receipt-mode update failure, system-message failure, and receiver propagation.
