### PR TITLE
fix: ExponentialDurationHelper freezes on iOS [WPB-27272]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/util/ExponentialDurationHelper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/util/ExponentialDurationHelper.kt
@@ -36,17 +36,24 @@ internal class ExponentialDurationHelperImpl(
     private val maxDuration: Duration,
     private val factor: Double = 2.0,
 ) : ExponentialDurationHelper {
-    private val currentDuration = AtomicReference(initialDuration)
+
+    // Wrapper class to avoid issues with Duration's equals/hashCode in AtomicReference
+    private data class DurationState(val value: Duration)
+
+    private val currentDuration = AtomicReference(DurationState(initialDuration))
 
     override fun reset() {
-        currentDuration.set(initialDuration)
+        currentDuration.set(DurationState(initialDuration))
     }
 
     override fun next(): Duration {
         while (true) {
             val current = currentDuration.get()
-            val next = current.times(factor).coerceAtMost(maxDuration)
-            if (currentDuration.compareAndSet(current, next)) return current
+            val next = DurationState(current.value.times(factor).coerceAtMost(maxDuration))
+
+            if (currentDuration.compareAndSet(current, next)) {
+                return current.value
+            }
         }
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-27272
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

iOS tests freeze.

### Causes (Optional)

`ExponentialDurationHelper` got changed and it now uses `co.touchlab.stately.concurrency.AtomicReference` and it behaves differently for iOS.
JVM and iOS both use identity-style `compareAndSet`, but the value being compared behaves differently.
On JVM `currentDuration.get()` gives back the same boxed `Duration` object reference that Java’s `AtomicReference` is holding, so `compareAndSet` sees the expected object and succeeds.
On iOS/Kotlin Native, Stately’s `AtomicReference` also does identity `compareAndSet`, but `Duration` is a value class. When it crosses the generic atomic API boundary, Native may unbox/rebox it. So current can be equal to the stored duration value, but not the same object identity. Then `compareAndSet`returns false, and the while (true) loop spins forever.

### Solutions

Use a reference wrapper so Stately’s Native `compareAndSet` compares the same object reference returned by `get()`.
That keeps the intended thread-safe reset/next behavior from the commit, but avoids the Kotlin/Native value-class boxing trap.
The wrapper changes the atomic value into a normal reference object:
```
data class DurationState(val value: Duration)
```
Now `get()` returns the actual stored `DurationState` object, and `compareAndSet` compares that stable object identity. The Duration inside can still be a value class, but `compareAndSet` no longer compares the `Duration` box itself.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
