### PR TITLE
feat: support email in deeplink configuration (WPB-27198)

### DIFF
--- a/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/unbound/configuration/ServerConfigDTO.kt
+++ b/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/unbound/configuration/ServerConfigDTO.kt
@@ -32,7 +32,8 @@ data class ServerConfigDTO(
         val website: String,
         val title: String,
         val isOnPremises: Boolean,
-        val apiProxy: ApiProxy?
+        val apiProxy: ApiProxy?,
+        val supportEmail: String? = null,
     )
 
     data class MetaData(

--- a/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/unbound/configuration/ServerConfigResponse.kt
+++ b/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/unbound/configuration/ServerConfigResponse.kt
@@ -28,7 +28,8 @@ import kotlinx.serialization.Serializable
 data class ServerConfigResponse(
     @SerialName("endpoints") val endpoints: EndPoints,
     @SerialName("title") val title: String,
-    @SerialName("apiProxy") val apiProxy: ApiProxy?
+    @SerialName("apiProxy") val apiProxy: ApiProxy? = null,
+    @SerialName("supportEmail") val supportEmail: String? = null,
 )
 
 @Serializable

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unbound/configuration/ServerConfigApi.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unbound/configuration/ServerConfigApi.kt
@@ -85,7 +85,8 @@ class ServerConfigApiImpl internal constructor(
                     isOnPremises = true,
                     apiProxy = apiProxy?.let { proxy ->
                         ServerConfigDTO.ApiProxy(proxy.needsAuthentication, proxy.host, proxy.port)
-                    }
+                    },
+                    supportEmail = supportEmail
                 )
             }
         }

--- a/logic/api/jvm/logic.api
+++ b/logic/api/jvm/logic.api
@@ -234,8 +234,10 @@ public final class com/wire/kalium/logic/configuration/server/ServerConfig$Compa
 
 public final class com/wire/kalium/logic/configuration/server/ServerConfig$Links {
 	public static final field Companion Lcom/wire/kalium/logic/configuration/server/ServerConfig$Links$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcom/wire/kalium/logic/configuration/server/ServerConfig$ApiProxy;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcom/wire/kalium/logic/configuration/server/ServerConfig$ApiProxy;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcom/wire/kalium/logic/configuration/server/ServerConfig$ApiProxy;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
@@ -244,8 +246,8 @@ public final class com/wire/kalium/logic/configuration/server/ServerConfig$Links
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Z
 	public final fun component9 ()Lcom/wire/kalium/logic/configuration/server/ServerConfig$ApiProxy;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcom/wire/kalium/logic/configuration/server/ServerConfig$ApiProxy;)Lcom/wire/kalium/logic/configuration/server/ServerConfig$Links;
-	public static synthetic fun copy$default (Lcom/wire/kalium/logic/configuration/server/ServerConfig$Links;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcom/wire/kalium/logic/configuration/server/ServerConfig$ApiProxy;ILjava/lang/Object;)Lcom/wire/kalium/logic/configuration/server/ServerConfig$Links;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcom/wire/kalium/logic/configuration/server/ServerConfig$ApiProxy;Ljava/lang/String;)Lcom/wire/kalium/logic/configuration/server/ServerConfig$Links;
+	public static synthetic fun copy$default (Lcom/wire/kalium/logic/configuration/server/ServerConfig$Links;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcom/wire/kalium/logic/configuration/server/ServerConfig$ApiProxy;Ljava/lang/String;ILjava/lang/Object;)Lcom/wire/kalium/logic/configuration/server/ServerConfig$Links;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAccounts ()Ljava/lang/String;
 	public final fun getApi ()Ljava/lang/String;
@@ -253,6 +255,7 @@ public final class com/wire/kalium/logic/configuration/server/ServerConfig$Links
 	public final fun getBlackList ()Ljava/lang/String;
 	public final fun getForgotPassword ()Ljava/lang/String;
 	public final fun getPricing ()Ljava/lang/String;
+	public final fun getSupportEmail ()Ljava/lang/String;
 	public final fun getTeams ()Ljava/lang/String;
 	public final fun getTitle ()Ljava/lang/String;
 	public final fun getTos ()Ljava/lang/String;

