### PR TITLE
refactor(call): use Instant for established time PR 3 [[WPB-10090]]

### DIFF
--- a/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/call/Call.kt
+++ b/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/call/Call.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.logic.data.call
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
+import kotlinx.datetime.Instant
 
 enum class CallStatus {
     STARTED,
@@ -45,7 +46,7 @@ data class Call(
     val conversationType: Conversation.Type,
     val callerName: String?,
     val callerTeamName: String?,
-    val establishedTime: String? = null,
+    val establishedTime: Instant? = null,
     val participants: List<Participant> = emptyList(),
     val maxParticipants: Int = 0 // Was used for tracking
 )

--- a/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallMetadataProfile.kt
+++ b/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallMetadataProfile.kt
@@ -42,7 +42,7 @@ data class CallMetadata(
     val conversationType: Conversation.Type,
     val callerName: String?,
     val callerTeamName: String?,
-    val establishedTime: String? = null,
+    val establishedTime: Instant? = null,
     val callStatus: CallStatus,
     val participants: List<ParticipantMinimized> = emptyList(),
     val maxParticipants: Int = 0, // Was used for tracking

--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -642,7 +642,7 @@ internal class CallManagerImpl internal constructor(
     private fun shouldPersistMissedCall(callMetadata: CallMetadata?, callStatus: CallStatus): Boolean = when (callStatus) {
         CallStatus.MISSED -> true
         CallStatus.CLOSED -> callMetadata?.let { metadata ->
-            metadata.establishedTime.isNullOrEmpty() &&
+            metadata.establishedTime == null &&
                     metadata.callStatus != CallStatus.CLOSED_INTERNALLY &&
                     metadata.callStatus != CallStatus.REJECTED &&
                     metadata.callStatus != CallStatus.STARTED

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnCloseCall.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnCloseCall.kt
@@ -109,7 +109,7 @@ internal class OnCloseCall(
         when (callStatus) {
             CallStatus.MISSED -> true
             CallStatus.CLOSED -> callMetadata?.callStatus?.let { currentCallStatus ->
-                callMetadata.establishedTime.isNullOrEmpty() &&
+                callMetadata.establishedTime == null &&
                         currentCallStatus != CallStatus.CLOSED_INTERNALLY &&
                         currentCallStatus != CallStatus.REJECTED &&
                         currentCallStatus != CallStatus.STARTED

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
@@ -361,7 +361,7 @@ internal class CallDataSource(
             callMetadata.copy(
                 callStatus = status,
                 establishedTime = when (status) {
-                    CallStatus.ESTABLISHED -> DateTimeUtil.currentIsoDateTimeString()
+                    CallStatus.ESTABLISHED -> DateTimeUtil.currentInstant()
                     else -> callMetadata.establishedTime
                 },
             )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/CreateAndPersistRecentlyEndedCallMetadataUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/CreateAndPersistRecentlyEndedCallMetadataUseCase.kt
@@ -62,7 +62,7 @@ internal class CreateAndPersistRecentlyEndedCallMetadataUseCaseImpl internal con
         val guestsProCount = conversationMembers.count { member -> member.user.userType.isGuest() && member.user.teamId != null }
         val isOutgoingCall = callStatus == CallStatus.STARTED
         val callDurationInSeconds = establishedTime?.let {
-            DateTimeUtil.calculateMillisDifference(it, DateTimeUtil.currentIsoDateTimeString()) / MILLIS_IN_SECOND
+            DateTimeUtil.calculateMillisDifference(it, DateTimeUtil.currentInstant()) / MILLIS_IN_SECOND
         } ?: 0L
 
         return RecentlyEndedCallMetadata(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallUseCase.kt
@@ -29,7 +29,6 @@ import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Instant
 
 /**
  * This use case is responsible for ending a call.
@@ -78,6 +77,6 @@ internal class EndCallUseCaseImpl(
 
         callManager.value.endCall(conversationId)
         callRepository.updateIsCameraOnById(conversationId, false)
-        endCallListener.onCallEndedAskForFeedback(shouldAskCallFeedback(endedCall?.establishedTime?.let { Instant.parse(it) }))
+        endCallListener.onCallEndedAskForFeedback(shouldAskCallFeedback(endedCall?.establishedTime))
     }
 }

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/scenario/OnCloseCallTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/scenario/OnCloseCallTest.kt
@@ -220,7 +220,7 @@ class OnCloseCallTest {
         testScope.runTest {
             val establishedCall = callMetadata.copy(
                 callStatus = CallStatus.ESTABLISHED,
-                establishedTime = "time",
+                establishedTime = Instant.parse("2026-01-01T12:00:00Z"),
                 conversationType = Conversation.Type.Group.Regular
             )
             val (arrangement, onCloseCall) = Arrangement(testScope)


### PR DESCRIPTION
## What changed

- Keep call `establishedTime` as `Instant?` in Kalium.
- Remove ISO string conversions when a call is established, ended, or measured.

## Why

This keeps call timestamps type-safe and avoids unnecessary formatting and parsing. It is in memory only, so no DB migration is needed.

## Stack

- #4332
- #4334
