### PR TITLE
feat: meetings feature flag [WPB-25681]

### DIFF
--- a/changelog.d/meetings-feature-flag.md
+++ b/changelog.d/meetings-feature-flag.md
@@ -1,0 +1,10 @@
+### Added
+- Added `UserSessionScope.isMeetingsEnabled` with `IsMeetingsEnabledUseCase` to let consumers check whether meetings are enabled for the current user and supported by the current API version.
+
+### Migration
+No action required. Consumers can use `UserSessionScope.isMeetingsEnabled()` before surfacing meetings UI.
+
+### Compatibility
+ABI: additive.
+Source: additive.
+Behavior: meetings sync now respects the backend meetings feature flag in addition to API v16 support.

--- a/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigModel.kt
+++ b/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigModel.kt
@@ -51,6 +51,7 @@ data class FeatureConfigModel(
     val enableUserProfileQRCodeConfigModel: EnableUserProfileQRCodeConfigModel?,
     val assetAuditLogConfigModel: AssetAuditLogConfigModel?,
     val preventAdminlessGroupsModel: PreventAdminlessGroupsConfigModel?,
+    val meetingsConfigModel: MeetingsConfigModel?,
 )
 
 enum class Status {
@@ -174,6 +175,12 @@ data class AssetAuditLogConfigModel(
 
 @Serializable
 data class PreventAdminlessGroupsConfigModel(
+    @SerialName("status")
+    val status: Status
+)
+
+@Serializable
+data class MeetingsConfigModel(
     @SerialName("status")
     val status: Status
 )

--- a/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/featureConfigs/FeatureConfigResponse.kt
+++ b/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/featureConfigs/FeatureConfigResponse.kt
@@ -75,6 +75,8 @@ data class FeatureConfigResponse(
     val assetAuditLog: FeatureConfigData.AssetAuditLog?,
     @SerialName("preventAdminlessGroups")
     val preventAdminlessGroups: FeatureConfigData.PreventAdminlessGroups?,
+    @SerialName("meetings")
+    val meetings: FeatureConfigData.Meetings?,
 )
 
 @Serializable
@@ -367,6 +369,13 @@ sealed class FeatureConfigData {
     @SerialName("preventAdminlessGroups")
     @Serializable
     data class PreventAdminlessGroups(
+        @SerialName("status")
+        val status: FeatureFlagStatusDTO
+    ) : FeatureConfigData()
+
+    @SerialName("meetings")
+    @Serializable
+    data class Meetings(
         @SerialName("status")
         val status: FeatureFlagStatusDTO
     ) : FeatureConfigData()

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserConfigDAO.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/UserConfigDAO.kt
@@ -88,6 +88,8 @@ interface UserConfigDAO {
     suspend fun getWireCellsConfig(): WireCellsConfigEntity?
     suspend fun isMlsFaultyKeysRepairExecuted(): Boolean
     suspend fun setMlsFaultyKeysRepairExecuted(repaired: Boolean)
+    suspend fun setMeetingsEnabled(enabled: Boolean)
+    suspend fun isMeetingsEnabled(): Boolean
 }
 
 @Suppress("TooManyFunctions")
@@ -319,6 +321,13 @@ internal class UserConfigDAOImpl internal constructor(
     override fun observeAppsEnabled(): Flow<Boolean> =
         metadataDAO.valueByKeyFlow(APPS_ENABLED_KEY).map { it?.toBoolean() ?: false }
 
+    override suspend fun setMeetingsEnabled(enabled: Boolean) {
+        metadataDAO.insertValue(enabled.toString(), MEETINGS_ENABLED)
+    }
+
+    override suspend fun isMeetingsEnabled(): Boolean =
+        metadataDAO.valueByKey(MEETINGS_ENABLED)?.toBoolean() ?: false
+
     private companion object {
         private const val DEFAULT_CIPHER_SUITE_KEY = "DEFAULT_CIPHER_SUITE"
         private const val SELF_DELETING_MESSAGES_KEY = "SELF_DELETING_MESSAGES"
@@ -340,5 +349,6 @@ internal class UserConfigDAOImpl internal constructor(
         private const val PREVENT_ADMINLESS_GROUPS_ENABLED = "prevent_adminless_groups"
         private const val WIRE_CELLS_CONFIG = "wire_cells_config"
         private const val MLS_FAULTY_CONVERSATIONS_REPAIRED = "mls_faulty_conversations_repaired"
+        private const val MEETINGS_ENABLED = "meetings_enabled"
     }
 }

--- a/logic/api/jvm/logic.api
+++ b/logic/api/jvm/logic.api
@@ -971,6 +971,7 @@ public final class com/wire/kalium/logic/feature/UserSessionScope : kotlinx/coro
 	public final fun isE2EIEnabled ()Lcom/wire/kalium/logic/feature/user/IsE2EIEnabledUseCase;
 	public final fun isFileSharingEnabled ()Lcom/wire/kalium/logic/feature/user/IsFileSharingEnabledUseCase;
 	public final fun isMLSEnabled ()Lcom/wire/kalium/logic/feature/user/IsMLSEnabledUseCase;
+	public final fun isMeetingsEnabled ()Lcom/wire/kalium/logic/feature/user/IsMeetingsEnabledUseCase;
 	public final fun isPreventAdminlessGroupsEnabled ()Lcom/wire/kalium/logic/feature/user/IsPreventAdminlessGroupsEnabledUseCase;
 	public final fun observeIfE2EIRequiredDuringLogin (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setIncrementalSyncUnprocessedEventsBatchLimit (Ljava/lang/Integer;)V
@@ -6757,6 +6758,10 @@ public abstract interface class com/wire/kalium/logic/feature/user/IsFileSharing
 }
 
 public abstract interface class com/wire/kalium/logic/feature/user/IsMLSEnabledUseCase {
+	public abstract fun invoke (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/wire/kalium/logic/feature/user/IsMeetingsEnabledUseCase {
 	public abstract fun invoke (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/logic/api/logic.klib.api
+++ b/logic/api/logic.klib.api
@@ -1715,6 +1715,10 @@ abstract interface com.wire.kalium.logic.feature.user/IsMLSEnabledUseCase { // c
     abstract suspend fun invoke(): kotlin/Boolean // com.wire.kalium.logic.feature.user/IsMLSEnabledUseCase.invoke|invoke(){}[0]
 }
 
+abstract interface com.wire.kalium.logic.feature.user/IsMeetingsEnabledUseCase { // com.wire.kalium.logic.feature.user/IsMeetingsEnabledUseCase|null[0]
+    abstract suspend fun invoke(): kotlin/Boolean // com.wire.kalium.logic.feature.user/IsMeetingsEnabledUseCase.invoke|invoke(){}[0]
+}
+
 abstract interface com.wire.kalium.logic.feature.user/IsPreventAdminlessGroupsEnabledUseCase { // com.wire.kalium.logic.feature.user/IsPreventAdminlessGroupsEnabledUseCase|null[0]
     abstract suspend fun invoke(): kotlin/Boolean // com.wire.kalium.logic.feature.user/IsPreventAdminlessGroupsEnabledUseCase.invoke|invoke(){}[0]
 }
@@ -5144,6 +5148,8 @@ final class com.wire.kalium.logic.feature/UserSessionScope : kotlinx.coroutines/
         final fun <get-isFileSharingEnabled>(): com.wire.kalium.logic.feature.user/IsFileSharingEnabledUseCase // com.wire.kalium.logic.feature/UserSessionScope.isFileSharingEnabled.<get-isFileSharingEnabled>|<get-isFileSharingEnabled>(){}[0]
     final val isMLSEnabled // com.wire.kalium.logic.feature/UserSessionScope.isMLSEnabled|{}isMLSEnabled[0]
         final fun <get-isMLSEnabled>(): com.wire.kalium.logic.feature.user/IsMLSEnabledUseCase // com.wire.kalium.logic.feature/UserSessionScope.isMLSEnabled.<get-isMLSEnabled>|<get-isMLSEnabled>(){}[0]
+    final val isMeetingsEnabled // com.wire.kalium.logic.feature/UserSessionScope.isMeetingsEnabled|{}isMeetingsEnabled[0]
+        final fun <get-isMeetingsEnabled>(): com.wire.kalium.logic.feature.user/IsMeetingsEnabledUseCase // com.wire.kalium.logic.feature/UserSessionScope.isMeetingsEnabled.<get-isMeetingsEnabled>|<get-isMeetingsEnabled>(){}[0]
     final val isPreventAdminlessGroupsEnabled // com.wire.kalium.logic.feature/UserSessionScope.isPreventAdminlessGroupsEnabled|{}isPreventAdminlessGroupsEnabled[0]
         final fun <get-isPreventAdminlessGroupsEnabled>(): com.wire.kalium.logic.feature.user/IsPreventAdminlessGroupsEnabledUseCase // com.wire.kalium.logic.feature/UserSessionScope.isPreventAdminlessGroupsEnabled.<get-isPreventAdminlessGroupsEnabled>|<get-isPreventAdminlessGroupsEnabled>(){}[0]
     final val kaliumFileSystem // com.wire.kalium.logic.feature/UserSessionScope.kaliumFileSystem|{}kaliumFileSystem[0]

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/UserConfigRepository.kt
@@ -172,6 +172,8 @@ internal interface UserConfigRepository {
     suspend fun getWireCellsConfig(): Either<StorageFailure, WireCellsConfig?>
     suspend fun isMLSFaultyKeysRepairExecuted(): Boolean
     suspend fun setMLSFaultyKeysRepairExecuted(repaired: Boolean): Either<StorageFailure, Unit>
+    suspend fun setMeetingsEnabled(enabled: Boolean): Either<StorageFailure, Unit>
+    suspend fun isMeetingsEnabled(): Boolean
 }
 
 @Suppress("TooManyFunctions")
@@ -656,4 +658,9 @@ internal class UserConfigDataSource internal constructor(
     override suspend fun setMLSFaultyKeysRepairExecuted(repaired: Boolean): Either<StorageFailure, Unit> = wrapStorageRequest {
         userConfigDAO.setMlsFaultyKeysRepairExecuted(repaired)
     }
+
+    override suspend fun setMeetingsEnabled(enabled: Boolean): Either<StorageFailure, Unit> = wrapStorageRequest {
+        userConfigDAO.setMeetingsEnabled(enabled)
+    }
+    override suspend fun isMeetingsEnabled(): Boolean = userConfigDAO.isMeetingsEnabled()
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -45,6 +45,7 @@ import com.wire.kalium.logic.data.featureConfig.MLSMigrationModel
 import com.wire.kalium.logic.data.featureConfig.MLSModel
 import com.wire.kalium.logic.data.featureConfig.SelfDeletingMessagesModel
 import com.wire.kalium.logic.data.featureConfig.EnableUserProfileQRCodeConfigModel
+import com.wire.kalium.logic.data.featureConfig.MeetingsConfigModel
 import com.wire.kalium.logic.data.featureConfig.PreventAdminlessGroupsConfigModel
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.GroupID
@@ -674,6 +675,17 @@ internal sealed class Event(open val id: String) {
             override fun toLogMap(): Map<String, Any?> = mapOf(
                 typeKey to "FeatureConfig.UnknownFeatureUpdated",
                 idKey to id,
+            )
+        }
+
+        internal data class MeetingsConfigUpdated(
+            override val id: String,
+            val model: MeetingsConfigModel,
+        ) : FeatureConfig(id) {
+            override fun toLogMap(): Map<String, Any?> = mapOf(
+                typeKey to "FeatureConfig.MeetingsConfigUpdated",
+                idKey to id,
+                featureStatusKey to model.status.name,
             )
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -597,6 +597,11 @@ internal class EventMapper(
             (featureConfigUpdatedDTO.data as FeatureConfigData.PreventAdminlessGroups).toModel()
         )
 
+        is FeatureConfigData.Meetings -> Event.FeatureConfig.MeetingsConfigUpdated(
+            id,
+            (featureConfigUpdatedDTO.data as FeatureConfigData.Meetings).toModel()
+        )
+
         // These features are NOT received through events. As FeatureConfig Events are deprecated
         is FeatureConfigData.ConsumableNotifications,
         is FeatureConfigData.Apps,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigMapper.kt
@@ -51,6 +51,7 @@ internal interface FeatureConfigMapper {
     fun fromDTO(data: FeatureConfigData.EnableUserProfileQRCode): EnableUserProfileQRCodeConfigModel
     fun fromDTO(data: FeatureConfigData.AssetAuditLog): AssetAuditLogConfigModel
     fun fromDTO(data: FeatureConfigData.PreventAdminlessGroups): PreventAdminlessGroupsConfigModel
+    fun fromDTO(data: FeatureConfigData.Meetings): MeetingsConfigModel
 }
 
 internal fun FeatureFlagStatusDTO.toModel(): Status =
@@ -62,6 +63,8 @@ internal fun FeatureFlagStatusDTO.toModel(): Status =
 internal fun FeatureConfigData.AssetAuditLog.toModel() = AssetAuditLogConfigModel(status.toModel())
 
 internal fun FeatureConfigData.PreventAdminlessGroups.toModel() = PreventAdminlessGroupsConfigModel(status.toModel())
+
+internal fun FeatureConfigData.Meetings.toModel() = MeetingsConfigModel(status.toModel())
 
 @Suppress("TooManyFunctions")
 internal class FeatureConfigMapperImpl : FeatureConfigMapper {
@@ -99,6 +102,9 @@ internal class FeatureConfigMapperImpl : FeatureConfigMapper {
                     fromDTO(it)
                 },
                 preventAdminlessGroupsModel = preventAdminlessGroups?.let {
+                    fromDTO(it)
+                },
+                meetingsConfigModel = meetings?.let {
                     fromDTO(it)
                 }
             )
@@ -232,6 +238,10 @@ internal class FeatureConfigMapperImpl : FeatureConfigMapper {
     )
 
     override fun fromDTO(data: FeatureConfigData.PreventAdminlessGroups) = PreventAdminlessGroupsConfigModel(
+        status = fromDTO(data.status)
+    )
+
+    override fun fromDTO(data: FeatureConfigData.Meetings) = MeetingsConfigModel(
         status = fromDTO(data.status)
     )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -394,6 +394,8 @@ import com.wire.kalium.logic.feature.user.IsFileSharingEnabledUseCase
 import com.wire.kalium.logic.feature.user.IsFileSharingEnabledUseCaseImpl
 import com.wire.kalium.logic.feature.user.IsMLSEnabledUseCase
 import com.wire.kalium.logic.feature.user.IsMLSEnabledUseCaseImpl
+import com.wire.kalium.logic.feature.user.IsMeetingsEnabledUseCase
+import com.wire.kalium.logic.feature.user.IsMeetingsEnabledUseCaseImpl
 import com.wire.kalium.logic.feature.user.IsPreventAdminlessGroupsEnabledUseCase
 import com.wire.kalium.logic.feature.user.IsPreventAdminlessGroupsEnabledUseCaseImpl
 import com.wire.kalium.logic.feature.user.MarkEnablingE2EIAsNotifiedUseCase
@@ -536,6 +538,7 @@ import com.wire.kalium.logic.sync.receiver.handler.DeleteForMeHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.DeleteMessageHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.EnableUserProfileQRCodeConfigHandler
 import com.wire.kalium.logic.sync.receiver.handler.LastReadContentHandlerImpl
+import com.wire.kalium.logic.sync.receiver.handler.MeetingsConfigHandler
 import com.wire.kalium.logic.sync.receiver.handler.MessageCompositeEditHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.MessageMultipartEditHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.MessageTextEditHandlerImpl
@@ -2235,6 +2238,9 @@ public class UserSessionScope internal constructor(
     private val preventAdminlessGroupsConfigHandler
         get() = PreventAdminlessGroupsConfigHandler(userConfigRepository)
 
+    private val meetingsConfigHandler
+        get() = MeetingsConfigHandler(userConfigRepository)
+
     private val featureConfigEventReceiver: FeatureConfigEventReceiver
         get() = FeatureConfigEventReceiverImpl(
             guestRoomConfigHandler,
@@ -2251,6 +2257,7 @@ public class UserSessionScope internal constructor(
             enableUserProfileQRCodeConfigHandler,
             assetAuditLogConfigHandler,
             preventAdminlessGroupsConfigHandler,
+            meetingsConfigHandler,
         )
 
     private val preKeyRepository: PreKeyRepository
@@ -2629,6 +2636,9 @@ public class UserSessionScope internal constructor(
     public val isPreventAdminlessGroupsEnabled: IsPreventAdminlessGroupsEnabledUseCase
         get() = IsPreventAdminlessGroupsEnabledUseCaseImpl(userConfigRepository)
 
+    public val isMeetingsEnabled: IsMeetingsEnabledUseCase
+        get() = IsMeetingsEnabledUseCaseImpl(userConfigRepository, featureSupport)
+
     public val observeFileSharingStatus: ObserveFileSharingStatusUseCase
         get() = ObserveFileSharingStatusUseCaseImpl(userConfigRepository)
 
@@ -2719,6 +2729,7 @@ public class UserSessionScope internal constructor(
             enableUserProfileQRCodeConfigHandler,
             assetAuditLogConfigHandler,
             preventAdminlessGroupsConfigHandler,
+            meetingsConfigHandler,
         )
 
     public val team: TeamScope
@@ -2952,7 +2963,7 @@ public class UserSessionScope internal constructor(
         get() = SyncMeetingsUseCaseImpl(
             meetingRepository = meetingRepository,
             userRepository = userRepository,
-            featureSupport = featureSupport,
+            isMeetingsEnabledUseCase = isMeetingsEnabled,
             transactionProvider = cryptoTransactionProvider
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCase.kt
@@ -42,6 +42,7 @@ import com.wire.kalium.logic.sync.receiver.handler.AllowedGlobalOperationsHandle
 import com.wire.kalium.logic.sync.receiver.handler.AssetAuditLogConfigHandler
 import com.wire.kalium.logic.sync.receiver.handler.CellsConfigHandler
 import com.wire.kalium.logic.sync.receiver.handler.EnableUserProfileQRCodeConfigHandler
+import com.wire.kalium.logic.sync.receiver.handler.MeetingsConfigHandler
 import com.wire.kalium.logic.sync.receiver.handler.PreventAdminlessGroupsConfigHandler
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.exceptions.isNoTeam
@@ -75,6 +76,7 @@ internal class SyncFeatureConfigsUseCaseImpl(
     private val enableUserProfileQRCodeConfigHandler: EnableUserProfileQRCodeConfigHandler,
     private val assetAuditLogConfigHandler: AssetAuditLogConfigHandler,
     private val preventAdminlessGroupsConfigHandler: PreventAdminlessGroupsConfigHandler,
+    private val meetingsConfigHandler: MeetingsConfigHandler,
 ) : SyncFeatureConfigsUseCase {
     override suspend operator fun invoke(): Either<CoreFailure, Unit> =
         featureConfigRepository.getFeatureConfigs().flatMap { it ->
@@ -104,6 +106,7 @@ internal class SyncFeatureConfigsUseCaseImpl(
             enableUserProfileQRCodeConfigHandler.handle(it.enableUserProfileQRCodeConfigModel)
             assetAuditLogConfigHandler.handle(it.assetAuditLogConfigModel)
             preventAdminlessGroupsConfigHandler.handle(it.preventAdminlessGroupsModel)
+            meetingsConfigHandler.handle(it.meetingsConfigModel)
             Either.Right(Unit)
         }.onFailure { networkFailure ->
             if (

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/meeting/SyncMeetingsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/meeting/SyncMeetingsUseCase.kt
@@ -27,10 +27,10 @@ import com.wire.kalium.logic.data.client.CryptoTransactionProvider
 import com.wire.kalium.logic.data.id.toModel
 import com.wire.kalium.logic.data.meeting.MeetingRepository
 import com.wire.kalium.logic.data.user.UserRepository
-import com.wire.kalium.logic.featureFlags.FeatureSupport
+import com.wire.kalium.logic.feature.user.IsMeetingsEnabledUseCase
 
 internal interface SyncMeetingsUseCase {
-    fun isEnabled(): Boolean
+    suspend fun isEnabled(): Boolean
     suspend operator fun invoke(): Either<CoreFailure, Unit>
 }
 
@@ -40,11 +40,11 @@ internal interface SyncMeetingsUseCase {
 internal class SyncMeetingsUseCaseImpl(
     private val meetingRepository: MeetingRepository,
     private val userRepository: UserRepository,
-    private val featureSupport: FeatureSupport,
+    private val isMeetingsEnabledUseCase: IsMeetingsEnabledUseCase,
     private val transactionProvider: CryptoTransactionProvider
 ) : SyncMeetingsUseCase {
 
-    override fun isEnabled(): Boolean = featureSupport.isMeetingsSupported
+    override suspend fun isEnabled(): Boolean = isMeetingsEnabledUseCase.invoke()
 
     override suspend operator fun invoke(): Either<CoreFailure, Unit> = when (isEnabled()) {
         false -> Either.Right(Unit)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/IsMeetingsEnabledUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/user/IsMeetingsEnabledUseCase.kt
@@ -1,0 +1,37 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.user
+
+import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.featureFlags.FeatureSupport
+
+/**
+ * Use case that reports whether the meetings feature is enabled for the current user and current API version supports it.
+ * @return `true` if meetings is enabled for the current user and supported by the current API version, `false` otherwise.
+ */
+public interface IsMeetingsEnabledUseCase {
+    public suspend operator fun invoke(): Boolean
+}
+
+internal class IsMeetingsEnabledUseCaseImpl(
+    private val userConfigRepository: UserConfigRepository,
+    private val featureSupport: FeatureSupport,
+) : IsMeetingsEnabledUseCase {
+    override suspend operator fun invoke(): Boolean = userConfigRepository.isMeetingsEnabled() && featureSupport.isMeetingsSupported
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiver.kt
@@ -39,6 +39,7 @@ import com.wire.kalium.logic.sync.receiver.handler.AllowedGlobalOperationsHandle
 import com.wire.kalium.logic.sync.receiver.handler.AssetAuditLogConfigHandler
 import com.wire.kalium.logic.sync.receiver.handler.CellsConfigHandler
 import com.wire.kalium.logic.sync.receiver.handler.EnableUserProfileQRCodeConfigHandler
+import com.wire.kalium.logic.sync.receiver.handler.MeetingsConfigHandler
 import com.wire.kalium.logic.sync.receiver.handler.PreventAdminlessGroupsConfigHandler
 import com.wire.kalium.logic.util.EventLoggingStatus
 import com.wire.kalium.logic.util.createEventProcessingLogger
@@ -62,6 +63,7 @@ internal class FeatureConfigEventReceiverImpl internal constructor(
     private val enableUserProfileQRCodeConfigHandler: EnableUserProfileQRCodeConfigHandler,
     private val assetAuditLogConfigHandler: AssetAuditLogConfigHandler,
     private val preventAdminlessGroupsConfigHandler: PreventAdminlessGroupsConfigHandler,
+    private val meetingsConfigHandler: MeetingsConfigHandler,
 ) : FeatureConfigEventReceiver {
 
     override suspend fun onEvent(
@@ -117,5 +119,6 @@ internal class FeatureConfigEventReceiverImpl internal constructor(
             is Event.FeatureConfig.AssetAuditLogConfigUpdated -> assetAuditLogConfigHandler.handle(event.model)
             is Event.FeatureConfig.PreventAdminlessGroupsConfigUpdated ->
                 preventAdminlessGroupsConfigHandler.handle(event.model)
+            is Event.FeatureConfig.MeetingsConfigUpdated -> meetingsConfigHandler.handle(event.model)
         }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/MeetingsConfigHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/handler/MeetingsConfigHandler.kt
@@ -1,0 +1,34 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.receiver.handler
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.data.featureConfig.MeetingsConfigModel
+import com.wire.kalium.logic.data.featureConfig.Status
+
+internal class MeetingsConfigHandler(
+    private val userConfigRepository: UserConfigRepository
+) {
+    internal suspend fun handle(model: MeetingsConfigModel?): Either<CoreFailure, Unit> =
+        when {
+            model == null -> Either.Right(Unit)
+            else -> userConfigRepository.setMeetingsEnabled(model.status == Status.ENABLED)
+        }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/FeatureConfigMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/FeatureConfigMapperTest.kt
@@ -133,6 +133,15 @@ class FeatureConfigMapperTest {
         assertEquals(Status.ENABLED, model.status)
     }
 
+    @Test
+    fun givenApiModelResponse_whenMappingMeetingsToModel_thenShouldBeMappedCorrectly() {
+        val (arrangement, mapper) = Arrangement().arrange()
+
+        val model = mapper.fromDTO(arrangement.featureConfigResponse.meetings!!)
+
+        assertEquals(Status.ENABLED, model.status)
+    }
+
     private class Arrangement {
         val featureConfigResponse = FeatureConfigResponse(
             FeatureConfigData.AppLock(
@@ -187,6 +196,7 @@ class FeatureConfigMapperTest {
             FeatureConfigData.EnableUserProfileQRCode(FeatureFlagStatusDTO.ENABLED),
             FeatureConfigData.AssetAuditLog(FeatureFlagStatusDTO.ENABLED),
             FeatureConfigData.PreventAdminlessGroups(FeatureFlagStatusDTO.ENABLED),
+            FeatureConfigData.Meetings(FeatureFlagStatusDTO.ENABLED),
         )
 
         val mapper: FeatureConfigMapper = FeatureConfigMapperImpl()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigRepositoryTest.kt
@@ -107,7 +107,8 @@ class FeatureConfigRepositoryTest {
             cellsInternalModel = CellsInternalModel(
                 status = Status.DISABLED,
                 config = CellsInternalConfigModel(null, CollaboraEdition.NO, null)
-            )
+            ),
+            meetingsConfigModel = MeetingsConfigModel(status = Status.DISABLED),
         )
 
         val expectedSuccess = Either.Right(featureConfigModel)
@@ -206,6 +207,7 @@ class FeatureConfigRepositoryTest {
             FeatureConfigData.EnableUserProfileQRCode(FeatureFlagStatusDTO.DISABLED),
             FeatureConfigData.AssetAuditLog(FeatureFlagStatusDTO.DISABLED),
             FeatureConfigData.PreventAdminlessGroups(FeatureFlagStatusDTO.DISABLED),
+            FeatureConfigData.Meetings(FeatureFlagStatusDTO.DISABLED),
         )
 
         val featureConfigApi: FeatureConfigApi = mock<FeatureConfigApi>(mode = MockMode.autoUnit)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/featureConfig/FeatureConfigTest.kt
@@ -78,6 +78,9 @@ object FeatureConfigTest {
         preventAdminlessGroupsModel: PreventAdminlessGroupsConfigModel? = PreventAdminlessGroupsConfigModel(
             status = Status.DISABLED,
         ),
+        meetingsConfigModel: MeetingsConfigModel? = MeetingsConfigModel(
+            status = Status.ENABLED,
+        ),
     ): FeatureConfigModel = FeatureConfigModel(
         appLockModel,
         classifiedDomainsModel,
@@ -104,5 +107,6 @@ object FeatureConfigTest {
         enableUserProfileQRCodeConfigModel,
         assetAuditLogConfigModel,
         preventAdminlessGroupsModel,
+        meetingsConfigModel,
     )
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/featureConfig/SyncFeatureConfigsUseCaseTest.kt
@@ -34,6 +34,7 @@ import com.wire.kalium.logic.data.featureConfig.E2EIModel
 import com.wire.kalium.logic.data.featureConfig.FeatureConfigModel
 import com.wire.kalium.logic.data.featureConfig.FeatureConfigRepository
 import com.wire.kalium.logic.data.featureConfig.FeatureConfigTest
+import com.wire.kalium.logic.data.featureConfig.MeetingsConfigModel
 import com.wire.kalium.logic.data.featureConfig.SelfDeletingMessagesConfigModel
 import com.wire.kalium.logic.data.featureConfig.SelfDeletingMessagesModel
 import com.wire.kalium.logic.data.featureConfig.Status
@@ -58,9 +59,10 @@ import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.sync.receiver.handler.AllowedGlobalOperationsHandler
 import com.wire.kalium.logic.sync.receiver.handler.AssetAuditLogConfigHandler
-import com.wire.kalium.logic.sync.receiver.handler.PreventAdminlessGroupsConfigHandler
 import com.wire.kalium.logic.sync.receiver.handler.CellsConfigHandler
 import com.wire.kalium.logic.sync.receiver.handler.EnableUserProfileQRCodeConfigHandler
+import com.wire.kalium.logic.sync.receiver.handler.MeetingsConfigHandler
+import com.wire.kalium.logic.sync.receiver.handler.PreventAdminlessGroupsConfigHandler
 import com.wire.kalium.logic.test_util.TestNetworkException
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
@@ -837,6 +839,48 @@ class SyncFeatureConfigsUseCaseTest {
         }
     }
 
+    @Test
+    fun givenMeetingsFeatureIsEnabled_whenSyncing_thenSetMeetingsEnabled() = runTest {
+        val (arrangement, syncFeatureConfigsUseCase) = arrangement()
+            .withRemoteFeatureConfigsSucceeding(FeatureConfigTest.newModel(meetingsConfigModel = MeetingsConfigModel(Status.ENABLED)))
+            .withGetSupportedProtocolsReturning(null)
+            .arrange()
+
+        syncFeatureConfigsUseCase()
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.userConfigDAO.setMeetingsEnabled(true)
+        }
+    }
+
+    @Test
+    fun givenMeetingsFeatureIsDisabled_whenSyncing_thenSetMeetingsDisabled() = runTest {
+        val (arrangement, syncFeatureConfigsUseCase) = arrangement()
+            .withRemoteFeatureConfigsSucceeding(FeatureConfigTest.newModel(meetingsConfigModel = MeetingsConfigModel(Status.DISABLED)))
+            .withGetSupportedProtocolsReturning(null)
+            .arrange()
+
+        syncFeatureConfigsUseCase()
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.userConfigDAO.setMeetingsEnabled(false)
+        }
+    }
+
+    @Test
+    fun givenMeetingsFeatureNotPresent_whenSyncing_thenSetMeetingsIsNotCalled() = runTest {
+        val (arrangement, syncFeatureConfigsUseCase) = arrangement()
+            .withRemoteFeatureConfigsSucceeding(FeatureConfigTest.newModel(meetingsConfigModel = null))
+            .withGetSupportedProtocolsReturning(null)
+            .arrange()
+
+        syncFeatureConfigsUseCase()
+
+        verifySuspend(VerifyMode.not) {
+            arrangement.userConfigDAO.setMeetingsEnabled(any())
+        }
+    }
+
     @OptIn(ExperimentalStdlibApi::class)
     private fun TestScope.arrangement() = Arrangement(coroutineContext[CoroutineDispatcher]!! as TestDispatcher)
 
@@ -951,6 +995,7 @@ class SyncFeatureConfigsUseCaseTest {
                 EnableUserProfileQRCodeConfigHandler(userConfigRepository),
                 AssetAuditLogConfigHandler(userConfigRepository),
                 PreventAdminlessGroupsConfigHandler(userConfigRepository),
+                MeetingsConfigHandler(userConfigRepository),
             )
             return this to syncFeatureConfigsUseCase
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/meeting/SyncMeetingsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/meeting/SyncMeetingsUseCaseTest.kt
@@ -21,16 +21,15 @@ import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.meeting.MeetingRepository
-import com.wire.kalium.logic.data.toModel
+import com.wire.kalium.logic.data.id.toModel
 import com.wire.kalium.logic.data.user.UserRepository
-import com.wire.kalium.logic.featureFlags.FeatureSupport
+import com.wire.kalium.logic.feature.user.IsMeetingsEnabledUseCase
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.meeting.MeetingEntity
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
-import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
@@ -39,14 +38,37 @@ import dev.mokkery.verifySuspend
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
 class SyncMeetingsUseCaseTest {
 
     @Test
-    fun givenMeetingFeatureNotSupported_whenInvoking_thenSkipAndReturnUnit() = runTest {
+    fun givenMeetingsEnabled_whenCheckingIsEnabled_thenReturnTrue() = runTest {
+        val (_, useCase) = Arrangement()
+            .withMeetingsEnabled(true)
+            .arrange()
+
+        val result = useCase.isEnabled()
+
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun givenMeetingsDisabled_whenCheckingIsEnabled_thenReturnFalse() = runTest {
+        val (_, useCase) = Arrangement()
+            .withMeetingsEnabled(false)
+            .arrange()
+
+        val result = useCase.isEnabled()
+
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun givenMeetingsDisabled_whenInvoking_thenSkipAndReturnUnit() = runTest {
         val (arrangement, useCase) = Arrangement()
-            .withMeetingSupportEnabled(false)
+            .withMeetingsEnabled(false)
             .arrange()
 
         val result = useCase()
@@ -58,7 +80,7 @@ class SyncMeetingsUseCaseTest {
     @Test
     fun givenFeatureNotSupportedFailure_whenInvoking_thenSkipAndReturnUnit() = runTest {
         val (_, useCase) = Arrangement()
-            .withMeetingSupportEnabled(true)
+            .withMeetingsEnabled(true)
             .withFetchMeetingsFailed(NetworkFailure.FeatureNotSupported)
             .arrange()
 
@@ -70,7 +92,7 @@ class SyncMeetingsUseCaseTest {
     @Test
     fun givenOtherFailure_whenInvoking_thenReturnFailure() = runTest {
         val (_, useCase) = Arrangement()
-            .withMeetingSupportEnabled(true)
+            .withMeetingsEnabled(true)
             .withFetchMeetingsFailed(NetworkFailure.NoNetworkConnection(null))
             .arrange()
 
@@ -82,7 +104,7 @@ class SyncMeetingsUseCaseTest {
     @Test
     fun givenNoMeetingsFetched_whenInvoking_thenDoNotFetchUsers() = runTest {
         val (arrangement, useCase) = Arrangement()
-            .withMeetingSupportEnabled(true)
+            .withMeetingsEnabled(true)
             .withFetchMeetingsSuccessful(emptyList())
             .arrange()
 
@@ -96,7 +118,7 @@ class SyncMeetingsUseCaseTest {
     @Test
     fun givenSuccess_whenInvoking_thenExecuteRequestsAndReturnUnit() = runTest {
         val (arrangement, useCase) = Arrangement()
-            .withMeetingSupportEnabled(true)
+            .withMeetingsEnabled(true)
             .withFetchMeetingsSuccessful(listOf(MEETING))
             .withFetchUsersSuccessful()
             .arrange()
@@ -111,10 +133,10 @@ class SyncMeetingsUseCaseTest {
     inner class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
         internal val meetingRepository = mock<MeetingRepository>(mode = MockMode.autoUnit)
         internal val userRepository = mock<UserRepository>(mode = MockMode.autoUnit)
-        internal val featureSupport = mock<FeatureSupport>(mode = MockMode.autoUnit)
+        internal val isMeetingsEnabledUseCase = mock<IsMeetingsEnabledUseCase>(mode = MockMode.autoUnit)
 
-        internal fun withMeetingSupportEnabled(enabled: Boolean) = apply {
-            every { featureSupport.isMeetingsSupported } returns enabled
+        internal fun withMeetingsEnabled(enabled: Boolean) = apply {
+            everySuspend { isMeetingsEnabledUseCase() } returns enabled
         }
 
         internal fun withFetchMeetingsFailed(failure: CoreFailure) = apply {
@@ -132,7 +154,7 @@ class SyncMeetingsUseCaseTest {
         internal suspend fun arrange() = this to SyncMeetingsUseCaseImpl(
             meetingRepository = meetingRepository,
             userRepository = userRepository,
-            featureSupport = featureSupport,
+            isMeetingsEnabledUseCase = isMeetingsEnabledUseCase,
             transactionProvider = cryptoTransactionProvider
         ).also {
             withTransactionReturning(Either.Right(Unit))

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/IsMeetingsEnabledUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/user/IsMeetingsEnabledUseCaseTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.user
+
+import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.featureFlags.FeatureSupport
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@ExperimentalCoroutinesApi
+class IsMeetingsEnabledUseCaseTest {
+
+    private fun testMeetings(enabled: Boolean, supported: Boolean, expected: Boolean) = runTest {
+        val (_, useCase) = Arrangement()
+            .withMeetingsEnabled(enabled)
+            .withMeetingsSupported(supported)
+            .arrange()
+
+        assertEquals(expected, useCase.invoke())
+    }
+
+    @Test
+    fun givenMeetingsEnabledAndSupported_whenInvoked_thenReturnsTrue() =
+        testMeetings(enabled = true, supported = true, expected = true)
+
+    @Test
+    fun givenMeetingsEnabledAndNotSupported_whenInvoked_thenReturnsFalse() =
+        testMeetings(enabled = true, supported = false, expected = false)
+
+    @Test
+    fun givenMeetingsNotEnabledAndSupported_whenInvoked_thenReturnsFalse() =
+        testMeetings(enabled = false, supported = true, expected = false)
+
+    @Test
+    fun givenMeetingsNotEnabledAndNotSupported_whenInvoked_thenReturnsFalse() =
+        testMeetings(enabled = false, supported = false, expected = false)
+
+    private class Arrangement {
+        val userConfigRepository: UserConfigRepository = mock()
+        val featureSupport: FeatureSupport = mock()
+
+        fun withMeetingsEnabled(enabled: Boolean) = apply {
+            everySuspend { userConfigRepository.isMeetingsEnabled() } returns enabled
+        }
+        fun withMeetingsSupported(supported: Boolean) = apply {
+            everySuspend { featureSupport.isMeetingsSupported } returns supported
+        }
+        fun arrange() = this to IsMeetingsEnabledUseCaseImpl(userConfigRepository, featureSupport)
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/FeatureConfigEventReceiverTest.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.data.featureConfig.ConferenceCallingModel
 import com.wire.kalium.logic.data.featureConfig.ConfigsStatusModel
 import com.wire.kalium.logic.data.featureConfig.MLSMigrationModel
 import com.wire.kalium.logic.data.featureConfig.MLSModel
+import com.wire.kalium.logic.data.featureConfig.MeetingsConfigModel
 import com.wire.kalium.logic.data.featureConfig.SelfDeletingMessagesConfigModel
 import com.wire.kalium.logic.data.featureConfig.SelfDeletingMessagesModel
 import com.wire.kalium.logic.data.featureConfig.Status
@@ -51,6 +52,7 @@ import com.wire.kalium.logic.sync.receiver.handler.AssetAuditLogConfigHandler
 import com.wire.kalium.logic.sync.receiver.handler.PreventAdminlessGroupsConfigHandler
 import com.wire.kalium.logic.sync.receiver.handler.CellsConfigHandler
 import com.wire.kalium.logic.sync.receiver.handler.EnableUserProfileQRCodeConfigHandler
+import com.wire.kalium.logic.sync.receiver.handler.MeetingsConfigHandler
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMokkeryImpl
 import com.wire.kalium.logic.util.shouldSucceed
@@ -189,11 +191,11 @@ class FeatureConfigEventReceiverTest {
             TestEvent.liveDeliveryInfo
         )
 
-            verifySuspend(VerifyMode.exactly(1)) {
-                arrangement.userConfigRepository.setTeamSettingsSelfDeletionStatus(matches {
-                    it.hasFeatureChanged == true && it.enforcedSelfDeletionTimer is TeamSelfDeleteTimer.Disabled
-                })
-            }
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.userConfigRepository.setTeamSettingsSelfDeletionStatus(matches {
+                it.hasFeatureChanged == true && it.enforcedSelfDeletionTimer is TeamSelfDeleteTimer.Disabled
+            })
+        }
     }
 
     @Test
@@ -393,6 +395,40 @@ class FeatureConfigEventReceiverTest {
         ).shouldSucceed()
     }
 
+    @Test
+    fun givenMeetingsFeatureIsEnabled_whenProcessingEvent_thenSetMeetingsEnabled() = runTest {
+        val (arrangement, featureConfigEventReceiver) = Arrangement()
+            .withMeetingsConfigSetup()
+            .arrange()
+
+        featureConfigEventReceiver.onEvent(
+            arrangement.transactionContext,
+            event = arrangement.newMeetingsConfigUpdatedEvent(MeetingsConfigModel(Status.ENABLED)),
+            deliveryInfo = TestEvent.liveDeliveryInfo
+        )
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.userConfigRepository.setMeetingsEnabled(true)
+        }
+    }
+
+    @Test
+    fun givenMeetingsFeatureIsDisabled_whenProcessingEvent_thenSetMeetingsDisabled() = runTest {
+        val (arrangement, featureConfigEventReceiver) = Arrangement()
+            .withMeetingsConfigSetup()
+            .arrange()
+
+        featureConfigEventReceiver.onEvent(
+            arrangement.transactionContext,
+            event = arrangement.newMeetingsConfigUpdatedEvent(MeetingsConfigModel(Status.DISABLED)),
+            deliveryInfo = TestEvent.liveDeliveryInfo
+        )
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.userConfigRepository.setMeetingsEnabled(false)
+        }
+    }
+
     private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMokkeryImpl() {
 
         var kaliumConfigs = KaliumConfigs()
@@ -416,6 +452,7 @@ class FeatureConfigEventReceiverTest {
                 EnableUserProfileQRCodeConfigHandler(userConfigRepository),
                 AssetAuditLogConfigHandler(userConfigRepository),
                 PreventAdminlessGroupsConfigHandler(userConfigRepository),
+                MeetingsConfigHandler(userConfigRepository),
             )
         }
 
@@ -495,6 +532,12 @@ class FeatureConfigEventReceiverTest {
             } returns Either.Right(Unit)
         }
 
+        suspend fun withMeetingsConfigSetup() = apply {
+            everySuspend {
+                userConfigRepository.setMeetingsEnabled(any())
+            } returns Either.Right(Unit)
+        }
+
         fun newFileSharingUpdatedEvent(
             model: ConfigsStatusModel
         ) = Event.FeatureConfig.FileSharingUpdated("eventId", model)
@@ -506,6 +549,8 @@ class FeatureConfigEventReceiverTest {
         fun newSelfDeletingMessagesUpdatedEvent(
             model: SelfDeletingMessagesModel
         ) = Event.FeatureConfig.SelfDeletingMessagesConfig("eventId", model)
+
+        fun newMeetingsConfigUpdatedEvent(model: MeetingsConfigModel) = Event.FeatureConfig.MeetingsConfigUpdated("eventId", model)
 
         fun arrange(block: suspend Arrangement.() -> Unit = {}) = run {
             runBlocking { block() }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorkerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorkerTest.kt
@@ -89,6 +89,28 @@ class SlowSyncWorkerTest {
     }
 
     @Test
+    fun givenMeetingsDisabled_whenPerformingSlowSync_thenDoNotExecuteMeetingsStep() = runTest(TestKaliumDispatcher.default) {
+        val (arrangement, worker) = Arrangement()
+            .withSyncSelfUserSuccess()
+            .withUpdateSupportedProtocolsSuccess()
+            .withSyncFeatureConfigsSuccess()
+            .withSyncConversationsSuccess()
+            .withSyncConnectionsSuccess()
+            .withSyncSelfTeamSuccess()
+            .withSyncContactsSuccess()
+            .withSyncMeetingsDisabled()
+            .withJoinMLSConversationsSuccess()
+            .withResolveOneOnOneConversationsSuccess()
+            .withFetchLegalHoldStatusSuccess()
+            .withNomadEnabled()
+            .arrange()
+
+        worker.slowSyncStepsFlow(successfullyMigration).collect()
+
+        assertUseCases(arrangement, stepsWithMeetingsDisabled())
+    }
+
+    @Test
     fun givenSyncSelfUserFails_whenPerformingSlowSync_thenThrowSyncException() = runTest(TestKaliumDispatcher.default) {
         val steps = hashSetOf(SlowSyncStep.MIGRATION, SlowSyncStep.SELF_USER)
         val (arrangement, worker) = Arrangement()
@@ -1042,5 +1064,8 @@ class SlowSyncWorkerTest {
 
         fun stepsWithNomadDisabled(): HashSet<SlowSyncStep> =
             SlowSyncStep.entries.filterNot { it == SlowSyncStep.NOMAD_MESSAGES }.toHashSet()
+
+        fun stepsWithMeetingsDisabled(): HashSet<SlowSyncStep> =
+            SlowSyncStep.entries.filterNot { it == SlowSyncStep.MEETINGS }.toHashSet()
     }
 }

--- a/test/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/FeatureConfigJson.kt
+++ b/test/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/FeatureConfigJson.kt
@@ -119,6 +119,9 @@ object FeatureConfigJson {
             |  },
             |  "apps": {
             |    "status": "disabled"
+            |  },
+            |  "meetings": {
+            |    "status": "enabled"
             |  }
             |}
         """.trimMargin()
@@ -165,6 +168,7 @@ object FeatureConfigJson {
             FeatureConfigData.EnableUserProfileQRCode(FeatureFlagStatusDTO.DISABLED),
             FeatureConfigData.AssetAuditLog(FeatureFlagStatusDTO.DISABLED),
             FeatureConfigData.PreventAdminlessGroups(FeatureFlagStatusDTO.DISABLED),
+            FeatureConfigData.Meetings(FeatureFlagStatusDTO.ENABLED),
         ),
         featureConfigResponseSerializer
     )

--- a/test/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/FeatureConfigResponseJson.kt
+++ b/test/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/FeatureConfigResponseJson.kt
@@ -92,6 +92,7 @@ object FeatureConfigResponseJson {
         FeatureConfigData.EnableUserProfileQRCode(FeatureFlagStatusDTO.ENABLED),
         FeatureConfigData.AssetAuditLog(FeatureFlagStatusDTO.ENABLED),
         FeatureConfigData.PreventAdminlessGroups(FeatureFlagStatusDTO.ENABLED),
+        FeatureConfigData.Meetings(FeatureFlagStatusDTO.ENABLED),
     )
     val valid = KtxSerializer.json.encodeToString(featureConfigResponse)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25681
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Handling `meetings` feature flag. Skipping the `meetings` slow sync step if the flag is disabled for the given user. Sharing use case to check if meetings is enabled for the given user.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Log in with account that has meetings disabled and check the slow sync steps in logs.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
