### PR TITLE
fix: log buffered MLS messages and epoch updates (WPB-23206)

### DIFF
--- a/core/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/CryptoTransactionContext.kt
+++ b/core/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/CryptoTransactionContext.kt
@@ -149,12 +149,12 @@ interface MlsCoreCryptoContext {
      * @param groupId MLS group where the message was received
      * @param message application message or handshake message
      *
-     * @return decrypted message bundle, which contains the decrypted message.
+     * @return the decrypted messages or the reason the message was buffered.
      */
    suspend fun decryptMessage(
        groupId: String,
        message: ByteArray
-   ): List<DecryptedMessageBundle>
+   ): MLSDecryptResult
 
     /**
      * Current members of the group.

--- a/core/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/MLSClient.kt
+++ b/core/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/MLSClient.kt
@@ -121,6 +121,12 @@ data class DecryptedMessageBundle(
     }
 }
 
+sealed interface MLSDecryptResult {
+    data class Success(val messages: List<DecryptedMessageBundle>) : MLSDecryptResult
+    data object BufferedFutureMessage : MLSDecryptResult
+    data object BufferedCommit : MLSDecryptResult
+}
+
 @JvmInline
 value class ExternalSenderKey(
     val value: ByteArray

--- a/core/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/MLSClientImpl.kt
+++ b/core/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/MLSClientImpl.kt
@@ -24,7 +24,6 @@ import com.wire.crypto.ConversationConfiguration
 import com.wire.crypto.CoreCryptoClient
 import com.wire.crypto.CoreCryptoContext
 import com.wire.crypto.CoreCryptoException
-import com.wire.crypto.DecryptedMessage
 import com.wire.crypto.MlsException
 import com.wire.crypto.toClientId
 import com.wire.crypto.toExternalSenderKey
@@ -154,40 +153,27 @@ class MLSClientImpl(
             return context.encryptMessage(groupId.toCrypto(), message)
         }
 
-        @Suppress("TooGenericExceptionCaught")
         override suspend fun decryptMessage(
             groupId: MLSGroupId,
             message: ByteArray,
-        ): List<DecryptedMessageBundle> {
-            var decryptedMessage: DecryptedMessage? = null
-            try {
-                val result = context.decryptMessage(
-                    groupId.toCrypto(),
-                    message
-                )
-                decryptedMessage = result
-
-            } catch (throwable: Throwable) {
-                val isBufferedFutureError = throwable is CoreCryptoException.Mls
-                        && (
-                        throwable.mlsError is MlsException.BufferedFutureMessage
-                                || throwable.mlsError is MlsException.BufferedCommit
-                        )
-                if (!isBufferedFutureError) {
-                    throw throwable
-                }
-            }
-
-            if (decryptedMessage == null) {
-                return emptyList()
-            }
+        ): MLSDecryptResult = try {
+            val decryptedMessage = context.decryptMessage(
+                groupId.toCrypto(),
+                message
+            )
 
             val mainMessageBundle = listOf(decryptedMessage.toBundle())
             val bufferedBundles = decryptedMessage.bufferedMessages
                 ?.map { it.toBundle() }
                 ?: emptyList()
 
-            return mainMessageBundle + bufferedBundles
+            MLSDecryptResult.Success(mainMessageBundle + bufferedBundles)
+        } catch (throwable: CoreCryptoException.Mls) {
+            when (throwable.mlsError) {
+                is MlsException.BufferedFutureMessage -> MLSDecryptResult.BufferedFutureMessage
+                is MlsException.BufferedCommit -> MLSDecryptResult.BufferedCommit
+                else -> throw throwable
+            }
         }
 
         override suspend fun members(groupId: MLSGroupId): List<CryptoQualifiedClientId> {

--- a/core/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/MLSClientTest.kt
+++ b/core/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/MLSClientTest.kt
@@ -109,7 +109,7 @@ class MLSClientTest : BaseMLSClientTest() {
 
         val result = aliceClient.transaction { it.decryptMessage(welcomeBundle.groupId, keyMaterialCommit.first.commit) }
 
-        assertNull(result.first().message)
+        assertNull((result as MLSDecryptResult.Success).messages.first().message)
     }
 
     @Test
@@ -164,7 +164,9 @@ class MLSClientTest : BaseMLSClientTest() {
         val welcomeBundle = aliceClient.transaction { it.processWelcomeMessage(welcome) }
 
         val applicationMessage = aliceClient.transaction { it.encryptMessage(welcomeBundle.groupId, PLAIN_TEXT.encodeToByteArray()) }
-        val bundle = bobClient.transaction { it.decryptMessage(welcomeBundle.groupId, applicationMessage).first() }
+        val bundle = bobClient.transaction {
+            (it.decryptMessage(welcomeBundle.groupId, applicationMessage) as MLSDecryptResult.Success).messages.first()
+        }
 
         assertNotNull(bundle.senderClientId)
         assertEquals(PLAIN_TEXT, bundle.message?.decodeToString())
@@ -237,7 +239,8 @@ class MLSClientTest : BaseMLSClientTest() {
         }
         val commit = bobArrangement.sendCommitBundleFlow.first().first.commit
 
-        assertNull(aliceClient.transaction { it.decryptMessage(MLS_CONVERSATION_ID, commit) }.first().message)
+        val result = aliceClient.transaction { it.decryptMessage(MLS_CONVERSATION_ID, commit) }
+        assertNull((result as MLSDecryptResult.Success).messages.first().message)
     }
 
     @Test
@@ -278,11 +281,12 @@ class MLSClientTest : BaseMLSClientTest() {
         val clientRemovalList = listOf(CAROL1.qualifiedClientId)
         bobClient.transaction { it.removeMember(welcomeBundle.groupId, clientRemovalList) }
         val commit = bobArrangement.sendCommitBundleFlow.first().first.commit
-        assertNull(aliceClient.transaction { it.decryptMessage(welcomeBundle.groupId, commit) }.first().message)
+        val result = aliceClient.transaction { it.decryptMessage(welcomeBundle.groupId, commit) }
+        assertNull((result as MLSDecryptResult.Success).messages.first().message)
     }
 
     @Test
-    fun givenThreeClients_whenProcessingCommitOutOfOrder_shouldCatchBufferedFutureMessageAndBuffer() = runTest {
+    fun givenCommitFromFutureEpoch_whenDecrypting_thenReturnBufferedFutureMessage() = runTest {
         val aliceArrangement = create(
             ALICE1,
             ::createMLSClient,
@@ -328,26 +332,9 @@ class MLSClientTest : BaseMLSClientTest() {
         val commitRemoveCarol = bobArrangement.sendCommitBundleFlow.first().first.commit
 
         // Alice tries to decrypt the removeCarol commit, which references an epoch Alice hasn't seen yet.
-        // In normal MLS logic, this triggers a "buffering" error, typically thrown as MlsException.BufferedFutureMessage
-        // wrapped in CoreCryptoException.Mls. The client code is supposed to swallow that error in a transaction
-        // and return an empty DecryptedMessage list.
+        val result = aliceClient.transaction { it.decryptMessage(MLS_CONVERSATION_ID, commitRemoveCarol) }
 
-        val decryptedBundlesResult = runCatching {
-            aliceClient.transaction { it.decryptMessage(MLS_CONVERSATION_ID, commitRemoveCarol) }
-        }
-
-        // The exception should be caught internally, so from the caller's perspective we succeed with an empty result.
-        // That indicates the message was buffered instead of fully decrypted.
-        assertTrue(
-            decryptedBundlesResult.isSuccess,
-            "Out-of-order commit should not propagate BufferedFutureMessage as an unhandled exception."
-        )
-
-        val decryptedBundles = decryptedBundlesResult.getOrThrow()
-        assertTrue(
-            decryptedBundles.isEmpty(),
-            "Decryption result should be empty for a buffered out-of-order commit."
-        )
+        assertEquals(MLSDecryptResult.BufferedFutureMessage, result)
     }
 
     @Test
@@ -397,10 +384,7 @@ class MLSClientTest : BaseMLSClientTest() {
 
         // Alice tries to decrypt the removeCarol commit first => out-of-order => should buffer
         val removeResult = aliceClient.transaction { it.decryptMessage(MLS_CONVERSATION_ID, commitRemoveCarol) }
-        assertTrue(
-            removeResult.isEmpty(),
-            "Out-of-order remove commit should be buffered and return an empty list."
-        )
+        assertEquals(MLSDecryptResult.BufferedFutureMessage, removeResult)
 
         // Now Alice processes the missing 'addCarol' commit.
         // By processing the addCarol commit, MLS should also flush any previously buffered commits (the removeCarol).
@@ -411,7 +395,7 @@ class MLSClientTest : BaseMLSClientTest() {
         // We expect 2 total commits to be processed now: (1) addCarol, (2) removeCarol.
         assertEquals(
             2,
-            addResult.size,
+            (addResult as MLSDecryptResult.Success).messages.size,
             "Processing the older 'addCarol' commit should also flush the buffered 'removeCarol' commit, resulting in 2 items."
         )
         assertEquals(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -41,6 +41,7 @@ import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.cryptography.CryptoQualifiedClientId
 import com.wire.kalium.cryptography.E2EIClient
 import com.wire.kalium.cryptography.MLSClient
+import com.wire.kalium.cryptography.MLSDecryptResult
 import com.wire.kalium.cryptography.MlsCoreCryptoContext
 import com.wire.kalium.cryptography.WireIdentity
 import com.wire.kalium.logic.data.client.toDao
@@ -348,14 +349,19 @@ internal class MLSConversationDataSource(
                 idMapper.toCryptoModel(groupID),
                 message
             )
-                .let { messages ->
-                    messages.map {
+        }.flatMap { result ->
+            when (result) {
+                MLSDecryptResult.BufferedFutureMessage -> Left(MLSFailure.BufferedFutureMessage)
+                MLSDecryptResult.BufferedCommit -> Left(MLSFailure.BufferedCommit)
+                is MLSDecryptResult.Success -> wrapMLSRequest {
+                    result.messages.map {
                         it.crlNewDistributionPoints?.let { newDistributionPoints ->
                             checkRevocationList(mlsContext, newDistributionPoints)
                         }
                         it.toModel(groupID)
                     }
                 }
+            }
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifier.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifier.kt
@@ -23,7 +23,9 @@ import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
 import com.wire.kalium.common.functional.map
 import com.wire.kalium.common.logger.kaliumLogger
+import com.wire.kalium.common.logger.logStructuredJson
 import com.wire.kalium.cryptography.CryptoTransactionContext
+import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.data.client.wrapInMLSContext
 import com.wire.kalium.logic.data.conversation.Conversation
@@ -50,6 +52,7 @@ internal interface StaleEpochVerifier {
     ): Either<CoreFailure, Unit>
 }
 
+@Suppress("LongParameterList")
 internal class StaleEpochVerifierImpl(
     private val systemMessageInserter: SystemMessageInserter,
     private val fetchConversationUseCase: FetchConversationUseCase,
@@ -67,24 +70,27 @@ internal class StaleEpochVerifierImpl(
         timestamp: Instant?
     ): Either<CoreFailure, Unit> {
         return if (subConversationId != null) {
-            verifySubConversationEpoch(transactionContext, conversationId, subConversationId)
+            verifySubConversationEpoch(transactionContext, conversationId, subConversationId, timestamp)
         } else {
-            verifyConversationEpoch(transactionContext, conversationId)
+            verifyConversationEpoch(transactionContext, conversationId, timestamp)
         }
     }
 
     private suspend fun verifyConversationEpoch(
         transactionContext: CryptoTransactionContext,
-        conversationId: ConversationId
+        conversationId: ConversationId,
+        timestamp: Instant?
     ): Either<CoreFailure, Unit> {
         logger.i("Verifying stale epoch for conversation ${conversationId.toLogString()}")
         return getUpdatedConversationProtocolInfo(transactionContext, conversationId).flatMap { remoteMlsInfo ->
-            transactionContext.wrapInMLSContext {
-                mlsConversationRepository.isLocalGroupEpochStale(it, remoteMlsInfo.groupId, remoteMlsInfo.epoch)
-            }
-                .map { epochIsStale ->
-                    epochIsStale
-                }
+            compareEpochsAndLog(
+                transactionContext = transactionContext,
+                conversationId = conversationId,
+                subConversationId = null,
+                groupId = remoteMlsInfo.groupId,
+                remoteEpoch = remoteMlsInfo.epoch,
+                timestamp = timestamp
+            ).map { it.isLocalEpochStale }
         }.flatMap { hasMissedCommits ->
             if (hasMissedCommits) {
                 logger.w("Epoch stale due to missing commits, re-joining")
@@ -104,17 +110,21 @@ internal class StaleEpochVerifierImpl(
     private suspend fun verifySubConversationEpoch(
         transactionContext: CryptoTransactionContext,
         conversationId: ConversationId,
-        subConversationId: SubconversationId
+        subConversationId: SubconversationId,
+        timestamp: Instant?
     ): Either<CoreFailure, Unit> {
         logger.i("Verifying stale epoch for subconversation ${subConversationId.toLogString()}")
         return subconversationRepository.fetchRemoteSubConversationDetails(conversationId, subConversationId)
             .flatMap { subConversationDetails ->
-                transactionContext.wrapInMLSContext {
-                    mlsConversationRepository.isLocalGroupEpochStale(it, subConversationDetails.groupId, subConversationDetails.epoch)
-                }
-                    .map { epochIsStale ->
-                        epochIsStale
-                    }
+                compareEpochsAndLog(
+                    transactionContext = transactionContext,
+                    conversationId = conversationId,
+                    subConversationId = subConversationId,
+                    groupId = subConversationDetails.groupId,
+                    remoteEpoch = subConversationDetails.epoch,
+                    timestamp = timestamp
+                )
+                    .map { it.isLocalEpochStale }
                     .flatMap { hasMissedCommits ->
                         if (hasMissedCommits) {
                             logger.w("Epoch stale due to missing commits, joining by external commit")
@@ -132,6 +142,40 @@ internal class StaleEpochVerifierImpl(
                         }
                     }
             }
+    }
+
+    private suspend fun compareEpochsAndLog(
+        transactionContext: CryptoTransactionContext,
+        conversationId: ConversationId,
+        subConversationId: SubconversationId?,
+        groupId: GroupID,
+        remoteEpoch: ULong,
+        timestamp: Instant?
+    ): Either<CoreFailure, EpochComparison> = transactionContext.wrapInMLSContext {
+        mlsConversationRepository.getLocalGroupEpoch(it, groupId)
+    }.map { localEpoch ->
+        EpochComparison(localEpoch, remoteEpoch).also { comparison ->
+            logger.logStructuredJson(
+                level = if (comparison.isLocalEpochStale) KaliumLogLevel.WARN else KaliumLogLevel.INFO,
+                leadingMessage = "MLS epoch comparison",
+                jsonStringKeyValues = mapOf(
+                    "conversationId" to conversationId.toLogString(),
+                    "subConversationId" to subConversationId?.toLogString(),
+                    "groupId" to groupId.toLogString(),
+                    "localEpoch" to comparison.localEpoch.toString(),
+                    "remoteEpoch" to comparison.remoteEpoch.toString(),
+                    "epochGap" to comparison.epochGap.toString(),
+                    "epochState" to comparison.state.name,
+                    "trigger" to if (timestamp == null) "SEND_FAILURE" else "RECEIVE_FAILURE",
+                    "messageTimestamp" to timestamp,
+                    "recoveryAction" to when {
+                        !comparison.isLocalEpochStale -> "NONE"
+                        subConversationId == null -> "REJOIN"
+                        else -> "EXTERNAL_COMMIT"
+                    }
+                )
+            )
+        }
     }
 
     @OptIn(ConversationPersistenceApi::class)
@@ -164,4 +208,23 @@ internal class StaleEpochVerifierImpl(
         val groupId: GroupID,
         val epoch: ULong
     )
+
+    private data class EpochComparison(
+        val localEpoch: ULong,
+        val remoteEpoch: ULong
+    ) {
+        val isLocalEpochStale: Boolean = localEpoch < remoteEpoch
+        val epochGap: ULong = if (isLocalEpochStale) remoteEpoch - localEpoch else localEpoch - remoteEpoch
+        val state: State = when {
+            isLocalEpochStale -> State.LOCAL_BEHIND_REMOTE
+            localEpoch > remoteEpoch -> State.LOCAL_AHEAD_OF_REMOTE
+            else -> State.IN_SYNC
+        }
+
+        enum class State {
+            LOCAL_BEHIND_REMOTE,
+            IN_SYNC,
+            LOCAL_AHEAD_OF_REMOTE
+        }
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageUnpacker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageUnpacker.kt
@@ -19,8 +19,10 @@
 package com.wire.kalium.logic.sync.receiver.conversation.message
 
 import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.MLSFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.common.functional.getOrNull
 import com.wire.kalium.common.functional.map
 import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.common.logger.logStructuredJson
@@ -139,7 +141,7 @@ internal class MLSMessageUnpackerImpl(
                         "groupID" to groupID.toLogString()
                     )
                 )
-                mlsConversationRepository.decryptMessage(mlsContext, Base64.decode(messageEvent.content), groupID)
+                decryptMessageAndLogIfBuffered(mlsContext, messageEvent, groupID)
             }
         } ?: conversationRepository.getConversationProtocolInfo(messageEvent.conversationId).flatMap { protocolInfo ->
             if (protocolInfo is Conversation.ProtocolInfo.MLSCapable) {
@@ -151,9 +153,35 @@ internal class MLSMessageUnpackerImpl(
                         "protocolInfo" to protocolInfo.toLogMap()
                     )
                 )
-                mlsConversationRepository.decryptMessage(mlsContext, Base64.decode(messageEvent.content), protocolInfo.groupId)
+                decryptMessageAndLogIfBuffered(mlsContext, messageEvent, protocolInfo.groupId)
             } else {
                 Either.Left(CoreFailure.NotSupportedByProteus)
             }
         }
+
+    private suspend fun decryptMessageAndLogIfBuffered(
+        mlsContext: MlsCoreCryptoContext,
+        messageEvent: Event.Conversation.NewMLSMessage,
+        groupId: GroupID
+    ): Either<CoreFailure, List<DecryptedMessageBundle>> {
+        val result = mlsConversationRepository.decryptMessage(mlsContext, Base64.decode(messageEvent.content), groupId)
+        val bufferType = when ((result as? Either.Left)?.value) {
+            MLSFailure.BufferedFutureMessage -> "FUTURE_MESSAGE"
+            MLSFailure.BufferedCommit -> "COMMIT"
+            else -> return result
+        }
+        val localEpoch = mlsConversationRepository.getLocalGroupEpoch(mlsContext, groupId).getOrNull()
+        logger.logStructuredJson(
+            level = KaliumLogLevel.WARN,
+            leadingMessage = "MLS message buffered",
+            jsonStringKeyValues = buildMap {
+                putAll(messageEvent.toLogMap())
+                put("subConversationId", messageEvent.subconversationId?.toLogString())
+                put("groupId", groupId.toLogString())
+                put("localEpoch", localEpoch?.toString())
+                put("bufferType", bufferType)
+            }
+        )
+        return result
+    }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -33,6 +33,7 @@ import com.wire.kalium.cryptography.E2EIClient
 import com.wire.kalium.cryptography.ExternalSenderKey
 import com.wire.kalium.cryptography.GroupInfoBundle
 import com.wire.kalium.cryptography.GroupInfoEncryptionType
+import com.wire.kalium.cryptography.MLSDecryptResult
 import com.wire.kalium.cryptography.RatchetTreeType
 import com.wire.kalium.cryptography.RotateBundle
 import com.wire.kalium.cryptography.WelcomeBundle
@@ -133,6 +134,21 @@ class MLSConversationRepositoryTest {
                 arrangement.certificateRevocationListRepository.addOrUpdateCRL(any(), any())
             }
         }
+
+    @Test
+    fun givenBufferedFutureMessage_whenDecryptingMessage_thenReturnBufferedFutureMessageFailure() = runTest {
+        val (arrangement, mlsConversationRepository) = Arrangement()
+            .withDecryptMLSMessageReturning(MLSDecryptResult.BufferedFutureMessage)
+            .arrange()
+
+        val result = mlsConversationRepository.decryptMessage(
+            arrangement.mlsContext,
+            Arrangement.COMMIT,
+            Arrangement.GROUP_ID
+        )
+
+        result.shouldFail { assertEquals(MLSFailure.BufferedFutureMessage, it) }
+    }
 
     @Test
     fun givenSuccessfulResponses_whenCallingEstablishMLSGroup_thenGroupIsCreatedAndCommitBundleIsSentAndAccepted() = runTest {
@@ -1776,9 +1792,13 @@ class MLSConversationRepositoryTest {
         }
 
         fun withDecryptMLSMessageSuccessful(decryptedMessage: com.wire.kalium.cryptography.DecryptedMessageBundle) = apply {
+            withDecryptMLSMessageReturning(MLSDecryptResult.Success(listOf(decryptedMessage)))
+        }
+
+        fun withDecryptMLSMessageReturning(result: MLSDecryptResult) = apply {
             everySuspend {
                 mlsContext.decryptMessage(any(), any())
-            } returns listOf(decryptedMessage)
+            } returns result
         }
 
         fun withRemoveMemberSuccessful() = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifierTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifierTest.kt
@@ -78,7 +78,7 @@ class StaleEpochVerifierTest {
     @Test
     fun givenMLSConversation_whenHandlingStaleEpoch_thenShouldFetchConversationAgain() = runTest {
         val (arrangement, staleEpochHandler) = arrange {
-            withIsGroupOutOfSync(Either.Right(false))
+            withLocalGroupEpoch(Either.Right(REMOTE_EPOCH))
             withFetchConversationResponse(Either.Right(MLS_CONVERSATION_RESPONSE))
         }
 
@@ -96,7 +96,7 @@ class StaleEpochVerifierTest {
     @Test
     fun givenEpochIsLatest_whenHandlingStaleEpoch_thenShouldNotRejoinTheConversation() = runTest {
         val (arrangement, staleEpochHandler) = arrange {
-            withIsGroupOutOfSync(Either.Right(false))
+            withLocalGroupEpoch(Either.Right(REMOTE_EPOCH))
             withFetchConversationResponse(Either.Right(MLS_CONVERSATION_RESPONSE))
         }
 
@@ -115,7 +115,7 @@ class StaleEpochVerifierTest {
     @Test
     fun givenStaleEpoch_whenHandlingStaleEpoch_thenShouldRejoinTheConversation() = runTest {
         val (arrangement, staleEpochHandler) = arrange {
-            withIsGroupOutOfSync(Either.Right(true))
+            withLocalGroupEpoch(Either.Right(REMOTE_EPOCH - 1UL))
             withFetchConversationResponse(Either.Right(MLS_CONVERSATION_RESPONSE))
             withJoinExistingMLSConversationUseCaseReturning(Either.Right(Unit))
             withInsertLostCommitSystemMessage(Either.Right(Unit))
@@ -136,7 +136,7 @@ class StaleEpochVerifierTest {
     @Test
     fun givenRejoiningFails_whenHandlingStaleEpoch_thenShouldNotInsertLostCommitSystemMessage() = runTest {
         val (arrangement, staleEpochHandler) = arrange {
-            withIsGroupOutOfSync(Either.Right(true))
+            withLocalGroupEpoch(Either.Right(REMOTE_EPOCH - 1UL))
             withFetchConversationResponse(Either.Right(MLS_CONVERSATION_RESPONSE))
             withJoinExistingMLSConversationUseCaseReturning(Either.Left(NetworkFailure.NoNetworkConnection(null)))
         }
@@ -151,7 +151,7 @@ class StaleEpochVerifierTest {
     @Test
     fun givenConversationIsRejoined_whenHandlingStaleEpoch_thenShouldInsertLostCommitSystemMessage() = runTest {
         val (arrangement, staleEpochHandler) = arrange {
-            withIsGroupOutOfSync(Either.Right(true))
+            withLocalGroupEpoch(Either.Right(REMOTE_EPOCH - 1UL))
             withFetchConversationResponse(Either.Right(MLS_CONVERSATION_RESPONSE))
             withJoinExistingMLSConversationUseCaseReturning(Either.Right(Unit))
             withInsertLostCommitSystemMessage(Either.Right(Unit))
@@ -169,7 +169,7 @@ class StaleEpochVerifierTest {
         val subConversationId = SubconversationId("subconversation-id")
         val (arrangement, staleEpochHandler) = arrange {
             withFetchRemoteSubConversationDetails(CONVERSATION_ID, subConversationId, Either.Right(TestSubConversationDetails))
-            withIsGroupOutOfSync(Either.Right(false))
+            withLocalGroupEpoch(Either.Right(TestSubConversationDetails.epoch))
         }
 
         val result = staleEpochHandler.verifyEpoch(arrangement.transactionContext, CONVERSATION_ID, subConversationId, null)
@@ -181,10 +181,9 @@ class StaleEpochVerifierTest {
         }
 
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.mlsConversationRepository.isLocalGroupEpochStale(
+            arrangement.mlsConversationRepository.getLocalGroupEpoch(
                 mokkeryAny(),
-                mokkeryEq(TestSubConversationDetails.groupId),
-                mokkeryEq(TestSubConversationDetails.epoch)
+                mokkeryEq(TestSubConversationDetails.groupId)
             )
         }
     }
@@ -194,7 +193,7 @@ class StaleEpochVerifierTest {
         val subConversationId = SubconversationId("subconversation-id")
         val (arrangement, staleEpochHandler) = arrange {
             withFetchRemoteSubConversationDetails(CONVERSATION_ID, subConversationId, Either.Right(TestSubConversationDetails))
-            withIsGroupOutOfSync(Either.Right(true))
+            withLocalGroupEpoch(Either.Right(TestSubConversationDetails.epoch - 1UL))
             withFetchRemoteSubConversationGroupInfo(CONVERSATION_ID, subConversationId, Either.Right(TestGroupInfo))
             withJoinGroupByExternalCommit(TestSubConversationDetails.groupId, TestGroupInfo, Either.Right(Unit))
         }
@@ -241,7 +240,7 @@ class StaleEpochVerifierTest {
         val subConversationId = SubconversationId("subconversation-id")
         val (arrangement, staleEpochHandler) = arrange {
             withFetchRemoteSubConversationDetails(CONVERSATION_ID, subConversationId, Either.Right(TestSubConversationDetails))
-            withIsGroupOutOfSync(Either.Right(true))
+            withLocalGroupEpoch(Either.Right(TestSubConversationDetails.epoch - 1UL))
             withFetchRemoteSubConversationGroupInfo(CONVERSATION_ID, subConversationId, Either.Right(TestGroupInfo))
             withJoinGroupByExternalCommit(
                 TestSubConversationDetails.groupId,
@@ -270,7 +269,7 @@ class StaleEpochVerifierTest {
         val subConversationId = SubconversationId("subconversation-id")
         val (arrangement, staleEpochHandler) = arrange {
             withFetchRemoteSubConversationDetails(CONVERSATION_ID, subConversationId, Either.Right(TestSubConversationDetails))
-            withIsGroupOutOfSync(Either.Right(false))
+            withLocalGroupEpoch(Either.Right(TestSubConversationDetails.epoch))
         }
 
         val result = staleEpochHandler.verifyEpoch(arrangement.transactionContext, CONVERSATION_ID, subConversationId, null)
@@ -307,7 +306,9 @@ class StaleEpochVerifierTest {
             val localProtocolInfo: Either<StorageFailure, Conversation.ProtocolInfo> = when (result) {
                 is Either.Left -> Either.Left(StorageFailure.Generic(IllegalStateException(result.value.toString())))
                 is Either.Right -> when (result.value.protocol) {
-                    ConvProtocol.MLS -> Either.Right(TestConversation.MLS_PROTOCOL_INFO)
+                    ConvProtocol.MLS -> Either.Right(
+                        TestConversation.MLS_PROTOCOL_INFO.copy(epoch = result.value.epoch ?: 0UL)
+                    )
                     else -> Either.Right(Conversation.ProtocolInfo.Proteus)
                 }
             }
@@ -317,8 +318,8 @@ class StaleEpochVerifierTest {
             } returns localProtocolInfo
         }
 
-        suspend fun withIsGroupOutOfSync(result: Either<CoreFailure, Boolean>) {
-            everySuspend { mlsConversationRepository.isLocalGroupEpochStale(mokkeryAny(), mokkeryAny(), mokkeryAny()) } returns result
+        suspend fun withLocalGroupEpoch(result: Either<CoreFailure, ULong>) {
+            everySuspend { mlsConversationRepository.getLocalGroupEpoch(mokkeryAny(), mokkeryAny()) } returns result
         }
 
         suspend fun withJoinExistingMLSConversationUseCaseReturning(result: Either<CoreFailure, Unit>) {
@@ -372,6 +373,7 @@ class StaleEpochVerifierTest {
         suspend fun arrange(configuration: suspend Arrangement.() -> Unit) = Arrangement(configuration).arrange()
 
         val CONVERSATION_ID = ConversationId("conversation-value", "conversation-domain")
+        const val REMOTE_EPOCH = 10UL
 
         val MLS_CONVERSATION_RESPONSE = ConversationResponse(
             creator = TestUser.USER_ID.value,
@@ -382,7 +384,7 @@ class StaleEpochVerifierTest {
             name = "mls-conversation",
             id = CONVERSATION_ID.toApi(),
             groupId = TestConversation.MLS_PROTOCOL_INFO.groupId.value,
-            epoch = TestConversation.MLS_PROTOCOL_INFO.epoch,
+            epoch = REMOTE_EPOCH,
             type = ConversationResponse.Type.GROUP,
             messageTimer = 0,
             teamId = null,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-23206
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-23206

----

# What is new in this PR?

### Issues
1. MLS events buffered by CoreCrypto are mapped to MLS handshake messages without exposing the buffering reason to higher layers.
2. Conversation epoch recovery lacks structured diagnostics for local and remote epoch updates.

### Solutions
- Surface `MLSFailure.BufferedFutureMessage` and `MLSFailure.BufferedCommit` so buffered MLS handshake events can be logged at the event-processing layer.
- Add structured buffering logs with the conversation, group, local epoch, and buffer type.
- Add structured local/remote epoch comparison logs, including the epoch gap, state, trigger, and recovery action.