### PR TITLE
feat: parallelize keypackage claimes [WPB-27236]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepository.kt
@@ -41,6 +41,10 @@ import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.sync.withPermit
 import kotlin.io.encoding.Base64
 
 internal interface KeyPackageRepository {
@@ -97,48 +101,57 @@ internal class KeyPackageDataSource(
         cipherSuite: CipherSuite
     ): Either<CoreFailure, KeyPackageClaimResult> =
         currentClientIdProvider().flatMap { selfClientId ->
-            userIds.chunked(maxConcurrentClaims)
-                .foldToEitherWhileRight(KeyPackageClaims()) { batch, accumulatedClaims ->
-                    claimBatch(batch, selfClientId, cipherSuite)
-                        .foldToEitherWhileRight(accumulatedClaims, ::accumulateClaim)
-                }
+            claimConcurrently(userIds, selfClientId, cipherSuite)
+                .foldToEitherWhileRight(KeyPackageClaims(), ::accumulateClaim)
                 .map(KeyPackageClaims::toResult)
         }
 
-    private suspend fun claimBatch(
+    private suspend fun claimConcurrently(
         userIds: List<UserId>,
         selfClientId: ClientId,
         cipherSuite: CipherSuite,
     ): List<UserKeyPackageClaim> = coroutineScope {
+        val semaphore = Semaphore(maxConcurrentClaims)
+        val abortStateMutex = Mutex()
+        var fatalFailureDetected = false
+
         userIds.map { userId ->
             async {
-                UserKeyPackageClaim(
-                    userId = userId,
-                    result = wrapApiRequest {
-                        keyPackageApi.claimKeyPackages(
-                            KeyPackageApi.Param.SkipOwnClient(
-                                userId.toApi(),
-                                selfClientId.value,
-                                cipherSuite = cipherSuite.tag
-                            )
-                        )
+                semaphore.withPermit {
+                    if (abortStateMutex.withLock { fatalFailureDetected }) {
+                        return@withPermit null
                     }
-                )
+
+                    UserKeyPackageClaim(
+                        userId = userId,
+                        result = wrapApiRequest {
+                            keyPackageApi.claimKeyPackages(
+                                KeyPackageApi.Param.SkipOwnClient(
+                                    userId.toApi(),
+                                    selfClientId.value,
+                                    cipherSuite = cipherSuite.tag
+                                )
+                            )
+                        }
+                    ).also { claim ->
+                        if (claim.hasFatalFailure()) {
+                            abortStateMutex.withLock { fatalFailureDetected = true }
+                        }
+                    }
+                }
             }
-        }.awaitAll()
+        }.awaitAll().filterNotNull()
     }
 
     private fun accumulateClaim(
         claim: UserKeyPackageClaim,
         accumulatedClaims: KeyPackageClaims,
     ): Either<CoreFailure, KeyPackageClaims> = claim.result.fold({ failure ->
-        when (failure) {
-            is NetworkFailure.NoNetworkConnection,
-            is NetworkFailure.ProxyError -> Either.Left(failure)
-            else -> {
-                accumulatedClaims.usersWithUnreachableBackend.add(claim.userId)
-                Either.Right(accumulatedClaims)
-            }
+        if (failure.isFatalClaimFailure()) {
+            Either.Left(failure)
+        } else {
+            accumulatedClaims.usersWithUnreachableBackend.add(claim.userId)
+            Either.Right(accumulatedClaims)
         }
     }) { claimedKeyPackages ->
         if (claimedKeyPackages.keyPackages.isEmpty() && claim.userId != selfUserId) {
@@ -199,6 +212,12 @@ internal class KeyPackageDataSource(
         const val DEFAULT_MAX_CONCURRENT_CLAIMS = 4
     }
 }
+
+private fun UserKeyPackageClaim.hasFatalFailure(): Boolean =
+    result is Either.Left && result.value.isFatalClaimFailure()
+
+private fun NetworkFailure.isFatalClaimFailure(): Boolean =
+    this is NetworkFailure.NoNetworkConnection || this is NetworkFailure.ProxyError
 
 private data class UserKeyPackageClaim(
     val userId: UserId,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepository.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.common.error.wrapMLSRequest
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
 import com.wire.kalium.common.functional.fold
+import com.wire.kalium.common.functional.foldToEitherWhileRight
 import com.wire.kalium.common.functional.map
 import com.wire.kalium.cryptography.MlsCoreCryptoContext
 import com.wire.kalium.logic.data.conversation.ClientId
@@ -33,9 +34,13 @@ import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.id.toApi
 import com.wire.kalium.logic.data.mls.CipherSuite
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.network.api.authenticated.keypackage.ClaimedKeyPackageList
 import com.wire.kalium.network.api.authenticated.keypackage.KeyPackageCountDTO
 import com.wire.kalium.network.api.authenticated.keypackage.KeyPackageDTO
 import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlin.io.encoding.Base64
 
 internal interface KeyPackageRepository {
@@ -80,43 +85,69 @@ internal class KeyPackageDataSource(
     private val currentClientIdProvider: CurrentClientIdProvider,
     private val keyPackageApi: KeyPackageApi,
     private val selfUserId: UserId,
+    private val maxConcurrentClaims: Int = DEFAULT_MAX_CONCURRENT_CLAIMS,
 ) : KeyPackageRepository {
+
+    init {
+        require(maxConcurrentClaims > 0) { "maxConcurrentClaims must be greater than zero" }
+    }
 
     override suspend fun claimKeyPackages(
         userIds: List<UserId>,
         cipherSuite: CipherSuite
     ): Either<CoreFailure, KeyPackageClaimResult> =
         currentClientIdProvider().flatMap { selfClientId ->
-            val noKeyPackageUsers = mutableSetOf<UserId>()
-            val federationFailedUsers = mutableSetOf<UserId>()
-            val claimedKeyPackages = mutableListOf<KeyPackageDTO>()
-            for (userId in userIds) {
-                wrapApiRequest {
-                    keyPackageApi.claimKeyPackages(
-                        KeyPackageApi.Param.SkipOwnClient(
-                            userId.toApi(),
-                            selfClientId.value,
-                            cipherSuite = cipherSuite.tag
-                        )
-                    )
-                }.fold({ failure ->
-                    when (failure) {
-                        is NetworkFailure.NoNetworkConnection,
-                        is NetworkFailure.ProxyError -> return@flatMap Either.Left(failure)
-                        is NetworkFailure.FederatedBackendFailure -> federationFailedUsers.add(userId)
-                        else -> federationFailedUsers.add(userId)
-                    }
-                }) {
-                    if (it.keyPackages.isEmpty() && userId != selfUserId) {
-                        noKeyPackageUsers.add(userId)
-                    } else {
-                        claimedKeyPackages.addAll(it.keyPackages)
-                    }
+            userIds.chunked(maxConcurrentClaims)
+                .foldToEitherWhileRight(KeyPackageClaims()) { batch, accumulatedClaims ->
+                    claimBatch(batch, selfClientId, cipherSuite)
+                        .foldToEitherWhileRight(accumulatedClaims, ::accumulateClaim)
                 }
-            }
-
-            Either.Right(KeyPackageClaimResult(claimedKeyPackages, noKeyPackageUsers, federationFailedUsers))
+                .map(KeyPackageClaims::toResult)
         }
+
+    private suspend fun claimBatch(
+        userIds: List<UserId>,
+        selfClientId: ClientId,
+        cipherSuite: CipherSuite,
+    ): List<UserKeyPackageClaim> = coroutineScope {
+        userIds.map { userId ->
+            async {
+                UserKeyPackageClaim(
+                    userId = userId,
+                    result = wrapApiRequest {
+                        keyPackageApi.claimKeyPackages(
+                            KeyPackageApi.Param.SkipOwnClient(
+                                userId.toApi(),
+                                selfClientId.value,
+                                cipherSuite = cipherSuite.tag
+                            )
+                        )
+                    }
+                )
+            }
+        }.awaitAll()
+    }
+
+    private fun accumulateClaim(
+        claim: UserKeyPackageClaim,
+        accumulatedClaims: KeyPackageClaims,
+    ): Either<CoreFailure, KeyPackageClaims> = claim.result.fold({ failure ->
+        when (failure) {
+            is NetworkFailure.NoNetworkConnection,
+            is NetworkFailure.ProxyError -> Either.Left(failure)
+            else -> {
+                accumulatedClaims.usersWithUnreachableBackend.add(claim.userId)
+                Either.Right(accumulatedClaims)
+            }
+        }
+    }) { claimedKeyPackages ->
+        if (claimedKeyPackages.keyPackages.isEmpty() && claim.userId != selfUserId) {
+            accumulatedClaims.usersWithoutKeyPackages.add(claim.userId)
+        } else {
+            accumulatedClaims.successfullyFetchedKeyPackages.addAll(claimedKeyPackages.keyPackages)
+        }
+        Either.Right(accumulatedClaims)
+    }
 
     override suspend fun uploadNewKeyPackages(
         mlsContext: MlsCoreCryptoContext,
@@ -163,4 +194,25 @@ internal class KeyPackageDataSource(
         wrapApiRequest {
             keyPackageApi.getAvailableKeyPackageCount(clientId.value, cipherSuite.tag)
         }
+
+    private companion object {
+        const val DEFAULT_MAX_CONCURRENT_CLAIMS = 4
+    }
+}
+
+private data class UserKeyPackageClaim(
+    val userId: UserId,
+    val result: Either<NetworkFailure, ClaimedKeyPackageList>,
+)
+
+private class KeyPackageClaims {
+    val successfullyFetchedKeyPackages = mutableListOf<KeyPackageDTO>()
+    val usersWithoutKeyPackages = mutableSetOf<UserId>()
+    val usersWithUnreachableBackend = mutableSetOf<UserId>()
+
+    fun toResult() = KeyPackageClaimResult(
+        successfullyFetchedKeyPackages = successfullyFetchedKeyPackages.toList(),
+        usersWithoutKeyPackages = usersWithoutKeyPackages.toSet(),
+        usersWithUnreachableBackend = usersWithUnreachableBackend.toSet(),
+    )
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepositoryTest.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.logic.data.keypackage
 import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.conversation.mls.KeyPackageClaimResult
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.id.PlainId
 import com.wire.kalium.logic.data.id.toApi
@@ -41,6 +42,7 @@ import com.wire.kalium.network.api.model.FederationErrorResponse
 import com.wire.kalium.network.exceptions.FederationError
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
+import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
@@ -49,6 +51,10 @@ import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import kotlin.io.encoding.Base64
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -95,6 +101,40 @@ internal class KeyPackageRepositoryTest {
         result.shouldSucceed { keyPackageResult ->
             assertEquals(listOf(Arrangement.CLAIMED_KEY_PACKAGES.keyPackages[0]), keyPackageResult.successfullyFetchedKeyPackages)
         }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun givenMoreUsersThanConcurrencyLimit_whenClaimingKeyPackages_thenClaimsAreExecutedInBoundedParallelBatches() = runTest {
+        val users = List(3) { index -> Arrangement.USER_ID.copy(value = "user$index") }
+        val releaseClaims = CompletableDeferred<Unit>()
+        var activeClaims = 0
+        var maximumActiveClaims = 0
+        val (arrangement, keyPackageRepository) = Arrangement()
+            .withCurrentClientId()
+            .arrange(maxConcurrentClaims = 2)
+
+        everySuspend { arrangement.keyPackageApi.claimKeyPackages(any()) } calls {
+            activeClaims += 1
+            maximumActiveClaims = maxOf(maximumActiveClaims, activeClaims)
+            releaseClaims.await()
+            activeClaims -= 1
+            NetworkResponse.Success(Arrangement.CLAIMED_KEY_PACKAGES, mapOf(), 200)
+        }
+
+        val result = async {
+            keyPackageRepository.claimKeyPackages(users, CIPHER_SUITE)
+        }
+        runCurrent()
+
+        assertEquals(2, activeClaims)
+        assertEquals(2, maximumActiveClaims)
+
+        releaseClaims.complete(Unit)
+        result.await().shouldSucceed { keyPackageResult ->
+            assertEquals(users.size, keyPackageResult.successfullyFetchedKeyPackages.size)
+        }
+        assertEquals(2, maximumActiveClaims)
     }
 
     @Test
@@ -220,7 +260,7 @@ internal class KeyPackageRepositoryTest {
         val (arrangement, keyPackageRepository) = Arrangement()
             .withCurrentClientId()
             .withClaimKeyPackagesNoNetworkError(user1)
-            .arrange()
+            .arrange(maxConcurrentClaims = 1)
 
         val result = keyPackageRepository.claimKeyPackages(listOf(user1, user2), CIPHER_SUITE)
 
@@ -230,6 +270,75 @@ internal class KeyPackageRepositoryTest {
                 eq(KeyPackageApi.Param.SkipOwnClient(user2.toApi(), Arrangement.SELF_CLIENT_ID.value, CIPHER_SUITE.tag))
             )
         }
+    }
+
+    @Test
+    fun givenNetworkFailureInsideBatch_whenClaimingKeyPackages_thenCoBatchUsersAreQueriedButLaterBatchesAreNot() = runTest {
+        // chunked(2) => batch1 = [failingUser, coBatchUser], batch2 = [laterBatchUser]
+        val failingUser = Arrangement.USER_ID.copy(value = "failing")
+        val coBatchUser = Arrangement.USER_ID.copy(value = "coBatch")
+        val laterBatchUser = Arrangement.USER_ID.copy(value = "laterBatch")
+        val (arrangement, keyPackageRepository) = Arrangement()
+            .withCurrentClientId()
+            .withClaimKeyPackagesNoNetworkError(failingUser)
+            .withClaimKeyPackagesSuccessful(coBatchUser)
+            .withClaimKeyPackagesSuccessful(laterBatchUser)
+            .arrange(maxConcurrentClaims = 2)
+
+        val result = keyPackageRepository.claimKeyPackages(listOf(failingUser, coBatchUser, laterBatchUser), CIPHER_SUITE)
+
+        result.shouldFail { assertIs<NetworkFailure.NoNetworkConnection>(it) }
+        // The failing user and its co-batch peer are both dispatched concurrently before the failure aborts the operation.
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.keyPackageApi.claimKeyPackages(
+                eq(KeyPackageApi.Param.SkipOwnClient(coBatchUser.toApi(), Arrangement.SELF_CLIENT_ID.value, CIPHER_SUITE.tag))
+            )
+        }
+        // Users belonging to a later batch are never queried once a preceding batch fails.
+        verifySuspend(VerifyMode.not) {
+            arrangement.keyPackageApi.claimKeyPackages(
+                eq(KeyPackageApi.Param.SkipOwnClient(laterBatchUser.toApi(), Arrangement.SELF_CLIENT_ID.value, CIPHER_SUITE.tag))
+            )
+        }
+    }
+
+    @Test
+    fun givenMixedResults_whenClaimingAtDifferentConcurrencyLevels_thenResultsAreConsistent() = runTest {
+        val successA = Arrangement.USER_ID.copy(value = "successA")
+        val successB = Arrangement.USER_ID.copy(value = "successB")
+        val noKeyPackages = Arrangement.USER_ID.copy(value = "noKP")
+        val federated = UserId("alice", "unreachable.com")
+        val serverError = Arrangement.USER_ID.copy(value = "serverError")
+        val users = listOf(successA, noKeyPackages, federated, successB, serverError)
+
+        suspend fun claimWith(maxConcurrentClaims: Int): KeyPackageClaimResult {
+            val (_, keyPackageRepository) = Arrangement()
+                .withCurrentClientId()
+                .withClaimKeyPackagesSuccessful(successA)
+                .withClaimKeyPackagesSuccessful(successB)
+                .withClaimKeyPackagesSuccessfulWithEmptyResponse(noKeyPackages)
+                .withClaimKeyPackagesFederationError(federated)
+                .withClaimKeyPackagesServerError(serverError)
+                .arrange(maxConcurrentClaims = maxConcurrentClaims)
+
+            lateinit var claimResult: KeyPackageClaimResult
+            keyPackageRepository.claimKeyPackages(users, CIPHER_SUITE).shouldSucceed { claimResult = it }
+            return claimResult
+        }
+
+        // maxConcurrentClaims = 1 reproduces the previous sequential behaviour; higher values are the new batched behaviour.
+        val sequentialResult = claimWith(maxConcurrentClaims = 1)
+        listOf(2, 4, users.size + 1).forEach { concurrency ->
+            assertEquals(
+                sequentialResult,
+                claimWith(maxConcurrentClaims = concurrency),
+                "Result diverged at maxConcurrentClaims=$concurrency"
+            )
+        }
+
+        assertEquals(2, sequentialResult.successfullyFetchedKeyPackages.size)
+        assertEquals(setOf(noKeyPackages), sequentialResult.usersWithoutKeyPackages)
+        assertEquals(setOf(federated, serverError), sequentialResult.usersWithUnreachableBackend)
     }
 
     @Test
@@ -333,7 +442,8 @@ internal class KeyPackageRepositoryTest {
             )
         }
 
-        fun arrange() = this to KeyPackageDataSource(currentClientIdProvider, keyPackageApi, SELF_USER_ID)
+        fun arrange(maxConcurrentClaims: Int = 4) =
+            this to KeyPackageDataSource(currentClientIdProvider, keyPackageApi, SELF_USER_ID, maxConcurrentClaims)
 
         internal companion object {
             const val KEY_PACKAGE_COUNT = 100

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepositoryTest.kt
@@ -51,9 +51,9 @@ import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import kotlin.io.encoding.Base64
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -105,21 +105,24 @@ internal class KeyPackageRepositoryTest {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun givenMoreUsersThanConcurrencyLimit_whenClaimingKeyPackages_thenClaimsAreExecutedInBoundedParallelBatches() = runTest {
+    fun givenMoreUsersThanConcurrencyLimit_whenClaimingKeyPackages_thenSemaphoreKeepsClaimsWithinLimit() = runTest {
         val users = List(3) { index -> Arrangement.USER_ID.copy(value = "user$index") }
-        val releaseClaims = CompletableDeferred<Unit>()
-        var activeClaims = 0
-        var maximumActiveClaims = 0
+        val claimStarted = List(users.size) { CompletableDeferred<Unit>() }
+        val releaseClaim = List(users.size) { CompletableDeferred<Unit>() }
         val (arrangement, keyPackageRepository) = Arrangement()
             .withCurrentClientId()
             .arrange(maxConcurrentClaims = 2)
 
-        everySuspend { arrangement.keyPackageApi.claimKeyPackages(any()) } calls {
-            activeClaims += 1
-            maximumActiveClaims = maxOf(maximumActiveClaims, activeClaims)
-            releaseClaims.await()
-            activeClaims -= 1
-            NetworkResponse.Success(Arrangement.CLAIMED_KEY_PACKAGES, mapOf(), 200)
+        users.forEachIndexed { index, user ->
+            everySuspend {
+                arrangement.keyPackageApi.claimKeyPackages(
+                    eq(KeyPackageApi.Param.SkipOwnClient(user.toApi(), Arrangement.SELF_CLIENT_ID.value, CIPHER_SUITE.tag))
+                )
+            } calls {
+                claimStarted[index].complete(Unit)
+                releaseClaim[index].await()
+                NetworkResponse.Success(Arrangement.CLAIMED_KEY_PACKAGES, mapOf(), 200)
+            }
         }
 
         val result = async {
@@ -127,14 +130,21 @@ internal class KeyPackageRepositoryTest {
         }
         runCurrent()
 
-        assertEquals(2, activeClaims)
-        assertEquals(2, maximumActiveClaims)
+        assertEquals(true, claimStarted[0].isCompleted)
+        assertEquals(true, claimStarted[1].isCompleted)
+        assertEquals(false, claimStarted[2].isCompleted)
 
-        releaseClaims.complete(Unit)
+        releaseClaim[0].complete(Unit)
+        runCurrent()
+
+        // A free semaphore permit starts the next claim without waiting for the other active claim.
+        assertEquals(true, claimStarted[2].isCompleted)
+
+        releaseClaim[1].complete(Unit)
+        releaseClaim[2].complete(Unit)
         result.await().shouldSucceed { keyPackageResult ->
             assertEquals(users.size, keyPackageResult.successfullyFetchedKeyPackages.size)
         }
-        assertEquals(2, maximumActiveClaims)
     }
 
     @Test
@@ -273,33 +283,53 @@ internal class KeyPackageRepositoryTest {
     }
 
     @Test
-    fun givenNetworkFailureInsideBatch_whenClaimingKeyPackages_thenCoBatchUsersAreQueriedButLaterBatchesAreNot() = runTest {
-        // chunked(2) => batch1 = [failingUser, coBatchUser], batch2 = [laterBatchUser]
+    fun givenFatalFailure_whenClaimingKeyPackages_thenActiveClaimsFinishButWaitingClaimsDoNotStart() = runTest {
         val failingUser = Arrangement.USER_ID.copy(value = "failing")
-        val coBatchUser = Arrangement.USER_ID.copy(value = "coBatch")
-        val laterBatchUser = Arrangement.USER_ID.copy(value = "laterBatch")
+        val activeUser = Arrangement.USER_ID.copy(value = "active")
+        val waitingUser = Arrangement.USER_ID.copy(value = "waiting")
+        val activeClaimStarted = CompletableDeferred<Unit>()
+        val releaseActiveClaim = CompletableDeferred<Unit>()
         val (arrangement, keyPackageRepository) = Arrangement()
             .withCurrentClientId()
-            .withClaimKeyPackagesNoNetworkError(failingUser)
-            .withClaimKeyPackagesSuccessful(coBatchUser)
-            .withClaimKeyPackagesSuccessful(laterBatchUser)
             .arrange(maxConcurrentClaims = 2)
 
-        val result = keyPackageRepository.claimKeyPackages(listOf(failingUser, coBatchUser, laterBatchUser), CIPHER_SUITE)
+        everySuspend {
+            arrangement.keyPackageApi.claimKeyPackages(
+                eq(KeyPackageApi.Param.SkipOwnClient(failingUser.toApi(), Arrangement.SELF_CLIENT_ID.value, CIPHER_SUITE.tag))
+            )
+        } calls {
+            activeClaimStarted.await()
+            NetworkResponse.Error(KaliumException.NoNetwork())
+        }
+        everySuspend {
+            arrangement.keyPackageApi.claimKeyPackages(
+                eq(KeyPackageApi.Param.SkipOwnClient(activeUser.toApi(), Arrangement.SELF_CLIENT_ID.value, CIPHER_SUITE.tag))
+            )
+        } calls {
+            activeClaimStarted.complete(Unit)
+            releaseActiveClaim.await()
+            NetworkResponse.Success(Arrangement.CLAIMED_KEY_PACKAGES, mapOf(), 200)
+        }
 
-        result.shouldFail { assertIs<NetworkFailure.NoNetworkConnection>(it) }
-        // The failing user and its co-batch peer are both dispatched concurrently before the failure aborts the operation.
+        val result = async {
+            keyPackageRepository.claimKeyPackages(listOf(failingUser, activeUser, waitingUser), CIPHER_SUITE)
+        }
+        runCurrent()
+
+        assertEquals(false, result.isCompleted)
         verifySuspend(VerifyMode.exactly(1)) {
             arrangement.keyPackageApi.claimKeyPackages(
-                eq(KeyPackageApi.Param.SkipOwnClient(coBatchUser.toApi(), Arrangement.SELF_CLIENT_ID.value, CIPHER_SUITE.tag))
+                eq(KeyPackageApi.Param.SkipOwnClient(activeUser.toApi(), Arrangement.SELF_CLIENT_ID.value, CIPHER_SUITE.tag))
             )
         }
-        // Users belonging to a later batch are never queried once a preceding batch fails.
         verifySuspend(VerifyMode.not) {
             arrangement.keyPackageApi.claimKeyPackages(
-                eq(KeyPackageApi.Param.SkipOwnClient(laterBatchUser.toApi(), Arrangement.SELF_CLIENT_ID.value, CIPHER_SUITE.tag))
+                eq(KeyPackageApi.Param.SkipOwnClient(waitingUser.toApi(), Arrangement.SELF_CLIENT_ID.value, CIPHER_SUITE.tag))
             )
         }
+
+        releaseActiveClaim.complete(Unit)
+        result.await().shouldFail { assertIs<NetworkFailure.NoNetworkConnection>(it) }
     }
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/keypackage/KeyPackageRepositoryTest.kt
@@ -103,6 +103,30 @@ internal class KeyPackageRepositoryTest {
         }
     }
 
+    @Test
+    fun givenUserHasKeyPackagesForMultipleClients_whenClaimingKeyPackages_thenAllClientKeyPackagesAreCollectedAndUserIsNotMissing() =
+        runTest {
+            val user = Arrangement.USER_ID
+            val (_, keyPackageRepository) = Arrangement()
+                .withCurrentClientId()
+                .withClaimKeyPackagesForMultipleClients(user)
+                .arrange()
+
+            val result = keyPackageRepository.claimKeyPackages(listOf(user), CIPHER_SUITE)
+
+            result.shouldSucceed { keyPackageResult ->
+                // Every client's key package present in the response is collected.
+                assertEquals(
+                    Arrangement.MULTI_CLIENT_CLAIMED_KEY_PACKAGES.keyPackages,
+                    keyPackageResult.successfullyFetchedKeyPackages
+                )
+                // A user is only reported as missing when the response is empty; a non-empty (incl. partial-client) response
+                // counts as a success, so the user must not appear in either failure bucket.
+                assertEquals(emptySet(), keyPackageResult.usersWithoutKeyPackages)
+                assertEquals(emptySet(), keyPackageResult.usersWithUnreachableBackend)
+            }
+        }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun givenMoreUsersThanConcurrencyLimit_whenClaimingKeyPackages_thenSemaphoreKeepsClaimsWithinLimit() = runTest {
@@ -424,6 +448,14 @@ internal class KeyPackageRepositoryTest {
             }.returns(NetworkResponse.Success(CLAIMED_KEY_PACKAGES, mapOf(), 200))
         }
 
+        suspend fun withClaimKeyPackagesForMultipleClients(userId: UserId) = apply {
+            everySuspend {
+                keyPackageApi.claimKeyPackages(
+                    eq(KeyPackageApi.Param.SkipOwnClient(userId.toApi(), SELF_CLIENT_ID.value, CIPHER_SUITE.tag))
+                )
+            }.returns(NetworkResponse.Success(MULTI_CLIENT_CLAIMED_KEY_PACKAGES, mapOf(), 200))
+        }
+
         suspend fun withClaimKeyPackagesSuccessfulWithEmptyResponse(userId: UserId) = apply {
             everySuspend {
                 keyPackageApi.claimKeyPackages(
@@ -491,6 +523,12 @@ internal class KeyPackageRepositoryTest {
             val CLAIMED_KEY_PACKAGES = ClaimedKeyPackageList(
                 listOf(
                     KeyPackageDTO(OTHER_CLIENT_ID.value, "wire.com", KeyPackage(), KeyPackageRef(), "user_id")
+                )
+            )
+            val MULTI_CLIENT_CLAIMED_KEY_PACKAGES = ClaimedKeyPackageList(
+                listOf(
+                    KeyPackageDTO("client_a", "wire.com", "keyPackageA", "refA", USER_ID.value),
+                    KeyPackageDTO("client_b", "wire.com", "keyPackageB", "refB", USER_ID.value),
                 )
             )
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-27236
<!--jira-description-action-hidden-marker-end-->
This PR improves MLS conversation migration performance by claiming key packages concurrently.
Key package claims now use a semaphore with a default limit of four concurrent requests. When a permit becomes available, the next claim starts immediately without waiting for a fixed batch to finish.

Existing error handling is preserved:
NoNetworkConnection and ProxyError abort the operation.
Claims waiting for a semaphore permit do not start after a fatal failure.
Claims already in progress are allowed to finish.
Federation and server errors remain non-fatal and are reported through usersWithUnreachableBackend.
Users without available key packages remain reported through usersWithoutKeyPackages.

Added coverage to verify:
Claims never exceed the configured concurrency limit.
A released semaphore permit immediately starts the next claim.
Fatal failures prevent waiting claims from starting.
Already-active claims finish after a fatal failure.
Results remain consistent across different concurrency limits.