### PR TITLE
fix: remove meetings slow sync step from current beta [WPB-25681]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SlowSyncStatus.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sync/SlowSyncStatus.kt
@@ -47,5 +47,4 @@ internal enum class SlowSyncStep {
     RESOLVE_ONE_ON_ONE_PROTOCOLS,
     LEGAL_HOLD,
     OPTIMIZE_DB,
-    MEETINGS,
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1494,7 +1494,6 @@ public class UserSessionScope internal constructor(
                 userAuthenticatedNetworkProvider = userAuthenticatedNetworkProvider,
                 logger = userScopedLogger
             ),
-            syncMeetings = syncMeetingsUseCase,
             optimizer = OptimizeDatabaseUseCaseImpl(userStorage.database.databaseOptimizer)
         )
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorker.kt
@@ -43,7 +43,6 @@ import com.wire.kalium.logic.feature.debug.OptimizeDatabaseResult
 import com.wire.kalium.logic.feature.debug.OptimizeDatabaseUseCase
 import com.wire.kalium.logic.feature.featureConfig.SyncFeatureConfigsUseCase
 import com.wire.kalium.logic.feature.legalhold.FetchLegalHoldForSelfUserFromRemoteUseCase
-import com.wire.kalium.logic.feature.meeting.SyncMeetingsUseCase
 import com.wire.kalium.logic.feature.team.SyncSelfTeamUseCase
 import com.wire.kalium.logic.feature.user.SyncContactsUseCase
 import com.wire.kalium.logic.feature.user.SyncSelfUserUseCase
@@ -88,7 +87,6 @@ internal class SlowSyncWorkerImpl(
     private val transactionProvider: CryptoTransactionProvider,
     private val optimizer: OptimizeDatabaseUseCase,
     private val syncNomadMessagesDuringSlowSync: SyncNomadMessagesDuringSlowSyncUseCase = NoOpSyncNomadMessagesDuringSlowSyncUseCase,
-    private val syncMeetings: SyncMeetingsUseCase,
     logger: KaliumLogger = kaliumLogger
 ) : SlowSyncWorker {
 
@@ -138,7 +136,6 @@ internal class SlowSyncWorkerImpl(
                 .continueWithStep(SlowSyncStep.SELF_TEAM, syncSelfTeam::invoke)
                 .continueWithStep(SlowSyncStep.LEGAL_HOLD) { fetchLegalHoldForSelfUserFromRemoteUseCase().map { } }
                 .continueWithStep(SlowSyncStep.CONTACTS, syncContacts::invoke)
-                .continueWithOptionalStep(syncMeetings.isEnabled(), SlowSyncStep.MEETINGS, syncMeetings::invoke)
                 .continueWithOptionalStep(
                     syncNomadMessagesDuringSlowSync.isEnabled(),
                     SlowSyncStep.NOMAD_MESSAGES,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorkerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncWorkerTest.kt
@@ -31,7 +31,6 @@ import com.wire.kalium.logic.feature.debug.OptimizeDatabaseResult
 import com.wire.kalium.logic.feature.debug.OptimizeDatabaseUseCase
 import com.wire.kalium.logic.feature.featureConfig.SyncFeatureConfigsUseCase
 import com.wire.kalium.logic.feature.legalhold.FetchLegalHoldForSelfUserFromRemoteUseCase
-import com.wire.kalium.logic.feature.meeting.SyncMeetingsUseCase
 import com.wire.kalium.logic.feature.team.SyncSelfTeamUseCase
 import com.wire.kalium.logic.feature.user.SyncContactsUseCase
 import com.wire.kalium.logic.feature.user.SyncSelfUserUseCase
@@ -77,7 +76,6 @@ class SlowSyncWorkerTest {
             .withSyncConnectionsSuccess()
             .withSyncSelfTeamSuccess()
             .withSyncContactsSuccess()
-            .withSyncMeetingsSuccess()
             .withJoinMLSConversationsSuccess()
             .withResolveOneOnOneConversationsSuccess()
             .withFetchLegalHoldStatusSuccess()
@@ -118,7 +116,6 @@ class SlowSyncWorkerTest {
             .withSyncSelfTeamSuccess()
             .withFetchLegalHoldStatusSuccess()
             .withSyncContactsSuccess()
-            .withSyncMeetingsSuccess()
             .withJoinMLSConversationsSuccess()
             .withResolveOneOnOneConversationsSuccess()
             .arrange()
@@ -139,7 +136,6 @@ class SlowSyncWorkerTest {
             .withSyncSelfTeamSuccess()
             .withFetchLegalHoldStatusSuccess()
             .withSyncContactsSuccess()
-            .withSyncMeetingsSuccess()
             .withSyncNomadAllMessagesSuccess()
             .withJoinMLSConversationsSuccess()
             .withResolveOneOnOneConversationsSuccess()
@@ -164,7 +160,6 @@ class SlowSyncWorkerTest {
                 SlowSyncStep.SELF_TEAM,
                 SlowSyncStep.LEGAL_HOLD,
                 SlowSyncStep.CONTACTS,
-                SlowSyncStep.MEETINGS,
                 SlowSyncStep.NOMAD_MESSAGES,
                 SlowSyncStep.JOINING_MLS_CONVERSATIONS,
                 SlowSyncStep.RESOLVE_ONE_ON_ONE_PROTOCOLS,
@@ -387,44 +382,6 @@ class SlowSyncWorkerTest {
     }
 
     @Test
-    fun givenSyncMeetingsFails_whenPerformingSlowSync_thenThrowSyncException() = runTest(TestKaliumDispatcher.default) {
-        val steps = hashSetOf(
-            SlowSyncStep.MIGRATION,
-            SlowSyncStep.SELF_USER,
-            SlowSyncStep.USER_PROPERTIES,
-            SlowSyncStep.UPDATE_SUPPORTED_PROTOCOLS,
-            SlowSyncStep.FEATURE_FLAGS,
-            SlowSyncStep.CONVERSATIONS,
-            SlowSyncStep.CONNECTIONS,
-            SlowSyncStep.SELF_TEAM,
-            SlowSyncStep.LEGAL_HOLD,
-            SlowSyncStep.CONTACTS,
-            SlowSyncStep.MEETINGS
-        )
-        val (arrangement, worker) = Arrangement()
-            .withSyncSelfUserSuccess()
-            .withUpdateSupportedProtocolsSuccess()
-            .withSyncFeatureConfigsSuccess()
-            .withSyncConversationsSuccess()
-            .withSyncConnectionsSuccess()
-            .withSyncSelfTeamSuccess()
-            .withFetchLegalHoldStatusSuccess()
-            .withSyncContactsSuccess()
-            .withSyncMeetingsFailure()
-            .arrange()
-
-        assertFailsWith<KaliumSyncException> {
-            worker.slowSyncStepsFlow(successfullyMigration).collect {
-                assertTrue {
-                    it in steps
-                }
-            }
-        }
-
-        assertUseCases(arrangement, steps)
-    }
-
-    @Test
     fun givenNomadMessagesSyncFails_whenPerformingSlowSync_thenThrowSyncException() = runTest(TestKaliumDispatcher.default) {
         val steps = hashSetOf(
             SlowSyncStep.MIGRATION,
@@ -437,7 +394,6 @@ class SlowSyncWorkerTest {
             SlowSyncStep.SELF_TEAM,
             SlowSyncStep.LEGAL_HOLD,
             SlowSyncStep.CONTACTS,
-            SlowSyncStep.MEETINGS,
             SlowSyncStep.NOMAD_MESSAGES,
         )
         val (arrangement, worker) = Arrangement()
@@ -449,7 +405,6 @@ class SlowSyncWorkerTest {
             .withSyncSelfTeamSuccess()
             .withFetchLegalHoldStatusSuccess()
             .withSyncContactsSuccess()
-            .withSyncMeetingsSuccess()
             .withSyncNomadAllMessagesFailure()
             .withNomadEnabled()
             .arrange()
@@ -478,7 +433,6 @@ class SlowSyncWorkerTest {
             SlowSyncStep.SELF_TEAM,
             SlowSyncStep.LEGAL_HOLD,
             SlowSyncStep.CONTACTS,
-            SlowSyncStep.MEETINGS,
             SlowSyncStep.JOINING_MLS_CONVERSATIONS
         )
         val (arrangement, worker) = Arrangement()
@@ -490,7 +444,6 @@ class SlowSyncWorkerTest {
             .withSyncSelfTeamSuccess()
             .withFetchLegalHoldStatusSuccess()
             .withSyncContactsSuccess()
-            .withSyncMeetingsSuccess()
             .withJoinMLSConversationsFailure()
             .arrange()
 
@@ -591,7 +544,6 @@ class SlowSyncWorkerTest {
             .withSyncSelfTeamSuccess()
             .withFetchLegalHoldStatusSuccess()
             .withSyncContactsSuccess()
-            .withSyncMeetingsSuccess()
             .withJoinMLSConversationsSuccess(allowJoinByExternalCommit = true)
             .withResolveOneOnOneConversationsSuccess(allowJoinByExternalCommit = true)
             .withFetchLegalHoldStatusSuccess()
@@ -615,7 +567,6 @@ class SlowSyncWorkerTest {
             .withSyncSelfTeamSuccess()
             .withFetchLegalHoldStatusSuccess()
             .withSyncContactsSuccess()
-            .withSyncMeetingsSuccess()
             .withJoinMLSConversationsSuccess(allowJoinByExternalCommit = false)
             .withResolveOneOnOneConversationsSuccess()
             .arrange()
@@ -643,7 +594,6 @@ class SlowSyncWorkerTest {
             .withSyncSelfTeamSuccess()
             .withFetchLegalHoldStatusSuccess()
             .withSyncContactsSuccess()
-            .withSyncMeetingsSuccess()
             .withJoinMLSConversationsSuccess(allowJoinByExternalCommit = true)
             .withResolveOneOnOneConversationsSuccess(allowJoinByExternalCommit = true)
             .arrange()
@@ -666,7 +616,6 @@ class SlowSyncWorkerTest {
             .withSyncSelfTeamSuccess()
             .withFetchLegalHoldStatusSuccess()
             .withSyncContactsSuccess()
-            .withSyncMeetingsSuccess()
             .withJoinMLSConversationsSuccess(allowJoinByExternalCommit = false)
             .withResolveOneOnOneConversationsSuccess(allowJoinByExternalCommit = false)
             .arrange()
@@ -694,7 +643,6 @@ class SlowSyncWorkerTest {
             .withSyncSelfTeamSuccess()
             .withFetchLegalHoldStatusSuccess()
             .withSyncContactsSuccess()
-            .withSyncMeetingsSuccess()
             .withJoinMLSConversationsSuccess(allowJoinByExternalCommit = true)
             .withResolveOneOnOneConversationsSuccess(allowJoinByExternalCommit = true)
             .arrange()
@@ -767,10 +715,6 @@ class SlowSyncWorkerTest {
             arrangement.syncContacts.invoke()
         }
 
-        verifySuspend(VerifyMode.exactly(if (steps.contains(SlowSyncStep.MEETINGS)) 1 else 0)) {
-            arrangement.syncMeetings.invoke()
-        }
-
         assertEquals(
             if (steps.contains(SlowSyncStep.NOMAD_MESSAGES)) 1 else 0,
             arrangement.syncNomadMessagesDuringSlowSync.invocations
@@ -805,7 +749,6 @@ class SlowSyncWorkerTest {
         val isClientAsyncNotificationsCapableProvider: IsClientAsyncNotificationsCapableProvider = mock()
         val syncNomadMessagesDuringSlowSync = FakeSyncNomadMessagesDuringSlowSyncUseCase()
         val optimizeDatabase: OptimizeDatabaseUseCase = mock()
-        val syncMeetings: SyncMeetingsUseCase = mock()
 
         init {
             runBlocking {
@@ -814,7 +757,6 @@ class SlowSyncWorkerTest {
                 withTransactionReturning(Either.Right(Unit))
                 withSyncUserPropertiesSuccess()
                 withOptimizeDatabaseSuccess()
-                withSyncMeetingsDisabled()
             }
         }
 
@@ -834,7 +776,6 @@ class SlowSyncWorkerTest {
             isClientAsyncNotificationsCapableProvider = isClientAsyncNotificationsCapableProvider,
             transactionProvider = cryptoTransactionProvider,
             syncNomadMessagesDuringSlowSync = syncNomadMessagesDuringSlowSync,
-            syncMeetings = syncMeetings,
             optimizer = optimizeDatabase
         )
 
@@ -932,20 +873,6 @@ class SlowSyncWorkerTest {
             everySuspend {
                 syncContacts.invoke()
             } returns success
-        }
-
-        fun withSyncMeetingsDisabled() = apply {
-            everySuspend { syncMeetings.isEnabled() } returns false
-        }
-
-        fun withSyncMeetingsFailure() = apply {
-            everySuspend { syncMeetings.isEnabled() } returns true
-            everySuspend { syncMeetings.invoke() } returns failure
-        }
-
-        fun withSyncMeetingsSuccess() = apply {
-            everySuspend { syncMeetings.isEnabled() } returns true
-            everySuspend { syncMeetings.invoke() } returns success
         }
 
         fun withJoinMLSConversationsFailure(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25681
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Meetings feature is not yet public, so until we have a feature flag handling implemented and working, it's better to remove this step from the slow sync process as the request can return failure and make the whole sync stuck.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
