### PR TITLE
fix(conversation-list): promote joinable calls [WPB-26713]

### DIFF
--- a/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationDetailsWithEvents.sq
+++ b/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/ConversationDetailsWithEvents.sq
@@ -96,7 +96,7 @@ WHERE archived = :fromArchive
     AND CASE WHEN :onlyInteractionsEnabled THEN interactionEnabled = 1 ELSE 1 END
 ORDER BY
     CASE
-        WHEN :newActivitiesOnTop AND type IN ('GROUP', 'CHANNEL', 'MEETING') AND qualifiedId IN :ongoingCallConversationIds
+        WHEN :newActivitiesOnTop AND qualifiedId IN :ongoingCallConversationIds
         THEN 1
         WHEN :newActivitiesOnTop THEN hasNewActivitiesToShow
         ELSE 0
@@ -136,7 +136,7 @@ WHERE
     AND CASE WHEN :onlyInteractionsEnabled THEN interactionEnabled = 1 ELSE 1 END
     ORDER BY
         CASE
-            WHEN :newActivitiesOnTop AND type IN ('GROUP', 'CHANNEL', 'MEETING') AND qualifiedId IN :ongoingCallConversationIds THEN 1
+            WHEN :newActivitiesOnTop AND qualifiedId IN :ongoingCallConversationIds THEN 1
             ELSE 0
         END DESC,
         CASE WHEN :newActivitiesOnTop THEN hasNewActivitiesToShow ELSE 0 END DESC,
@@ -178,7 +178,7 @@ WHERE
     AND name LIKE ('%' || :searchQuery || '%')
 ORDER BY
     CASE
-        WHEN :newActivitiesOnTop AND type IN ('GROUP', 'CHANNEL', 'MEETING') AND qualifiedId IN :ongoingCallConversationIds THEN 1
+        WHEN :newActivitiesOnTop AND qualifiedId IN :ongoingCallConversationIds THEN 1
         ELSE 0
     END DESC,
     CASE WHEN :newActivitiesOnTop THEN hasNewActivitiesToShow ELSE 0 END DESC,

--- a/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/conversation/ConversationExtensionsTest.kt
+++ b/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/conversation/ConversationExtensionsTest.kt
@@ -39,6 +39,7 @@ import com.wire.kalium.persistence.dao.conversation.folder.ConversationFolderDAO
 import com.wire.kalium.persistence.dao.conversation.folder.ConversationFolderEntity
 import com.wire.kalium.persistence.dao.conversation.folder.ConversationFolderTypeEntity
 import com.wire.kalium.persistence.dao.member.MemberDAO
+import com.wire.kalium.persistence.dao.member.MemberEntity
 import com.wire.kalium.persistence.dao.message.KaliumPager
 import com.wire.kalium.persistence.dao.message.MessageDAO
 import com.wire.kalium.persistence.dao.message.draft.MessageDraftDAO
@@ -163,6 +164,56 @@ class ConversationExtensionsTest : BaseDatabaseTest() {
         refreshEvents.receive()
         assertEquals("${CONVERSATION_ID_PREFIX}1", presenter.snapshot().items.first().conversationViewEntity.id.value)
         collectionJob.cancel()
+    }
+
+    @Test
+    fun givenOneOnOneOngoingCallIdsChange_whenCollectingPagingData_thenReloadMovesCallToTop() = runTest(dispatcher) {
+        populateOneOnOneData(count = 2)
+        val ongoingCallConversationIds = MutableStateFlow(emptyList<ConversationIDEntity>())
+        val pager = conversationExtensions.getPagerForConversationDetailsWithEventsSearch(
+            pagingConfig = PagingConfig(PAGE_SIZE),
+            queryConfig = ConversationExtensions.QueryConfig(
+                newActivitiesOnTop = true,
+                ongoingCallConversationIds = ongoingCallConversationIds.value,
+                ongoingCallConversationIdsFlow = ongoingCallConversationIds,
+            ),
+        )
+        val refreshEvents = Channel<Unit>(Channel.UNLIMITED)
+        val presenter = object : PagingDataPresenter<ConversationDetailsWithEventsEntity>(dispatcher) {
+            override suspend fun presentPagingDataEvent(event: PagingDataEvent<ConversationDetailsWithEventsEntity>) {
+                if (event is PagingDataEvent.Refresh) refreshEvents.send(Unit)
+            }
+        }
+        val collectionJob = launch {
+            pager.pagingDataFlow.collectLatest(presenter::collectFrom)
+        }
+
+        refreshEvents.receive()
+        assertEquals("${CONVERSATION_ID_PREFIX}0", presenter.snapshot().items.first().conversationViewEntity.id.value)
+
+        ongoingCallConversationIds.value = listOf(ConversationIDEntity("${CONVERSATION_ID_PREFIX}1", "domain"))
+
+        refreshEvents.receive()
+        assertEquals("${CONVERSATION_ID_PREFIX}1", presenter.snapshot().items.first().conversationViewEntity.id.value)
+        collectionJob.cancel()
+    }
+
+    @Test
+    fun givenOneOnOneOngoingCall_whenGettingSearchedPage_thenCallIsMovedToTop() = runTest(dispatcher) {
+        populateOneOnOneData(count = 2)
+        val ongoingCallConversationId = ConversationIDEntity("${CONVERSATION_ID_PREFIX}1", "domain")
+        val result = conversationExtensions.getPagerForConversationDetailsWithEventsSearch(
+            pagingConfig = PagingConfig(PAGE_SIZE),
+            queryConfig = ConversationExtensions.QueryConfig(
+                searchQuery = "conversation",
+                newActivitiesOnTop = true,
+                ongoingCallConversationIds = listOf(ongoingCallConversationId),
+                conversationFilter = ConversationFilterEntity.ONE_ON_ONE,
+            ),
+        ).pagingSource.refresh()
+
+        assertIs<PagingSource.LoadResult.Page<Int, ConversationDetailsWithEventsEntity>>(result)
+        assertEquals(ongoingCallConversationId, result.data.first().conversationViewEntity.id)
     }
 
     @Test
@@ -482,6 +533,33 @@ class ConversationExtensionsTest : BaseDatabaseTest() {
                 archived = archived,
             )
             conversationDAO.insertConversation(conversation)
+        }
+    }
+
+    private suspend fun populateOneOnOneData(count: Int) {
+        repeat(count) {
+            val conversationId = ConversationIDEntity("$CONVERSATION_ID_PREFIX$it", "domain")
+            val otherUserId = UserIDEntity("user_$it", "domain")
+            val lastModified = Instant.fromEpochSeconds(CONVERSATION_COUNT - it.toLong())
+            conversationDAO.insertConversation(
+                newConversationEntity(conversationId).copy(
+                    name = "conversation $it",
+                    lastModifiedDate = lastModified,
+                )
+            )
+            userDAO.upsertUser(
+                newUserEntity(qualifiedID = otherUserId).copy(
+                    name = "conversation $it",
+                    activeOneOnOneConversationId = conversationId
+                )
+            )
+            memberDAO.insertMembersWithQualifiedId(
+                listOf(
+                    MemberEntity(otherUserId, MemberEntity.Role.Member),
+                    MemberEntity(selfUserId, MemberEntity.Role.Member)
+                ),
+                conversationId
+            )
         }
     }
 

--- a/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -1646,6 +1646,36 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
+    fun givenOneOnOneWithOngoingCall_whenGettingAllConversationsWithEventsAndNewActivitiesOnTop_thenReturnRightOrder() = runTest {
+        val newerConversation = conversationEntity1.copy(
+            lastModifiedDate = Instant.fromEpochMilliseconds(2)
+        )
+        val olderConversationWithCall = conversationEntity2.copy(
+            lastModifiedDate = Instant.fromEpochMilliseconds(1)
+        )
+        conversationDAO.insertConversation(newerConversation)
+        conversationDAO.insertConversation(olderConversationWithCall)
+        userDAO.upsertUser(user1)
+        userDAO.upsertUser(user2)
+        memberDAO.insertMembersWithQualifiedId(
+            listOf(member1, MemberEntity(selfUserId, MemberEntity.Role.Member)),
+            newerConversation.id
+        )
+        memberDAO.insertMembersWithQualifiedId(
+            listOf(member2, MemberEntity(selfUserId, MemberEntity.Role.Member)),
+            olderConversationWithCall.id
+        )
+
+        conversationDAO.getAllConversationDetailsWithEvents(
+            newActivitiesOnTop = true,
+            ongoingCallConversationIds = listOf(olderConversationWithCall.id)
+        ).first().let {
+            assertEquals(olderConversationWithCall.id, it[0].conversationViewEntity.id)
+            assertEquals(newerConversation.id, it[1].conversationViewEntity.id)
+        }
+    }
+
+    @Test
     fun givenConversationWithUnreadEvents_whenGettingAllConversationsWithEventsAndNewActivitiesOnTop_thenReturnRightOrder() = runTest {
         val conversationEntity1 = conversationEntity1.copy(
             id = ConversationIDEntity("conversation1", "domain"),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26713
<!--jira-description-action-hidden-marker-end-->
## Intent

Fix [WPB-26713](https://wearezeta.atlassian.net/browse/WPB-26713) by promoting every joinable call conversation into New Activity, including incoming 1:1 calls.

## Root cause

Conversation ordering used a hard-coded list of call-capable conversation types. One-on-one conversations were omitted, so an incoming 1:1 call could be represented by the UI without moving to the New Activity section.

## Changes

- Use `ongoingCallConversationIds` as the source of truth for call promotion in regular, filtered, and searched conversation queries.
- Preserve pager invalidation when joinable-call IDs change so an already-visible 1:1 conversation moves immediately.
- Cover non-paginated ordering, paginated live updates, and searched 1:1 lists.

## Reproduction

1. Keep the conversation list open with a 1:1 conversation outside New Activity.
2. Mute that conversation or set the receiving user to Away.
3. Receive a 1:1 call.
4. Observe that the conversation does not move into New Activity.

## Result

Joinable 1:1 conversations are ordered consistently with group calls. Meeting visibility remains controlled by the existing conversation filters; call IDs only affect ordering.

## Validation

- Persistence JVM test suite
- Kalium static analysis
- Android consumer unit suite


[WPB-26713]: https://wearezeta.atlassian.net/browse/WPB-26713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