### PR TITLE
chore(sync): add structured recovery telemetry [WPB-27273]

### DIFF
--- a/data/network-util/src/commonMain/kotlin/com/wire/kalium/network/NetworkStateObserver.kt
+++ b/data/network-util/src/commonMain/kotlin/com/wire/kalium/network/NetworkStateObserver.kt
@@ -36,7 +36,6 @@ interface NetworkStateObserver {
      */
     suspend fun delayUntilConnectedWithInternetAgain(delay: Duration): Boolean {
         // Delay for given amount but break it if reconnected again.
-        kaliumUtilLogger.i("$TAG delayUntilConnectedWithInternetAgain for $delay")
         return withTimeoutOrNull(delay) {
             // Drop the current value, so it will complete only if the connection changed again to connected during that time.
             observeNetworkState()

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/network/NetworkStateObserverImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/network/NetworkStateObserverImpl.kt
@@ -24,8 +24,6 @@ import android.net.Network
 import android.net.NetworkCapabilities
 import android.os.Build
 import com.wire.kalium.common.logger.kaliumLogger
-import com.wire.kalium.common.logger.logStructuredJson
-import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.network.CurrentNetwork
 import com.wire.kalium.network.NetworkState
 import com.wire.kalium.network.NetworkStateObserver
@@ -45,6 +43,8 @@ internal actual class NetworkStateObserverImpl(
     connectivityManager: ConnectivityManager,
     kaliumDispatcher: KaliumDispatcher = KaliumDispatcherImpl,
 ) : NetworkStateObserver {
+
+    private val logger = kaliumLogger.withTextTag(NetworkStateObserver.TAG)
 
     constructor(
         appContext: Context,
@@ -82,22 +82,26 @@ internal actual class NetworkStateObserverImpl(
                 networkCapabilities: NetworkCapabilities
             ) {
                 super.onCapabilitiesChanged(network, networkCapabilities)
-                val loggerMessage = mutableMapOf<String, String>().apply {
-                    put("internet", networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET).toString())
-                    put("validated", networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED).toString())
-                    put("not restricted", networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_RESTRICTED).toString())
+                val networkState = networkCapabilities.toState()
+                val telemetry = mutableMapOf<String, Any?>().apply {
+                    put("networkId", network.networkHandle.toString())
+                    put("networkType", networkCapabilities.toCurrentNetworkType().name)
+                    put("networkState", networkState.telemetryName())
+                    put("internet", networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET))
+                    put("validated", networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED))
+                    put("notRestricted", networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_RESTRICTED))
 
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                        put("foreground", networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_FOREGROUND).toString())
-                        put("not congested", networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_CONGESTED).toString())
-                        put("not suspended", networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_SUSPENDED).toString())
+                        put("foreground", networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_FOREGROUND))
+                        put("notCongested", networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_CONGESTED))
+                        put("notSuspended", networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_SUSPENDED))
                     }
 
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                        put("signalStrength", networkCapabilities.signalStrength.toString())
+                        put("signalStrength", networkCapabilities.signalStrength)
                     }
                 }
-                kaliumLogger.logStructuredJson(KaliumLogLevel.INFO, "${NetworkStateObserver.TAG} capabilities changed", loggerMessage)
+                logger.logNetworkTelemetry(NetworkTelemetryEvent.NETWORK_CAPABILITIES_CHANGED, data = telemetry)
                 defaultNetworkDataStateFlow.update {
                     DefaultNetworkData.Connected(
                         network,
@@ -107,32 +111,47 @@ internal actual class NetworkStateObserverImpl(
             }
 
             override fun onLost(network: Network) {
-                kaliumLogger.i("${NetworkStateObserver.TAG} lost connection")
                 defaultNetworkDataStateFlow.update { DefaultNetworkData.NotConnected }
+                logNetworkEvent(
+                    event = NetworkTelemetryEvent.NETWORK_LOST,
+                    network = network,
+                    networkState = NetworkState.NotConnected,
+                )
                 super.onLost(network)
             }
 
             override fun onUnavailable() {
-                kaliumLogger.i("${NetworkStateObserver.TAG} connection unavailable")
                 defaultNetworkDataStateFlow.update { DefaultNetworkData.NotConnected }
+                logNetworkEvent(
+                    event = NetworkTelemetryEvent.NETWORK_UNAVAILABLE,
+                    networkState = NetworkState.NotConnected,
+                )
                 super.onUnavailable()
             }
 
             override fun onAvailable(network: Network) {
-                kaliumLogger.i("${NetworkStateObserver.TAG} connection available")
                 defaultNetworkDataStateFlow.update { DefaultNetworkData.Connected(network) }
+                logNetworkEvent(
+                    event = NetworkTelemetryEvent.NETWORK_AVAILABLE,
+                    network = network,
+                    networkState = NetworkState.ConnectedWithoutInternet,
+                )
                 super.onAvailable(network)
             }
 
             override fun onLosing(network: Network, maxMsToLive: Int) {
-                kaliumLogger.i("${NetworkStateObserver.TAG} losing connection maxMsToLive: $maxMsToLive")
+                logNetworkEvent(
+                    event = NetworkTelemetryEvent.NETWORK_LOSING,
+                    network = network,
+                    networkState = defaultNetworkDataStateFlow.value.toState(),
+                    data = mapOf("maxMsToLive" to maxMsToLive),
+                )
                 super.onLosing(network, maxMsToLive)
             }
 
             override fun onBlockedStatusChanged(network: Network, blocked: Boolean) {
-                kaliumLogger.i("${NetworkStateObserver.TAG} block connection changed to $blocked")
                 defaultNetworkDataStateFlow.update {
-                    val updatedValue = when (it) {
+                    when (it) {
                         is DefaultNetworkData.Connected -> {
                             it.copy(isBlocked = blocked)
                         }
@@ -142,13 +161,33 @@ internal actual class NetworkStateObserverImpl(
                             else DefaultNetworkData.Connected(network)
                         }
                     }
-                    kaliumLogger.d("${NetworkStateObserver.TAG} default network state $it changed to $updatedValue")
-                    updatedValue
                 }
+                logNetworkEvent(
+                    event = NetworkTelemetryEvent.NETWORK_BLOCKED_STATUS_CHANGED,
+                    network = network,
+                    networkState = defaultNetworkDataStateFlow.value.toState(),
+                    data = mapOf("blocked" to blocked),
+                )
                 super.onBlockedStatusChanged(network, blocked)
             }
         }
         connectivityManager.registerDefaultNetworkCallback(callback)
+    }
+
+    private fun logNetworkEvent(
+        event: NetworkTelemetryEvent,
+        networkState: NetworkState,
+        network: Network? = null,
+        data: Map<String, Any?> = emptyMap(),
+    ) {
+        logger.logNetworkTelemetry(
+            event = event,
+            data = buildMap {
+                network?.networkHandle?.toString()?.let { put("networkId", it) }
+                put("networkState", networkState.telemetryName())
+                putAll(data)
+            }
+        )
     }
 
     private fun NetworkCapabilities?.hasInternetValidated(): Boolean {
@@ -198,4 +237,5 @@ internal actual class NetworkStateObserverImpl(
             val isBlocked: Boolean = false
         ) : DefaultNetworkData()
     }
+
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/network/NetworkTelemetry.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/network/NetworkTelemetry.kt
@@ -1,0 +1,57 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.network
+
+import com.wire.kalium.common.logger.logStructuredJson
+import com.wire.kalium.logger.KaliumLogLevel
+import com.wire.kalium.logger.KaliumLogger
+import com.wire.kalium.network.NetworkState
+
+internal const val NETWORK_TELEMETRY_LEADING_MESSAGE = "Network telemetry"
+
+internal enum class NetworkTelemetryEvent {
+    NETWORK_CAPABILITIES_CHANGED,
+    NETWORK_LOST,
+    NETWORK_UNAVAILABLE,
+    NETWORK_AVAILABLE,
+    NETWORK_LOSING,
+    NETWORK_BLOCKED_STATUS_CHANGED,
+}
+
+internal fun KaliumLogger.logNetworkTelemetry(
+    event: NetworkTelemetryEvent,
+    level: KaliumLogLevel = KaliumLogLevel.INFO,
+    data: Map<String, Any?> = emptyMap(),
+) {
+    logStructuredJson(
+        level = level,
+        leadingMessage = NETWORK_TELEMETRY_LEADING_MESSAGE,
+        jsonStringKeyValues = buildMap {
+            put("schemaVersion", 1)
+            put("event", event.name)
+            put("component", "NETWORK_OBSERVER")
+            putAll(data)
+        }
+    )
+}
+
+internal fun NetworkState.telemetryName(): String = when (this) {
+    NetworkState.ConnectedWithInternet -> "CONNECTED_WITH_INTERNET"
+    NetworkState.ConnectedWithoutInternet -> "CONNECTED_WITHOUT_INTERNET"
+    NetworkState.NotConnected -> "NOT_CONNECTED"
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncExecutor.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncExecutor.kt
@@ -18,6 +18,7 @@
 package com.wire.kalium.logic.sync
 
 import com.wire.kalium.common.logger.kaliumLogger
+import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.SYNC
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
@@ -37,7 +38,6 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.runningFold
 import kotlinx.coroutines.launch
 
@@ -67,7 +67,12 @@ public abstract class SyncExecutor {
          */
         internal fun release() {
             if (isEndless) {
-                logger.w("Sync request was marked as endless, so it was not released and will keep running. Following the Sync Scope.")
+                logger.logSyncTelemetry(
+                    event = SyncTelemetryEvent.REQUEST_RETAINED,
+                    component = SyncTelemetryComponent.EXECUTOR,
+                    level = KaliumLogLevel.WARN,
+                    data = mapOf("reason" to "KEEP_SYNC_ALWAYS_ON")
+                )
                 return
             }
             job.cancel()
@@ -99,14 +104,21 @@ internal class SyncExecutorImpl(
     userScopedLogger: KaliumLogger = kaliumLogger,
 ) : SyncExecutor() {
 
+    private enum class ExecutionTrigger {
+        FIRST_REQUEST,
+        NEW_REQUEST_WHILE_FAILED,
+    }
+
     private data class SyncDemand(
         val requesterCount: Int = 0,
         val restartVersion: Long = 0,
+        val executionTrigger: ExecutionTrigger? = null,
     )
 
     private data class SyncExecution(
         val shouldSync: Boolean,
         val restartVersion: Long,
+        val trigger: ExecutionTrigger?,
     )
 
     // Keep logical request lifetimes separate from transient collectors that only wait for a sync state.
@@ -117,36 +129,87 @@ internal class SyncExecutorImpl(
     override fun startAndStopSyncAsNeeded() {
         scope.launch {
             syncRequestDemandFlow.subscriptionCount
-                .onEach {
-                    logger.d("!! Sync requester count changed to $it")
-                }
                 .runningFold(SyncDemand()) { previous, requesterCount ->
                     val requestAdded = requesterCount > previous.requesterCount
+                    val syncState = syncStateObserver.syncState.value
                     // The first request starts sync. An additional request restarts it only when
                     // recovery is backing off, avoiding disruption to an already-live connection.
                     val shouldRestart = requestAdded &&
-                        (previous.requesterCount == 0 || syncStateObserver.syncState.value is SyncState.Failed)
+                        (previous.requesterCount == 0 || syncState is SyncState.Failed)
+                    val executionTrigger = when {
+                        !shouldRestart -> null
+                        previous.requesterCount == 0 -> ExecutionTrigger.FIRST_REQUEST
+                        else -> ExecutionTrigger.NEW_REQUEST_WHILE_FAILED
+                    }
+                    logRequesterCountChanged(previous, requesterCount, syncState, executionTrigger)
                     SyncDemand(
                         requesterCount = requesterCount,
                         restartVersion = previous.restartVersion + if (shouldRestart) 1 else 0,
+                        executionTrigger = executionTrigger ?: previous.executionTrigger,
                     )
                 }
                 .map { demand ->
                     SyncExecution(
                         shouldSync = demand.requesterCount > 0,
                         restartVersion = demand.restartVersion,
+                        trigger = demand.executionTrigger,
                     )
                 }
                 .distinctUntilChanged()
                 .collectLatest { execution ->
                     if (execution.shouldSync) {
-                        logger.i("!! Starting Sync to fulfill requests !!")
+                        logger.logSyncTelemetry(
+                            event = SyncTelemetryEvent.EXECUTION_STARTED,
+                            component = SyncTelemetryComponent.EXECUTOR,
+                            data = mapOf(
+                                "restartVersion" to execution.restartVersion,
+                                "trigger" to execution.trigger?.name,
+                            )
+                        )
                         performSync()
                     } else {
-                        logger.i("!! Stopping sync, as there are no requests for it. !!")
+                        logger.logSyncTelemetry(
+                            event = SyncTelemetryEvent.EXECUTION_STOPPED,
+                            component = SyncTelemetryComponent.EXECUTOR,
+                            data = mapOf(
+                                "restartVersion" to execution.restartVersion,
+                                "reason" to "NO_ACTIVE_REQUESTS",
+                            )
+                        )
                     }
                 }
         }
+    }
+
+    private fun logRequesterCountChanged(
+        previous: SyncDemand,
+        requesterCount: Int,
+        syncState: SyncState,
+        executionTrigger: ExecutionTrigger?,
+    ) {
+        val action = when {
+            executionTrigger == ExecutionTrigger.FIRST_REQUEST -> "START"
+            executionTrigger == ExecutionTrigger.NEW_REQUEST_WHILE_FAILED -> "RESTART"
+            requesterCount == 0 && previous.requesterCount > 0 -> "STOP"
+            requesterCount > 0 -> "KEEP_RUNNING"
+            else -> "IDLE"
+        }
+        logger.logSyncTelemetry(
+            event = SyncTelemetryEvent.REQUEST_COUNT_CHANGED,
+            component = SyncTelemetryComponent.EXECUTOR,
+            level = KaliumLogLevel.DEBUG,
+            data = buildMap {
+                put("previousRequesterCount", previous.requesterCount)
+                put("requesterCount", requesterCount)
+                put("syncState", syncState.telemetryName())
+                put("action", action)
+                put("trigger", executionTrigger?.name)
+                if (syncState is SyncState.Failed) {
+                    put("retryDelayInMillis", syncState.retryDelay.inWholeMilliseconds)
+                    putAll(syncState.cause.telemetryData())
+                }
+            }
+        )
     }
 
     private suspend fun performSync() {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncManagerLogger.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncManagerLogger.kt
@@ -17,13 +17,11 @@
  */
 package com.wire.kalium.logic.sync
 
-import kotlin.uuid.Uuid
-import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.logger.KaliumLogger
-import com.wire.kalium.common.logger.logStructuredJson
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlin.time.Duration
+import kotlin.uuid.Uuid
 
 /**
  * Logs the sync process by providing structured logs.
@@ -40,15 +38,12 @@ internal class SyncManagerLogger(
      * Logs the sync process start.
      */
     fun logSyncStarted() {
-        logger.withFeatureId(KaliumLogger.Companion.ApplicationFlow.SYNC).logStructuredJson(
-            level = KaliumLogLevel.INFO,
-            leadingMessage = "Started sync process",
-            jsonStringKeyValues = mapOf(
-                "syncMetadata" to mapOf(
-                    "id" to syncId,
-                    "status" to SyncStatus.STARTED.name,
-                    "type" to syncType.name
-                )
+        logger.withFeatureId(KaliumLogger.Companion.ApplicationFlow.SYNC).logSyncTelemetry(
+            event = SyncTelemetryEvent.SYNC_PROCESS_STARTED,
+            component = syncType.telemetryComponent(),
+            data = mapOf(
+                "syncId" to syncId,
+                "status" to SyncStatus.STARTED.name,
             )
         )
     }
@@ -61,17 +56,14 @@ internal class SyncManagerLogger(
      * @param duration optional the duration of the sync process.
      */
     fun logSyncCompleted(duration: Duration = Clock.System.now() - syncStartedMoment) {
-        val logMap = mapOf(
-            "id" to syncId,
-            "status" to SyncStatus.COMPLETED.name,
-            "type" to syncType.name,
-            "performanceData" to mapOf("timeTakenInMillis" to duration.inWholeMilliseconds)
-        )
-
-        logger.withFeatureId(KaliumLogger.Companion.ApplicationFlow.SYNC).logStructuredJson(
-            level = KaliumLogLevel.INFO,
-            leadingMessage = "Completed sync process",
-            jsonStringKeyValues = mapOf("syncMetadata" to logMap)
+        logger.withFeatureId(KaliumLogger.Companion.ApplicationFlow.SYNC).logSyncTelemetry(
+            event = SyncTelemetryEvent.SYNC_PROCESS_COMPLETED,
+            component = syncType.telemetryComponent(),
+            data = mapOf(
+                "syncId" to syncId,
+                "status" to SyncStatus.COMPLETED.name,
+                "durationInMillis" to duration.inWholeMilliseconds,
+            )
         )
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncRetryDelay.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncRetryDelay.kt
@@ -18,6 +18,7 @@
 package com.wire.kalium.logic.sync
 
 import com.wire.kalium.logger.KaliumLogger
+import com.wire.kalium.logic.network.telemetryName
 import com.wire.kalium.logic.util.ExponentialDurationHelper
 import com.wire.kalium.network.NetworkStateObserver
 import kotlin.time.Duration
@@ -34,12 +35,30 @@ internal suspend fun NetworkStateObserver.delayBeforeSyncRetry(
     retryDelay: Duration,
     exponentialDurationHelper: ExponentialDurationHelper,
     logger: KaliumLogger,
+    syncType: SyncType,
 ) {
-    logger.i("Waiting $retryDelay or until reconnection before retrying")
-    if (delayUntilConnectedWithInternetAgain(retryDelay)) {
-        logger.i("Network reconnected - resetting retry delay and retrying")
+    val component = syncType.telemetryComponent()
+    logger.logSyncTelemetry(
+        event = SyncTelemetryEvent.RETRY_WAIT_STARTED,
+        component = component,
+        data = retryTelemetryData(retryDelay)
+    )
+    val reconnected = delayUntilConnectedWithInternetAgain(retryDelay)
+    if (reconnected) {
         exponentialDurationHelper.reset()
-    } else {
-        logger.i("Retry delay elapsed - retrying")
     }
+    logger.logSyncTelemetry(
+        event = SyncTelemetryEvent.RETRY_TRIGGERED,
+        component = component,
+        data = retryTelemetryData(retryDelay) + mapOf(
+            "trigger" to if (reconnected) "NETWORK_RECONNECTED" else "RETRY_DELAY_ELAPSED",
+            "backoffReset" to reconnected,
+        )
+    )
+}
+
+private fun NetworkStateObserver.retryTelemetryData(retryDelay: Duration): Map<String, Any?> = buildMap {
+    put("retryDelayInMillis", retryDelay.inWholeMilliseconds)
+    put("networkState", observeNetworkState().value.telemetryName())
+    observeCurrentNetwork().value?.id?.let { put("networkId", it) }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncTelemetry.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncTelemetry.kt
@@ -1,0 +1,89 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.NetworkFailure
+import com.wire.kalium.common.logger.logStructuredJson
+import com.wire.kalium.logger.KaliumLogLevel
+import com.wire.kalium.logger.KaliumLogger
+import com.wire.kalium.logic.data.sync.SyncState
+
+internal const val SYNC_TELEMETRY_LEADING_MESSAGE = "Sync telemetry"
+
+internal enum class SyncTelemetryEvent {
+    REQUEST_COUNT_CHANGED,
+    EXECUTION_STARTED,
+    EXECUTION_STOPPED,
+    REQUEST_RETAINED,
+    SYNC_FAILED,
+    RETRY_BACKOFF_RESET,
+    RETRY_WAIT_STARTED,
+    RETRY_TRIGGERED,
+    SYNC_PROCESS_STARTED,
+    SYNC_PROCESS_COMPLETED,
+}
+
+internal enum class SyncTelemetryComponent {
+    EXECUTOR,
+    INCREMENTAL,
+    SLOW,
+}
+
+internal fun KaliumLogger.logSyncTelemetry(
+    event: SyncTelemetryEvent,
+    component: SyncTelemetryComponent,
+    level: KaliumLogLevel = KaliumLogLevel.INFO,
+    data: Map<String, Any?> = emptyMap(),
+) {
+    logStructuredJson(
+        level = level,
+        leadingMessage = SYNC_TELEMETRY_LEADING_MESSAGE,
+        jsonStringKeyValues = buildMap {
+            put("schemaVersion", 1)
+            put("event", event.name)
+            put("component", component.name)
+            putAll(data)
+        }
+    )
+}
+
+internal fun SyncState.telemetryName(): String = when (this) {
+    SyncState.Waiting -> "WAITING"
+    SyncState.SlowSync -> "SLOW_SYNC"
+    SyncState.GatheringPendingEvents -> "GATHERING_PENDING_EVENTS"
+    SyncState.Live -> "LIVE"
+    is SyncState.Failed -> "FAILED"
+}
+
+internal fun CoreFailure.telemetryData(): Map<String, Any?> = buildMap {
+    put("failureType", this@telemetryData::class.simpleName)
+    val cause = when (val failure = this@telemetryData) {
+        is NetworkFailure.NoNetworkConnection -> failure.cause
+        is NetworkFailure.ProxyError -> failure.cause
+        is NetworkFailure.ServerMiscommunication -> failure.rootCause
+        is CoreFailure.Unknown -> failure.rootCause
+        else -> null
+    }
+    put("causeType", cause?.let { it::class.simpleName })
+}
+
+internal fun SyncType.telemetryComponent(): SyncTelemetryComponent = when (this) {
+    SyncType.INCREMENTAL -> SyncTelemetryComponent.INCREMENTAL
+    SyncType.SLOW -> SyncTelemetryComponent.SLOW
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
@@ -19,15 +19,20 @@
 package com.wire.kalium.logic.sync.incremental
 
 import com.wire.kalium.common.logger.kaliumLogger
+import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.SYNC
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.sync.SyncExceptionHandler
+import com.wire.kalium.logic.sync.SyncTelemetryComponent
+import com.wire.kalium.logic.sync.SyncTelemetryEvent
 import com.wire.kalium.logic.sync.SyncType
 import com.wire.kalium.logic.sync.UserSessionWorkScheduler
 import com.wire.kalium.logic.sync.delayBeforeSyncRetry
+import com.wire.kalium.logic.sync.logSyncTelemetry
+import com.wire.kalium.logic.sync.telemetryData
 import com.wire.kalium.logic.sync.provideNewSyncManagerLogger
 import com.wire.kalium.logic.sync.slow.SlowSyncManager
 import com.wire.kalium.logic.util.ExponentialDurationHelper
@@ -107,20 +112,35 @@ internal fun IncrementalSyncManager(
 
     private fun coroutineExceptionHandler(onRetry: suspend () -> Unit) = SyncExceptionHandler(
         onCancellation = {
-            logger.i("Cancellation exception handled in SyncExceptionHandler for IncrementalSyncManager")
+            logger.logSyncTelemetry(
+                event = SyncTelemetryEvent.EXECUTION_STOPPED,
+                component = SyncTelemetryComponent.INCREMENTAL,
+                data = mapOf("reason" to "CANCELLED")
+            )
             withContext(NonCancellable) {
                 incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Pending)
             }
         },
         onFailure = { failure ->
-            logger.i("ExceptionHandler error $failure")
             val delay = exponentialDurationHelper.next()
+            logger.logSyncTelemetry(
+                event = SyncTelemetryEvent.SYNC_FAILED,
+                component = SyncTelemetryComponent.INCREMENTAL,
+                level = KaliumLogLevel.WARN,
+                data = failure.telemetryData() +
+                    ("retryDelayInMillis" to delay.inWholeMilliseconds)
+            )
             incrementalSyncRepository.updateIncrementalSyncState(
                 IncrementalSyncStatus.Failed(failure, delay)
             )
 
             incrementalSyncRecoveryHandler.recover(failure = failure) {
-                networkStateObserver.delayBeforeSyncRetry(delay, exponentialDurationHelper, logger)
+                networkStateObserver.delayBeforeSyncRetry(
+                    retryDelay = delay,
+                    exponentialDurationHelper = exponentialDurationHelper,
+                    logger = logger,
+                    syncType = SyncType.INCREMENTAL,
+                )
                 onRetry()
             }
         }
@@ -138,6 +158,11 @@ internal fun IncrementalSyncManager(
             }
             // Always start sync with a fresh retry delay
             exponentialDurationHelper.reset()
+            logger.logSyncTelemetry(
+                event = SyncTelemetryEvent.RETRY_BACKOFF_RESET,
+                component = SyncTelemetryComponent.INCREMENTAL,
+                data = mapOf("reason" to "SYNC_COLLECTION_STARTED")
+            )
             launch { doIncrementalSync() }
         }
     }
@@ -158,6 +183,12 @@ internal fun IncrementalSyncManager(
                     EventSource.LIVE -> {
                         syncLogger.logSyncCompleted(duration = Clock.System.now() - syncData.second)
                         exponentialDurationHelper.reset()
+                        logger.logSyncTelemetry(
+                            event = SyncTelemetryEvent.RETRY_BACKOFF_RESET,
+                            component = SyncTelemetryComponent.INCREMENTAL,
+                            level = KaliumLogLevel.DEBUG,
+                            data = mapOf("reason" to "SYNC_LIVE")
+                        )
                         userSessionWorkScheduler.resetBackoffForPeriodicUserConfigSync()
                         IncrementalSyncStatus.Live
                     }
@@ -168,7 +199,11 @@ internal fun IncrementalSyncManager(
                 if (eventSource == EventSource.LIVE) Uuid.random().toString() to Clock.System.now() else syncData
             }.collect()
         incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Pending)
-        logger.i("IncrementalSync stopped.")
+        logger.logSyncTelemetry(
+            event = SyncTelemetryEvent.EXECUTION_STOPPED,
+            component = SyncTelemetryComponent.INCREMENTAL,
+            data = mapOf("reason" to "EVENT_FLOW_COMPLETED")
+        )
     } catch (t: Throwable) {
         exceptionHandler.handleException(t)
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
@@ -20,15 +20,20 @@ package com.wire.kalium.logic.sync.slow
 
 import com.wire.kalium.common.functional.combine
 import com.wire.kalium.common.logger.kaliumLogger
+import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.SYNC
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.sync.SlowSyncRepository
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.sync.SyncExceptionHandler
+import com.wire.kalium.logic.sync.SyncTelemetryComponent
+import com.wire.kalium.logic.sync.SyncTelemetryEvent
 import com.wire.kalium.logic.sync.SyncType
 import com.wire.kalium.logic.sync.delayBeforeSyncRetry
 import com.wire.kalium.logic.sync.incremental.IncrementalSyncManager
+import com.wire.kalium.logic.sync.logSyncTelemetry
+import com.wire.kalium.logic.sync.telemetryData
 import com.wire.kalium.logic.sync.provideNewSyncManagerLogger
 import com.wire.kalium.logic.sync.slow.migration.SyncMigrationStepsProvider
 import com.wire.kalium.logic.sync.slow.migration.steps.SyncMigrationStep
@@ -106,16 +111,32 @@ internal fun SlowSyncManager(
 
     private fun coroutineExceptionHandler(onRetry: suspend () -> Unit) = SyncExceptionHandler(
         onCancellation = {
+            logger.logSyncTelemetry(
+                event = SyncTelemetryEvent.EXECUTION_STOPPED,
+                component = SyncTelemetryComponent.SLOW,
+                data = mapOf("reason" to "CANCELLED")
+            )
             withContext(NonCancellable) {
                 slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Pending)
             }
         },
         onFailure = { failure ->
-            logger.i("SlowSync ExceptionHandler error $failure")
             val delay = exponentialDurationHelper.next()
+            logger.logSyncTelemetry(
+                event = SyncTelemetryEvent.SYNC_FAILED,
+                component = SyncTelemetryComponent.SLOW,
+                level = KaliumLogLevel.WARN,
+                data = failure.telemetryData() +
+                    ("retryDelayInMillis" to delay.inWholeMilliseconds)
+            )
             slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Failed(failure, delay))
             slowSyncRecoveryHandler.recover(failure) {
-                networkStateObserver.delayBeforeSyncRetry(delay, exponentialDurationHelper, logger)
+                networkStateObserver.delayBeforeSyncRetry(
+                    retryDelay = delay,
+                    exponentialDurationHelper = exponentialDurationHelper,
+                    logger = logger,
+                    syncType = SyncType.SLOW,
+                )
                 onRetry()
             }
         }
@@ -151,6 +172,11 @@ internal fun SlowSyncManager(
         coroutineScope {
             // A new sync request must not inherit a stale retry delay from a previous collector.
             exponentialDurationHelper.reset()
+            logger.logSyncTelemetry(
+                event = SyncTelemetryEvent.RETRY_BACKOFF_RESET,
+                component = SyncTelemetryComponent.SLOW,
+                data = mapOf("reason" to "SYNC_COLLECTION_STARTED")
+            )
             launch {
                 // TODO: Instead of forwarding repository state, we could just emit within the flow. Killing the repository completely.
                 slowSyncRepository.slowSyncStatus.collect { slowSyncStatus ->
@@ -205,6 +231,12 @@ internal fun SlowSyncManager(
             }
 
             exponentialDurationHelper.reset()
+            logger.logSyncTelemetry(
+                event = SyncTelemetryEvent.RETRY_BACKOFF_RESET,
+                component = SyncTelemetryComponent.SLOW,
+                level = KaliumLogLevel.DEBUG,
+                data = mapOf("reason" to "SLOW_SYNC_RESOLVED")
+            )
             slowSyncRepository.updateSlowSyncStatus(SlowSyncStatus.Complete)
         } else {
             // STOP SYNC

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/network/NetworkTelemetryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/network/NetworkTelemetryTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.network
+
+import co.touchlab.kermit.LogWriter
+import co.touchlab.kermit.Severity
+import com.wire.kalium.logger.KaliumLogLevel
+import com.wire.kalium.logger.KaliumLogger
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+
+class NetworkTelemetryTest {
+
+    @Test
+    fun givenNetworkTelemetry_whenLogging_thenShouldWriteStableStructuredFields() {
+        val writer = RecordingLogWriter()
+        val logger = KaliumLogger(
+            config = KaliumLogger.Config(
+                initialLevel = KaliumLogLevel.DEBUG,
+                initialLogWriterList = listOf(writer),
+            ),
+            tag = "NetworkTelemetryTest",
+        )
+
+        logger.logNetworkTelemetry(
+            event = NetworkTelemetryEvent.NETWORK_AVAILABLE,
+            data = mapOf(
+                "networkId" to "network-id",
+                "networkState" to "CONNECTED_WITHOUT_INTERNET",
+            )
+        )
+
+        val entry = writer.entries.single()
+        assertEquals(Severity.Info, entry.severity)
+        assertContains(entry.message, "Network telemetry:")
+        assertContains(entry.message, "\"schemaVersion\":1")
+        assertContains(entry.message, "\"event\":\"NETWORK_AVAILABLE\"")
+        assertContains(entry.message, "\"component\":\"NETWORK_OBSERVER\"")
+        assertContains(entry.message, "\"networkId\":\"network-id\"")
+    }
+
+    private class RecordingLogWriter : LogWriter() {
+        val entries = mutableListOf<Entry>()
+
+        override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) {
+            entries += Entry(severity, message)
+        }
+    }
+
+    private data class Entry(
+        val severity: Severity,
+        val message: String,
+    )
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/SyncTelemetryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/SyncTelemetryTest.kt
@@ -1,0 +1,160 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync
+
+import co.touchlab.kermit.LogWriter
+import co.touchlab.kermit.Severity
+import com.wire.kalium.common.error.NetworkFailure
+import com.wire.kalium.logger.KaliumLogLevel
+import com.wire.kalium.logger.KaliumLogger
+import com.wire.kalium.logic.util.ExponentialDurationHelper
+import com.wire.kalium.network.CurrentNetwork
+import com.wire.kalium.network.NetworkState
+import com.wire.kalium.network.NetworkStateObserver
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import okio.IOException
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+class SyncTelemetryTest {
+
+    @Test
+    fun givenNetworkFailure_whenBuildingTelemetry_thenShouldIncludeTypesWithoutExceptionMessage() {
+        val data = NetworkFailure.NoNetworkConnection(IOException("sensitive details")).telemetryData()
+
+        assertEquals("NoNetworkConnection", data["failureType"])
+        assertEquals("IOException", data["causeType"])
+        assertFalse(data.values.contains("sensitive details"))
+    }
+
+    @Test
+    fun givenSyncTelemetry_whenLogging_thenShouldWriteStableStructuredFields() {
+        val writer = RecordingLogWriter()
+        val logger = KaliumLogger(
+            config = KaliumLogger.Config(
+                initialLevel = KaliumLogLevel.DEBUG,
+                initialLogWriterList = listOf(writer),
+            ),
+            tag = "SyncTelemetryTest",
+        )
+
+        logger.logSyncTelemetry(
+            event = SyncTelemetryEvent.RETRY_TRIGGERED,
+            component = SyncTelemetryComponent.INCREMENTAL,
+            data = mapOf(
+                "trigger" to "NETWORK_RECONNECTED",
+                "retryDelayInMillis" to 1_000L,
+                "backoffReset" to true,
+            )
+        )
+
+        val entry = writer.entries.single()
+        assertEquals(Severity.Info, entry.severity)
+        assertEquals("SyncTelemetryTest", entry.tag)
+        assertContains(entry.message, "Sync telemetry:")
+        assertContains(entry.message, "\"schemaVersion\":1")
+        assertContains(entry.message, "\"event\":\"RETRY_TRIGGERED\"")
+        assertContains(entry.message, "\"component\":\"INCREMENTAL\"")
+        assertContains(entry.message, "\"trigger\":\"NETWORK_RECONNECTED\"")
+        assertContains(entry.message, "\"retryDelayInMillis\":1000")
+        assertContains(entry.message, "\"backoffReset\":true")
+    }
+
+    @Test
+    fun givenSyncProcessEvents_whenLogging_thenShouldUseTheSharedFlatTelemetryEnvelope() {
+        val writer = RecordingLogWriter()
+        val logger = recordingLogger(writer)
+        val syncLogger = SyncManagerLogger(
+            logger = logger,
+            syncId = "sync-id",
+            syncType = SyncType.SLOW,
+            syncStartedMoment = Instant.fromEpochMilliseconds(0),
+        )
+
+        syncLogger.logSyncStarted()
+        syncLogger.logSyncCompleted(2.seconds)
+
+        val started = writer.entries[0].message
+        val completed = writer.entries[1].message
+        assertContains(started, "Sync telemetry:")
+        assertContains(started, "\"event\":\"SYNC_PROCESS_STARTED\"")
+        assertContains(started, "\"syncId\":\"sync-id\"")
+        assertContains(completed, "Sync telemetry:")
+        assertContains(completed, "\"event\":\"SYNC_PROCESS_COMPLETED\"")
+        assertContains(completed, "\"durationInMillis\":2000")
+        assertFalse(started.contains("syncMetadata"))
+        assertFalse(completed.contains("syncMetadata"))
+    }
+
+    @Test
+    fun givenAConnectedNetwork_whenWaitingToRetry_thenBothRetryEventsShouldContainItsNetworkId() = runTest {
+        val writer = RecordingLogWriter()
+        val logger = recordingLogger(writer)
+        val observer = object : NetworkStateObserver {
+            private val networkState = MutableStateFlow<NetworkState>(NetworkState.ConnectedWithInternet)
+            private val currentNetwork = MutableStateFlow<CurrentNetwork?>(
+                CurrentNetwork(id = "network-id", type = CurrentNetwork.Type.WIFI, hasInternetAccess = true)
+            )
+
+            override fun observeNetworkState(): StateFlow<NetworkState> = networkState
+            override fun observeCurrentNetwork(): StateFlow<CurrentNetwork?> = currentNetwork
+            override suspend fun delayUntilConnectedWithInternetAgain(delay: Duration): Boolean = false
+        }
+
+        observer.delayBeforeSyncRetry(
+            retryDelay = 2.seconds,
+            exponentialDurationHelper = ExponentialDurationHelper(1.seconds, 10.seconds),
+            logger = logger,
+            syncType = SyncType.INCREMENTAL,
+        )
+
+        assertEquals(2, writer.entries.size)
+        writer.entries.forEach { assertContains(it.message, "\"networkId\":\"network-id\"") }
+        assertContains(writer.entries[0].message, "\"event\":\"RETRY_WAIT_STARTED\"")
+        assertContains(writer.entries[1].message, "\"event\":\"RETRY_TRIGGERED\"")
+    }
+
+    private fun recordingLogger(writer: RecordingLogWriter) = KaliumLogger(
+        config = KaliumLogger.Config(
+            initialLevel = KaliumLogLevel.DEBUG,
+            initialLogWriterList = listOf(writer),
+        ),
+        tag = "SyncTelemetryTest",
+    )
+
+    private class RecordingLogWriter : LogWriter() {
+        val entries = mutableListOf<Entry>()
+
+        override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) {
+            entries += Entry(severity, message, tag)
+        }
+    }
+
+    private data class Entry(
+        val severity: Severity,
+        val message: String,
+        val tag: String,
+    )
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-27273
<!--jira-description-action-hidden-marker-end-->
## Summary

- add stable structured envelopes and typed events for sync recovery and Android network telemetry
- cover sync demand, execution, failures, backoff resets, retry waits, retry triggers, and network callbacks
- correlate retry events with the active network ID and keep failure fields privacy-safe
- align slow and incremental cancellation telemetry while reducing routine happy-path reset noise
- migrate sync process start/completion records to the shared flat sync telemetry schema

## Why

The reconnect recovery added by the base PR needs telemetry that can distinguish subscriber-driven restarts, network-driven retries, timeout-driven retries, and backoff resets. The previous prose logs could not be reliably joined or queried, which made the reported long-offline recovery failure difficult to diagnose.

## Stack

This PR is stacked on #4310 (`mo/fix/sync-retry-after-no-internet`) and contains telemetry only. A corresponding wire-android PR will consume this Kalium commit and add app-lifecycle telemetry.

## Validation

- full Kalium logic JVM test suite
- focused slow-sync, incremental-sync, and telemetry regression tests
- Android host tests for `NetworkStateObserverImpl`
- Kalium Detekt
- consuming wire-android lifecycle test
