### PR TITLE
fix: last read event not sent (WPB-26157)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase.kt
@@ -93,55 +93,75 @@ public class UpdateConversationReadDateUseCase internal constructor(
         doWork(conversationId, time)
     }
 
-    private suspend fun doWork(conversationId: QualifiedID, time: Instant) {
+    private suspend fun doWork(conversationId: QualifiedID, requestedLastRead: Instant) {
         coroutineScope {
             conversationRepository.observeConversationById(conversationId).first().onFailure {
                 logger.w("Failed to update conversation read date; StorageFailure $it")
             }.onSuccess { conversation ->
-                if (conversation.lastReadDate >= time) {
+                val storedLastRead = conversation.lastReadDate
+
+                if (storedLastRead > requestedLastRead) {
                     logger.d(
                         "Skipping last-read update for '${conversationId.toLogString()}': " +
-                            "stored=${conversation.lastReadDate} >= requested=$time"
+                            "stored=$storedLastRead > requested=$requestedLastRead"
                     )
-                    // Skipping, as current lastRead is already newer than the scheduled one
                     return@onSuccess
                 }
 
-                val shouldRunOptionalSideEffects = currentCoroutineContext()[kotlinx.coroutines.Job] != NonCancellable
+                val needsLocalPersistence = storedLastRead < requestedLastRead
+                // Network operations must stay cancellable. NonCancellable execution is used only to finish local persistence.
+                val canPerformRemoteSync = currentCoroutineContext()[kotlinx.coroutines.Job] != NonCancellable
 
-                if (shouldRunOptionalSideEffects) {
-                    launch {
-                        sendConfirmation(conversationId, conversation.lastReadDate, time)
-                    }
-                }
-
-                withContext(NonCancellable) {
-                    val updateResult = conversationRepository.updateConversationReadDate(conversationId, time)
-                    updateResult.onSuccess {
-                        logger.d("Persisted last-read for '${conversationId.toLogString()}' at $time")
-                        persistenceEventHookNotifier.onConversationLastReadPersisted(
-                            ConversationLastReadEventData(conversationId, time),
-                            selfUserId
-                        )
-                    }
-                }
-                if (shouldRunOptionalSideEffects) {
-                    launch {
-                        selfConversationIdProvider().flatMap { selfConversationIds ->
-                            selfConversationIds.foldToEitherWhileRight(Unit) { selfConversationId, _ ->
-                                sendLastReadMessageToOtherClients(conversationId, selfConversationId, time)
-                            }
+                if (needsLocalPersistence) {
+                    if (canPerformRemoteSync) {
+                        launch {
+                            sendReadConfirmations(conversationId, storedLastRead, requestedLastRead)
                         }
+                    }
+                    persistLastRead(conversationId, requestedLastRead)
+                }
+
+                if (canPerformRemoteSync) {
+                    launch {
+                        syncLastReadWithOtherClients(conversationId, requestedLastRead)
                     }
                 }
             }
         }
     }
 
-    private suspend fun sendLastReadMessageToOtherClients(
+    private suspend fun sendReadConfirmations(
         conversationId: QualifiedID,
+        previouslyReadUntil: Instant,
+        newlyReadUntil: Instant,
+    ) {
+        sendConfirmation(conversationId, previouslyReadUntil, newlyReadUntil)
+    }
+
+    private suspend fun persistLastRead(conversationId: QualifiedID, time: Instant) {
+        withContext(NonCancellable) {
+            conversationRepository.updateConversationReadDate(conversationId, time).onSuccess {
+                logger.d("Persisted last-read for '${conversationId.toLogString()}' at $time")
+                persistenceEventHookNotifier.onConversationLastReadPersisted(
+                    ConversationLastReadEventData(conversationId, time),
+                    selfUserId
+                )
+            }
+        }
+    }
+
+    private suspend fun syncLastReadWithOtherClients(conversationId: QualifiedID, lastRead: Instant) {
+        selfConversationIdProvider().flatMap { selfConversationIds ->
+            selfConversationIds.foldToEitherWhileRight(Unit) { selfConversationId, _ ->
+                sendLastReadToSelfConversation(conversationId, selfConversationId, lastRead)
+            }
+        }
+    }
+
+    private suspend fun sendLastReadToSelfConversation(
+        readConversationId: QualifiedID,
         selfConversationId: QualifiedID,
-        time: Instant
+        lastRead: Instant
     ): Either<CoreFailure, Unit> {
         val generatedMessageUuid = Uuid.random().toString()
 
@@ -150,8 +170,8 @@ public class UpdateConversationReadDateUseCase internal constructor(
                 id = generatedMessageUuid,
                 content = MessageContent.LastRead(
                     messageId = generatedMessageUuid,
-                    conversationId = conversationId,
-                    time = time
+                    conversationId = readConversationId,
+                    time = lastRead
                 ),
                 conversationId = selfConversationId,
                 date = Clock.System.now(),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCaseTest.kt
@@ -87,6 +87,38 @@ class UpdateConversationReadDateUseCaseTest {
     }
 
     @Test
+    fun givenLastReadWasAlreadyPersistedLocally_whenQueuedWorkRuns_thenShouldSyncOtherSelfClients() = runTest {
+        val lastRead = Clock.System.now()
+        val conversationId = TestConversation.CONVERSATION.id
+        val (arrangement, updateConversationReadDateUseCase) = arrange {
+            withObserveByIdReturning(
+                TestConversation.CONVERSATION.copy(lastReadDate = lastRead)
+            )
+        }
+
+        updateConversationReadDateUseCase(conversationId, lastRead)
+
+        verifySuspend(VerifyMode.not) {
+            arrangement.sendConfirmation(any(), any(), any())
+        }
+        verifySuspend(VerifyMode.not) {
+            arrangement.conversationRepository.updateConversationReadDate(any(), any())
+        }
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.messageSender.sendMessage(
+                message = matching { message ->
+                    val content = message.content
+                    assertIs<MessageContent.LastRead>(content)
+                    assertEquals(conversationId, content.conversationId)
+                    assertEquals(lastRead, content.time)
+                    true
+                },
+                messageTarget = any()
+            )
+        }
+    }
+
+    @Test
     fun givenProvidedTimeIsNewerThanPersistedLastReadForConversation_whenWorking_thenShouldTryToSendReceipts() = runTest {
         val persistedLastRead = Clock.System.now()
         val newLastRead = persistedLastRead + 1.seconds


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26157
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-26157
----

# What's new in this PR?

### Issues
Last read is not sent to other clients if conversation with unread messages is closed within 3 seconds.

### Causes (Optional)

When closed within three seconds:
- Reading schedules UpdateConversationReadDateUseCase in the three-second debounce queue.
- Closing triggers onConversationClosed() and immediately persists the same timestamp locally.
- The queued worker later observes stored == requested.
- The old stored >= requested condition returned before sending LastRead.

When left open longer, the queued worker runs first, sees an older stored timestamp, and sends LastRead.

### Solutions

Skip only strictly older queued timestamps.
Allow equal, already-persisted timestamps to synchronize with other self-clients.
Avoid duplicate database writes and persistence hooks.

Refactored the code to make it more readable.