### PR TITLE
feat: delete meeting for everyone [WPB-20269]

### DIFF
--- a/changelog.d/delete-meeting-use-case.md
+++ b/changelog.d/delete-meeting-use-case.md
@@ -1,0 +1,10 @@
+### Added
+- Added `MeetingScope.deleteMeeting` with `DeleteMeetingUseCase` to delete a meeting by ID.
+
+### Migration
+No action required unless consumers want to expose meeting deletion.
+
+### Compatibility
+ABI: additive.
+Source: additive.
+Behavior: no behavior change unless consumers call the new meeting deletion API.

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/meeting/MeetingApi.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/meeting/MeetingApi.kt
@@ -20,11 +20,13 @@ package com.wire.kalium.network.api.base.authenticated.meeting
 
 import com.wire.kalium.network.api.authenticated.meeting.MeetingDTO
 import com.wire.kalium.network.api.base.authenticated.BaseApi
+import com.wire.kalium.network.api.model.MeetingId
 import com.wire.kalium.network.utils.NetworkResponse
 
 @Suppress("TooManyFunctions")
 interface MeetingApi : BaseApi {
     suspend fun fetchMeetings(): NetworkResponse<List<MeetingDTO>>
+    suspend fun deleteMeeting(meetingId: MeetingId): NetworkResponse<Unit>
 
     companion object {
         const val MIN_API_VERSION_MEETINGS = 16

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/MeetingApiV0.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/MeetingApiV0.kt
@@ -21,10 +21,14 @@ package com.wire.kalium.network.api.v0.authenticated
 import com.wire.kalium.network.api.authenticated.meeting.MeetingDTO
 import com.wire.kalium.network.api.base.authenticated.meeting.MeetingApi
 import com.wire.kalium.network.api.base.authenticated.meeting.MeetingApi.Companion.MIN_API_VERSION_MEETINGS
+import com.wire.kalium.network.api.model.MeetingId
 import com.wire.kalium.network.utils.NetworkResponse
 
 @Suppress("TooManyFunctions")
 internal open class MeetingApiV0 internal constructor() : MeetingApi {
     override suspend fun fetchMeetings(): NetworkResponse<List<MeetingDTO>> =
+        getApiNotSupportedError("fetchMeetings", MIN_API_VERSION_MEETINGS)
+
+    override suspend fun deleteMeeting(meetingId: MeetingId): NetworkResponse<Unit> =
         getApiNotSupportedError("fetchMeetings", MIN_API_VERSION_MEETINGS)
 }

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v16/authenticated/MeetingApiV16.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v16/authenticated/MeetingApiV16.kt
@@ -19,9 +19,11 @@ package com.wire.kalium.network.api.v16.authenticated
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
 import com.wire.kalium.network.api.authenticated.meeting.MeetingDTO
+import com.wire.kalium.network.api.model.MeetingId
 import com.wire.kalium.network.api.v15.authenticated.MeetingApiV15
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.wrapRequest
+import io.ktor.client.request.delete
 import io.ktor.client.request.get
 
 internal open class MeetingApiV16 internal constructor(
@@ -32,6 +34,10 @@ internal open class MeetingApiV16 internal constructor(
 
     override suspend fun fetchMeetings(): NetworkResponse<List<MeetingDTO>> = wrapRequest {
         httpClient.get("$PATH_MEETINGS/$PATH_LIST")
+    }
+
+    override suspend fun deleteMeeting(meetingId: MeetingId): NetworkResponse<Unit> = wrapRequest {
+        httpClient.delete("$PATH_MEETINGS/${meetingId.domain}/${meetingId.value}")
     }
 
     companion object {

--- a/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Meetings.sq
+++ b/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Meetings.sq
@@ -67,6 +67,10 @@ WHERE meeting_id = ?
 ORDER BY occurrence_start DESC
 LIMIT 1;
 
+deleteMeeting:
+DELETE FROM Meeting
+WHERE meeting_id = ?;
+
 deleteMeetingOccurrences:
 DELETE FROM MeetingOccurrence
 WHERE meeting_id = ?;

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/meeting/MeetingDao.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/meeting/MeetingDao.kt
@@ -45,6 +45,7 @@ interface MeetingDao {
         startingOffset: Long,
         from: Instant,
     ): KaliumPager<MeetingOccurrenceDetailsEntity>
+    suspend fun deleteMeeting(meetingId: QualifiedIDEntity)
 }
 
 internal class MeetingDaoImpl(
@@ -128,6 +129,12 @@ internal class MeetingDaoImpl(
             ),
             readDispatcher = readDispatcher,
         )
+
+    override suspend fun deleteMeeting(meetingId: QualifiedIDEntity) {
+        withContext(writeDispatcher.value) {
+            meetingsQueries.deleteMeeting(meetingId)
+        }
+    }
 
     private fun meetingPagingSource(from: Instant, startingOffset: Long, prefetchDistance: Int): MeetingPagingSource =
         MeetingPagingSource(

--- a/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/meeting/MeetingDaoTest.kt
+++ b/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/meeting/MeetingDaoTest.kt
@@ -320,6 +320,32 @@ class MeetingDaoTest : BaseDatabaseTest() {
             assertEquals(true, occurrences.all { it.occurrence_start <= until })
         }
 
+    @Test
+    fun givenStoredMeeting_whenDeletingMeeting_thenMeetingAndOccurrencesAreDeleted() = runTest(dispatcher) {
+        val now = Clock.System.now()
+        val meeting = newMeeting(
+            startTime = now + 1.days,
+            recurrence = MeetingEntity.RecurrenceEntity(frequency = Frequency.DAILY, interval = 1, until = now + 5.days)
+        )
+        val otherMeeting = newMeeting(
+            meetingId = QualifiedIDEntity("other-meeting", "wire.com"),
+            conversationId = QualifiedIDEntity("other-conversation", "wire.com"),
+            startTime = now + 1.days
+        )
+        insertMeetingDependencies(meeting)
+        insertMeetingDependencies(otherMeeting)
+        meetingDao.upsertMeetings(listOf(meeting, otherMeeting), GenerationLimit.Window(now, now + GENERATION_DAYS.days))
+        assertEquals(true, isMeetingStored(meeting))
+        assertEquals(true, occurrencesFor(meeting).isNotEmpty())
+
+        meetingDao.deleteMeeting(meeting.meetingId)
+
+        assertEquals(false, isMeetingStored(meeting))
+        assertEquals(true, occurrencesFor(meeting).isEmpty())
+        assertEquals(true, isMeetingStored(otherMeeting))
+        assertEquals(true, occurrencesFor(otherMeeting).isNotEmpty())
+    }
+
     private suspend fun insertMeetingDependencies(meeting: MeetingEntity) {
         databaseBuilder.userDAO.upsertUser(newUserEntity(meeting.creatorId))
         databaseBuilder.conversationDAO.insertConversation(newConversationEntity(meeting.conversationId))

--- a/logic/api/jvm/logic.api
+++ b/logic/api/jvm/logic.api
@@ -5263,6 +5263,31 @@ public abstract interface class com/wire/kalium/logic/feature/legalhold/ObserveL
 	public abstract fun invoke (Lcom/wire/kalium/logic/data/id/QualifiedID;)Lkotlinx/coroutines/flow/Flow;
 }
 
+public abstract interface class com/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase {
+	public abstract fun invoke (Lcom/wire/kalium/logic/data/id/QualifiedID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase$Result {
+}
+
+public final class com/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase$Result$Failure : com/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase$Result {
+	public fun <init> (Lcom/wire/kalium/common/error/CoreFailure;)V
+	public final fun component1 ()Lcom/wire/kalium/common/error/CoreFailure;
+	public final fun copy (Lcom/wire/kalium/common/error/CoreFailure;)Lcom/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase$Result$Failure;
+	public static synthetic fun copy$default (Lcom/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase$Result$Failure;Lcom/wire/kalium/common/error/CoreFailure;ILjava/lang/Object;)Lcom/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase$Result$Failure;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCoreFailure ()Lcom/wire/kalium/common/error/CoreFailure;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase$Result$Success : com/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase$Result {
+	public static final field INSTANCE Lcom/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase$Result$Success;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class com/wire/kalium/logic/feature/meeting/GetPaginatedMeetingOccurrencesUseCase {
 	public abstract fun invoke (Landroidx/paging/PagingConfig;JLkotlinx/datetime/Instant;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun invoke$default (Lcom/wire/kalium/logic/feature/meeting/GetPaginatedMeetingOccurrencesUseCase;Landroidx/paging/PagingConfig;JLkotlinx/datetime/Instant;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -5273,6 +5298,7 @@ public final class com/wire/kalium/logic/feature/meeting/GetPaginatedMeetingOccu
 }
 
 public final class com/wire/kalium/logic/feature/meeting/MeetingScope {
+	public final fun getDeleteMeeting ()Lcom/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase;
 	public final fun getGetPaginatedMeetingOccurrenceDetails ()Lcom/wire/kalium/logic/feature/meeting/GetPaginatedMeetingOccurrencesUseCase;
 	public final fun getObserveMeetingOccurrence ()Lcom/wire/kalium/logic/feature/meeting/ObserveMeetingOccurrenceUseCase;
 }

--- a/logic/api/logic.klib.api
+++ b/logic/api/logic.klib.api
@@ -1340,6 +1340,31 @@ abstract interface com.wire.kalium.logic.feature.legalhold/ObserveLegalHoldState
     abstract fun invoke(com.wire.kalium.logic.data.id/QualifiedID): kotlinx.coroutines.flow/Flow<com.wire.kalium.logic.feature.legalhold/LegalHoldState> // com.wire.kalium.logic.feature.legalhold/ObserveLegalHoldStateForUserUseCase.invoke|invoke(com.wire.kalium.logic.data.id.QualifiedID){}[0]
 }
 
+abstract interface com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase { // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase|null[0]
+    abstract suspend fun invoke(com.wire.kalium.logic.data.id/QualifiedID): com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.invoke|invoke(com.wire.kalium.logic.data.id.QualifiedID){}[0]
+
+    sealed interface Result { // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result|null[0]
+        final class Failure : com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result { // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Failure|null[0]
+            constructor <init>(com.wire.kalium.common.error/CoreFailure) // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Failure.<init>|<init>(com.wire.kalium.common.error.CoreFailure){}[0]
+
+            final val coreFailure // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Failure.coreFailure|{}coreFailure[0]
+                final fun <get-coreFailure>(): com.wire.kalium.common.error/CoreFailure // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Failure.coreFailure.<get-coreFailure>|<get-coreFailure>(){}[0]
+
+            final fun component1(): com.wire.kalium.common.error/CoreFailure // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Failure.component1|component1(){}[0]
+            final fun copy(com.wire.kalium.common.error/CoreFailure = ...): com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Failure // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Failure.copy|copy(com.wire.kalium.common.error.CoreFailure){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Failure.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Failure.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Failure.toString|toString(){}[0]
+        }
+
+        final object Success : com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result { // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Success|null[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Success.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Success.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Success.toString|toString(){}[0]
+        }
+    }
+}
+
 abstract interface com.wire.kalium.logic.feature.meeting/GetPaginatedMeetingOccurrencesUseCase { // com.wire.kalium.logic.feature.meeting/GetPaginatedMeetingOccurrencesUseCase|null[0]
     abstract suspend fun invoke(androidx.paging/PagingConfig, kotlin/Long, kotlinx.datetime/Instant = ...): kotlinx.coroutines.flow/Flow<androidx.paging/PagingData<com.wire.kalium.logic.data.meeting/MeetingOccurrence>> // com.wire.kalium.logic.feature.meeting/GetPaginatedMeetingOccurrencesUseCase.invoke|invoke(androidx.paging.PagingConfig;kotlin.Long;kotlinx.datetime.Instant){}[0]
 }
@@ -4227,6 +4252,8 @@ final class com.wire.kalium.logic.feature.incallreaction/SendInCallReactionUseCa
 }
 
 final class com.wire.kalium.logic.feature.meeting/MeetingScope { // com.wire.kalium.logic.feature.meeting/MeetingScope|null[0]
+    final val deleteMeeting // com.wire.kalium.logic.feature.meeting/MeetingScope.deleteMeeting|{}deleteMeeting[0]
+        final fun <get-deleteMeeting>(): com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase // com.wire.kalium.logic.feature.meeting/MeetingScope.deleteMeeting.<get-deleteMeeting>|<get-deleteMeeting>(){}[0]
     final val getPaginatedMeetingOccurrenceDetails // com.wire.kalium.logic.feature.meeting/MeetingScope.getPaginatedMeetingOccurrenceDetails|{}getPaginatedMeetingOccurrenceDetails[0]
         final fun <get-getPaginatedMeetingOccurrenceDetails>(): com.wire.kalium.logic.feature.meeting/GetPaginatedMeetingOccurrencesUseCase // com.wire.kalium.logic.feature.meeting/MeetingScope.getPaginatedMeetingOccurrenceDetails.<get-getPaginatedMeetingOccurrenceDetails>|<get-getPaginatedMeetingOccurrenceDetails>(){}[0]
     final val observeMeetingOccurrence // com.wire.kalium.logic.feature.meeting/MeetingScope.observeMeetingOccurrence|{}observeMeetingOccurrence[0]

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepository.kt
@@ -26,6 +26,9 @@ import com.wire.kalium.common.error.wrapApiRequest
 import com.wire.kalium.common.error.wrapStorageRequest
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.logic.data.id.MeetingId
+import com.wire.kalium.logic.data.id.toApi
+import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.network.api.base.authenticated.meeting.MeetingApi
 import com.wire.kalium.persistence.dao.meeting.MeetingDao
@@ -57,6 +60,8 @@ internal interface MeetingRepository {
         startingOffset: Long,
         from: Instant = currentInstant().asStartOfDay(),
     ): Flow<PagingData<MeetingOccurrence>>
+
+    suspend fun deleteMeeting(meetingId: MeetingId): Either<CoreFailure, Unit>
 }
 
 internal class MeetingDataSource(
@@ -106,6 +111,15 @@ internal class MeetingDataSource(
         startingOffset = startingOffset,
         from = from,
     ).pagingDataFlow.map { pagingData -> pagingData.map(meetingMapper::fromDaoToModel) }
+
+    override suspend fun deleteMeeting(meetingId: MeetingId): Either<CoreFailure, Unit> =
+        wrapApiRequest {
+            meetingApi.deleteMeeting(meetingId.toApi())
+        }.flatMap {
+            wrapStorageRequest {
+                meetingDAO.deleteMeeting(meetingId.toDao())
+            }
+        }
 }
 
 private const val OCCURRENCE_GENERATION_WINDOW_DAYS = 90

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase.kt
@@ -15,30 +15,33 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-
 package com.wire.kalium.logic.feature.meeting
 
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.fold
+import com.wire.kalium.logic.data.id.MeetingId
 import com.wire.kalium.logic.data.meeting.MeetingRepository
-import com.wire.kalium.util.KaliumDispatcher
 
-public class MeetingScope internal constructor(
-    private val dispatcher: KaliumDispatcher,
+/**
+ * Use case for deleting a meeting by its ID.
+ */
+public interface DeleteMeetingUseCase {
+    public suspend operator fun invoke(meetingId: MeetingId): Result
+
+    public sealed interface Result {
+        public data object Success : Result
+        public data class Failure(val coreFailure: CoreFailure) : Result
+    }
+}
+
+internal class DeleteMeetingUseCaseImpl(
     private val meetingRepository: MeetingRepository,
-) {
-    public val getPaginatedMeetingOccurrenceDetails: GetPaginatedMeetingOccurrencesUseCase
-        get() = GetPaginatedMeetingOccurrencesUseCaseImpl(
-            dispatcher = dispatcher,
-            meetingRepository = meetingRepository,
-        )
-
-    public val observeMeetingOccurrence: ObserveMeetingOccurrenceUseCase
-        get() = ObserveMeetingOccurrenceUseCaseImpl(
-            dispatcher = dispatcher,
-            meetingRepository = meetingRepository,
-        )
-
-    public val deleteMeeting: DeleteMeetingUseCase
-        get() = DeleteMeetingUseCaseImpl(
-            meetingRepository = meetingRepository,
-        )
+) : DeleteMeetingUseCase {
+    override suspend operator fun invoke(meetingId: MeetingId): DeleteMeetingUseCase.Result {
+        return meetingRepository.deleteMeeting(meetingId).fold({
+            DeleteMeetingUseCase.Result.Failure(it)
+        }, {
+            DeleteMeetingUseCase.Result.Success
+        })
+    }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepositoryTest.kt
@@ -17,14 +17,20 @@
  */
 package com.wire.kalium.logic.data.meeting
 
+import com.wire.kalium.common.error.NetworkFailure
+import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.getOrNull
 import com.wire.kalium.common.functional.isRight
+import com.wire.kalium.logic.data.id.MeetingId
+import com.wire.kalium.logic.data.id.toApi
+import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.di.MapperProvider
+import com.wire.kalium.logic.test_util.TestNetworkException
 import com.wire.kalium.network.api.authenticated.meeting.MeetingDTO
 import com.wire.kalium.network.api.base.authenticated.meeting.MeetingApi
 import com.wire.kalium.network.api.model.ConversationId
-import com.wire.kalium.network.api.model.MeetingId
 import com.wire.kalium.network.api.model.UserId
+import com.wire.kalium.network.api.model.MeetingId as NetworkMeetingId
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.dao.meeting.MeetingDao
 import com.wire.kalium.persistence.dao.meeting.MeetingOccurrencesGenerator.GenerationLimit
@@ -39,6 +45,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class MeetingRepositoryTest {
@@ -46,7 +53,7 @@ class MeetingRepositoryTest {
     @Test
     fun whenFetchAndPersistMeetings_thenMeetingsAreFetchedAndPersistedWithNowDateTime() = runTest {
         val meetingDTO = MeetingDTO(
-            meetingId = MeetingId("meeting1", "domain"),
+            meetingId = NetworkMeetingId("meeting1", "domain"),
             conversationId = ConversationId("conversation1", "domain"),
             creatorId = UserId("user1", "domain"),
             createdAt = Instant.parse("2026-06-01T00:00:00Z"),
@@ -92,6 +99,40 @@ class MeetingRepositoryTest {
         }
     }
 
+    @Test
+    fun givenApiDeleteSucceeds_whenDeleteMeeting_thenMeetingIsDeletedLocally() = runTest {
+        val meetingId = MeetingId("meeting1", "domain")
+        val (arrangement, repository) = Arrangement()
+            .withDeleteMeetingSuccess(meetingId)
+            .arrange()
+
+        val result = repository.deleteMeeting(meetingId)
+
+        assertTrue(result.isRight())
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingApi.deleteMeeting(meetingId.toApi())
+            arrangement.meetingDao.deleteMeeting(meetingId.toDao())
+        }
+    }
+
+    @Test
+    fun givenApiDeleteFails_whenDeleteMeeting_thenMeetingIsNotDeletedLocally() = runTest {
+        val meetingId = MeetingId("meeting1", "domain")
+        val (arrangement, repository) = Arrangement()
+            .withDeleteMeetingFailure(meetingId)
+            .arrange()
+
+        val result = repository.deleteMeeting(meetingId)
+
+        assertIs<Either.Left<NetworkFailure.ServerMiscommunication>>(result)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingApi.deleteMeeting(meetingId.toApi())
+        }
+        verifySuspend(VerifyMode.not) {
+            arrangement.meetingDao.deleteMeeting(meetingId.toDao())
+        }
+    }
+
     inner class Arrangement {
         internal val meetingDao = mock<MeetingDao>(mode = MockMode.autoUnit)
         internal val meetingApi = mock<MeetingApi>(mode = MockMode.autoUnit)
@@ -100,6 +141,15 @@ class MeetingRepositoryTest {
         internal fun withFetchMeetingsSuccess(result: List<MeetingDTO>) = apply {
             everySuspend { meetingApi.fetchMeetings() } returns NetworkResponse.Success(result, mapOf(), HttpStatusCode.OK.value)
         }
+
+        internal fun withDeleteMeetingSuccess(meetingId: MeetingId) = apply {
+            everySuspend { meetingApi.deleteMeeting(meetingId.toApi()) } returns NetworkResponse.Success(Unit, mapOf(), HttpStatusCode.OK.value)
+        }
+
+        internal fun withDeleteMeetingFailure(meetingId: MeetingId) = apply {
+            everySuspend { meetingApi.deleteMeeting(meetingId.toApi()) } returns NetworkResponse.Error(TestNetworkException.generic)
+        }
+
         internal fun arrange() = this to MeetingDataSource(meetingDAO = meetingDao, meetingApi = meetingApi)
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/meeting/DeleteMeetingUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/meeting/DeleteMeetingUseCaseTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.meeting
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.id.MeetingId
+import com.wire.kalium.logic.data.meeting.MeetingRepository
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class DeleteMeetingUseCaseTest {
+
+    @Test
+    fun givenRepositoryDeleteSucceeds_whenInvoking_thenReturnsSuccess() = runTest {
+        val meetingId = MeetingId("meetingId", "domain")
+        val (arrangement, useCase) = Arrangement()
+            .withDeleteMeetingReturning(meetingId, Either.Right(Unit))
+            .arrange()
+
+        val result = useCase(meetingId)
+
+        assertEquals(DeleteMeetingUseCase.Result.Success, result)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingRepository.deleteMeeting(meetingId)
+        }
+    }
+
+    @Test
+    fun givenRepositoryDeleteFails_whenInvoking_thenReturnsFailure() = runTest {
+        val meetingId = MeetingId("meetingId", "domain")
+        val failure = CoreFailure.Unknown(RuntimeException("delete failed"))
+        val (_, useCase) = Arrangement()
+            .withDeleteMeetingReturning(meetingId, Either.Left(failure))
+            .arrange()
+
+        val result = useCase(meetingId)
+
+        assertEquals(failure, assertIs<DeleteMeetingUseCase.Result.Failure>(result).coreFailure)
+    }
+
+    inner class Arrangement {
+        internal val meetingRepository = mock<MeetingRepository>(mode = MockMode.autoUnit)
+
+        internal fun withDeleteMeetingReturning(meetingId: MeetingId, result: Either<CoreFailure, Unit>) = apply {
+            everySuspend { meetingRepository.deleteMeeting(meetingId) } returns result
+        }
+
+        internal fun arrange() = this to DeleteMeetingUseCaseImpl(meetingRepository)
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-20269
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Use case to delete a meeting for all participants.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
