### PR TITLE
fix(client): restore MLS registration after client removal [WPB-27228] [WPB-27362]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/CryptoTransactionProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/client/CryptoTransactionProvider.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.cryptography.CryptoTransactionContext
 import com.wire.kalium.cryptography.MlsCoreCryptoContext
 import com.wire.kalium.cryptography.ProteusCoreCryptoContext
+import com.wire.kalium.cryptography.exceptions.ProteusException
 import com.wire.kalium.util.InternalCryptoAccess
 
 /**
@@ -83,8 +84,15 @@ internal class CryptoTransactionProviderImpl(
                     proteus.transaction(name.toTransactionName("proteus")) { proteusContext ->
                         block(proteusContext)
                     }
+                } catch (e: ProteusException) {
+                    if (e.isDestroyedCoreCryptoException()) {
+                        kaliumLogger.w("Tried to use destroyed ProteusClient in transaction '$name'", e)
+                        CoreFailure.MissingClientRegistration.left()
+                    } else {
+                        throw e
+                    }
                 } catch (e: IllegalStateException) {
-                    if (e.message?.contains("already been destroyed") == true) {
+                    if (e.isDestroyedCoreCryptoException()) {
                         kaliumLogger.w("Tried to use destroyed ProteusClient in transaction '$name'", e)
                         CoreFailure.MissingClientRegistration.left()
                     } else {
@@ -105,7 +113,7 @@ internal class CryptoTransactionProviderImpl(
                         block(mlsContext)
                     }
                 } catch (e: IllegalStateException) {
-                    if (e.message?.contains("already been destroyed") == true) {
+                    if (e.isDestroyedCoreCryptoException()) {
                         kaliumLogger.w("Tried to use destroyed MLSClient in transaction '$name'", e)
                         MLSFailure.Disabled.left()
                     } else {
@@ -130,8 +138,15 @@ internal class CryptoTransactionProviderImpl(
                     block(withCryptoContext(proteusCtx, mlsCtx))
                 } ?: block(withCryptoContext(proteusCtx, null))
             }
+        } catch (e: ProteusException) {
+            if (e.isDestroyedCoreCryptoException()) {
+                kaliumLogger.w("Tried to use destroyed crypto client in combined transaction '$name'", e)
+                CoreFailure.MissingClientRegistration.left()
+            } else {
+                throw e
+            }
         } catch (e: IllegalStateException) {
-            if (e.message?.contains("already been destroyed") == true) {
+            if (e.isDestroyedCoreCryptoException()) {
                 kaliumLogger.w("Tried to use destroyed crypto client in combined transaction '$name'", e)
                 CoreFailure.MissingClientRegistration.left()
             } else {
@@ -149,3 +164,7 @@ internal class CryptoTransactionProviderImpl(
         return this?.let { "${protocol}_$it" } ?: protocol
     }
 }
+
+private fun Throwable.isDestroyedCoreCryptoException(): Boolean =
+    generateSequence(this) { it.cause }
+        .any { it.message?.contains("already been destroyed") == true }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -2706,7 +2706,7 @@ public class UserSessionScope internal constructor(
         get() = IsAllowedToRegisterMLSClientUseCaseImpl(
             featureSupport,
             mlsPublicKeysRepository,
-            userConfigRepository
+            featureConfigRepository
         )
 
     private val syncFeatureConfigsUseCase: SyncFeatureConfigsUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1719,7 +1719,8 @@ public class UserSessionScope internal constructor(
             incrementalSyncRepository,
             lazy { mlsConversationRepository },
             lazy { subconversationRepository },
-            cryptoTransactionProvider
+            cryptoTransactionProvider,
+            parentContext = coroutineContext,
         )
 
     private val callManager: Lazy<CallManager> = lazy {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCase.kt
@@ -163,6 +163,7 @@ internal class LogoutUseCaseImpl @Suppress("LongParameterList") constructor(
         clearClientDataUseCase()
         logoutRepository.clearClientRelatedLocalMetadata()
         clientRepository.clearCurrentClientId()
+        clientRepository.clearRetainedClientId()
         clientRepository.clearHasRegisteredMLSClient()
         clientRepository.clearNewClients()
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/GetOrRegisterClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/GetOrRegisterClientUseCase.kt
@@ -68,6 +68,9 @@ internal class GetOrRegisterClientUseCaseImpl(
                         is VerifyExistingClientResult.Failure.Generic -> RegisterClientResult.Failure.Generic(result.genericFailure)
                         is VerifyExistingClientResult.Failure.ClientNotRegistered -> {
                             clearOldClientRelatedData()
+                            // Clearing client metadata also clears the feature configuration used to decide whether
+                            // the replacement client must be registered with MLS support.
+                            syncFeatureConfigsUseCase()
                             null
                         }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/IsAllowedToRegisterMLSClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/IsAllowedToRegisterMLSClientUseCase.kt
@@ -18,19 +18,23 @@
 
 package com.wire.kalium.logic.feature.client
 
-import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.data.featureConfig.FeatureConfigRepository
+import com.wire.kalium.logic.data.featureConfig.Status
 import com.wire.kalium.logic.data.mlspublickeys.MLSPublicKeysRepository
+import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.featureFlags.FeatureSupport
 import com.wire.kalium.common.functional.getOrElse
 import com.wire.kalium.common.functional.isRight
+import com.wire.kalium.common.functional.map
 import com.wire.kalium.util.DelicateKaliumApi
 
 /**
  * Answers the question if the self user allowed to register an MLS client
  *
  * Which we are allowed to do if:
- * - MLS support is enabled.
- * - MLS supported is configured on the backend, which can be verified by looking for the existence of MLS public keys.
+ * - This build supports MLS.
+ * - MLS is enabled and supported in the current backend feature configuration.
+ * - MLS public keys are available on the backend.
  */
 @DelicateKaliumApi("This use case performs network calls, consider using IsMLSEnabledUseCase.")
 internal interface IsAllowedToRegisterMLSClientUseCase {
@@ -41,12 +45,19 @@ internal interface IsAllowedToRegisterMLSClientUseCase {
 internal class IsAllowedToRegisterMLSClientUseCaseImpl(
     private val featureSupport: FeatureSupport,
     private val mlsPublicKeysRepository: MLSPublicKeysRepository,
-    private val userConfigRepository: UserConfigRepository
+    private val featureConfigRepository: FeatureConfigRepository
 ) : IsAllowedToRegisterMLSClientUseCase {
 
     override suspend operator fun invoke(): Boolean {
-        return featureSupport.isMLSSupported
-                && userConfigRepository.isMLSEnabled().getOrElse(false)
-                && mlsPublicKeysRepository.getKeys().isRight()
+        if (!featureSupport.isMLSSupported) return false
+
+        val isMLSEnabledRemotely = featureConfigRepository.getFeatureConfigs()
+            .map { featureConfig ->
+                featureConfig.mlsModel.status == Status.ENABLED &&
+                        SupportedProtocol.MLS in featureConfig.mlsModel.supportedProtocols
+            }
+            .getOrElse(false)
+
+        return isMLSEnabledRemotely && mlsPublicKeysRepository.getKeys().isRight()
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PendingProposalScheduler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/PendingProposalScheduler.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Instant
+import kotlin.coroutines.CoroutineContext
 
 /**
  * Schedule pending MLS proposals in a conversation to be committed at a given
@@ -72,7 +73,8 @@ internal class PendingProposalSchedulerImpl(
     private val mlsConversationRepository: Lazy<MLSConversationRepository>,
     private val subconversationRepository: Lazy<SubconversationRepository>,
     private val transactionProvider: CryptoTransactionProvider,
-    kaliumDispatcher: KaliumDispatcher = KaliumDispatcherImpl
+    kaliumDispatcher: KaliumDispatcher = KaliumDispatcherImpl,
+    parentContext: CoroutineContext = SupervisorJob(),
 ) : PendingProposalScheduler {
 
     /**
@@ -80,7 +82,7 @@ internal class PendingProposalSchedulerImpl(
      * This means using this dispatcher only a single coroutine will be processed at a time.
      */
     private val dispatcher = kaliumDispatcher.default.limitedParallelism(1)
-    private val commitPendingProposalsScope = CoroutineScope(SupervisorJob() + dispatcher)
+    private val commitPendingProposalsScope = CoroutineScope(parentContext + dispatcher)
 
     init {
         commitPendingProposalsScope.launch {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/CryptoTransactionProviderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/client/CryptoTransactionProviderTest.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.cryptography.MLSClient
 import com.wire.kalium.cryptography.MlsCoreCryptoContext
 import com.wire.kalium.cryptography.ProteusClient
 import com.wire.kalium.cryptography.ProteusCoreCryptoContext
+import com.wire.kalium.cryptography.exceptions.ProteusException
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.util.InternalCryptoAccess
 import dev.mokkery.MockMode
@@ -76,6 +77,29 @@ class CryptoTransactionProviderCrashTest {
     fun givenMainTransactionWhenProteusClientThrows_thenReturnsMissingClientFailure() = runTest {
         val (_, provider) = Arrangement()
             .withProteusTransactionThrowing(IllegalStateException("CoreCrypto object has already been destroyed"))
+            .withMlsTransactionSucceeds()
+            .arrange()
+
+        val result = provider.transaction<Unit>("test") {
+            error("should not be called")
+        }
+
+        result.shouldFail {
+            assertEquals(CoreFailure.MissingClientRegistration, it)
+        }
+    }
+
+    @Test
+    fun givenMainTransactionThrowsWrappedDestroyedCoreCryptoException_thenReturnsMissingClientFailure() = runTest {
+        val destroyedCoreCryptoException = IllegalStateException("CoreCrypto object has already been destroyed")
+        val wrappedException = ProteusException(
+            message = destroyedCoreCryptoException.message,
+            code = ProteusException.Code.UNKNOWN_ERROR,
+            intCode = null,
+            cause = destroyedCoreCryptoException,
+        )
+        val (_, provider) = Arrangement()
+            .withProteusTransactionThrowing(wrappedException)
             .withMlsTransactionSucceeds()
             .arrange()
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/auth/LogoutUseCaseTest.kt
@@ -297,6 +297,9 @@ class LogoutUseCaseTest {
                 arrangement.clientRepository.clearCurrentClientId()
             }
             verifySuspend(VerifyMode.exactly(1)) {
+                arrangement.clientRepository.clearRetainedClientId()
+            }
+            verifySuspend(VerifyMode.exactly(1)) {
                 arrangement.clientRepository.clearHasRegisteredMLSClient()
             }
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/GetOrRegisterClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/GetOrRegisterClientUseCaseTest.kt
@@ -32,6 +32,7 @@ import com.wire.kalium.logic.feature.featureConfig.SyncFeatureConfigsUseCase
 import com.wire.kalium.logic.feature.session.UpgradeCurrentSessionUseCase
 import com.wire.kalium.logic.framework.TestClient
 import dev.mokkery.MockMode
+import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
@@ -121,6 +122,43 @@ class GetOrRegisterClientUseCaseTest {
         verifySuspend(VerifyMode.exactly(1)) {
             arrangement.clientRepository.persistClientId(eq(clientId))
         }
+    }
+
+    @Test
+    fun givenInvalidClientIsRetained_whenMetadataIsCleared_thenRefreshFeatureConfigBeforeRegisteringNewClient() = runTest {
+        val clientId = ClientId("clientId")
+        val client = TestClient.CLIENT.copy(id = clientId)
+        val (arrangement, useCase) = Arrangement()
+            .withSyncFeatureConfigResult()
+            .withRetainedClientIdResult(Either.Right(clientId))
+            .withVerifyExistingClientResult(VerifyExistingClientResult.Failure.ClientNotRegistered)
+            .withRegisterClientResult(RegisterClientResult.Success(client))
+            .withClearRetainedClientIdResult(Either.Right(Unit))
+            .withClearHasConsumableNotifications(Either.Right(Unit))
+            .withUpgradeCurrentSessionResult(Either.Right(Unit))
+            .withPersistClientIdResult(Either.Right(Unit))
+            .withPersistHasConsumableNotifications(false)
+            .withSetUpdateFirebaseTokenFlagResult(Either.Right(Unit))
+            .arrange()
+        val calls = mutableListOf<String>()
+        everySuspend { arrangement.syncFeatureConfigsUseCase.invoke() } calls {
+            calls += "syncFeatureConfigs"
+            Either.Right(Unit)
+        }
+        everySuspend { arrangement.logoutRepository.clearClientRelatedLocalMetadata() } calls {
+            calls += "clearClientMetadata"
+        }
+        everySuspend { arrangement.registerClientUseCase.invoke(any()) } calls {
+            calls += "registerClient"
+            RegisterClientResult.Success(client)
+        }
+
+        useCase.invoke(RegisterClientParam("", listOf()))
+
+        assertEquals(
+            listOf("syncFeatureConfigs", "clearClientMetadata", "syncFeatureConfigs", "registerClient"),
+            calls
+        )
     }
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/IsAllowedToRegisterMLSClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/IsAllowedToRegisterMLSClientUseCaseTest.kt
@@ -18,12 +18,16 @@
 package com.wire.kalium.logic.feature.client
 
 import com.wire.kalium.common.error.CoreFailure
-import com.wire.kalium.common.error.StorageFailure
-import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.common.error.NetworkFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.featureConfig.FeatureConfigRepository
+import com.wire.kalium.logic.data.featureConfig.FeatureConfigTest
+import com.wire.kalium.logic.data.featureConfig.MLSModel
+import com.wire.kalium.logic.data.featureConfig.Status
 import com.wire.kalium.logic.data.mls.MLSPublicKeys
 import com.wire.kalium.logic.data.mlspublickeys.MLSPublicKeysRepository
+import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.featureFlags.FeatureSupport
-import com.wire.kalium.common.functional.Either
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.every
@@ -39,7 +43,7 @@ class IsAllowedToRegisterMLSClientUseCaseTest {
     fun givenAllMlsConditionsAreMet_whenUseCaseInvoked_returnsTrue() = runTest {
         val (_, isAllowedToRegisterMLSClientUseCase) = Arrangement()
             .withMlsFeatureFlag(true)
-            .withUserConfigMlsEnabled(true)
+            .withRemoteMlsConfig()
             .withGetPublicKeysSuccessful()
             .arrange()
 
@@ -52,8 +56,6 @@ class IsAllowedToRegisterMLSClientUseCaseTest {
     fun givenMlsFeatureFlagDisabled_whenUseCaseInvoked_returnsFalse() = runTest {
         val (_, isAllowedToRegisterMLSClientUseCase) = Arrangement()
             .withMlsFeatureFlag(false)
-            .withUserConfigMlsEnabled(true)
-            .withGetPublicKeysSuccessful()
             .arrange()
 
         val result = isAllowedToRegisterMLSClientUseCase()
@@ -62,11 +64,34 @@ class IsAllowedToRegisterMLSClientUseCaseTest {
     }
 
     @Test
-    fun givenUserConfigMlsDisabled_whenUseCaseInvoked_returnsFalse() = runTest {
+    fun givenRemoteMlsFeatureDisabled_whenUseCaseInvoked_returnsFalse() = runTest {
         val (_, isAllowedToRegisterMLSClientUseCase) = Arrangement()
             .withMlsFeatureFlag(true)
-            .withUserConfigMlsEnabled(false)
-            .withGetPublicKeysSuccessful()
+            .withRemoteMlsConfig(status = Status.DISABLED)
+            .arrange()
+
+        val result = isAllowedToRegisterMLSClientUseCase()
+
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun givenRemoteMlsProtocolUnsupported_whenUseCaseInvoked_returnsFalse() = runTest {
+        val (_, isAllowedToRegisterMLSClientUseCase) = Arrangement()
+            .withMlsFeatureFlag(true)
+            .withRemoteMlsConfig(supportedProtocols = setOf(SupportedProtocol.PROTEUS))
+            .arrange()
+
+        val result = isAllowedToRegisterMLSClientUseCase()
+
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun givenRemoteFeatureConfigFailure_whenUseCaseInvoked_returnsFalse() = runTest {
+        val (_, isAllowedToRegisterMLSClientUseCase) = Arrangement()
+            .withMlsFeatureFlag(true)
+            .withRemoteFeatureConfigFailure()
             .arrange()
 
         val result = isAllowedToRegisterMLSClientUseCase()
@@ -78,7 +103,7 @@ class IsAllowedToRegisterMLSClientUseCaseTest {
     fun givenPublicKeysFailure_whenUseCaseInvoked_returnsFalse() = runTest {
         val (_, isAllowedToRegisterMLSClientUseCase) = Arrangement()
             .withMlsFeatureFlag(true)
-            .withUserConfigMlsEnabled(true)
+            .withRemoteMlsConfig()
             .withGetPublicKeysFailed()
             .arrange()
 
@@ -86,26 +111,12 @@ class IsAllowedToRegisterMLSClientUseCaseTest {
 
         assertEquals(false, result)
     }
-
-    @Test
-    fun givenUserConfigDataNotFound_whenUseCaseInvoked_returnsFalse() = runTest {
-        val (_, isAllowedToRegisterMLSClientUseCase) = Arrangement()
-            .withMlsFeatureFlag(true)
-            .withUserConfigDataNotFound()
-            .withGetPublicKeysFailed()
-            .arrange()
-
-        val result = isAllowedToRegisterMLSClientUseCase()
-
-        assertEquals(false, result)
-    }
-
 
     private class Arrangement {
 
         val featureSupport = mock<FeatureSupport>(mode = MockMode.autoUnit)
         val mlsPublicKeysRepository = mock<MLSPublicKeysRepository>(mode = MockMode.autoUnit)
-        val userConfigRepository = mock<UserConfigRepository>(mode = MockMode.autoUnit)
+        val featureConfigRepository = mock<FeatureConfigRepository>(mode = MockMode.autoUnit)
 
         fun withMlsFeatureFlag(enabled: Boolean) = apply {
             every {
@@ -113,16 +124,28 @@ class IsAllowedToRegisterMLSClientUseCaseTest {
             } returns enabled
         }
 
-        suspend fun withUserConfigMlsEnabled(enabled: Boolean) = apply {
+        suspend fun withRemoteMlsConfig(
+            status: Status = Status.ENABLED,
+            supportedProtocols: Set<SupportedProtocol> = setOf(SupportedProtocol.PROTEUS, SupportedProtocol.MLS)
+        ) = apply {
             everySuspend {
-                userConfigRepository.isMLSEnabled()
-            } returns Either.Right(enabled)
+                featureConfigRepository.getFeatureConfigs()
+            } returns Either.Right(
+                FeatureConfigTest.newModel(
+                    mlsModel = MLSModel(
+                        defaultProtocol = SupportedProtocol.MLS,
+                        supportedProtocols = supportedProtocols,
+                        supportedCipherSuite = null,
+                        status = status
+                    )
+                )
+            )
         }
 
-        suspend fun withUserConfigDataNotFound() = apply {
+        suspend fun withRemoteFeatureConfigFailure() = apply {
             everySuspend {
-                userConfigRepository.isMLSEnabled()
-            } returns Either.Left(StorageFailure.DataNotFound)
+                featureConfigRepository.getFeatureConfigs()
+            } returns Either.Left(NetworkFailure.NoNetworkConnection(null))
         }
 
         suspend fun withGetPublicKeysSuccessful() = apply {
@@ -140,7 +163,7 @@ class IsAllowedToRegisterMLSClientUseCaseTest {
         fun arrange() = this to IsAllowedToRegisterMLSClientUseCaseImpl(
             featureSupport = featureSupport,
             mlsPublicKeysRepository = mlsPublicKeysRepository,
-            userConfigRepository = userConfigRepository
+            featureConfigRepository = featureConfigRepository
         )
 
         companion object {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/PendingProposalSchedulerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/PendingProposalSchedulerTest.kt
@@ -44,6 +44,7 @@ import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.consumeAsFlow
@@ -54,6 +55,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import kotlinx.datetime.Instant
+import kotlin.coroutines.CoroutineContext
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.seconds
 
@@ -103,6 +105,23 @@ class PendingProposalSchedulerTest {
 
         verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsConversationRepository.commitPendingProposals(any(), eq(MockConversation.GROUP_ID))
+        }
+    }
+
+    @Test
+    fun givenUserSessionScopeIsCancelled_whenSyncFinishes_thenPendingProposalsAreNotCommitted() = runTest {
+        val userSessionJob = SupervisorJob()
+        val (arrangement, _) = Arrangement()
+            .withScheduledProposalTimers(listOf(ProposalTimer(MockConversation.GROUP_ID, Arrangement.INSTANT_PAST)))
+            .withCommitPendingProposalsSuccessful()
+            .arrange(testDispatcher(), userSessionJob)
+
+        userSessionJob.cancel()
+        arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Live)
+        advanceUntilIdle()
+
+        verifySuspend(VerifyMode.not) {
+            arrangement.mlsConversationRepository.commitPendingProposals(any(), any())
         }
     }
 
@@ -262,12 +281,16 @@ class PendingProposalSchedulerTest {
         val mlsConversationRepository = mock<MLSConversationRepository>(mode = MockMode.autoUnit)
         val subconversationRepository = mock<SubconversationRepository>(mode = MockMode.autoUnit)
 
-        suspend fun arrange(testDispatcher: KaliumDispatcher) = this to PendingProposalSchedulerImpl(
+        suspend fun arrange(
+            testDispatcher: KaliumDispatcher,
+            parentContext: CoroutineContext = SupervisorJob(),
+        ) = this to PendingProposalSchedulerImpl(
             incrementalSyncRepository,
             lazy { mlsConversationRepository },
             lazy { subconversationRepository },
             cryptoTransactionProvider,
-            testDispatcher
+            testDispatcher,
+            parentContext,
         ).also {
             withTransactionReturning(Either.Right(Unit))
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-27228
<!--jira-description-action-hidden-marker-end-->
## Goal

Restore MLS client registration after remote client deletion and safely stop session work before CoreCrypto is destroyed.

## Reproduction

1. Log in with an MLS-capable client.
2. Delete that client remotely.
3. Let the app receive its own client-removal event and log out.
4. Confirm the removed-client dialog and log in again without restarting the process.
5. MLS conversations can remain in `PENDING_JOIN`; pending session work can also crash with `CoreCrypto object has already been destroyed` during teardown.

## Root cause

The forced-logout metadata wipe cleared the current client ID but preserved the retained client ID. The next login therefore tried to verify a client that had already been deleted remotely.

When verification failed, stale-client cleanup cleared locally persisted feature configuration after the initial feature-config sync. Client registration then consulted the cleared local MLS value and created a Proteus-only client. MLS registration happened later, after the first slow sync had saved its event ID, so a subsequent slow sync could not use external commits to join the pending conversations.

The pending-proposal scheduler also owned an independent coroutine scope. It could survive `UserSessionScope` cancellation and start a combined crypto transaction after logout had destroyed CoreCrypto. Proteus wraps the underlying destroyed-object `IllegalStateException` in `ProteusException`, so the existing fallback did not recognize it.

```mermaid
flowchart LR
    A["Remote client removal"] --> B["Cancel UserSessionScope"]
    B --> C["Stop pending session work"]
    C --> D["Destroy CoreCrypto"]
    D --> E["Clear retained client metadata"]
    E --> F["Read MLS eligibility remotely"]
    F --> G["Register MLS-capable client"]
    G --> H["First slow sync joins MLS conversations"]
```

## Changes

- Clear the retained client ID during removed-client and deleted-account metadata wipes.
- Resync feature configuration after stale retained-client cleanup.
- Use the backend MLS feature status and supported protocols as the authoritative registration decision.
- Fail closed when remote configuration cannot be fetched instead of using stale local state.
- Make the pending-proposal scheduler a child of `UserSessionScope` so logout drains it before CoreCrypto teardown.
- Treat wrapped destroyed-CoreCrypto failures as missing client registration instead of allowing a fatal background exception.
- Cover retained-client cleanup, sync ordering, remote MLS configuration, scheduler cancellation, and wrapped CoreCrypto failures.

## Impact

A replacement client is registered with MLS before its first slow sync, allowing pending MLS conversations to join through external commits. Confirming the removed-client flow no longer leaves background session work using destroyed cryptographic state.
