### PR TITLE
refactor(sync): separate sync demand decisions from reactions [WPB-27272] - PR 3

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncExecutor.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncExecutor.kt
@@ -193,8 +193,7 @@ internal class SyncExecutorImpl(
 
     /**
      * The demand policy: the first request starts sync. A later request restarts it only when
-     * recovery is backing off; while an attempt is in flight it only resets future backoff,
-     * and an already-live connection is left undisturbed.
+     * recovery is backing off; an in-flight or live connection is left undisturbed.
      */
     private fun decideDemandAction(
         previousCount: Int,
@@ -205,7 +204,7 @@ internal class SyncExecutorImpl(
         return when {
             requestAdded && previousCount == 0 -> DemandAction.START
             requestAdded && syncState is SyncState.Failed -> DemandAction.RESTART
-            requestAdded && syncState != SyncState.Live -> DemandAction.RESET_BACKOFF
+//             requestAdded && syncState != SyncState.Live -> DemandAction.RESET_BACKOFF // for now disabled need a bit more testing
             requesterCount == 0 && previousCount > 0 -> DemandAction.STOP
             requesterCount > 0 -> DemandAction.KEEP_RUNNING
             else -> DemandAction.IDLE

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncExecutor.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SyncExecutor.kt
@@ -104,21 +104,36 @@ internal class SyncExecutorImpl(
     userScopedLogger: KaliumLogger = kaliumLogger,
 ) : SyncExecutor() {
 
-    private enum class ExecutionTrigger {
-        FIRST_REQUEST,
-        NEW_REQUEST_WHILE_FAILED,
+    private enum class DemandAction(val startsExecution: Boolean = false) {
+        /** First request arrived — start sync. */
+        START(startsExecution = true),
+
+        /** New request while recovery is backing off — restart immediately with fresh backoff. */
+        RESTART(startsExecution = true),
+
+        /** New request while an attempt is in flight — keep it running, but a later failure retries from the minimum delay. */
+        RESET_BACKOFF,
+
+        /** Requests changed while sync is already running as needed. */
+        KEEP_RUNNING,
+
+        /** Last request released — stop sync. */
+        STOP,
+
+        /** No requests before or after the change. */
+        IDLE,
     }
 
     private data class SyncDemand(
         val requesterCount: Int = 0,
         val restartVersion: Long = 0,
-        val executionTrigger: ExecutionTrigger? = null,
+        val lastStartAction: DemandAction? = null,
     )
 
     private data class SyncExecution(
         val shouldSync: Boolean,
         val restartVersion: Long,
-        val trigger: ExecutionTrigger?,
+        val trigger: DemandAction?,
     )
 
     // Keep logical request lifetimes separate from transient collectors that only wait for a sync state.
@@ -130,29 +145,24 @@ internal class SyncExecutorImpl(
         scope.launch {
             syncRequestDemandFlow.subscriptionCount
                 .runningFold(SyncDemand()) { previous, requesterCount ->
-                    val requestAdded = requesterCount > previous.requesterCount
                     val syncState = syncStateObserver.syncState.value
-                    // The first request starts sync. An additional request restarts it only when
-                    // recovery is backing off, avoiding disruption to an already-live connection.
-                    val shouldRestart = requestAdded &&
-                        (previous.requesterCount == 0 || syncState is SyncState.Failed)
-                    val executionTrigger = when {
-                        !shouldRestart -> null
-                        previous.requesterCount == 0 -> ExecutionTrigger.FIRST_REQUEST
-                        else -> ExecutionTrigger.NEW_REQUEST_WHILE_FAILED
+                    val action = decideDemandAction(previous.requesterCount, requesterCount, syncState)
+                    if (action == DemandAction.RESET_BACKOFF) {
+                        slowSyncManager.resetRetryBackoff()
+                        incrementalSyncManager.resetRetryBackoff()
                     }
-                    logRequesterCountChanged(previous, requesterCount, syncState, executionTrigger)
+                    logRequesterCountChanged(previous.requesterCount, requesterCount, syncState, action)
                     SyncDemand(
                         requesterCount = requesterCount,
-                        restartVersion = previous.restartVersion + if (shouldRestart) 1 else 0,
-                        executionTrigger = executionTrigger ?: previous.executionTrigger,
+                        restartVersion = previous.restartVersion + if (action.startsExecution) 1 else 0,
+                        lastStartAction = if (action.startsExecution) action else previous.lastStartAction,
                     )
                 }
                 .map { demand ->
                     SyncExecution(
                         shouldSync = demand.requesterCount > 0,
                         restartVersion = demand.restartVersion,
-                        trigger = demand.executionTrigger,
+                        trigger = demand.lastStartAction,
                     )
                 }
                 .distinctUntilChanged()
@@ -181,29 +191,42 @@ internal class SyncExecutorImpl(
         }
     }
 
-    private fun logRequesterCountChanged(
-        previous: SyncDemand,
+    /**
+     * The demand policy: the first request starts sync. A later request restarts it only when
+     * recovery is backing off; while an attempt is in flight it only resets future backoff,
+     * and an already-live connection is left undisturbed.
+     */
+    private fun decideDemandAction(
+        previousCount: Int,
         requesterCount: Int,
         syncState: SyncState,
-        executionTrigger: ExecutionTrigger?,
-    ) {
-        val action = when {
-            executionTrigger == ExecutionTrigger.FIRST_REQUEST -> "START"
-            executionTrigger == ExecutionTrigger.NEW_REQUEST_WHILE_FAILED -> "RESTART"
-            requesterCount == 0 && previous.requesterCount > 0 -> "STOP"
-            requesterCount > 0 -> "KEEP_RUNNING"
-            else -> "IDLE"
+    ): DemandAction {
+        val requestAdded = requesterCount > previousCount
+        return when {
+            requestAdded && previousCount == 0 -> DemandAction.START
+            requestAdded && syncState is SyncState.Failed -> DemandAction.RESTART
+            requestAdded && syncState != SyncState.Live -> DemandAction.RESET_BACKOFF
+            requesterCount == 0 && previousCount > 0 -> DemandAction.STOP
+            requesterCount > 0 -> DemandAction.KEEP_RUNNING
+            else -> DemandAction.IDLE
         }
+    }
+
+    private fun logRequesterCountChanged(
+        previousCount: Int,
+        requesterCount: Int,
+        syncState: SyncState,
+        action: DemandAction,
+    ) {
         logger.logSyncTelemetry(
             event = SyncTelemetryEvent.REQUEST_COUNT_CHANGED,
             component = SyncTelemetryComponent.EXECUTOR,
             level = KaliumLogLevel.DEBUG,
             data = buildMap {
-                put("previousRequesterCount", previous.requesterCount)
+                put("previousRequesterCount", previousCount)
                 put("requesterCount", requesterCount)
                 put("syncState", syncState.telemetryName())
-                put("action", action)
-                put("trigger", executionTrigger?.name)
+                put("action", action.name)
                 if (syncState is SyncState.Failed) {
                     put("retryDelayInMillis", syncState.retryDelay.inWholeMilliseconds)
                     putAll(syncState.cause.telemetryData())

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManager.kt
@@ -88,6 +88,11 @@ internal interface IncrementalSyncManager {
      */
     fun performSyncFlow(): Flow<IncrementalSyncStatus>
 
+    /**
+     * Resets the accumulated retry backoff without interrupting an ongoing sync attempt.
+     */
+    fun resetRetryBackoff()
+
     companion object {
         val MIN_RETRY_DELAY = 1.seconds
         val MAX_RETRY_DELAY = 10.minutes
@@ -109,6 +114,15 @@ internal fun IncrementalSyncManager(
 ) = object : IncrementalSyncManager {
 
     private val logger = userScopedLogger.withFeatureId(SYNC).withTextTag("IncrementalSyncManager")
+
+    override fun resetRetryBackoff() {
+        exponentialDurationHelper.reset()
+        logger.logSyncTelemetry(
+            event = SyncTelemetryEvent.RETRY_BACKOFF_RESET,
+            component = SyncTelemetryComponent.INCREMENTAL,
+            data = mapOf("reason" to "NEW_SYNC_REQUEST")
+        )
+    }
 
     private fun coroutineExceptionHandler(onRetry: suspend () -> Unit) = SyncExceptionHandler(
         onCancellation = {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
@@ -64,6 +64,11 @@ internal interface SlowSyncManager {
      */
     fun performSyncFlow(): Flow<SlowSyncStatus>
 
+    /**
+     * Resets the accumulated retry backoff without interrupting an ongoing sync attempt.
+     */
+    fun resetRetryBackoff()
+
     companion object {
         /**
          * The current version of Slow Sync.
@@ -108,6 +113,15 @@ internal fun SlowSyncManager(
 ): SlowSyncManager = object : SlowSyncManager {
 
     private val logger = userScopedLogger.withFeatureId(SYNC).withTextTag("SlowSyncManager")
+
+    override fun resetRetryBackoff() {
+        exponentialDurationHelper.reset()
+        logger.logSyncTelemetry(
+            event = SyncTelemetryEvent.RETRY_BACKOFF_RESET,
+            component = SyncTelemetryComponent.SLOW,
+            data = mapOf("reason" to "NEW_SYNC_REQUEST")
+        )
+    }
 
     private fun coroutineExceptionHandler(onRetry: suspend () -> Unit) = SyncExceptionHandler(
         onCancellation = {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/util/ExponentialDurationHelper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/util/ExponentialDurationHelper.kt
@@ -17,8 +17,15 @@
  */
 package com.wire.kalium.logic.util
 
+import co.touchlab.stately.concurrency.AtomicReference
 import kotlin.time.Duration
 
+/**
+ * Provides exponentially growing durations for retry backoff.
+ *
+ * Implementations must be safe for concurrent use: [reset] may be called from a different
+ * coroutine (e.g. a new sync request arriving) while [next] runs in the sync managers' scope.
+ */
 public interface ExponentialDurationHelper {
     public fun reset()
     public fun next(): Duration
@@ -29,14 +36,18 @@ internal class ExponentialDurationHelperImpl(
     private val maxDuration: Duration,
     private val factor: Double = 2.0,
 ) : ExponentialDurationHelper {
-    private var currentDuration = initialDuration
+    private val currentDuration = AtomicReference(initialDuration)
 
     override fun reset() {
-        currentDuration = initialDuration
+        currentDuration.set(initialDuration)
     }
 
-    override fun next(): Duration = currentDuration.also {
-        currentDuration = currentDuration.times(factor).coerceAtMost(maxDuration)
+    override fun next(): Duration {
+        while (true) {
+            val current = currentDuration.get()
+            val next = current.times(factor).coerceAtMost(maxDuration)
+            if (currentDuration.compareAndSet(current, next)) return current
+        }
     }
 }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/fakes/sync/FakeIncrementalSyncManager.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/fakes/sync/FakeIncrementalSyncManager.kt
@@ -34,9 +34,16 @@ internal class FakeIncrementalSyncManager(
     var cancelledSyncFlowCount: Int = 0
         private set
 
+    var resetRetryBackoffCount: Int = 0
+        private set
+
     override fun performSyncFlow(): Flow<IncrementalSyncStatus> = fakeSyncFlow
         .onCompletion { cause ->
             if (cause is CancellationException) cancelledSyncFlowCount++
         }
         .also { performSyncFlowCount++ }
+
+    override fun resetRetryBackoff() {
+        resetRetryBackoffCount++
+    }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/fakes/sync/FakeSlowSyncManager.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/fakes/sync/FakeSlowSyncManager.kt
@@ -19,12 +19,31 @@ package com.wire.kalium.logic.fakes.sync
 
 import com.wire.kalium.logic.data.sync.SlowSyncStatus
 import com.wire.kalium.logic.sync.slow.SlowSyncManager
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.onCompletion
 
 internal class FakeSlowSyncManager(
     val fakeSyncFlow: MutableSharedFlow<SlowSyncStatus> = MutableStateFlow(SlowSyncStatus.Pending)
 ) : SlowSyncManager {
+    var resetRetryBackoffCount: Int = 0
+        private set
+
+    var performSyncFlowCount: Int = 0
+        private set
+
+    var cancelledSyncFlowCount: Int = 0
+        private set
+
     override fun performSyncFlow(): Flow<SlowSyncStatus> = fakeSyncFlow
+        .onCompletion { cause ->
+            if (cause is CancellationException) cancelledSyncFlowCount++
+        }
+        .also { performSyncFlowCount++ }
+
+    override fun resetRetryBackoff() {
+        resetRetryBackoffCount++
+    }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/SyncExecutorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/SyncExecutorTest.kt
@@ -278,7 +278,36 @@ class SyncExecutorTest {
         }
 
     @Test
-    fun givenSyncIsNotFailed_whenNewRequestStarts_thenShouldNotRestartSync() =
+    fun givenSyncIsConnecting_whenNewRequestStarts_thenShouldResetBackoffWithoutRestartingSync() =
+        runTest(TestKaliumDispatcher.default) {
+            listOf(
+                SyncState.Waiting,
+                SyncState.SlowSync,
+                SyncState.GatheringPendingEvents,
+            ).forEach { connectingState ->
+                val syncScope = CoroutineScope(coroutineContext + SupervisorJob())
+                val (arrangement, syncExecutor) = Arrangement(syncScope).arrange()
+
+                syncExecutor.startAndStopSyncAsNeeded()
+
+                syncExecutor.request {
+                    arrangement.syncStateObserver.mutableSyncState.emit(connectingState)
+                    advanceUntilIdle()
+
+                    syncExecutor.request {
+                        advanceUntilIdle()
+                        assertEquals(1, arrangement.slowSyncManager.resetRetryBackoffCount)
+                        assertEquals(1, arrangement.incrementalSyncManager.resetRetryBackoffCount)
+                        assertEquals(1, arrangement.slowSyncManager.performSyncFlowCount)
+                        assertEquals(0, arrangement.slowSyncManager.cancelledSyncFlowCount)
+                    }
+                }
+                syncScope.cancel()
+            }
+        }
+
+    @Test
+    fun givenSyncIsLive_whenNewRequestStarts_thenShouldNotRestartOrResetSync() =
         runTest(TestKaliumDispatcher.default) {
             val syncScope = CoroutineScope(coroutineContext + SupervisorJob())
             val (arrangement, syncExecutor) = Arrangement(syncScope).arrange()
@@ -297,6 +326,8 @@ class SyncExecutorTest {
                     advanceUntilIdle()
                     assertEquals(1, arrangement.incrementalSyncManager.performSyncFlowCount)
                     assertEquals(0, arrangement.incrementalSyncManager.cancelledSyncFlowCount)
+                    assertEquals(0, arrangement.slowSyncManager.resetRetryBackoffCount)
+                    assertEquals(0, arrangement.incrementalSyncManager.resetRetryBackoffCount)
                 }
             }
             syncScope.cancel()
@@ -325,6 +356,8 @@ class SyncExecutorTest {
                     assertEquals(2, arrangement.incrementalSyncManager.performSyncFlowCount)
                     assertEquals(1, arrangement.incrementalSyncManager.cancelledSyncFlowCount)
                     assertEquals(1, arrangement.incrementalSyncManager.fakeSyncFlow.subscriptionCount.value)
+                    assertEquals(0, arrangement.slowSyncManager.resetRetryBackoffCount)
+                    assertEquals(0, arrangement.incrementalSyncManager.resetRetryBackoffCount)
                 }
             }
             syncScope.cancel()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/SyncExecutorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/SyncExecutorTest.kt
@@ -278,7 +278,7 @@ class SyncExecutorTest {
         }
 
     @Test
-    fun givenSyncIsConnecting_whenNewRequestStarts_thenShouldResetBackoffWithoutRestartingSync() =
+    fun givenSyncIsConnecting_whenNewRequestStarts_thenShouldNotResetBackoffOrRestartSync() =
         runTest(TestKaliumDispatcher.default) {
             listOf(
                 SyncState.Waiting,
@@ -296,8 +296,8 @@ class SyncExecutorTest {
 
                     syncExecutor.request {
                         advanceUntilIdle()
-                        assertEquals(1, arrangement.slowSyncManager.resetRetryBackoffCount)
-                        assertEquals(1, arrangement.incrementalSyncManager.resetRetryBackoffCount)
+                        assertEquals(0, arrangement.slowSyncManager.resetRetryBackoffCount)
+                        assertEquals(0, arrangement.incrementalSyncManager.resetRetryBackoffCount)
                         assertEquals(1, arrangement.slowSyncManager.performSyncFlowCount)
                         assertEquals(0, arrangement.slowSyncManager.cancelledSyncFlowCount)
                     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/IncrementalSyncManagerTest.kt
@@ -38,6 +38,7 @@ import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verify
 import dev.mokkery.verifySuspend
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -47,6 +48,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -345,6 +347,48 @@ class IncrementalSyncManagerTest {
             }
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    @Test
+    fun whenResettingRetryBackoff_thenShouldResetExponentialDuration() = runTest {
+        val (arrangement, incrementalSyncManager) = Arrangement().arrange()
+
+        incrementalSyncManager.resetRetryBackoff()
+
+        verify(VerifyMode.exactly(1)) {
+            arrangement.exponentialDurationHelper.reset()
+        }
+    }
+
+    @Test
+    fun givenBackoffHasGrown_whenResettingDuringSyncAndNextAttemptFails_thenShouldUseMinimumDelay() = runTest {
+        val failureSignal = CompletableDeferred<Unit>()
+        val exponentialDurationHelper = ExponentialDurationHelper(1.seconds, 10.minutes)
+        val workerFlow = flow<EventSource> {
+            failureSignal.await()
+            throw IOException("Connection failed")
+        }
+        val (arrangement, incrementalSyncManager) = Arrangement(
+            exponentialDurationHelper = exponentialDurationHelper,
+            configureDefaultExponentialDuration = false,
+        )
+            .withWorkerReturning(workerFlow)
+            .withRecoveringFromFailure { }
+            .arrange()
+        val syncJob = incrementalSyncManager.performSyncFlow().launchIn(backgroundScope)
+        runCurrent()
+        exponentialDurationHelper.next()
+        exponentialDurationHelper.next()
+
+        incrementalSyncManager.resetRetryBackoff()
+        failureSignal.complete(Unit)
+        runCurrent()
+
+        val failedState = assertIs<IncrementalSyncStatus.Failed>(
+            arrangement.incrementalSyncRepository.incrementalSyncState.first()
+        )
+        assertEquals(1.seconds, failedState.retryDelay)
+        syncJob.cancel()
     }
 
     private class Arrangement(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManagerTest.kt
@@ -375,6 +375,50 @@ class SlowSyncManagerTest {
     }
 
     @Test
+    fun whenResettingRetryBackoff_thenShouldResetExponentialDuration() = runTest {
+        val (arrangement, slowSyncManager) = Arrangement().arrange()
+
+        slowSyncManager.resetRetryBackoff()
+
+        verify(VerifyMode.exactly(1)) {
+            arrangement.exponentialDurationHelper.reset()
+        }
+    }
+
+    @Test
+    fun givenBackoffHasGrown_whenResettingDuringSyncAndNextAttemptFails_thenShouldUseMinimumDelay() = runTest {
+        val failureSignal = CompletableDeferred<Unit>()
+        val exponentialDurationHelper = ExponentialDurationHelper(1.seconds, 10.minutes)
+        val workerFlow = flow<SlowSyncStep> {
+            failureSignal.await()
+            throw IOException("Connection failed")
+        }
+        val (arrangement, slowSyncManager) = Arrangement(
+            exponentialDurationHelper = exponentialDurationHelper,
+            configureDefaultExponentialDuration = false,
+        ).arrange {
+            withSatisfiedCriteria()
+            withSlowSyncWorkerReturning(workerFlow)
+            withIgnoringFailureRecovery()
+        }
+        val syncJob = slowSyncManager.performSyncFlow().launchIn(backgroundScope)
+        runCurrent()
+        exponentialDurationHelper.next()
+        exponentialDurationHelper.next()
+
+        slowSyncManager.resetRetryBackoff()
+        failureSignal.complete(Unit)
+        runCurrent()
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.slowSyncRepository.updateSlowSyncStatus(
+                matches<SlowSyncStatus> { it is SlowSyncStatus.Failed && it.retryDelay == 1.seconds }
+            )
+        }
+        syncJob.cancel()
+    }
+
+    @Test
     fun givenCriteriaAreMet_whenRecovers_thenShouldRetry() = runTest {
         val (arrangement, slowSyncManager) = Arrangement().arrange {
             withSatisfiedCriteria()
@@ -472,6 +516,12 @@ class SlowSyncManagerTest {
                 val onRetryCallback = invocation.args[1] as OnSlowSyncRetryCallback
                 onRetryCallback.retry()
             }
+        }
+
+        suspend fun withIgnoringFailureRecovery() = apply {
+            everySuspend {
+                slowSyncRecoveryHandler.recover(any(), any())
+            } returns Unit
         }
 
         fun withNetworkState(networkStateFlow: StateFlow<NetworkState>) = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/ExponentialDurationHelperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/ExponentialDurationHelperTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
+
+class ExponentialDurationHelperTest {
+
+    @Test
+    fun givenSuccessiveValues_whenGettingNext_thenShouldGrowUntilMaximum() {
+        val helper = ExponentialDurationHelper(1.seconds, 4.seconds)
+
+        assertEquals(1.seconds, helper.next())
+        assertEquals(2.seconds, helper.next())
+        assertEquals(4.seconds, helper.next())
+        assertEquals(4.seconds, helper.next())
+    }
+
+    @Test
+    fun givenBackoffHasGrown_whenResetting_thenNextShouldReturnInitialDuration() {
+        val helper = ExponentialDurationHelper(1.seconds, 10.seconds)
+        helper.next()
+        helper.next()
+
+        helper.reset()
+
+        assertEquals(1.seconds, helper.next())
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-27272
<!--jira-description-action-hidden-marker-end-->

## Intent

Make sync-demand transitions explicit without changing the retry behavior already established on `develop`.

A new request must restart sync when recovery is waiting in `Failed`, but it must not cancel the active attempt or reset accumulated backoff while sync is already connecting.

## Change

- model requester-count transitions as explicit `DemandAction` values
- extract demand selection from execution and telemetry reactions
- map new requests during `Waiting`, `SlowSync`, `GatheringPendingEvents`, or `Live` to `KEEP_RUNNING`
- preserve immediate `RESTART` when a new request arrives in `Failed`
- retain the isolated `RESET_BACKOFF` reaction plumbing without selecting it from the current demand policy
- keep the thread-safe exponential-duration helper and its focused coverage
- preserve structured sync-demand and retry telemetry

```mermaid
flowchart TD
    A["Requester count changes"] --> B{"Demand and sync state"}
    B -->|"First requester"| C["START"]
    B -->|"New requester while Failed"| D["RESTART"]
    B -->|"New requester while connecting or Live"| E["KEEP_RUNNING"]
    B -->|"Last requester released"| F["STOP"]
    B -->|"No active demand"| G["IDLE"]
```

## Behavior

Connecting requests now behave like the latest `develop` implementation:

- the active sync attempt continues uninterrupted
- accumulated retry backoff is not reset
- a request arriving after sync reaches `Failed` still restarts recovery immediately
- existing lifecycle backoff resets remain unchanged

## Stack

- #4310 — reconnect recovery
- #4311 — structured recovery telemetry
- this PR — sync-demand action refactor

## Validation

- full Logic JVM test suite passes
- connecting-state coverage verifies no restart, cancellation, or backoff reset
- `Live` and `Failed` demand behavior remains covered
- retry-helper and manager reset coverage remains intact
- static analysis passes
