### PR TITLE
fix: suppress redundant admin promotion messages

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandler.kt
@@ -35,6 +35,7 @@ import com.wire.kalium.logic.util.EventLoggingStatus
 import com.wire.kalium.logic.util.createEventProcessingLogger
 import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.serialization.toJsonElement
+import kotlinx.coroutines.flow.first
 import kotlinx.datetime.Instant
 
 internal interface MemberChangeEventHandler {
@@ -88,6 +89,8 @@ internal class MemberChangeEventHandlerImpl(
         event: Event.Conversation.MemberChanged.MemberChangedRole
     ) {
         val eventLogger = kaliumLogger.createEventProcessingLogger(event)
+        val changedMember = event.member ?: return
+        var memberWasAlreadyAdmin = false
         // Attempt to fetch conversation details if needed, as this might be an unknown conversation
         fetchConversationIfUnknown(transactionContext, event.conversationId)
             .run {
@@ -103,11 +106,18 @@ internal class MemberChangeEventHandlerImpl(
                     logger.w("Failure fetching conversation details on MemberChange Event: ${logMap.toJsonElement()}")
                 }
                 // Even if unable to fetch conversation details, at least attempt updating the member
-                conversationRepository.updateMemberFromEvent(event.member!!, event.conversationId)
+                memberWasAlreadyAdmin = conversationRepository.observeConversationMembers(event.conversationId)
+                    .first()
+                    .any { member ->
+                        member.id == changedMember.id && member.role == Conversation.Member.Role.Admin
+                    }
+                conversationRepository.updateMemberFromEvent(changedMember, event.conversationId)
             }
             .onFailure { eventLogger.logFailure(it) }
             .onSuccess {
-                event.member?.takeIf { it.role == Conversation.Member.Role.Admin }?.let { promotedMember ->
+                changedMember.takeIf {
+                    it.role == Conversation.Member.Role.Admin && !memberWasAlreadyAdmin
+                }?.let { promotedMember ->
                     persistMessage(
                         Message.System(
                             id = event.id,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandlerTest.kt
@@ -41,6 +41,7 @@ import dev.mokkery.matcher.matches
 import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 
@@ -211,6 +212,24 @@ class MemberChangeEventHandlerTest {
     }
 
     @Test
+    fun givenUserIsAlreadyAdmin_whenHandlingAdminRoleChange_thenSystemMessageIsNotPersisted() = runTest {
+        val adminMember = Member(TestUser.OTHER_USER_ID, Member.Role.Admin)
+        val event = TestEvent.memberChange(member = adminMember)
+
+        val (arrangement, eventHandler) = Arrangement()
+            .withFetchConversationIfUnknownSucceeding()
+            .withExistingMembers(listOf(adminMember))
+            .withUpdateMemberSucceeding()
+            .arrange()
+
+        eventHandler.handle(arrangement.transactionContext, event)
+
+        verifySuspend(VerifyMode.not) {
+            arrangement.persistMessage(any())
+        }
+    }
+
+    @Test
     fun givenSelfUserRoleChangedToMember_whenHandlingMemberChangedRole_thenNoSystemMessageIsPersisted() = runTest {
         val selfMember = Member(TestUser.USER_ID, Member.Role.Member)
         val event = TestEvent.memberChange(member = selfMember)
@@ -241,6 +260,10 @@ class MemberChangeEventHandlerTest {
             selfUserId = TestUser.USER_ID,
         )
 
+        init {
+            everySuspend { conversationRepository.observeConversationMembers(any()) } returns flowOf(emptyList())
+        }
+
         suspend fun withFetchConversationIfUnknownSucceeding() = apply {
             everySuspend {
                 fetchConversationIfUnknown(any(), any(), eq(ConversationSyncReason.Other))
@@ -257,6 +280,10 @@ class MemberChangeEventHandlerTest {
             everySuspend {
                 conversationRepository.updateMemberFromEvent(any(), any())
             } returns Either.Right(Unit)
+        }
+
+        suspend fun withExistingMembers(members: List<Member>) = apply {
+            everySuspend { conversationRepository.observeConversationMembers(any()) } returns flowOf(members)
         }
 
         suspend fun withUpdateMutedStatusLocally(result: Either<StorageFailure, Unit>) = apply {


### PR DESCRIPTION
## Summary
- Read the stored conversation member role before applying a role-change event.
- Persist an admin-promotion system message only for a non-admin to admin transition.
- Keep processing repeated role assignments without adding duplicate history entries.

## Why
The backend can emit distinct near-simultaneous MemberChangedRole(Admin) events for the same member. Each event has a unique ID, so event-ID deduplication cannot identify the redundant user-visible state change.

## Verification
- Focused MemberChangeEventHandlerTest JVM suite passes.