--- a/logic/api/logic.klib.api
+++ b/logic/api/logic.klib.api
@@ -2480,7 +2480,7 @@ final class com.wire.kalium.logic.configuration.server/ServerConfig { // com.wir
     }
 
     final class Links { // com.wire.kalium.logic.configuration.server/ServerConfig.Links|null[0]
-        constructor <init>(kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/Boolean, com.wire.kalium.logic.configuration.server/ServerConfig.ApiProxy?) // com.wire.kalium.logic.configuration.server/ServerConfig.Links.<init>|<init>(kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.Boolean;com.wire.kalium.logic.configuration.server.ServerConfig.ApiProxy?){}[0]
+        constructor <init>(kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/String, kotlin/Boolean, com.wire.kalium.logic.configuration.server/ServerConfig.ApiProxy?, kotlin/String? = ...) // com.wire.kalium.logic.configuration.server/ServerConfig.Links.<init>|<init>(kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.Boolean;com.wire.kalium.logic.configuration.server.ServerConfig.ApiProxy?;kotlin.String?){}[0]
 
         final val accounts // com.wire.kalium.logic.configuration.server/ServerConfig.Links.accounts|{}accounts[0]
             final fun <get-accounts>(): kotlin/String // com.wire.kalium.logic.configuration.server/ServerConfig.Links.accounts.<get-accounts>|<get-accounts>(){}[0]
@@ -2496,6 +2496,8 @@ final class com.wire.kalium.logic.configuration.server/ServerConfig { // com.wir
             final fun <get-isOnPremises>(): kotlin/Boolean // com.wire.kalium.logic.configuration.server/ServerConfig.Links.isOnPremises.<get-isOnPremises>|<get-isOnPremises>(){}[0]
         final val pricing // com.wire.kalium.logic.configuration.server/ServerConfig.Links.pricing|{}pricing[0]
             final fun <get-pricing>(): kotlin/String // com.wire.kalium.logic.configuration.server/ServerConfig.Links.pricing.<get-pricing>|<get-pricing>(){}[0]
+        final val supportEmail // com.wire.kalium.logic.configuration.server/ServerConfig.Links.supportEmail|{}supportEmail[0]
+            final fun <get-supportEmail>(): kotlin/String? // com.wire.kalium.logic.configuration.server/ServerConfig.Links.supportEmail.<get-supportEmail>|<get-supportEmail>(){}[0]
         final val teams // com.wire.kalium.logic.configuration.server/ServerConfig.Links.teams|{}teams[0]
             final fun <get-teams>(): kotlin/String // com.wire.kalium.logic.configuration.server/ServerConfig.Links.teams.<get-teams>|<get-teams>(){}[0]
         final val title // com.wire.kalium.logic.configuration.server/ServerConfig.Links.title|{}title[0]
@@ -2508,6 +2510,7 @@ final class com.wire.kalium.logic.configuration.server/ServerConfig { // com.wir
             final fun <get-website>(): kotlin/String // com.wire.kalium.logic.configuration.server/ServerConfig.Links.website.<get-website>|<get-website>(){}[0]
 
         final fun component1(): kotlin/String // com.wire.kalium.logic.configuration.server/ServerConfig.Links.component1|component1(){}[0]
+        final fun component10(): kotlin/String? // com.wire.kalium.logic.configuration.server/ServerConfig.Links.component10|component10(){}[0]
         final fun component2(): kotlin/String // com.wire.kalium.logic.configuration.server/ServerConfig.Links.component2|component2(){}[0]
         final fun component3(): kotlin/String // com.wire.kalium.logic.configuration.server/ServerConfig.Links.component3|component3(){}[0]
         final fun component4(): kotlin/String // com.wire.kalium.logic.configuration.server/ServerConfig.Links.component4|component4(){}[0]
@@ -2516,7 +2519,7 @@ final class com.wire.kalium.logic.configuration.server/ServerConfig { // com.wir
         final fun component7(): kotlin/String // com.wire.kalium.logic.configuration.server/ServerConfig.Links.component7|component7(){}[0]
         final fun component8(): kotlin/Boolean // com.wire.kalium.logic.configuration.server/ServerConfig.Links.component8|component8(){}[0]
         final fun component9(): com.wire.kalium.logic.configuration.server/ServerConfig.ApiProxy? // com.wire.kalium.logic.configuration.server/ServerConfig.Links.component9|component9(){}[0]
-        final fun copy(kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., kotlin/Boolean = ..., com.wire.kalium.logic.configuration.server/ServerConfig.ApiProxy? = ...): com.wire.kalium.logic.configuration.server/ServerConfig.Links // com.wire.kalium.logic.configuration.server/ServerConfig.Links.copy|copy(kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.Boolean;com.wire.kalium.logic.configuration.server.ServerConfig.ApiProxy?){}[0]
+        final fun copy(kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., kotlin/Boolean = ..., com.wire.kalium.logic.configuration.server/ServerConfig.ApiProxy? = ..., kotlin/String? = ...): com.wire.kalium.logic.configuration.server/ServerConfig.Links // com.wire.kalium.logic.configuration.server/ServerConfig.Links.copy|copy(kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.String;kotlin.Boolean;com.wire.kalium.logic.configuration.server.ServerConfig.ApiProxy?;kotlin.String?){}[0]
         final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic.configuration.server/ServerConfig.Links.equals|equals(kotlin.Any?){}[0]
         final fun hashCode(): kotlin/Int // com.wire.kalium.logic.configuration.server/ServerConfig.Links.hashCode|hashCode(){}[0]
         final fun toString(): kotlin/String // com.wire.kalium.logic.configuration.server/ServerConfig.Links.toString|toString(){}[0]

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfig.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfig.kt
@@ -59,7 +59,8 @@ public data class ServerConfig(
         @SerialName("websiteUrl") val website: String,
         @SerialName("title") val title: String,
         @SerialName("is_on_premises") val isOnPremises: Boolean,
-        @SerialName("apiProxy") val apiProxy: ApiProxy?
+        @SerialName("apiProxy") val apiProxy: ApiProxy?,
+        @SerialName("supportEmail") val supportEmail: String? = null,
     ) {
         val forgotPassword: String
             get() = URLBuilder().apply {
@@ -186,15 +187,16 @@ internal class ServerConfigMapperImpl(
         ServerConfigDTO(
             id = id,
             links = ServerConfigDTO.Links(
-                links.api,
-                links.accounts,
-                links.webSocket,
-                links.blackList,
-                links.teams,
-                links.website,
-                links.title,
+                api = links.api,
+                accounts = links.accounts,
+                webSocket = links.webSocket,
+                blackList = links.blackList,
+                teams = links.teams,
+                website = links.website,
+                title = links.title,
                 isOnPremises = links.isOnPremises,
-                apiProxy = links.apiProxy?.let { toDTO(it) }
+                apiProxy = links.apiProxy?.let { toDTO(it) },
+                supportEmail = links.supportEmail,
             ),
             metaData = ServerConfigDTO.MetaData(
                 federation = metaData.federation,
@@ -214,7 +216,8 @@ internal class ServerConfigMapperImpl(
             links.website,
             title,
             isOnPremises,
-            links.apiProxy?.let { toDTO(it) }
+            links.apiProxy?.let { toDTO(it) },
+            links.supportEmail,
         )
     }
 
@@ -260,7 +263,8 @@ internal class ServerConfigMapperImpl(
             teams = teams,
             title = title,
             isOnPremises = isOnPremises,
-            apiProxy = apiProxy?.let { fromDTO(it) }
+            apiProxy = apiProxy?.let { fromDTO(it) },
+            supportEmail = supportEmail,
         )
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigMapperTest.kt
@@ -51,6 +51,15 @@ class ServerConfigMapperTest {
     }
 
     @Test
+    fun givenServerConfigDtoWithSupportEmail_whenMappingToLinks_thenSupportEmailIsRetained() {
+        val links = newServerConfigDTO(1).links.copy(supportEmail = "support@example.com")
+
+        val actual = serverConfigMapper.fromDTO(links)
+
+        assertEquals("support@example.com", actual.supportEmail)
+    }
+
+    @Test
     fun givenAServerConfig_whenMappingToBackendConfig_thenValuesAreMappedCorrectly() {
         val serverConfig: ServerConfig = SERVER_CONFIG_TEST
         val expected: ServerConfigDTO =


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-27198
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-27198
----

# What's new in this PR?

Adding new optional "supportEmail" field to deeplink configuration.
This field will be used to configure a custom support email address for Wire Gov application.