### PR TITLE
perf(datetime): avoid current time string round trip [WPB-10090]

### DIFF
--- a/core/util/src/commonMain/kotlin/com.wire.kalium.util/DateTimeUtil.kt
+++ b/core/util/src/commonMain/kotlin/com.wire.kalium.util/DateTimeUtil.kt
@@ -95,12 +95,14 @@ object DateTimeUtil : PlatformDateTimeUtil() {
     fun currentSimpleDateTimeString(): String = fromInstantToSimpleDateTimeString(Clock.System.now())
 
     /**
-     * Return the current date-time as [kotlinx.datetime.Instant].
-     * It's parsed to string and back to ensure that it has the same proper accuracy (three decimal places - milliseconds)
-     * @return current date-time as [kotlinx.datetime.Instant]
+     * Return the current date-time as [kotlinx.datetime.Instant], truncated to millisecond precision.
+     * @return current date-time as [kotlinx.datetime.Instant] with millisecond precision
      */
     fun currentInstant(): Instant =
-        Instant.parse(currentIsoDateTimeString())
+        currentInstant(Clock.System)
+
+    internal fun currentInstant(clock: Clock): Instant =
+        clock.now().let { Instant.fromEpochMilliseconds(it.toEpochMilliseconds()) }
 
     /**
      * Parse epoch timestamp in milliseconds into date-time in ISO-8601 format
@@ -117,13 +119,6 @@ object DateTimeUtil : PlatformDateTimeUtil() {
      */
     fun fromIsoDateTimeStringToEpochMillis(isoDateTime: String): Long =
         Instant.parse(isoDateTime).toEpochMilliseconds()
-
-    /**
-     * Parse date-time in ISO-8601 format into epoch timestamp in milliseconds
-     * @receiver date in ISO-8601 format (YYYY-MM-DDTHH:mm:ss.SSSZ)
-     * @return epoch timestamp in milliseconds
-     */
-    fun String.toEpochMillis(): Long = fromIsoDateTimeStringToEpochMillis(this)
 
     /**
      * Parse epoch timestamp in milliseconds into date-time in ISO-8601 format

--- a/core/util/src/commonTest/kotlin/com/wire/kalium/util/DateTimeUtilTest.kt
+++ b/core/util/src/commonTest/kotlin/com/wire/kalium/util/DateTimeUtilTest.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.util
 
 import com.wire.kalium.util.string.IgnoreIOS
 import com.wire.kalium.util.string.IgnoreJS
+import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -89,6 +90,34 @@ class DateTimeUtilTest {
     fun whenGettingCurrentIsoDateTimeString_thenMillisShouldNotBeIgnored() {
         val result = DateTimeUtil.currentIsoDateTimeString()
         assertTrue(regex.matches(result))
+    }
+
+    @Test
+    fun whenGettingCurrentInstant_thenPrecisionShouldBeTruncatedToMilliseconds() {
+        val currentTime = Instant.parse("2022-12-20T17:30:00.123456789Z")
+        val clock = object : Clock {
+            override fun now(): Instant = currentTime
+        }
+
+        val result = DateTimeUtil.currentInstant(clock)
+
+        assertEquals(Instant.parse("2022-12-20T17:30:00.123Z"), result)
+    }
+
+    @Test
+    fun whenGettingCurrentInstant_thenCurrentClockMillisecondsShouldBePreserved() {
+        lateinit var generatedInstant: Instant
+        val clock = object : Clock {
+            override fun now(): Instant = Clock.System.now().also { generatedInstant = it }
+        }
+
+        val result = DateTimeUtil.currentInstant(clock)
+        val resultIso = DateTimeUtil.fromInstantToIsoDateTimeString(result)
+        val expectedMilliseconds = (generatedInstant.toEpochMilliseconds() % 1000).toString().padStart(3, '0')
+        val resultMilliseconds = resultIso.substringAfterLast('.').removeSuffix("Z")
+
+        assertEquals(generatedInstant.toEpochMilliseconds(), result.toEpochMilliseconds())
+        assertEquals(expectedMilliseconds, resultMilliseconds)
     }
 
     @Test


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-10090
<!--jira-description-action-hidden-marker-end-->
`currentInstant()` now truncates through epoch milliseconds instead of formatting and parsing a string.

This keeps the same millisecond precision while avoiding the extra formatter/parser work and allocations. It also removes the unused `String.toEpochMillis()` helper.

Added coverage for fixed sub-millisecond input and the real system clock.

### Benchmarks

The direct path was faster in both runs:

| Environment | String round trip | Epoch milliseconds | Improvement |
| --- | ---: | ---: | ---: |
| JVM 21 | 676.7 ns/op, 2,752 B/op | 29.6 ns/op, 40 B/op | 22.9x faster |
| Pixel 6, Android 17 | 7,443 ns/op, 130 allocations/op | 104 ns/op, 4 allocations/op | 71.5x faster |

On the Pixel 6, the string path also triggered a blocking allocation GC and a 73 ms GC wait. The device CPU was not locked, so the absolute timings can move around, but the difference between the two paths is clear.
