### PR TITLE
chore(persistence): mark legacy query as debug API [WPB-8645]

### DIFF
--- a/data/persistence/build.gradle.kts
+++ b/data/persistence/build.gradle.kts
@@ -78,6 +78,7 @@ kotlin {
             }
         }
         val commonTest by getting {
+            languageSettings.optIn("com.wire.kalium.util.DebugKaliumApi")
             dependencies {
                 // coroutines
                 implementation(libs.coroutines.test)

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.persistence.dao.conversation
 
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.UserIDEntity
+import com.wire.kalium.util.DebugKaliumApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.Instant
 import kotlin.time.Duration
@@ -78,6 +79,8 @@ interface ConversationDAO {
         filter: ConversationFilterEntity,
         strictMLSFilter: Boolean = true,
     ): Flow<List<ConversationViewEntity>>
+
+    @DebugKaliumApi("Legacy conversation-list query retained for tests and performance benchmarks.")
     fun getAllConversationDetailsWithEvents(
         fromArchive: Boolean = false,
         onlyInteractionEnabled: Boolean = false,

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
@@ -39,6 +39,7 @@ import com.wire.kalium.persistence.util.mapToOneOrDefault
 import com.wire.kalium.persistence.util.mapToOneOrNull
 import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
+import com.wire.kalium.util.DebugKaliumApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOn
@@ -349,6 +350,7 @@ internal class ConversationDAOImpl internal constructor(
             .flowOn(readDispatcher.value)
     }
 
+    @DebugKaliumApi("Legacy conversation-list query retained for tests and performance benchmarks.")
     override fun getAllConversationDetailsWithEvents(
         fromArchive: Boolean,
         onlyInteractionEnabled: Boolean,

--- a/test/android-benchmarks/build.gradle.kts
+++ b/test/android-benchmarks/build.gradle.kts
@@ -65,6 +65,12 @@ kotlin {
     }
 }
 
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask<*>>()
+    .matching { it.name.contains("AndroidTest", ignoreCase = true) }
+    .configureEach {
+        compilerOptions.optIn.add("com.wire.kalium.util.DebugKaliumApi")
+    }
+
 dependencies {
     coreLibraryDesugaring(libs.desugarJdkLibs)
     androidTestImplementation(projects.data.persistence)

--- a/test/benchmarks/build.gradle.kts
+++ b/test/benchmarks/build.gradle.kts
@@ -24,6 +24,7 @@ kotlin {
 
     sourceSets {
         val commonMain by getting {
+            languageSettings.optIn("com.wire.kalium.util.DebugKaliumApi")
             dependencies {
                 implementation(projects.data.persistence)
                 implementation(projects.logic)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8645
<!--jira-description-action-hidden-marker-end-->
## Intent

Make the legacy conversation-details-with-events query explicitly debug-only because production conversation lists use the paginated query or `getAllConversationDetails()`.

## Changes

- Mark the DAO contract and implementation with `@DebugKaliumApi`.
- Opt persistence tests in once at the test source-set level.
- Opt the JVM and Android benchmark modules in at module/test-compilation level.
- Keep production source sets unopted so accidental runtime usage produces a warning.

## Impact

There is no runtime behavior change. The annotation documents and enforces the intended test and performance-benchmark scope.

## Validation

- Persistence JVM test suite
- JVM benchmark compilation
- Android benchmark compilation
- Kalium static analysis
