### PR TITLE
feat: recover MLS conversations after key packages refill (WPB-27077)

### DIFF
--- a/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -320,6 +320,20 @@ SELECT * FROM Conversation WHERE mls_group_id = ? AND deleted_locally = 0;
 selectByGroupState:
 SELECT * FROM Conversation WHERE mls_group_state = ? AND (protocol IS 'MLS' OR protocol IS 'MIXED') AND deleted_locally = 0;
 
+selectActiveMLSConversationsForMembershipAudit:
+SELECT * FROM Conversation
+WHERE protocol IN ('MLS', 'MIXED')
+AND deleted_locally = 0
+AND (
+    type IS 'SELF'
+    OR EXISTS (
+        SELECT 1
+        FROM Member
+        WHERE Member.conversation IS Conversation.qualified_id
+        AND Member.user IS (SELECT SelfUser.id FROM SelfUser LIMIT 1)
+    )
+);
+
 selectActiveOneOnOneConversation:
 SELECT * FROM Conversation
 WHERE qualified_id = (SELECT active_one_on_one_conversation_id FROM User WHERE qualified_id = :user_id) AND deleted_locally = 0;

--- a/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
+++ b/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Conversations.sq
@@ -323,6 +323,20 @@ SELECT * FROM Conversation WHERE mls_group_id = ? AND deleted_locally = 0;
 selectByGroupState:
 SELECT * FROM Conversation WHERE mls_group_state = ? AND (protocol IS 'MLS' OR protocol IS 'MIXED') AND deleted_locally = 0;
 
+selectActiveMLSConversationsForMembershipAudit:
+SELECT * FROM Conversation
+WHERE protocol IN ('MLS', 'MIXED')
+AND deleted_locally = 0
+AND (
+    type IS 'SELF'
+    OR EXISTS (
+        SELECT 1
+        FROM Member
+        WHERE Member.conversation IS Conversation.qualified_id
+        AND Member.user IS (SELECT SelfUser.id FROM SelfUser LIMIT 1)
+    )
+);
+
 selectActiveOneOnOneConversation:
 SELECT * FROM Conversation
 WHERE qualified_id = (SELECT active_one_on_one_conversation_id FROM User WHERE qualified_id = :user_id) AND deleted_locally = 0;

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
@@ -105,6 +105,7 @@ interface ConversationDAO {
     suspend fun getConversationProtocolInfo(qualifiedID: QualifiedIDEntity): ConversationEntity.ProtocolInfo?
     suspend fun getConversationIdByGroupID(groupID: String): QualifiedIDEntity?
     suspend fun getConversationsByGroupState(groupState: ConversationEntity.GroupState): List<ConversationEntity>
+    suspend fun getActiveMLSConversationsForMembershipAudit(): List<ConversationEntity>
     suspend fun deleteConversationByQualifiedID(qualifiedID: QualifiedIDEntity): Boolean
     suspend fun setConversationDeletedLocally(qualifiedID: QualifiedIDEntity, deletedLocally: Boolean)
 

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
@@ -106,6 +106,7 @@ interface ConversationDAO {
     suspend fun getConversationProtocolInfo(qualifiedID: QualifiedIDEntity): ConversationEntity.ProtocolInfo?
     suspend fun getConversationIdByGroupID(groupID: String): QualifiedIDEntity?
     suspend fun getConversationsByGroupState(groupState: ConversationEntity.GroupState): List<ConversationEntity>
+    suspend fun getActiveMLSConversationsForMembershipAudit(): List<ConversationEntity>
     suspend fun deleteConversationByQualifiedID(qualifiedID: QualifiedIDEntity): Boolean
     suspend fun setConversationDeletedLocally(qualifiedID: QualifiedIDEntity, deletedLocally: Boolean)
 

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
@@ -434,6 +434,12 @@ internal class ConversationDAOImpl internal constructor(
                 .awaitAsList()
         }
 
+    override suspend fun getActiveMLSConversationsForMembershipAudit(): List<ConversationEntity> =
+        withContext(readDispatcher.value) {
+            conversationQueries.selectActiveMLSConversationsForMembershipAudit(conversationMapper::toConversationEntity)
+                .awaitAsList()
+        }
+
     override suspend fun deleteConversationByQualifiedID(qualifiedID: QualifiedIDEntity) = withContext(writeDispatcher.value) {
         conversationQueries.transactionWithResult {
             conversationQueries.deleteConversation(qualifiedID)

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
@@ -443,6 +443,12 @@ internal class ConversationDAOImpl internal constructor(
                 .awaitAsList()
         }
 
+    override suspend fun getActiveMLSConversationsForMembershipAudit(): List<ConversationEntity> =
+        withContext(readDispatcher.value) {
+            conversationQueries.selectActiveMLSConversationsForMembershipAudit(conversationMapper::toConversationEntity)
+                .awaitAsList()
+        }
+
     override suspend fun deleteConversationByQualifiedID(qualifiedID: QualifiedIDEntity) = withContext(writeDispatcher.value) {
         conversationQueries.transactionWithResult {
             conversationQueries.deleteConversation(qualifiedID)

--- a/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -193,6 +193,41 @@ class ConversationDAOTest : BaseDatabaseTest() {
     }
 
     @Test
+    fun givenConversationsWithDifferentProtocolsAndMembership_whenGettingMembershipAuditList_thenOnlyActiveMLSMembershipsReturned() =
+        runTest {
+            val deletedMLSConversation = conversationEntity4.copy(id = QualifiedIDEntity("deleted-mls", "wire.com"))
+            val removedMLSConversation = conversationEntity4.copy(id = QualifiedIDEntity("removed-mls", "wire.com"))
+            val selfMLSConversation = conversationEntity2.copy(
+                id = QualifiedIDEntity("self-mls", "wire.com"),
+                type = ConversationEntity.Type.SELF
+            )
+            conversationDAO.insertConversations(
+                listOf(
+                    conversationEntity1,
+                    conversationEntity2,
+                    conversationEntity3,
+                    conversationEntity6,
+                    deletedMLSConversation,
+                    removedMLSConversation,
+                    selfMLSConversation
+                )
+            )
+            insertSelfMember(conversationEntity1.id)
+            insertSelfMember(conversationEntity2.id)
+            insertSelfMember(conversationEntity3.id)
+            insertSelfMember(conversationEntity6.id)
+            insertSelfMember(deletedMLSConversation.id)
+            conversationDAO.setConversationDeletedLocally(deletedMLSConversation.id, true)
+
+            val result = conversationDAO.getActiveMLSConversationsForMembershipAudit()
+
+            assertEquals(
+                setOf(conversationEntity2.id, conversationEntity3.id, conversationEntity6.id, selfMLSConversation.id),
+                result.map { it.id }.toSet()
+            )
+        }
+
+    @Test
     fun givenExistingGroupConversations_WhenGetConversationIds_ThenAllGroupTypesWithGivenProtocolAreReturned() = runTest {
         val channel = conversationEntity5.copy(
             id = QualifiedIDEntity("channel", "test"),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -200,6 +200,8 @@ internal interface ConversationRepository {
         groupState: GroupState
     ): Either<StorageFailure, List<Conversation>>
 
+    suspend fun getActiveMLSConversationsForMembershipAudit(): Either<StorageFailure, List<Conversation>>
+
     suspend fun updateConversationGroupState(groupID: GroupID, groupState: GroupState): Either<StorageFailure, Unit>
     suspend fun updateConversationGroupStateByConversationId(
         conversationId: ConversationId,
@@ -631,6 +633,12 @@ internal class ConversationDataSource internal constructor(
     ): Either<StorageFailure, List<Conversation>> =
         wrapStorageRequest {
             conversationDAO.getConversationsByGroupState(conversationMapper.toDAOGroupState(groupState))
+                .map(conversationMapper::fromDaoModel)
+        }
+
+    override suspend fun getActiveMLSConversationsForMembershipAudit(): Either<StorageFailure, List<Conversation>> =
+        wrapStorageRequest {
+            conversationDAO.getActiveMLSConversationsForMembershipAudit()
                 .map(conversationMapper::fromDaoModel)
         }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationUseCase.kt
@@ -95,10 +95,11 @@ internal class JoinExistingMLSConversationUseCaseImpl(
                 Either.Left(StorageFailure.DataNotFound)
             }, { conversation ->
                 withContext(dispatcher) {
-                    refreshConversationMetadataIfPendingAfterReset(
+                    refreshConversationMetadataIfNeeded(
                         transactionContext = transactionContext,
                         conversation = conversation,
-                        currentPublicKeys = mlsPublicKeys
+                        currentPublicKeys = mlsPublicKeys,
+                        allowJoinByExternalCommit = allowJoinByExternalCommit
                     ).flatMap { refreshedConversation ->
                         joinOrEstablishMLSGroupAndRetry(
                             transactionContext,
@@ -111,16 +112,26 @@ internal class JoinExistingMLSConversationUseCaseImpl(
             })
         }
 
-    private suspend fun refreshConversationMetadataIfPendingAfterReset(
+    private suspend fun refreshConversationMetadataIfNeeded(
         transactionContext: CryptoTransactionContext,
         conversation: Conversation,
-        currentPublicKeys: MLSPublicKeys?
+        currentPublicKeys: MLSPublicKeys?,
+        allowJoinByExternalCommit: Boolean,
     ): Either<CoreFailure, RefreshedConversation> {
         val protocol = conversation.protocol as? Conversation.ProtocolInfo.MLSCapable
             ?: return Either.Right(RefreshedConversation(conversation, currentPublicKeys))
+        // MLS migration can leave local epoch-zero metadata marked as established even
+        // though this client missed the group. Refresh it before choosing establish vs external commit.
+        val requiresAuthoritativeMetadata = protocol.groupState ==
+            Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_AFTER_RESET ||
+            (
+                allowJoinByExternalCommit &&
+                    protocol.groupState == Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED &&
+                    protocol.epoch == 0UL
+                )
 
         return when {
-            protocol.groupState != Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_AFTER_RESET ->
+            !requiresAuthoritativeMetadata ->
                 Either.Right(RefreshedConversation(conversation, currentPublicKeys))
 
             conversation.type == Conversation.Type.OneOnOne -> {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationUseCase.kt
@@ -137,11 +137,13 @@ internal class JoinExistingMLSConversationUseCaseImpl(
             conversation.type == Conversation.Type.OneOnOne -> {
                 logger.d("Refreshing oneOnOne conversation metadata before rejoining ${conversation.id.toLogString()}")
                 conversationRepository.getConversationMembers(conversation.id).flatMap { members ->
-                    fetchMLSOneToOneConversation(transactionContext, members.first()).map { refreshedConversation ->
-                        RefreshedConversation(
-                            conversation = refreshedConversation,
-                            publicKeys = refreshedConversation.mlsPublicKeys ?: currentPublicKeys
-                        )
+                    getOtherMember(conversation.id, members).flatMap { otherMember ->
+                        fetchMLSOneToOneConversation(transactionContext, otherMember).map { refreshedConversation ->
+                            RefreshedConversation(
+                                conversation = refreshedConversation,
+                                publicKeys = refreshedConversation.mlsPublicKeys ?: currentPublicKeys
+                            )
+                        }
                     }
                 }
             }
@@ -189,9 +191,11 @@ internal class JoinExistingMLSConversationUseCaseImpl(
                         )
                         // Re-fetch the current epoch and try again
                         if (conversation.type == Conversation.Type.OneOnOne) {
-                            conversationRepository.getConversationMembers(conversation.id).flatMap {
-                                fetchMLSOneToOneConversation(transactionContext, it.first()).map {
-                                    it.mlsPublicKeys
+                            conversationRepository.getConversationMembers(conversation.id).flatMap { members ->
+                                getOtherMember(conversation.id, members).flatMap { otherMember ->
+                                    fetchMLSOneToOneConversation(transactionContext, otherMember).map {
+                                        it.mlsPublicKeys
+                                    }
                                 }
                             }
                         } else {
@@ -329,6 +333,19 @@ internal class JoinExistingMLSConversationUseCaseImpl(
             }
         }
     }
+
+    private fun getOtherMember(
+        conversationId: ConversationId,
+        members: List<UserId>
+    ): Either<CoreFailure, UserId> = members.singleOrNull { it != selfUserId }
+        ?.let { Either.Right(it) }
+        ?: Either.Left(
+            CoreFailure.Unknown(
+                IllegalStateException(
+                    "Expected exactly one other member in one-on-one conversation ${conversationId.toLogString()}"
+                )
+            )
+        )
 
     private fun Conversation.logData(
         failure: CoreFailure? = null

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/MLSMembershipAuditRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/keypackage/MLSMembershipAuditRepository.kt
@@ -1,0 +1,85 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.data.keypackage
+
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.error.wrapStorageRequest
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.map
+import com.wire.kalium.persistence.dao.MetadataDAO
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+internal enum class MLSMembershipAuditState {
+    NOT_REQUIRED,
+    REQUIRED,
+    REQUIRED_AFTER_SLOW_SYNC
+}
+
+internal interface MLSMembershipAuditRepository {
+    fun observeAuditRequired(): Flow<Boolean>
+    fun observeAuditState(): Flow<MLSMembershipAuditState>
+    suspend fun isAuditRequired(): Either<StorageFailure, Boolean>
+    suspend fun getAuditState(): Either<StorageFailure, MLSMembershipAuditState>
+    suspend fun markAuditRequired(): Either<StorageFailure, Unit>
+    suspend fun markAuditRequiredAfterSlowSync(): Either<StorageFailure, Unit>
+    suspend fun clearAuditRequired(): Either<StorageFailure, Unit>
+}
+
+internal class MLSMembershipAuditRepositoryImpl(
+    private val metadataDAO: MetadataDAO
+) : MLSMembershipAuditRepository {
+
+    override fun observeAuditRequired(): Flow<Boolean> =
+        observeAuditState().map { it != MLSMembershipAuditState.NOT_REQUIRED }
+
+    override fun observeAuditState(): Flow<MLSMembershipAuditState> =
+        metadataDAO.valueByKeyFlow(MLS_MEMBERSHIP_AUDIT_REQUIRED_KEY).map { it.toAuditState() }
+
+    override suspend fun isAuditRequired(): Either<StorageFailure, Boolean> =
+        getAuditState().map { it != MLSMembershipAuditState.NOT_REQUIRED }
+
+    override suspend fun getAuditState(): Either<StorageFailure, MLSMembershipAuditState> = wrapStorageRequest {
+        metadataDAO.valueByKey(MLS_MEMBERSHIP_AUDIT_REQUIRED_KEY).toAuditState()
+    }
+
+    override suspend fun markAuditRequired(): Either<StorageFailure, Unit> = wrapStorageRequest {
+        metadataDAO.insertValue(value = AUDIT_REQUIRED_VALUE, key = MLS_MEMBERSHIP_AUDIT_REQUIRED_KEY)
+    }
+
+    override suspend fun markAuditRequiredAfterSlowSync(): Either<StorageFailure, Unit> = wrapStorageRequest {
+        metadataDAO.insertValue(value = AUDIT_REQUIRED_AFTER_SLOW_SYNC_VALUE, key = MLS_MEMBERSHIP_AUDIT_REQUIRED_KEY)
+    }
+
+    override suspend fun clearAuditRequired(): Either<StorageFailure, Unit> = wrapStorageRequest {
+        metadataDAO.deleteValue(key = MLS_MEMBERSHIP_AUDIT_REQUIRED_KEY)
+    }
+
+    private companion object {
+        const val MLS_MEMBERSHIP_AUDIT_REQUIRED_KEY = "mlsMembershipAuditRequired"
+        const val AUDIT_REQUIRED_VALUE = "true"
+        const val AUDIT_REQUIRED_AFTER_SLOW_SYNC_VALUE = "required_after_slow_sync"
+
+        fun String?.toAuditState(): MLSMembershipAuditState = when (this) {
+            AUDIT_REQUIRED_VALUE -> MLSMembershipAuditState.REQUIRED
+            AUDIT_REQUIRED_AFTER_SLOW_SYNC_VALUE -> MLSMembershipAuditState.REQUIRED_AFTER_SLOW_SYNC
+            else -> MLSMembershipAuditState.NOT_REQUIRED
+        }
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -149,6 +149,8 @@ import com.wire.kalium.logic.data.keypackage.KeyPackageDataSource
 import com.wire.kalium.logic.data.keypackage.KeyPackageLimitsProvider
 import com.wire.kalium.logic.data.keypackage.KeyPackageLimitsProviderImpl
 import com.wire.kalium.logic.data.keypackage.KeyPackageRepository
+import com.wire.kalium.logic.data.keypackage.MLSMembershipAuditRepository
+import com.wire.kalium.logic.data.keypackage.MLSMembershipAuditRepositoryImpl
 import com.wire.kalium.logic.data.logout.LogoutDataSource
 import com.wire.kalium.logic.data.logout.LogoutRepository
 import com.wire.kalium.logic.data.meeting.MeetingDataSource
@@ -268,9 +270,13 @@ import com.wire.kalium.logic.feature.client.RegisterMLSClientUseCaseImpl
 import com.wire.kalium.logic.feature.connection.ConnectionScope
 import com.wire.kalium.logic.feature.connection.SyncConnectionsUseCase
 import com.wire.kalium.logic.feature.connection.SyncConnectionsUseCaseImpl
+import com.wire.kalium.logic.feature.conversation.AuditMLSConversationMembershipUseCase
+import com.wire.kalium.logic.feature.conversation.AuditMLSConversationMembershipUseCaseImpl
 import com.wire.kalium.logic.feature.conversation.ConversationScope
 import com.wire.kalium.logic.feature.conversation.ConversationsRecoveryManager
 import com.wire.kalium.logic.feature.conversation.ConversationsRecoveryManagerImpl
+import com.wire.kalium.logic.feature.conversation.MLSConversationMembershipAuditManager
+import com.wire.kalium.logic.feature.conversation.MLSConversationMembershipAuditManagerImpl
 import com.wire.kalium.logic.feature.conversation.MLSConversationsRecoveryManager
 import com.wire.kalium.logic.feature.conversation.MLSConversationsRecoveryManagerImpl
 import com.wire.kalium.logic.feature.conversation.MLSFaultyKeysConversationsRepairUseCaseImpl
@@ -1024,6 +1030,9 @@ public class UserSessionScope internal constructor(
     private val slowSyncRepository: SlowSyncRepository by lazy {
         SlowSyncRepositoryImpl(userStorage.database.metadataDAO, userScopedLogger)
     }
+    private val mlsMembershipAuditRepository: MLSMembershipAuditRepository by lazy {
+        MLSMembershipAuditRepositoryImpl(userStorage.database.metadataDAO)
+    }
     private val incrementalSyncRepository: IncrementalSyncRepository by lazy {
         InMemoryIncrementalSyncRepository(userScopedLogger)
     }
@@ -1369,7 +1378,8 @@ public class UserSessionScope internal constructor(
             keyPackageLimitsProvider,
             userConfigRepository,
             userId,
-            currentCryptoStateChangeHookNotifier
+            currentCryptoStateChangeHookNotifier,
+            mlsMembershipAuditRepository,
         )
 
     private val recoverMLSConversationsUseCase: RecoverMLSConversationsUseCase
@@ -1380,6 +1390,23 @@ public class UserSessionScope internal constructor(
             mlsConversationRepository,
             joinExistingMLSConversationUseCase
         )
+
+    private val auditMLSConversationMembershipUseCase: AuditMLSConversationMembershipUseCase
+        get() = AuditMLSConversationMembershipUseCaseImpl(
+            conversationRepository,
+            mlsConversationRepository,
+            joinExistingMLSConversationUseCase
+        )
+
+    private val mlsConversationMembershipAuditManager: MLSConversationMembershipAuditManager by lazy {
+        MLSConversationMembershipAuditManagerImpl(
+            incrementalSyncRepository,
+            slowSyncRepository,
+            mlsMembershipAuditRepository,
+            lazy { auditMLSConversationMembershipUseCase },
+            cryptoTransactionProvider
+        )
+    }
 
     private val joinExistingMLSConversations: JoinExistingMLSConversationsUseCase
         get() = JoinExistingMLSConversationsUseCaseImpl(
@@ -1649,6 +1676,7 @@ public class UserSessionScope internal constructor(
         lazy { client.refillKeyPackages },
         lazy { client.mlsKeyPackageCountUseCase },
         lazy { users.timestampKeyRepository },
+        lazy { mlsConversationMembershipAuditManager },
         cryptoTransactionProvider
     )
 
@@ -1677,7 +1705,8 @@ public class UserSessionScope internal constructor(
                     keyPackageLimitsProvider,
                     userConfigRepository,
                     userId,
-                    currentCryptoStateChangeHookNotifier
+                    currentCryptoStateChangeHookNotifier,
+                    mlsMembershipAuditRepository,
                 )
             },
             this,
@@ -2389,7 +2418,8 @@ public class UserSessionScope internal constructor(
             syncFeatureConfigsUseCase,
             userConfigRepository,
             cryptoTransactionProvider,
-            currentCryptoStateChangeHookNotifier
+            currentCryptoStateChangeHookNotifier,
+            mlsMembershipAuditRepository
         )
     }
     public val conversations: ConversationScope by lazy {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -150,6 +150,8 @@ import com.wire.kalium.logic.data.keypackage.KeyPackageDataSource
 import com.wire.kalium.logic.data.keypackage.KeyPackageLimitsProvider
 import com.wire.kalium.logic.data.keypackage.KeyPackageLimitsProviderImpl
 import com.wire.kalium.logic.data.keypackage.KeyPackageRepository
+import com.wire.kalium.logic.data.keypackage.MLSMembershipAuditRepository
+import com.wire.kalium.logic.data.keypackage.MLSMembershipAuditRepositoryImpl
 import com.wire.kalium.logic.data.logout.LogoutDataSource
 import com.wire.kalium.logic.data.logout.LogoutRepository
 import com.wire.kalium.logic.data.meeting.MeetingDataSource
@@ -270,9 +272,13 @@ import com.wire.kalium.logic.feature.client.RegisterMLSClientUseCaseImpl
 import com.wire.kalium.logic.feature.connection.ConnectionScope
 import com.wire.kalium.logic.feature.connection.SyncConnectionsUseCase
 import com.wire.kalium.logic.feature.connection.SyncConnectionsUseCaseImpl
+import com.wire.kalium.logic.feature.conversation.AuditMLSConversationMembershipUseCase
+import com.wire.kalium.logic.feature.conversation.AuditMLSConversationMembershipUseCaseImpl
 import com.wire.kalium.logic.feature.conversation.ConversationScope
 import com.wire.kalium.logic.feature.conversation.ConversationsRecoveryManager
 import com.wire.kalium.logic.feature.conversation.ConversationsRecoveryManagerImpl
+import com.wire.kalium.logic.feature.conversation.MLSConversationMembershipAuditManager
+import com.wire.kalium.logic.feature.conversation.MLSConversationMembershipAuditManagerImpl
 import com.wire.kalium.logic.feature.conversation.MLSConversationsRecoveryManager
 import com.wire.kalium.logic.feature.conversation.MLSConversationsRecoveryManagerImpl
 import com.wire.kalium.logic.feature.conversation.MLSFaultyKeysConversationsRepairUseCaseImpl
@@ -1039,6 +1045,9 @@ public class UserSessionScope internal constructor(
     private val slowSyncRepository: SlowSyncRepository by lazy {
         SlowSyncRepositoryImpl(userStorage.database.metadataDAO, userScopedLogger)
     }
+    private val mlsMembershipAuditRepository: MLSMembershipAuditRepository by lazy {
+        MLSMembershipAuditRepositoryImpl(userStorage.database.metadataDAO)
+    }
     private val incrementalSyncRepository: IncrementalSyncRepository by lazy {
         InMemoryIncrementalSyncRepository(userScopedLogger)
     }
@@ -1385,7 +1394,8 @@ public class UserSessionScope internal constructor(
             keyPackageLimitsProvider,
             userConfigRepository,
             userId,
-            currentCryptoStateChangeHookNotifier
+            currentCryptoStateChangeHookNotifier,
+            mlsMembershipAuditRepository,
         )
 
     private val recoverMLSConversationsUseCase: RecoverMLSConversationsUseCase
@@ -1397,6 +1407,23 @@ public class UserSessionScope internal constructor(
             joinExistingMLSConversationUseCase,
             userId,
         )
+
+    private val auditMLSConversationMembershipUseCase: AuditMLSConversationMembershipUseCase
+        get() = AuditMLSConversationMembershipUseCaseImpl(
+            conversationRepository,
+            mlsConversationRepository,
+            joinExistingMLSConversationUseCase
+        )
+
+    private val mlsConversationMembershipAuditManager: MLSConversationMembershipAuditManager by lazy {
+        MLSConversationMembershipAuditManagerImpl(
+            incrementalSyncRepository,
+            slowSyncRepository,
+            mlsMembershipAuditRepository,
+            lazy { auditMLSConversationMembershipUseCase },
+            cryptoTransactionProvider
+        )
+    }
 
     private val joinExistingMLSConversations: JoinExistingMLSConversationsUseCase
         get() = JoinExistingMLSConversationsUseCaseImpl(
@@ -1675,6 +1702,7 @@ public class UserSessionScope internal constructor(
         lazy { client.refillKeyPackages },
         lazy { client.mlsKeyPackageCountUseCase },
         lazy { users.timestampKeyRepository },
+        lazy { mlsConversationMembershipAuditManager },
         cryptoTransactionProvider
     )
 
@@ -1703,7 +1731,8 @@ public class UserSessionScope internal constructor(
                     keyPackageLimitsProvider,
                     userConfigRepository,
                     userId,
-                    currentCryptoStateChangeHookNotifier
+                    currentCryptoStateChangeHookNotifier,
+                    mlsMembershipAuditRepository,
                 )
             },
             this,
@@ -2438,7 +2467,8 @@ public class UserSessionScope internal constructor(
             syncFeatureConfigsUseCase,
             userConfigRepository,
             cryptoTransactionProvider,
-            currentCryptoStateChangeHookNotifier
+            currentCryptoStateChangeHookNotifier,
+            mlsMembershipAuditRepository
         )
     }
     public val conversations: ConversationScope by lazy {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/ClientScope.kt
@@ -29,6 +29,7 @@ import com.wire.kalium.logic.data.client.remote.ClientRemoteRepository
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.keypackage.KeyPackageLimitsProvider
 import com.wire.kalium.logic.data.keypackage.KeyPackageRepository
+import com.wire.kalium.logic.data.keypackage.MLSMembershipAuditRepository
 import com.wire.kalium.logic.data.logout.LogoutRepository
 import com.wire.kalium.logic.data.notification.PushTokenRepository
 import com.wire.kalium.logic.data.prekey.PreKeyRepository
@@ -78,6 +79,7 @@ public class ClientScope @OptIn(DelicateKaliumApi::class) internal constructor(
     private val userConfigRepository: UserConfigRepository,
     private val transactionProvider: CryptoTransactionProvider,
     private val cryptoStateChangeHookNotifier: CryptoStateChangeHookNotifier,
+    private val mlsMembershipAuditRepository: MLSMembershipAuditRepository,
 ) {
 
     @OptIn(DelicateKaliumApi::class)
@@ -127,6 +129,7 @@ public class ClientScope @OptIn(DelicateKaliumApi::class) internal constructor(
             currentClientIdProvider = clientIdProvider,
             selfUserId = selfUserId,
             cryptoStateChangeHookNotifier = cryptoStateChangeHookNotifier,
+            mlsMembershipAuditRepository = mlsMembershipAuditRepository,
         )
 
     public val observeCurrentClientId: ObserveCurrentClientIdUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/RegisterMLSClientUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/client/RegisterMLSClientUseCase.kt
@@ -34,6 +34,7 @@ import com.wire.kalium.logic.data.client.toModel
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.keypackage.KeyPackageLimitsProvider
 import com.wire.kalium.logic.data.keypackage.KeyPackageRepository
+import com.wire.kalium.logic.data.keypackage.MLSMembershipAuditRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.messaging.hooks.CryptoStateChangeHookNotifier
 
@@ -58,7 +59,8 @@ internal class RegisterMLSClientUseCaseImpl(
     private val keyPackageLimitsProvider: KeyPackageLimitsProvider,
     private val userConfigRepository: UserConfigRepository,
     private val selfUserId: UserId,
-    private val cryptoStateChangeHookNotifier: CryptoStateChangeHookNotifier
+    private val cryptoStateChangeHookNotifier: CryptoStateChangeHookNotifier,
+    private val mlsMembershipAuditRepository: MLSMembershipAuditRepository,
 ) : RegisterMLSClientUseCase {
 
     override suspend operator fun invoke(clientId: ClientId): Either<CoreFailure, RegisterMLSClientResult> {
@@ -74,6 +76,9 @@ internal class RegisterMLSClientUseCaseImpl(
             wrapMLSRequest { mlsClient.getPublicKey() }
                 .flatMap { (publicKey, cipherSuite) ->
                     clientRepository.registerMLSClient(clientId, publicKey, cipherSuite.toModel())
+                }.flatMap {
+                    kaliumLogger.d("Deferring MLS membership audit until MLS client registration slow sync completes")
+                    mlsMembershipAuditRepository.markAuditRequiredAfterSlowSync()
                 }.flatMap {
                     mlsClient.transaction("uploadNewKeyPackages") { context ->
                         keyPackageRepository.uploadNewKeyPackages(context, clientId, keyPackageLimitsProvider.refillAmount())

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/AuditMLSConversationMembershipUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/AuditMLSConversationMembershipUseCase.kt
@@ -1,0 +1,129 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.common.functional.fold
+import com.wire.kalium.common.functional.onFailure
+import com.wire.kalium.common.functional.onSuccess
+import com.wire.kalium.common.logger.kaliumLogger
+import com.wire.kalium.cryptography.CryptoTransactionContext
+import com.wire.kalium.logic.data.client.wrapInMLSContext
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCase
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+
+internal sealed interface AuditMLSConversationMembershipResult {
+    data object Success : AuditMLSConversationMembershipResult
+    data class Failure(val failure: CoreFailure) : AuditMLSConversationMembershipResult
+}
+
+/**
+ * Audits all active MLS-capable conversations to verify that their groups exist in the local
+ * CoreCrypto state and rejoins any missing groups.
+ *
+ * This is used after the backend key-package count reaches zero and packages have been refilled,
+ * or after an existing Proteus client registers for MLS. Conversations created or migrated while
+ * the client had no available key packages or MLS identity may not have included it. The caller
+ * must wait until incremental sync is live and invoke this use case in a transaction separate from
+ * key-package upload, so slow sync and pending Welcome events are processed first.
+ *
+ * The audit is idempotent: existing groups are skipped, all conversations are attempted even if
+ * individual checks or rejoins fail, and [AuditMLSConversationMembershipResult.Failure] is returned
+ * when any conversation failed so the durable audit marker can be retained for a later retry.
+ */
+internal interface AuditMLSConversationMembershipUseCase {
+    suspend operator fun invoke(transactionContext: CryptoTransactionContext): AuditMLSConversationMembershipResult
+}
+
+internal class AuditMLSConversationMembershipUseCaseImpl(
+    private val conversationRepository: ConversationRepository,
+    private val mlsConversationRepository: MLSConversationRepository,
+    private val joinExistingMLSConversationUseCase: JoinExistingMLSConversationUseCase,
+) : AuditMLSConversationMembershipUseCase {
+
+    private val logger = kaliumLogger.withTextTag("AuditMLSConversationMembershipUseCase")
+
+    override suspend fun invoke(transactionContext: CryptoTransactionContext): AuditMLSConversationMembershipResult {
+        logger.d("Starting MLS conversation membership audit")
+        return conversationRepository.getActiveMLSConversationsForMembershipAudit().fold(
+            { failure ->
+                logger.d("MLS conversation membership audit failed to load conversations: $failure")
+                AuditMLSConversationMembershipResult.Failure(failure)
+            },
+            { conversations ->
+                logger.d("Auditing MLS membership for ${conversations.size} active conversation(s)")
+                var firstFailure: CoreFailure? = null
+                conversations.forEach { conversation ->
+                    auditConversation(transactionContext, conversation).fold(
+                        { failure -> if (firstFailure == null) firstFailure = failure },
+                        {}
+                    )
+                }
+                firstFailure?.let { failure ->
+                    logger.d("MLS conversation membership audit completed with failures: $failure")
+                    AuditMLSConversationMembershipResult.Failure(failure)
+                } ?: run {
+                    logger.d("MLS conversation membership audit completed successfully")
+                    AuditMLSConversationMembershipResult.Success
+                }
+            }
+        )
+    }
+
+    private suspend fun auditConversation(
+        transactionContext: CryptoTransactionContext,
+        conversation: Conversation
+    ): Either<CoreFailure, Unit> {
+        val protocol = conversation.protocol as? Conversation.ProtocolInfo.MLSCapable
+            ?: return Either.Right(Unit).also {
+                logger.d("Skipping non-MLS conversation ${conversation.id.toLogString()} during membership audit")
+            }
+        logger.d(
+            "Checking MLS membership for conversation ${conversation.id.toLogString()}, " +
+                "group ${protocol.groupId.toLogString()}"
+        )
+        return transactionContext.wrapInMLSContext { mlsContext ->
+            mlsConversationRepository.hasEstablishedMLSGroup(mlsContext, protocol.groupId)
+        }.onFailure { failure ->
+            logger.d(
+                "Failed to check MLS membership for conversation ${conversation.id.toLogString()}: $failure"
+            )
+        }.flatMap { exists ->
+            if (exists) {
+                logger.d("MLS group already exists for conversation ${conversation.id.toLogString()}")
+                Either.Right(Unit)
+            } else {
+                logger.d("MLS group is missing for conversation ${conversation.id.toLogString()}, attempting to rejoin")
+                joinExistingMLSConversationUseCase(
+                    transactionContext = transactionContext,
+                    conversationId = conversation.id,
+                    allowJoinByExternalCommit = true
+                ).onSuccess {
+                    logger.d("Successfully rejoined MLS group for conversation ${conversation.id.toLogString()}")
+                }.onFailure { failure ->
+                    logger.d("Failed to rejoin MLS group for conversation ${conversation.id.toLogString()}: $failure")
+                }
+            }
+        }
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/AuditMLSConversationMembershipUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/AuditMLSConversationMembershipUseCase.kt
@@ -19,9 +19,11 @@
 package com.wire.kalium.logic.feature.conversation
 
 import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.MLSFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
 import com.wire.kalium.common.functional.fold
+import com.wire.kalium.common.functional.left
 import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.common.functional.onSuccess
 import com.wire.kalium.common.logger.kaliumLogger
@@ -31,6 +33,7 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCase
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.id.ConversationId
 
 internal sealed interface AuditMLSConversationMembershipResult {
     data object Success : AuditMLSConversationMembershipResult
@@ -118,12 +121,29 @@ internal class AuditMLSConversationMembershipUseCaseImpl(
                     transactionContext = transactionContext,
                     conversationId = conversation.id,
                     allowJoinByExternalCommit = true
-                ).onSuccess {
+                ).flatMap {
+                    verifyMembershipAfterRejoin(transactionContext, conversation.id)
+                }.onSuccess {
                     logger.d("Successfully rejoined MLS group for conversation ${conversation.id.toLogString()}")
                 }.onFailure { failure ->
                     logger.d("Failed to rejoin MLS group for conversation ${conversation.id.toLogString()}: $failure")
                 }
             }
+        }
+    }
+
+    private suspend fun verifyMembershipAfterRejoin(
+        transactionContext: CryptoTransactionContext,
+        conversationId: ConversationId
+    ): Either<CoreFailure, Unit> = conversationRepository.getNonDeletedConversationById(conversationId).flatMap { conversation ->
+        val protocol = conversation.protocol as? Conversation.ProtocolInfo.MLSCapable
+            ?: return@flatMap CoreFailure.Unknown(
+                IllegalStateException("Expected MLS-capable protocol after rejoining ${conversationId.toLogString()}")
+            ).left()
+        transactionContext.wrapInMLSContext { mlsContext ->
+            mlsConversationRepository.hasEstablishedMLSGroup(mlsContext, protocol.groupId)
+        }.flatMap { exists ->
+            if (exists) Either.Right(Unit) else Either.Left(MLSFailure.ConversationNotFound)
         }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationMembershipAuditManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationMembershipAuditManager.kt
@@ -1,0 +1,157 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.common.functional.onFailure
+import com.wire.kalium.common.logger.kaliumLogger
+import com.wire.kalium.logic.data.client.CryptoTransactionProvider
+import com.wire.kalium.logic.data.keypackage.MLSMembershipAuditRepository
+import com.wire.kalium.logic.data.keypackage.MLSMembershipAuditState
+import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
+import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
+import com.wire.kalium.logic.data.sync.SlowSyncRepository
+import com.wire.kalium.logic.data.sync.SlowSyncStatus
+import com.wire.kalium.logic.feature.keypackage.RefillKeyPackagesResult
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+internal interface MLSConversationMembershipAuditManager {
+    fun observeShouldForceKeyPackageCheck(): Flow<Boolean>
+
+    suspend fun auditIfNeeded(
+        refillResult: RefillKeyPackagesResult.Success
+    ): Either<CoreFailure, Unit>
+}
+
+internal class MLSConversationMembershipAuditManagerImpl(
+    private val incrementalSyncRepository: IncrementalSyncRepository,
+    private val slowSyncRepository: SlowSyncRepository,
+    private val auditRepository: MLSMembershipAuditRepository,
+    private val auditMLSConversationMembership: Lazy<AuditMLSConversationMembershipUseCase>,
+    private val transactionProvider: CryptoTransactionProvider,
+) : MLSConversationMembershipAuditManager {
+
+    private var waitingForPostRegistrationSync = false
+    private var observedPostRegistrationSlowSync = false
+
+    override fun observeShouldForceKeyPackageCheck(): Flow<Boolean> =
+        combine(
+            incrementalSyncRepository.incrementalSyncState,
+            slowSyncRepository.slowSyncStatus,
+            auditRepository.observeAuditState()
+        ) { incrementalSyncState, slowSyncState, auditState ->
+            Triple(incrementalSyncState, slowSyncState, auditState)
+        }.map { (incrementalSyncState, slowSyncState, auditState) ->
+            when (auditState) {
+                MLSMembershipAuditState.NOT_REQUIRED -> {
+                    resetPostRegistrationSyncObservation()
+                    false
+                }
+
+                MLSMembershipAuditState.REQUIRED -> {
+                    resetPostRegistrationSyncObservation()
+                    isSyncReadyForAudit(incrementalSyncState, slowSyncState)
+                }
+
+                MLSMembershipAuditState.REQUIRED_AFTER_SLOW_SYNC -> {
+                    handleAuditWaitingForSlowSync(incrementalSyncState, slowSyncState)
+                    false
+                }
+            }
+        }.distinctUntilChanged()
+
+    override suspend fun auditIfNeeded(
+        refillResult: RefillKeyPackagesResult.Success
+    ): Either<CoreFailure, Unit> =
+        auditRepository.getAuditState().flatMap { auditState ->
+
+            val keyPackagesAreAvailable = refillResult.refilled || refillResult.availableCountBeforeRefill > 0
+
+            val shouldRunAudit = when {
+                auditState != MLSMembershipAuditState.REQUIRED -> false
+                !keyPackagesAreAvailable -> false
+                else -> isCurrentSyncReadyForAudit()
+            }
+
+            if (shouldRunAudit) {
+                runAudit()
+            } else {
+                Either.Right(Unit)
+            }
+        }
+
+    private suspend fun handleAuditWaitingForSlowSync(
+        incrementalSyncState: IncrementalSyncStatus,
+        slowSyncState: SlowSyncStatus,
+    ) {
+        if (!waitingForPostRegistrationSync) {
+            waitingForPostRegistrationSync = true
+            observedPostRegistrationSlowSync = slowSyncState !is SlowSyncStatus.Complete
+            kaliumLogger.d("Deferring post-registration MLS membership audit until the next completed sync")
+            return
+        }
+
+        if (slowSyncState !is SlowSyncStatus.Complete) {
+            observedPostRegistrationSlowSync = true
+        } else if (
+            observedPostRegistrationSlowSync &&
+            incrementalSyncState is IncrementalSyncStatus.Live
+        ) {
+            kaliumLogger.i("Post-registration sync completed; MLS membership audit is ready")
+            auditRepository.markAuditRequired()
+                .onFailure { kaliumLogger.w("Failed to make post-registration MLS membership audit ready: $it") }
+        }
+    }
+
+    private fun resetPostRegistrationSyncObservation() {
+        waitingForPostRegistrationSync = false
+        observedPostRegistrationSlowSync = false
+    }
+
+    private fun isSyncReadyForAudit(
+        incrementalSyncState: IncrementalSyncStatus,
+        slowSyncState: SlowSyncStatus,
+    ): Boolean =
+        incrementalSyncState is IncrementalSyncStatus.Live &&
+            slowSyncState is SlowSyncStatus.Complete
+
+    private suspend fun isCurrentSyncReadyForAudit(): Boolean =
+        isSyncReadyForAudit(
+            incrementalSyncRepository.incrementalSyncState.first(),
+            slowSyncRepository.slowSyncStatus.value
+        )
+
+    private suspend fun runAudit(): Either<CoreFailure, Unit> {
+        kaliumLogger.i("Auditing MLS conversation membership after key package recovery")
+        return transactionProvider.transaction("KeyPackageMembershipAudit") { transactionContext ->
+            when (val result = auditMLSConversationMembership.value(transactionContext)) {
+                AuditMLSConversationMembershipResult.Success -> Either.Right(Unit)
+                is AuditMLSConversationMembershipResult.Failure -> Either.Left(result.failure)
+            }
+        }.flatMap {
+            auditRepository.clearAuditRequired()
+        }
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/KeyPackageManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/KeyPackageManager.kt
@@ -18,9 +18,11 @@
 
 package com.wire.kalium.logic.feature.keypackage
 
+import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
 import com.wire.kalium.common.functional.getOrElse
+import com.wire.kalium.common.functional.map
 import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.logic.data.client.ClientRepository
@@ -29,12 +31,16 @@ import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.feature.TimestampKeyRepository
 import com.wire.kalium.logic.feature.TimestampKeys.LAST_KEY_PACKAGE_COUNT_CHECK
+import com.wire.kalium.logic.feature.conversation.MLSConversationMembershipAuditManager
 import com.wire.kalium.logic.featureFlags.FeatureSupport
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import kotlin.time.Duration.Companion.hours
 
@@ -46,6 +52,15 @@ internal val KEY_PACKAGE_COUNT_CHECK_DURATION = 24.hours
  */
 internal interface KeyPackageManager
 
+/**
+ * Keeps the current MLS client's backend key-package pool replenished.
+ *
+ * The manager starts observing sync state when it is created. Whenever incremental sync is live,
+ * it checks whether MLS is available and the client is registered, then performs the periodic
+ * key-package check when its interval elapsed, the local MLS count is low, or membership recovery
+ * explicitly requests a check. A successful check is forwarded to [MLSConversationMembershipAuditManager]
+ * after the MLS transaction closes so conversation recovery can run independently when required.
+ */
 @Suppress("LongParameterList")
 internal class KeyPackageManagerImpl(
     private val featureSupport: FeatureSupport,
@@ -54,6 +69,7 @@ internal class KeyPackageManagerImpl(
     private val refillKeyPackagesUseCase: Lazy<RefillKeyPackagesUseCase>,
     private val keyPackageCountUseCase: Lazy<MLSKeyPackageCountUseCase>,
     private val timestampKeyRepository: Lazy<TimestampKeyRepository>,
+    private val membershipAuditManager: Lazy<MLSConversationMembershipAuditManager>,
     private val transactionProvider: CryptoTransactionProvider,
     kaliumDispatcher: KaliumDispatcher = KaliumDispatcherImpl
 ) : KeyPackageManager {
@@ -69,44 +85,85 @@ internal class KeyPackageManagerImpl(
 
     init {
         refillKeyPackageJob = refillKeyPackagesScope.launch {
-            incrementalSyncRepository.incrementalSyncState.collect { syncState ->
-                ensureActive()
-                if (syncState is IncrementalSyncStatus.Live &&
-                    featureSupport.isMLSSupported &&
-                    clientRepository.value.hasRegisteredMLSClient().getOrElse(false)
-                ) {
-                    refillKeyPackagesIfNeeded()
-                }
+            combine(
+                incrementalSyncRepository.incrementalSyncState,
+                membershipAuditManager.value.observeShouldForceKeyPackageCheck()
+            ) { syncState, shouldForceKeyPackageCheck ->
+                syncState to shouldForceKeyPackageCheck
             }
+                .filter { it.first is IncrementalSyncStatus.Live }
+                .collect { (_, shouldForceKeyPackageCheck) ->
+                    handleSyncState(shouldForceKeyPackageCheck)
+                }
         }
     }
 
-    private suspend fun refillKeyPackagesIfNeeded() {
+    /**
+     * Applies the sync, feature-support, and MLS-client-registration gates before checking packages.
+     */
+    @Suppress("ReturnCount")
+    private suspend fun handleSyncState(
+        shouldForceKeyPackageCheck: Boolean,
+    ) {
+        currentCoroutineContext().ensureActive()
+
+        if (!featureSupport.isMLSSupported) return
+        if (!clientRepository.value.hasRegisteredMLSClient().getOrElse(false)) return
+
+        refillKeyPackagesIfNeeded(shouldForceKeyPackageCheck)
+    }
+
+    /**
+     * Evaluates the periodic and recovery triggers and starts a backend package check when needed.
+     */
+    private suspend fun refillKeyPackagesIfNeeded(shouldForceKeyPackageCheck: Boolean) {
+        shouldCheckKeyPackages(shouldForceKeyPackageCheck)
+            .flatMap { shouldCheck ->
+                if (shouldCheck) refillKeyPackages() else Either.Right(Unit)
+            }
+            .onFailure { kaliumLogger.w("Error while refilling key packages or auditing MLS membership: $it") }
+    }
+
+    /**
+     * Combines the elapsed check interval, cached MLS package count, and audit force-check signal.
+     */
+    private suspend fun shouldCheckKeyPackages(
+        shouldForceKeyPackageCheck: Boolean
+    ): Either<CoreFailure, Boolean> =
         timestampKeyRepository.value.hasPassed(LAST_KEY_PACKAGE_COUNT_CHECK, KEY_PACKAGE_COUNT_CHECK_DURATION)
-            .flatMap { lastKeyPackageCountCheckHasPassed ->
-                val forceRefill = keyPackageCountUseCase.value(fromAPI = false).let {
-                    when (it) {
-                        is MLSKeyPackageCountResult.Success -> it.needsRefill
-                        // if that fails, during the next sync we will check again! so it doesn't matter to skip one time!
-                        else -> false
-                    }
+            .map { lastKeyPackageCountCheckHasPassed ->
+                val cachedCountNeedsRefill = when (val result = keyPackageCountUseCase.value(fromAPI = false)) {
+                    is MLSKeyPackageCountResult.Success -> result.needsRefill
+                    // If this fails, the count will be checked again after the next sync.
+                    else -> false
                 }
-                if (lastKeyPackageCountCheckHasPassed || forceRefill) {
-                    kaliumLogger.i("Checking if we need to refill key packages")
-                    transactionProvider.mlsTransaction("KeyPackageManager") { mlsContext ->
-                        when (val result = refillKeyPackagesUseCase.value(mlsContext)) {
-                            is RefillKeyPackagesResult.Success -> {
-                                timestampKeyRepository.value.reset(LAST_KEY_PACKAGE_COUNT_CHECK)
-                                Either.Right(Unit)
-                            }
-                            is RefillKeyPackagesResult.Failure -> {
-                                Either.Left(result.failure)
-                            }
-                        }
-                    }
-                } else {
-                    Either.Right(Unit)
-                }
-            }.onFailure { kaliumLogger.w("Error while refilling key packages: $it") }
+                shouldForceKeyPackageCheck || lastKeyPackageCountCheckHasPassed || cachedCountNeedsRefill
+            }
+
+    /**
+     * Checks and refills backend key packages inside one MLS transaction.
+     */
+    private suspend fun refillKeyPackages(): Either<CoreFailure, Unit> {
+        kaliumLogger.i("Checking if we need to refill key packages")
+        return transactionProvider.mlsTransaction("KeyPackageManager") { mlsContext ->
+            when (val result = refillKeyPackagesUseCase.value(mlsContext)) {
+                is RefillKeyPackagesResult.Success -> Either.Right(result)
+                is RefillKeyPackagesResult.Failure -> Either.Left(result.failure)
+            }
+        }.flatMap { refillResult ->
+            handleSuccessfulKeyPackageCheck(refillResult)
+        }
+    }
+
+    /**
+     * Resets the periodic-check timestamp and delegates membership recovery after the MLS transaction.
+     */
+    private suspend fun handleSuccessfulKeyPackageCheck(
+        refillResult: RefillKeyPackagesResult.Success
+    ): Either<CoreFailure, Unit> {
+        val timestampResetResult = timestampKeyRepository.value.reset(LAST_KEY_PACKAGE_COUNT_CHECK)
+        // Membership recovery must still be attempted if resetting the periodic-check timestamp fails.
+        return membershipAuditManager.value.auditIfNeeded(refillResult)
+            .flatMap { timestampResetResult }
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/RefillKeyPackageUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/keypackage/RefillKeyPackageUseCase.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
 import com.wire.kalium.common.functional.fold
 import com.wire.kalium.common.functional.getOrElse
+import com.wire.kalium.common.functional.map
 import com.wire.kalium.common.functional.onSuccess
 import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.cryptography.MlsCoreCryptoContext
@@ -30,12 +31,16 @@ import com.wire.kalium.logic.data.client.toModel
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.keypackage.KeyPackageLimitsProvider
 import com.wire.kalium.logic.data.keypackage.KeyPackageRepository
+import com.wire.kalium.logic.data.keypackage.MLSMembershipAuditRepository
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.messaging.hooks.CryptoStateChangeHookNotifier
 
 internal sealed class RefillKeyPackagesResult {
 
-    internal data object Success : RefillKeyPackagesResult()
+    internal data class Success(
+        val availableCountBeforeRefill: Int,
+        val refilled: Boolean,
+    ) : RefillKeyPackagesResult()
     internal data class Failure(val failure: CoreFailure) : RefillKeyPackagesResult()
 
 }
@@ -56,6 +61,7 @@ internal class RefillKeyPackagesUseCaseImpl(
     private val currentClientIdProvider: CurrentClientIdProvider,
     private val selfUserId: UserId,
     private val cryptoStateChangeHookNotifier: CryptoStateChangeHookNotifier,
+    private val mlsMembershipAuditRepository: MLSMembershipAuditRepository,
 ) : RefillKeyPackagesUseCase {
     override suspend operator fun invoke(mlsContext: MlsCoreCryptoContext): RefillKeyPackagesResult {
         val selfClientId = currentClientIdProvider().getOrElse {
@@ -63,22 +69,28 @@ internal class RefillKeyPackagesUseCaseImpl(
         }
         val cipherSuite = mlsContext.getDefaultCipherSuite().toModel()
         return keyPackageRepository.getAvailableKeyPackageCount(selfClientId, cipherSuite)
-            .flatMap {
-                kaliumLogger.i("Key packages: Found ${it.count} available key packages")
-                if (keyPackageLimitsProvider.needsRefill(it.count)) {
-                    kaliumLogger.i("Key packages: Refilling key packages...")
-                    val amount = keyPackageLimitsProvider.refillAmount()
-                    keyPackageRepository.uploadNewKeyPackages(mlsContext, selfClientId, amount)
-                        .onSuccess { cryptoStateChangeHookNotifier.onCryptoStateChanged(selfUserId) }
-                        .flatMap { Either.Right(Unit) }
+            .flatMap { keyPackageCount ->
+                val availableCountBeforeRefill = keyPackageCount.count
+                kaliumLogger.i("Key packages: Found $availableCountBeforeRefill available key packages")
+                val persistAuditRequired = if (availableCountBeforeRefill == 0) {
+                    mlsMembershipAuditRepository.markAuditRequired()
                 } else {
-                    kaliumLogger.i("Key packages: Refill not needed")
                     Either.Right(Unit)
+                }
+                persistAuditRequired.flatMap {
+                    if (keyPackageLimitsProvider.needsRefill(availableCountBeforeRefill)) {
+                        kaliumLogger.i("Key packages: Refilling key packages...")
+                        val amount = keyPackageLimitsProvider.refillAmount()
+                        keyPackageRepository.uploadNewKeyPackages(mlsContext, selfClientId, amount)
+                            .onSuccess { cryptoStateChangeHookNotifier.onCryptoStateChanged(selfUserId) }
+                            .map { RefillKeyPackagesResult.Success(availableCountBeforeRefill, refilled = true) }
+                    } else {
+                        kaliumLogger.i("Key packages: Refill not needed")
+                        Either.Right(RefillKeyPackagesResult.Success(availableCountBeforeRefill, refilled = false))
+                    }
                 }
             }.fold({ failure ->
                 RefillKeyPackagesResult.Failure(failure)
-            }, {
-                RefillKeyPackagesResult.Success
-            })
+            }, { it })
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandler.kt
@@ -166,7 +166,7 @@ internal class MLSWelcomeEventHandlerImpl(
                             false
                         }
 
-                        RefillKeyPackagesResult.Success -> {
+                        is RefillKeyPackagesResult.Success -> {
                             true
                         }
                     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/keypackage/MLSMembershipAuditRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/keypackage/MLSMembershipAuditRepositoryTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.data.keypackage
+
+import com.wire.kalium.common.functional.getOrElse
+import com.wire.kalium.persistence.dao.MetadataDAO
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.matcher.eq
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MLSMembershipAuditRepositoryTest {
+
+    @Test
+    fun givenPersistedMarker_whenReadingAndObserving_thenAuditIsRequired() = runTest {
+        val metadataDAO = mock<MetadataDAO>()
+        everySuspend { metadataDAO.valueByKey(any()) } returns "true"
+        every { metadataDAO.valueByKeyFlow(any()) } returns flowOf(null, "true")
+        val repository = MLSMembershipAuditRepositoryImpl(metadataDAO)
+
+        assertEquals(true, repository.isAuditRequired().getOrElse(false))
+        assertEquals(listOf(false, true), repository.observeAuditRequired().toList())
+        assertEquals(
+            listOf(MLSMembershipAuditState.NOT_REQUIRED, MLSMembershipAuditState.REQUIRED),
+            repository.observeAuditState().toList()
+        )
+    }
+
+    @Test
+    fun whenMarkingAndClearingAuditRequirement_thenMetadataIsPersistedAndDeleted() = runTest {
+        val metadataDAO = mock<MetadataDAO>()
+        everySuspend { metadataDAO.insertValue(any(), any()) } returns Unit
+        everySuspend { metadataDAO.deleteValue(any()) } returns Unit
+        val repository = MLSMembershipAuditRepositoryImpl(metadataDAO)
+
+        repository.markAuditRequired()
+        repository.clearAuditRequired()
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            metadataDAO.insertValue(eq("true"), any())
+        }
+        verifySuspend(VerifyMode.exactly(1)) {
+            metadataDAO.deleteValue(any())
+        }
+    }
+
+    @Test
+    fun whenMarkingAuditAfterSlowSync_thenDeferredStateIsPersisted() = runTest {
+        val metadataDAO = mock<MetadataDAO>()
+        everySuspend { metadataDAO.insertValue(any(), any()) } returns Unit
+        val repository = MLSMembershipAuditRepositoryImpl(metadataDAO)
+
+        repository.markAuditRequiredAfterSlowSync()
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            metadataDAO.insertValue(eq("required_after_slow_sync"), any())
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/RegisterMLSClientUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/client/RegisterMLSClientUseCaseTest.kt
@@ -31,10 +31,12 @@ import com.wire.kalium.logic.data.client.MLSClientProvider
 import com.wire.kalium.logic.data.client.toModel
 import com.wire.kalium.logic.data.keypackage.KeyPackageLimitsProvider
 import com.wire.kalium.logic.data.keypackage.KeyPackageRepository
+import com.wire.kalium.logic.data.keypackage.MLSMembershipAuditRepository
 import com.wire.kalium.logic.feature.client.RegisterMLSClientUseCaseTest.Arrangement.Companion.E2EI_TEAM_SETTINGS
 import com.wire.kalium.logic.feature.client.RegisterMLSClientUseCaseTest.Arrangement.Companion.MLS_CIPHER_SUITE
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.messaging.hooks.NoOpCryptoStateChangeHookNotifier
 import com.wire.kalium.util.DateTimeUtil
@@ -62,6 +64,7 @@ class RegisterMLSClientUseCaseTest {
                 .withGettingE2EISettingsReturns(Either.Right(E2EI_TEAM_SETTINGS.copy(isRequired = e2eiIsRequired)))
                 .withGetPublicKey(Arrangement.MLS_PUBLIC_KEY, Arrangement.MLS_CIPHER_SUITE)
                 .withRegisterMLSClient(Either.Right(Unit))
+                .withAuditAfterSlowSyncMarked()
                 .withKeyPackageLimits(Arrangement.REFILL_AMOUNT)
                 .withUploadKeyPackagesSuccessful()
                 .withMLSTransaction<Unit>()
@@ -73,17 +76,16 @@ class RegisterMLSClientUseCaseTest {
 
             assertIs<RegisterMLSClientResult.Success>(result.value)
 
-            verifySuspend(VerifyMode.exactly(1)) {
+            verifySuspend(VerifyMode.order) {
                 arrangement.clientRepository.registerMLSClient(
                     TestClient.CLIENT_ID,
                     Arrangement.MLS_PUBLIC_KEY,
                     MLS_CIPHER_SUITE.toModel()
                 )
-            }
-
-            verifySuspend {
+                arrangement.mlsMembershipAuditRepository.markAuditRequiredAfterSlowSync()
                 arrangement.keyPackageRepository.uploadNewKeyPackages(any(), TestClient.CLIENT_ID, Arrangement.REFILL_AMOUNT)
             }
+
         }
 
     @Test
@@ -97,6 +99,7 @@ class RegisterMLSClientUseCaseTest {
                 .withGettingE2EISettingsReturns(Either.Right(E2EI_TEAM_SETTINGS.copy(isRequired = e2eiIsRequired)))
                 .withGetPublicKey(Arrangement.MLS_PUBLIC_KEY, Arrangement.MLS_CIPHER_SUITE)
                 .withRegisterMLSClient(Either.Right(Unit))
+                .withAuditAfterSlowSyncMarked()
                 .withKeyPackageLimits(Arrangement.REFILL_AMOUNT)
                 .withUploadKeyPackagesSuccessful()
                 .arrange()
@@ -108,6 +111,7 @@ class RegisterMLSClientUseCaseTest {
             assertIs<RegisterMLSClientResult.E2EICertificateRequired>(result.value)
 
             verifySuspend(VerifyMode.not) {
+                arrangement.mlsMembershipAuditRepository.markAuditRequiredAfterSlowSync()
                 arrangement.clientRepository.registerMLSClient(
                     TestClient.CLIENT_ID,
                     Arrangement.MLS_PUBLIC_KEY,
@@ -129,6 +133,7 @@ class RegisterMLSClientUseCaseTest {
                 .withGettingE2EISettingsReturns(Either.Right(E2EI_TEAM_SETTINGS.copy(isRequired = e2eiIsRequired)))
                 .withGetPublicKey(Arrangement.MLS_PUBLIC_KEY, Arrangement.MLS_CIPHER_SUITE)
                 .withRegisterMLSClient(Either.Right(Unit))
+                .withAuditAfterSlowSyncMarked()
                 .withKeyPackageLimits(Arrangement.REFILL_AMOUNT)
                 .withUploadKeyPackagesSuccessful()
                 .withMLSTransaction<Unit>()
@@ -153,6 +158,31 @@ class RegisterMLSClientUseCaseTest {
             }
         }
 
+    @Test
+    fun givenAuditMarkerCannotBePersisted_whenInvoked_thenClientIsRegisteredAndPackagesAreNotUploaded() = runTest {
+        val (arrangement, registerMLSClient) = Arrangement()
+            .withGetMLSClientSuccessful()
+            .withGettingE2EISettingsReturns(Either.Right(E2EI_TEAM_SETTINGS.copy(isRequired = false)))
+            .withGetPublicKey(Arrangement.MLS_PUBLIC_KEY, Arrangement.MLS_CIPHER_SUITE)
+            .withRegisterMLSClient(Either.Right(Unit))
+            .withAuditAfterSlowSyncMarkFailed()
+            .arrange()
+
+        registerMLSClient(TestClient.CLIENT_ID).shouldFail()
+
+        verifySuspend(VerifyMode.order) {
+            arrangement.clientRepository.registerMLSClient(
+                TestClient.CLIENT_ID,
+                Arrangement.MLS_PUBLIC_KEY,
+                MLS_CIPHER_SUITE.toModel()
+            )
+            arrangement.mlsMembershipAuditRepository.markAuditRequiredAfterSlowSync()
+        }
+        verifySuspend(VerifyMode.not) {
+            arrangement.keyPackageRepository.uploadNewKeyPackages(any(), any(), any())
+        }
+    }
+
     private class Arrangement {
         val mlsClient: MLSClient = mock(mode = MockMode.autoUnit)
         val mlsContext: MlsCoreCryptoContext = mock(mode = MockMode.autoUnit)
@@ -161,6 +191,7 @@ class RegisterMLSClientUseCaseTest {
         val keyPackageRepository: KeyPackageRepository = mock(mode = MockMode.autoUnit)
         val keyPackageLimitsProvider: KeyPackageLimitsProvider = mock(mode = MockMode.autoUnit)
         val userConfigRepository: UserConfigRepository = mock(mode = MockMode.autoUnit)
+        val mlsMembershipAuditRepository: MLSMembershipAuditRepository = mock(mode = MockMode.autoUnit)
 
         suspend fun withGettingE2EISettingsReturns(result: Either<StorageFailure, E2EISettings>) = apply {
             everySuspend {
@@ -178,6 +209,18 @@ class RegisterMLSClientUseCaseTest {
             everySuspend {
                 clientRepository.registerMLSClient(any(), any(), any())
             } returns result
+        }
+
+        suspend fun withAuditAfterSlowSyncMarked() = apply {
+            everySuspend {
+                mlsMembershipAuditRepository.markAuditRequiredAfterSlowSync()
+            } returns Either.Right(Unit)
+        }
+
+        suspend fun withAuditAfterSlowSyncMarkFailed() = apply {
+            everySuspend {
+                mlsMembershipAuditRepository.markAuditRequiredAfterSlowSync()
+            } returns Either.Left(StorageFailure.DataNotFound)
         }
 
         fun withKeyPackageLimits(refillAmount: Int) = apply {
@@ -221,7 +264,8 @@ class RegisterMLSClientUseCaseTest {
             keyPackageLimitsProvider,
             userConfigRepository,
             TestUser.SELF.id,
-            NoOpCryptoStateChangeHookNotifier
+            NoOpCryptoStateChangeHookNotifier,
+            mlsMembershipAuditRepository,
         )
 
         companion object {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/AuditMLSConversationMembershipUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/AuditMLSConversationMembershipUseCaseTest.kt
@@ -1,0 +1,179 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.common.error.MLSFailure
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCase
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.GroupID
+import com.wire.kalium.logic.data.mls.CipherSuite
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import com.wire.kalium.util.DateTimeUtil
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.matcher.eq
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertIs
+
+class AuditMLSConversationMembershipUseCaseTest {
+
+    @Test
+    fun givenExistingAndMissingGroups_whenAuditing_thenOnlyMissingGroupIsJoined() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withConversations(listOf(MLS_CONVERSATION, MIXED_CONVERSATION))
+            .withGroupExists(MLS_GROUP_ID, exists = true)
+            .withGroupExists(MIXED_GROUP_ID, exists = false)
+            .withJoinSuccessful()
+            .arrange()
+
+        val result = useCase(arrangement.transactionContext)
+
+        verifySuspend(VerifyMode.not) {
+            arrangement.joinExistingMLSConversationUseCase.invoke(
+                any(),
+                eq(MLS_CONVERSATION.id),
+                any(),
+                any()
+            )
+        }
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.joinExistingMLSConversationUseCase.invoke(
+                any(),
+                eq(MIXED_CONVERSATION.id),
+                any(),
+                eq(true)
+            )
+        }
+        assertIs<AuditMLSConversationMembershipResult.Success>(result)
+    }
+
+    @Test
+    fun givenOneGroupCheckFails_whenAuditing_thenRemainingGroupsAreAttemptedAndResultFails() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withConversations(listOf(MLS_CONVERSATION, MIXED_CONVERSATION))
+            .withGroupCheckFailed(MLS_GROUP_ID)
+            .withGroupExists(MIXED_GROUP_ID, exists = false)
+            .withJoinSuccessful()
+            .arrange()
+
+        val result = useCase(arrangement.transactionContext)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.joinExistingMLSConversationUseCase.invoke(
+                any(),
+                eq(MIXED_CONVERSATION.id),
+                any(),
+                eq(true)
+            )
+        }
+        assertIs<AuditMLSConversationMembershipResult.Failure>(result)
+    }
+
+    @Test
+    fun givenConversationQueryFails_whenAuditing_thenFailureIsReturned() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withConversationQueryFailed()
+            .arrange()
+
+        val result = useCase(arrangement.transactionContext)
+
+        verifySuspend(VerifyMode.not) {
+            arrangement.mlsConversationRepository.hasEstablishedMLSGroup(any(), any())
+        }
+        assertIs<AuditMLSConversationMembershipResult.Failure>(result)
+    }
+
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        val conversationRepository = mock<ConversationRepository>(mode = MockMode.autoUnit)
+        val mlsConversationRepository = mock<MLSConversationRepository>(mode = MockMode.autoUnit)
+        val joinExistingMLSConversationUseCase = mock<JoinExistingMLSConversationUseCase>(mode = MockMode.autoUnit)
+
+        suspend fun withConversations(conversations: List<Conversation>) = apply {
+            everySuspend {
+                conversationRepository.getActiveMLSConversationsForMembershipAudit()
+            } returns Either.Right(conversations)
+        }
+
+        suspend fun withConversationQueryFailed() = apply {
+            everySuspend {
+                conversationRepository.getActiveMLSConversationsForMembershipAudit()
+            } returns Either.Left(StorageFailure.DataNotFound)
+        }
+
+        suspend fun withGroupExists(groupID: GroupID, exists: Boolean) = apply {
+            everySuspend {
+                mlsConversationRepository.hasEstablishedMLSGroup(any(), eq(groupID))
+            } returns Either.Right(exists)
+        }
+
+        suspend fun withGroupCheckFailed(groupID: GroupID) = apply {
+            everySuspend {
+                mlsConversationRepository.hasEstablishedMLSGroup(any(), eq(groupID))
+            } returns Either.Left(MLSFailure.ConversationNotFound)
+        }
+
+        suspend fun withJoinSuccessful() = apply {
+            everySuspend {
+                joinExistingMLSConversationUseCase.invoke(any(), any(), any(), any())
+            } returns Either.Right(Unit)
+        }
+
+        fun arrange() = this to AuditMLSConversationMembershipUseCaseImpl(
+            conversationRepository,
+            mlsConversationRepository,
+            joinExistingMLSConversationUseCase
+        )
+    }
+
+    private companion object {
+        val MLS_GROUP_ID = GroupID("mls-group")
+        val MIXED_GROUP_ID = GroupID("mixed-group")
+        val MLS_CONVERSATION = TestConversation.GROUP(
+            protocolInfo = Conversation.ProtocolInfo.MLS(
+                groupId = MLS_GROUP_ID,
+                groupState = Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED,
+                epoch = 1UL,
+                keyingMaterialLastUpdate = DateTimeUtil.currentInstant(),
+                cipherSuite = CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+            )
+        ).copy(id = ConversationId("mls", "domain"))
+        val MIXED_CONVERSATION = TestConversation.GROUP(
+            protocolInfo = Conversation.ProtocolInfo.Mixed(
+                groupId = MIXED_GROUP_ID,
+                groupState = Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_WELCOME_MESSAGE,
+                epoch = 1UL,
+                keyingMaterialLastUpdate = DateTimeUtil.currentInstant(),
+                cipherSuite = CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+            )
+        ).copy(id = ConversationId("mixed", "domain"))
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/AuditMLSConversationMembershipUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/AuditMLSConversationMembershipUseCaseTest.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.logic.feature.conversation
 
+import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.MLSFailure
 import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.functional.Either
@@ -33,6 +34,7 @@ import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProvider
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
 import com.wire.kalium.util.DateTimeUtil
 import dev.mokkery.MockMode
+import dev.mokkery.answering.sequentiallyReturns
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
@@ -51,7 +53,8 @@ class AuditMLSConversationMembershipUseCaseTest {
         val (arrangement, useCase) = Arrangement()
             .withConversations(listOf(MLS_CONVERSATION, MIXED_CONVERSATION))
             .withGroupExists(MLS_GROUP_ID, exists = true)
-            .withGroupExists(MIXED_GROUP_ID, exists = false)
+            .withGroupCheckResults(MIXED_GROUP_ID, Either.Right(false), Either.Right(true))
+            .withConversationById(MIXED_CONVERSATION)
             .withJoinSuccessful()
             .arrange()
 
@@ -81,7 +84,8 @@ class AuditMLSConversationMembershipUseCaseTest {
         val (arrangement, useCase) = Arrangement()
             .withConversations(listOf(MLS_CONVERSATION, MIXED_CONVERSATION))
             .withGroupCheckFailed(MLS_GROUP_ID)
-            .withGroupExists(MIXED_GROUP_ID, exists = false)
+            .withGroupCheckResults(MIXED_GROUP_ID, Either.Right(false), Either.Right(true))
+            .withConversationById(MIXED_CONVERSATION)
             .withJoinSuccessful()
             .arrange()
 
@@ -94,6 +98,114 @@ class AuditMLSConversationMembershipUseCaseTest {
                 any(),
                 eq(true)
             )
+        }
+        assertIs<AuditMLSConversationMembershipResult.Failure>(result)
+    }
+
+    @Test
+    fun givenJoinSucceedsButGroupIsStillMissing_whenAuditing_thenFailureIsReturned() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withConversations(listOf(MIXED_CONVERSATION))
+            .withGroupCheckResults(MIXED_GROUP_ID, Either.Right(false), Either.Right(false))
+            .withConversationById(MIXED_CONVERSATION)
+            .withJoinSuccessful()
+            .arrange()
+
+        val result = useCase(arrangement.transactionContext)
+
+        val failure = assertIs<AuditMLSConversationMembershipResult.Failure>(result)
+        assertIs<MLSFailure.ConversationNotFound>(failure.failure)
+    }
+
+    @Test
+    fun givenJoinSucceedsButPostJoinGroupCheckFails_whenAuditing_thenFailureIsReturned() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withConversations(listOf(MIXED_CONVERSATION))
+            .withGroupCheckResults(
+                MIXED_GROUP_ID,
+                Either.Right(false),
+                Either.Left(MLSFailure.ConversationNotFound)
+            )
+            .withConversationById(MIXED_CONVERSATION)
+            .withJoinSuccessful()
+            .arrange()
+
+        val result = useCase(arrangement.transactionContext)
+
+        val failure = assertIs<AuditMLSConversationMembershipResult.Failure>(result)
+        assertIs<MLSFailure.ConversationNotFound>(failure.failure)
+    }
+
+    @Test
+    fun givenGroupIdChangesDuringJoin_whenAuditing_thenRefreshedGroupIsVerified() = runTest {
+        val refreshedConversation = MIXED_CONVERSATION.copy(
+            protocol = (MIXED_CONVERSATION.protocol as Conversation.ProtocolInfo.Mixed).copy(groupId = REFRESHED_GROUP_ID)
+        )
+        val (arrangement, useCase) = Arrangement()
+            .withConversations(listOf(MIXED_CONVERSATION))
+            .withGroupExists(MIXED_GROUP_ID, exists = false)
+            .withGroupExists(REFRESHED_GROUP_ID, exists = true)
+            .withConversationById(refreshedConversation)
+            .withJoinSuccessful()
+            .arrange()
+
+        val result = useCase(arrangement.transactionContext)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.mlsConversationRepository.hasEstablishedMLSGroup(any(), eq(MIXED_GROUP_ID))
+            arrangement.mlsConversationRepository.hasEstablishedMLSGroup(any(), eq(REFRESHED_GROUP_ID))
+        }
+        assertIs<AuditMLSConversationMembershipResult.Success>(result)
+    }
+
+    @Test
+    fun givenConversationReloadFailsAfterJoin_whenAuditing_thenFailureIsReturned() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withConversations(listOf(MIXED_CONVERSATION))
+            .withGroupExists(MIXED_GROUP_ID, exists = false)
+            .withConversationByIdFailed(MIXED_CONVERSATION.id)
+            .withJoinSuccessful()
+            .arrange()
+
+        val result = useCase(arrangement.transactionContext)
+
+        val failure = assertIs<AuditMLSConversationMembershipResult.Failure>(result)
+        assertIs<StorageFailure.DataNotFound>(failure.failure)
+    }
+
+    @Test
+    fun givenConversationIsNoLongerMLSCapableAfterJoin_whenAuditing_thenFailureIsReturned() = runTest {
+        val refreshedConversation = MIXED_CONVERSATION.copy(protocol = Conversation.ProtocolInfo.Proteus)
+        val (arrangement, useCase) = Arrangement()
+            .withConversations(listOf(MIXED_CONVERSATION))
+            .withGroupExists(MIXED_GROUP_ID, exists = false)
+            .withConversationById(refreshedConversation)
+            .withJoinSuccessful()
+            .arrange()
+
+        val result = useCase(arrangement.transactionContext)
+
+        val failure = assertIs<AuditMLSConversationMembershipResult.Failure>(result)
+        val unknownFailure = assertIs<CoreFailure.Unknown>(failure.failure)
+        assertIs<IllegalStateException>(unknownFailure.rootCause)
+    }
+
+    @Test
+    fun givenPostJoinVerificationFails_whenAuditing_thenRemainingConversationsAreAttempted() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withConversations(listOf(MLS_CONVERSATION, MIXED_CONVERSATION))
+            .withGroupCheckResults(MLS_GROUP_ID, Either.Right(false), Either.Right(false))
+            .withGroupCheckResults(MIXED_GROUP_ID, Either.Right(false), Either.Right(true))
+            .withConversationById(MLS_CONVERSATION)
+            .withConversationById(MIXED_CONVERSATION)
+            .withJoinSuccessful()
+            .arrange()
+
+        val result = useCase(arrangement.transactionContext)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.joinExistingMLSConversationUseCase.invoke(any(), eq(MLS_CONVERSATION.id), any(), eq(true))
+            arrangement.joinExistingMLSConversationUseCase.invoke(any(), eq(MIXED_CONVERSATION.id), any(), eq(true))
         }
         assertIs<AuditMLSConversationMembershipResult.Failure>(result)
     }
@@ -141,6 +253,24 @@ class AuditMLSConversationMembershipUseCaseTest {
             } returns Either.Left(MLSFailure.ConversationNotFound)
         }
 
+        suspend fun withGroupCheckResults(groupID: GroupID, vararg results: Either<MLSFailure, Boolean>) = apply {
+            everySuspend {
+                mlsConversationRepository.hasEstablishedMLSGroup(any(), eq(groupID))
+            } sequentiallyReturns results.toList()
+        }
+
+        suspend fun withConversationById(conversation: Conversation) = apply {
+            everySuspend {
+                conversationRepository.getNonDeletedConversationById(eq(conversation.id))
+            } returns Either.Right(conversation)
+        }
+
+        suspend fun withConversationByIdFailed(conversationId: ConversationId) = apply {
+            everySuspend {
+                conversationRepository.getNonDeletedConversationById(eq(conversationId))
+            } returns Either.Left(StorageFailure.DataNotFound)
+        }
+
         suspend fun withJoinSuccessful() = apply {
             everySuspend {
                 joinExistingMLSConversationUseCase.invoke(any(), any(), any(), any())
@@ -157,6 +287,7 @@ class AuditMLSConversationMembershipUseCaseTest {
     private companion object {
         val MLS_GROUP_ID = GroupID("mls-group")
         val MIXED_GROUP_ID = GroupID("mixed-group")
+        val REFRESHED_GROUP_ID = GroupID("refreshed-group")
         val MLS_CONVERSATION = TestConversation.GROUP(
             protocolInfo = Conversation.ProtocolInfo.MLS(
                 groupId = MLS_GROUP_ID,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCaseTest.kt
@@ -300,6 +300,42 @@ class JoinExistingMLSConversationUseCaseTest {
     }
 
     @Test
+    fun givenMigratedConversationWithStaleZeroEpoch_whenInvokingUseCase_thenRefreshBeforeExternalCommit() = runTest {
+        val (arrangement, joinExistingMLSConversationUseCase) = Arrangement(testKaliumDispatcher)
+            .withIsMLSSupported(true)
+            .withHasRegisteredMLSClient(true)
+            .withGetConversationsByIdSequentially(
+                Arrangement.MLS_MIGRATED_STALE_GROUP_CONVERSATION,
+                Arrangement.MLS_MIGRATED_REFRESHED_GROUP_CONVERSATION
+            )
+            .withFetchConversationSuccessful()
+            .withFetchingGroupInfoSuccessful()
+            .withJoinByExternalCommitSuccessful()
+            .arrange()
+
+        joinExistingMLSConversationUseCase(
+            arrangement.transactionContext,
+            Arrangement.MLS_MIGRATED_STALE_GROUP_CONVERSATION.id
+        ).shouldSucceed()
+
+        verifySuspend(VerifyMode.order) {
+            arrangement.fetchConversation(
+                any(),
+                eq(Arrangement.MLS_MIGRATED_STALE_GROUP_CONVERSATION.id),
+                eq(ConversationSyncReason.Other)
+            )
+            arrangement.mlsConversationRepository.joinGroupByExternalCommit(
+                any(),
+                eq(Arrangement.GROUP_ID3),
+                any()
+            )
+        }
+        verifySuspend(VerifyMode.not) {
+            arrangement.mlsConversationRepository.establishMLSGroup(any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
     fun givenNonRecoverableFailure_whenInvokingUseCase_ThenFailureIsReported() = runTest {
         val (arrangement, joinExistingMLSConversationsUseCase) = Arrangement(testKaliumDispatcher)
             .withIsMLSSupported(true)
@@ -513,6 +549,26 @@ class JoinExistingMLSConversationUseCaseTest {
                     cipherSuite = CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
                 )
             ).copy(id = ConversationId("id-pending-after-reset", "domain"))
+
+            val MLS_MIGRATED_STALE_GROUP_CONVERSATION = TestConversation.GROUP(
+                Conversation.ProtocolInfo.MLS(
+                    GROUP_ID3,
+                    Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED,
+                    epoch = 0UL,
+                    keyingMaterialLastUpdate = DateTimeUtil.currentInstant(),
+                    cipherSuite = CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+                )
+            ).copy(id = ConversationId("id-migrated-stale", "domain"))
+
+            val MLS_MIGRATED_REFRESHED_GROUP_CONVERSATION = MLS_MIGRATED_STALE_GROUP_CONVERSATION.copy(
+                protocol = Conversation.ProtocolInfo.MLS(
+                    GROUP_ID3,
+                    Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN,
+                    epoch = 2UL,
+                    keyingMaterialLastUpdate = DateTimeUtil.currentInstant(),
+                    cipherSuite = CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+                )
+            )
 
             val MLS_ESTABLISHED_GROUP_CONVERSATION = TestConversation.GROUP(
                 Conversation.ProtocolInfo.MLS(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationUseCaseTest.kt
@@ -336,6 +336,66 @@ class JoinExistingMLSConversationUseCaseTest {
     }
 
     @Test
+    fun givenStaleOneOnOneConversationWithSelfMemberFirst_whenInvokingUseCase_thenRefreshUsingOtherMember() = runTest {
+        verifyStaleOneOnOneRefreshUsesOtherMember(
+            members = listOf(TestUser.USER_ID, TestUser.OTHER_USER_ID),
+            dispatcher = testKaliumDispatcher
+        )
+    }
+
+    @Test
+    fun givenStaleOneOnOneConversationWithSelfMemberLast_whenInvokingUseCase_thenRefreshUsingOtherMember() = runTest {
+        verifyStaleOneOnOneRefreshUsesOtherMember(
+            members = listOf(TestUser.OTHER_USER_ID, TestUser.USER_ID),
+            dispatcher = testKaliumDispatcher
+        )
+    }
+
+    @Test
+    fun givenStaleMessageForOneOnOneConversation_whenRetrying_thenRefreshUsingOtherMember() = runTest {
+        val conversation = Arrangement.MLS_MIGRATED_REFRESHED_ONE_ON_ONE_CONVERSATION
+        val (arrangement, joinExistingMLSConversationUseCase) = Arrangement(testKaliumDispatcher)
+            .withIsMLSSupported(true)
+            .withHasRegisteredMLSClient(true)
+            .withGetConversationsByIdSequentially(conversation, conversation)
+            .withGetConversationMembersSuccessful(listOf(TestUser.USER_ID, TestUser.OTHER_USER_ID))
+            .withFetchMLSOneToOneConversationSuccessful(conversation)
+            .withFetchingGroupInfoSuccessful()
+            .withJoinByExternalCommitSuccessful()
+            .withJoinByExternalCommitGroupFailing(Arrangement.MLS_STALE_MESSAGE_FAILURE, times = 1)
+            .arrange()
+
+        joinExistingMLSConversationUseCase(arrangement.transactionContext, conversation.id).shouldSucceed()
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.fetchMLSOneToOneConversation(any(), eq(TestUser.OTHER_USER_ID))
+        }
+        verifySuspend(VerifyMode.exactly(2)) {
+            arrangement.mlsConversationRepository.joinGroupByExternalCommit(
+                any(),
+                eq(Arrangement.GROUP_ID_ONE_ON_ONE),
+                any()
+            )
+        }
+    }
+
+    @Test
+    fun givenStaleOneOnOneConversationWithoutOtherMember_whenInvokingUseCase_thenFailureIsReported() = runTest {
+        verifyInvalidOneOnOneMembersFail(
+            members = listOf(TestUser.USER_ID),
+            dispatcher = testKaliumDispatcher
+        )
+    }
+
+    @Test
+    fun givenStaleOneOnOneConversationWithMultipleOtherMembers_whenInvokingUseCase_thenFailureIsReported() = runTest {
+        verifyInvalidOneOnOneMembersFail(
+            members = listOf(TestUser.USER_ID, TestUser.OTHER_USER_ID, Arrangement.ANOTHER_USER_ID),
+            dispatcher = testKaliumDispatcher
+        )
+    }
+
+    @Test
     fun givenNonRecoverableFailure_whenInvokingUseCase_ThenFailureIsReported() = runTest {
         val (arrangement, joinExistingMLSConversationsUseCase) = Arrangement(testKaliumDispatcher)
             .withIsMLSSupported(true)
@@ -346,6 +406,51 @@ class JoinExistingMLSConversationUseCaseTest {
             .arrange()
 
         joinExistingMLSConversationsUseCase(arrangement.transactionContext, Arrangement.MLS_CONVERSATION1.id).shouldFail()
+    }
+
+    private suspend fun verifyStaleOneOnOneRefreshUsesOtherMember(
+        members: List<UserId>,
+        dispatcher: KaliumDispatcher
+    ) {
+        val staleConversation = Arrangement.MLS_MIGRATED_STALE_ONE_ON_ONE_CONVERSATION
+        val refreshedConversation = Arrangement.MLS_MIGRATED_REFRESHED_ONE_ON_ONE_CONVERSATION
+        val (arrangement, joinExistingMLSConversationUseCase) = Arrangement(dispatcher)
+            .withIsMLSSupported(true)
+            .withHasRegisteredMLSClient(true)
+            .withGetConversationsByIdSuccessful(staleConversation)
+            .withGetConversationMembersSuccessful(members)
+            .withFetchMLSOneToOneConversationSuccessful(refreshedConversation)
+            .withFetchingGroupInfoSuccessful()
+            .withJoinByExternalCommitSuccessful()
+            .arrange()
+
+        joinExistingMLSConversationUseCase(arrangement.transactionContext, staleConversation.id).shouldSucceed()
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.fetchMLSOneToOneConversation(any(), eq(TestUser.OTHER_USER_ID))
+        }
+    }
+
+    private suspend fun verifyInvalidOneOnOneMembersFail(
+        members: List<UserId>,
+        dispatcher: KaliumDispatcher
+    ) {
+        val conversation = Arrangement.MLS_MIGRATED_STALE_ONE_ON_ONE_CONVERSATION
+        val (arrangement, joinExistingMLSConversationUseCase) = Arrangement(dispatcher)
+            .withIsMLSSupported(true)
+            .withHasRegisteredMLSClient(true)
+            .withGetConversationsByIdSuccessful(conversation)
+            .withGetConversationMembersSuccessful(members)
+            .arrange()
+
+        joinExistingMLSConversationUseCase(arrangement.transactionContext, conversation.id).shouldFail()
+
+        verifySuspend(VerifyMode.not) {
+            arrangement.fetchMLSOneToOneConversation(any(), any())
+        }
+        verifySuspend(VerifyMode.not) {
+            arrangement.mlsConversationRepository.joinGroupByExternalCommit(any(), any(), any())
+        }
     }
 
     private class Arrangement(var dispatcher: KaliumDispatcher = TestKaliumDispatcher) :
@@ -428,6 +533,12 @@ class JoinExistingMLSConversationUseCaseTest {
             } returns Either.Right(members)
         }
 
+        suspend fun withFetchMLSOneToOneConversationSuccessful(conversation: Conversation) = apply {
+            everySuspend {
+                fetchMLSOneToOneConversation(any(), any())
+            } returns Either.Right(conversation)
+        }
+
         suspend fun withEstablishMLSGroupSuccessful(additionResult: MLSAdditionResult) = apply {
             everySuspend {
                 mlsConversationRepository.establishMLSGroup(any(), any(), any(), any(), any())
@@ -499,6 +610,7 @@ class JoinExistingMLSConversationUseCaseTest {
             val GROUP_ID_ONE_ON_ONE = GroupID("group-one-on-ne")
             val GROUP_ID_SELF = GroupID("group-self")
             val LOCAL_GROUP_EPOCH = 7UL
+            val ANOTHER_USER_ID = UserId("another-user", "domain")
 
             val MLS_CONVERSATION1 = TestConversation.GROUP(
                 Conversation.ProtocolInfo.MLS(
@@ -563,6 +675,26 @@ class JoinExistingMLSConversationUseCaseTest {
             val MLS_MIGRATED_REFRESHED_GROUP_CONVERSATION = MLS_MIGRATED_STALE_GROUP_CONVERSATION.copy(
                 protocol = Conversation.ProtocolInfo.MLS(
                     GROUP_ID3,
+                    Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN,
+                    epoch = 2UL,
+                    keyingMaterialLastUpdate = DateTimeUtil.currentInstant(),
+                    cipherSuite = CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+                )
+            )
+
+            val MLS_MIGRATED_STALE_ONE_ON_ONE_CONVERSATION = TestConversation.ONE_ON_ONE(
+                Conversation.ProtocolInfo.MLS(
+                    GROUP_ID_ONE_ON_ONE,
+                    Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED,
+                    epoch = 0UL,
+                    keyingMaterialLastUpdate = DateTimeUtil.currentInstant(),
+                    cipherSuite = CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+                )
+            ).copy(id = ConversationId("one-on-one-migrated-stale", "domain"))
+
+            val MLS_MIGRATED_REFRESHED_ONE_ON_ONE_CONVERSATION = MLS_MIGRATED_STALE_ONE_ON_ONE_CONVERSATION.copy(
+                protocol = Conversation.ProtocolInfo.MLS(
+                    GROUP_ID_ONE_ON_ONE,
                     Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN,
                     epoch = 2UL,
                     keyingMaterialLastUpdate = DateTimeUtil.currentInstant(),

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationMembershipAuditManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/MLSConversationMembershipAuditManagerTest.kt
@@ -1,0 +1,300 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.conversation
+
+import app.cash.turbine.test
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.keypackage.MLSMembershipAuditRepository
+import com.wire.kalium.logic.data.keypackage.MLSMembershipAuditState
+import com.wire.kalium.logic.data.sync.InMemoryIncrementalSyncRepository
+import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
+import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
+import com.wire.kalium.logic.data.sync.SlowSyncRepository
+import com.wire.kalium.logic.data.sync.SlowSyncStatus
+import com.wire.kalium.logic.feature.keypackage.RefillKeyPackagesResult
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class MLSConversationMembershipAuditManagerTest {
+
+    @Test
+    fun givenRequiredAudit_whenIncrementalSyncBecomesLive_thenKeyPackageCheckIsRequested() = runTest {
+        val (arrangement, manager) = Arrangement()
+            .withAuditState(MLSMembershipAuditState.REQUIRED)
+            .arrange()
+
+        manager.observeShouldForceKeyPackageCheck().test {
+            assertFalse(awaitItem())
+
+            arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Live)
+
+            assertTrue(awaitItem())
+        }
+    }
+
+    @Test
+    fun givenRequiredAuditAndLiveSync_whenSlowSyncCompletes_thenKeyPackageCheckIsRequested() = runTest {
+        val (arrangement, manager) = Arrangement()
+            .withAuditState(MLSMembershipAuditState.REQUIRED)
+            .withSlowSyncState(SlowSyncStatus.Pending)
+            .withIncrementalSyncState(IncrementalSyncStatus.Live)
+            .arrange()
+
+        manager.observeShouldForceKeyPackageCheck().test {
+            assertFalse(awaitItem())
+
+            arrangement.slowSyncState.value = SlowSyncStatus.Complete
+
+            assertTrue(awaitItem())
+        }
+    }
+
+    @Test
+    fun givenDeferredAudit_whenPostRegistrationSlowSyncCompletes_thenAuditBecomesRequired() = runTest {
+        val (arrangement, manager) = Arrangement()
+            .withAuditState(MLSMembershipAuditState.REQUIRED_AFTER_SLOW_SYNC)
+            .withIncrementalSyncState(IncrementalSyncStatus.Live)
+            .arrange()
+
+        manager.observeShouldForceKeyPackageCheck().test {
+            assertFalse(awaitItem())
+
+            arrangement.slowSyncState.value = SlowSyncStatus.Pending
+            arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Pending)
+            arrangement.slowSyncState.value = SlowSyncStatus.Complete
+            arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Live)
+
+            assertTrue(awaitItem())
+            verifySuspend(VerifyMode.exactly(1)) {
+                arrangement.auditRepository.markAuditRequired()
+            }
+        }
+    }
+
+    @Test
+    fun givenDeferredAuditAfterRestart_whenSyncIsAlreadyComplete_thenAnotherSlowSyncCycleIsRequired() = runTest {
+        val (_, manager) = Arrangement()
+            .withAuditState(MLSMembershipAuditState.REQUIRED_AFTER_SLOW_SYNC)
+            .withIncrementalSyncState(IncrementalSyncStatus.Live)
+            .arrange()
+
+        manager.observeShouldForceKeyPackageCheck().test {
+            assertFalse(awaitItem())
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun givenAuditIsRequiredAndPackagesAreAvailable_whenAuditing_thenAuditRunsAndMarkerIsCleared() = runTest {
+        val (arrangement, manager) = Arrangement()
+            .withAuditState(MLSMembershipAuditState.REQUIRED)
+            .withIncrementalSyncState(IncrementalSyncStatus.Live)
+            .withAuditSuccessful()
+            .arrange()
+
+        val result = manager.auditIfNeeded(
+            RefillKeyPackagesResult.Success(availableCountBeforeRefill = 10, refilled = false)
+        )
+
+        assertIs<Either.Right<Unit>>(result)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.auditMLSConversationMembership.invoke(any())
+            arrangement.auditRepository.clearAuditRequired()
+        }
+    }
+
+    @Test
+    fun givenAuditIsRequiredAndPackagesWereRefilled_whenAuditing_thenAuditRuns() = runTest {
+        val (arrangement, manager) = Arrangement()
+            .withAuditState(MLSMembershipAuditState.REQUIRED)
+            .withIncrementalSyncState(IncrementalSyncStatus.Live)
+            .withAuditSuccessful()
+            .arrange()
+
+        val result = manager.auditIfNeeded(
+            RefillKeyPackagesResult.Success(availableCountBeforeRefill = 0, refilled = true)
+        )
+
+        assertIs<Either.Right<Unit>>(result)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.auditMLSConversationMembership.invoke(any())
+        }
+    }
+
+    @Test
+    fun givenAuditIsRequiredButNoPackagesAreAvailable_whenAuditing_thenAuditIsDeferred() = runTest {
+        val (arrangement, manager) = Arrangement()
+            .withAuditState(MLSMembershipAuditState.REQUIRED)
+            .withIncrementalSyncState(IncrementalSyncStatus.Live)
+            .arrange()
+
+        val result = manager.auditIfNeeded(
+            RefillKeyPackagesResult.Success(availableCountBeforeRefill = 0, refilled = false)
+        )
+
+        assertIs<Either.Right<Unit>>(result)
+        verifySuspend(VerifyMode.not) {
+            arrangement.auditMLSConversationMembership.invoke(any())
+            arrangement.auditRepository.clearAuditRequired()
+        }
+    }
+
+    @Test
+    fun givenAuditIsRequiredWhileSlowSyncIsPending_whenAuditing_thenAuditIsDeferred() = runTest {
+        val (arrangement, manager) = Arrangement()
+            .withAuditState(MLSMembershipAuditState.REQUIRED)
+            .withIncrementalSyncState(IncrementalSyncStatus.Live)
+            .withSlowSyncState(SlowSyncStatus.Pending)
+            .arrange()
+
+        val result = manager.auditIfNeeded(
+            RefillKeyPackagesResult.Success(availableCountBeforeRefill = 10, refilled = false)
+        )
+
+        assertIs<Either.Right<Unit>>(result)
+        verifySuspend(VerifyMode.not) {
+            arrangement.auditMLSConversationMembership.invoke(any())
+            arrangement.auditRepository.clearAuditRequired()
+        }
+    }
+
+    @Test
+    fun givenAuditFails_whenAuditing_thenMarkerIsRetained() = runTest {
+        val (arrangement, manager) = Arrangement()
+            .withAuditState(MLSMembershipAuditState.REQUIRED)
+            .withIncrementalSyncState(IncrementalSyncStatus.Live)
+            .withAuditFailed()
+            .arrange()
+
+        val result = manager.auditIfNeeded(
+            RefillKeyPackagesResult.Success(availableCountBeforeRefill = 0, refilled = true)
+        )
+
+        assertIs<Either.Left<CoreFailure>>(result)
+        verifySuspend(VerifyMode.not) {
+            arrangement.auditRepository.clearAuditRequired()
+        }
+    }
+
+    @Test
+    fun givenMarkerClearFails_whenAuditing_thenFailureIsReturnedAndMarkerRemainsRequired() = runTest {
+        val (arrangement, manager) = Arrangement()
+            .withAuditState(MLSMembershipAuditState.REQUIRED)
+            .withIncrementalSyncState(IncrementalSyncStatus.Live)
+            .withAuditSuccessful()
+            .withAuditClearFailed()
+            .arrange()
+
+        val result = manager.auditIfNeeded(
+            RefillKeyPackagesResult.Success(availableCountBeforeRefill = 10, refilled = false)
+        )
+
+        assertIs<Either.Left<StorageFailure>>(result)
+        assertEquals(MLSMembershipAuditState.REQUIRED, arrangement.auditState.value)
+    }
+
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        val incrementalSyncRepository: IncrementalSyncRepository = InMemoryIncrementalSyncRepository()
+        val slowSyncRepository: SlowSyncRepository = mock()
+        val auditRepository: MLSMembershipAuditRepository = mock()
+        val auditMLSConversationMembership: AuditMLSConversationMembershipUseCase = mock()
+        val slowSyncState = MutableStateFlow<SlowSyncStatus>(SlowSyncStatus.Complete)
+        val auditState = MutableStateFlow(MLSMembershipAuditState.NOT_REQUIRED)
+        private var auditClearFailure: StorageFailure? = null
+
+        fun withAuditState(state: MLSMembershipAuditState) = apply {
+            auditState.value = state
+        }
+
+        fun withSlowSyncState(state: SlowSyncStatus) = apply {
+            slowSyncState.value = state
+        }
+
+        suspend fun withIncrementalSyncState(state: IncrementalSyncStatus) = apply {
+            incrementalSyncRepository.updateIncrementalSyncState(state)
+        }
+
+        suspend fun withAuditSuccessful() = apply {
+            everySuspend {
+                auditMLSConversationMembership.invoke(any())
+            } returns AuditMLSConversationMembershipResult.Success
+        }
+
+        suspend fun withAuditFailed() = apply {
+            everySuspend {
+                auditMLSConversationMembership.invoke(any())
+            } returns AuditMLSConversationMembershipResult.Failure(CoreFailure.MissingClientRegistration)
+        }
+
+        fun withAuditClearFailed() = apply {
+            auditClearFailure = StorageFailure.DataNotFound
+        }
+
+        suspend fun arrange(): Pair<Arrangement, MLSConversationMembershipAuditManager> {
+            every {
+                slowSyncRepository.slowSyncStatus
+            } returns slowSyncState
+            every {
+                auditRepository.observeAuditState()
+            } returns auditState
+            everySuspend {
+                auditRepository.getAuditState()
+            } calls { Either.Right(auditState.value) }
+            everySuspend {
+                auditRepository.markAuditRequired()
+            } calls {
+                auditState.value = MLSMembershipAuditState.REQUIRED
+                Either.Right(Unit)
+            }
+            everySuspend {
+                auditRepository.clearAuditRequired()
+            } calls {
+                auditClearFailure?.let { Either.Left(it) } ?: run {
+                    auditState.value = MLSMembershipAuditState.NOT_REQUIRED
+                    Either.Right(Unit)
+                }
+            }
+            withTransactionReturning(Either.Right(Unit))
+            return this to MLSConversationMembershipAuditManagerImpl(
+                incrementalSyncRepository,
+                slowSyncRepository,
+                auditRepository,
+                lazy { auditMLSConversationMembership },
+                cryptoTransactionProvider
+            )
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/keypackage/KeyPackageManagerTests.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/keypackage/KeyPackageManagerTests.kt
@@ -19,12 +19,14 @@
 package com.wire.kalium.logic.feature.keypackage
 
 import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.client.ClientRepository
 import com.wire.kalium.logic.data.sync.InMemoryIncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncRepository
 import com.wire.kalium.logic.data.sync.IncrementalSyncStatus
 import com.wire.kalium.logic.feature.TimestampKeyRepository
+import com.wire.kalium.logic.feature.conversation.MLSConversationMembershipAuditManager
 import com.wire.kalium.logic.featureFlags.FeatureSupport
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
@@ -37,6 +39,7 @@ import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import kotlin.test.Test
@@ -140,6 +143,146 @@ class KeyPackageManagerTests {
             }
         }
 
+    @Test
+    fun givenSyncIsNotLive_whenAuditIsRequired_thenRefillAndAuditAreNotPerformed() =
+        runTest(TestKaliumDispatcher.default) {
+            val (arrangement, _) = Arrangement()
+                .withIsMLSSupported(true)
+                .withHasRegisteredMLSClient(true)
+                .withShouldForceKeyPackageCheck(true)
+                .arrange()
+
+            arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Pending)
+            yield()
+
+            verifySuspend(VerifyMode.not) {
+                arrangement.refillKeyPackagesUseCase.invoke(any())
+            }
+            verifySuspend(VerifyMode.not) {
+                arrangement.membershipAuditManager.auditIfNeeded(any())
+            }
+        }
+
+    @Test
+    fun givenAuditRequestsKeyPackageCheck_whenTimestampAndCachedCountDoNot_thenRefillCheckIsForced() =
+        runTest(TestKaliumDispatcher.default) {
+            val (arrangement, _) = Arrangement()
+                .withIsMLSSupported(true)
+                .withHasRegisteredMLSClient(true)
+                .withLastKeyPackageCountCheck(false)
+                .withKeyPackageCountFailed()
+                .withShouldForceKeyPackageCheck(true)
+                .withRefillKeyPackagesUseCaseSuccessful(availableCountBeforeRefill = 10, refilled = false)
+                .withUpdateLastKeyPackageCountCheckSuccessful()
+                .arrange()
+
+            arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Live)
+            yield()
+
+            verifySuspend(VerifyMode.exactly(1)) {
+                arrangement.refillKeyPackagesUseCase.invoke(any())
+            }
+            verifySuspend(VerifyMode.exactly(1)) {
+                arrangement.membershipAuditManager.auditIfNeeded(
+                    RefillKeyPackagesResult.Success(availableCountBeforeRefill = 10, refilled = false)
+                )
+            }
+        }
+
+    @Test
+    fun givenAuditRequestsKeyPackageCheckWhileSyncIsAlreadyLive_thenManagerIsWoken() =
+        runTest(TestKaliumDispatcher.default) {
+            val (arrangement, _) = Arrangement()
+                .withIsMLSSupported(true)
+                .withHasRegisteredMLSClient(true)
+                .withLastKeyPackageCountCheck(false)
+                .withKeyPackageCountFailed()
+                .withRefillKeyPackagesUseCaseSuccessful(availableCountBeforeRefill = 10, refilled = false)
+                .withUpdateLastKeyPackageCountCheckSuccessful()
+                .arrange()
+
+            arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Live)
+            yield()
+            verifySuspend(VerifyMode.not) {
+                arrangement.refillKeyPackagesUseCase.invoke(any())
+            }
+
+            arrangement.withShouldForceKeyPackageCheck(true)
+            yield()
+
+            verifySuspend(VerifyMode.exactly(1)) {
+                arrangement.refillKeyPackagesUseCase.invoke(any())
+            }
+        }
+
+    @Test
+    fun givenKeyPackageCheckFails_whenSyncIsLive_thenTimestampAndAuditAreNotUpdated() =
+        runTest(TestKaliumDispatcher.default) {
+            val (arrangement, _) = Arrangement()
+                .withIsMLSSupported(true)
+                .withHasRegisteredMLSClient(true)
+                .withLastKeyPackageCountCheck(true)
+                .withKeyPackageCountFailed()
+                .withRefillKeyPackagesUseCaseFailed()
+                .arrange()
+
+            arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Live)
+            yield()
+
+            verifySuspend(VerifyMode.not) {
+                arrangement.timestampKeyRepository.reset(any())
+                arrangement.membershipAuditManager.auditIfNeeded(any())
+            }
+        }
+
+    @Test
+    fun givenTimestampResetFails_whenKeyPackageCheckSucceeds_thenAuditIsStillAttempted() =
+        runTest(TestKaliumDispatcher.default) {
+            val (arrangement, _) = Arrangement()
+                .withIsMLSSupported(true)
+                .withHasRegisteredMLSClient(true)
+                .withLastKeyPackageCountCheck(true)
+                .withKeyPackageCountFailed()
+                .withRefillKeyPackagesUseCaseSuccessful(availableCountBeforeRefill = 0, refilled = true)
+                .withUpdateLastKeyPackageCountCheckFailed()
+                .arrange()
+
+            arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Live)
+            yield()
+
+            verifySuspend(VerifyMode.exactly(1)) {
+                arrangement.membershipAuditManager.auditIfNeeded(
+                    RefillKeyPackagesResult.Success(availableCountBeforeRefill = 0, refilled = true)
+                )
+            }
+        }
+
+    @Test
+    fun givenKeyPackageCheckSucceeds_whenSyncIsLive_thenAuditIsDelegatedAfterRefill() =
+        runTest(TestKaliumDispatcher.default) {
+            val refillResult = RefillKeyPackagesResult.Success(availableCountBeforeRefill = 10, refilled = false)
+            val (arrangement, _) = Arrangement()
+                .withIsMLSSupported(true)
+                .withHasRegisteredMLSClient(true)
+                .withLastKeyPackageCountCheck(true)
+                .withKeyPackageCountFailed()
+                .withRefillKeyPackagesUseCaseSuccessful(
+                    availableCountBeforeRefill = refillResult.availableCountBeforeRefill,
+                    refilled = refillResult.refilled
+                )
+                .withUpdateLastKeyPackageCountCheckSuccessful()
+                .arrange()
+
+            arrangement.incrementalSyncRepository.updateIncrementalSyncState(IncrementalSyncStatus.Live)
+            yield()
+
+            verifySuspend(VerifyMode.order) {
+                arrangement.refillKeyPackagesUseCase.invoke(any())
+                arrangement.timestampKeyRepository.reset(any())
+                arrangement.membershipAuditManager.auditIfNeeded(refillResult)
+            }
+        }
+
     private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
 
         val incrementalSyncRepository: IncrementalSyncRepository = InMemoryIncrementalSyncRepository()
@@ -148,6 +291,8 @@ class KeyPackageManagerTests {
         val timestampKeyRepository: TimestampKeyRepository = mock()
         val refillKeyPackagesUseCase: RefillKeyPackagesUseCase = mock()
         val keyPackageCountUseCase: MLSKeyPackageCountUseCase = mock()
+        val membershipAuditManager: MLSConversationMembershipAuditManager = mock()
+        private val shouldForceKeyPackageCheck = MutableStateFlow(false)
 
         suspend fun withLastKeyPackageCountCheck(hasPassed: Boolean) = apply {
             everySuspend {
@@ -155,16 +300,31 @@ class KeyPackageManagerTests {
             } returns Either.Right(hasPassed)
         }
 
-        suspend fun withRefillKeyPackagesUseCaseSuccessful() = apply {
+        suspend fun withRefillKeyPackagesUseCaseSuccessful(
+            availableCountBeforeRefill: Int = 10,
+            refilled: Boolean = true,
+        ) = apply {
             everySuspend {
                 refillKeyPackagesUseCase.invoke(any())
-            } returns RefillKeyPackagesResult.Success
+            } returns RefillKeyPackagesResult.Success(availableCountBeforeRefill, refilled)
         }
 
         suspend fun withUpdateLastKeyPackageCountCheckSuccessful() = apply {
             everySuspend {
                 timestampKeyRepository.reset(any())
             } returns Either.Right(Unit)
+        }
+
+        suspend fun withUpdateLastKeyPackageCountCheckFailed() = apply {
+            everySuspend {
+                timestampKeyRepository.reset(any())
+            } returns Either.Left(StorageFailure.DataNotFound)
+        }
+
+        suspend fun withRefillKeyPackagesUseCaseFailed() = apply {
+            everySuspend {
+                refillKeyPackagesUseCase.invoke(any())
+            } returns RefillKeyPackagesResult.Failure(CoreFailure.MissingClientRegistration)
         }
 
         suspend fun withKeyPackageCountReturnsRefillTrue() = apply {
@@ -183,6 +343,10 @@ class KeyPackageManagerTests {
             } returns MLSKeyPackageCountResult.Failure.Generic(CoreFailure.MissingClientRegistration)
         }
 
+        fun withShouldForceKeyPackageCheck(shouldForce: Boolean) = apply {
+            shouldForceKeyPackageCheck.value = shouldForce
+        }
+
         fun withIsMLSSupported(supported: Boolean) = apply {
             every {
                 featureSupport.isMLSSupported
@@ -195,17 +359,25 @@ class KeyPackageManagerTests {
             } returns Either.Right(result)
         }
 
-        suspend fun arrange() = this to KeyPackageManagerImpl(
-            featureSupport,
-            incrementalSyncRepository,
-            lazy { clientRepository },
-            lazy { refillKeyPackagesUseCase },
-            lazy { keyPackageCountUseCase },
-            lazy { timestampKeyRepository },
-            cryptoTransactionProvider,
-            TestKaliumDispatcher
-        ).also {
+        suspend fun arrange(): Pair<Arrangement, KeyPackageManagerImpl> {
+            every {
+                membershipAuditManager.observeShouldForceKeyPackageCheck()
+            } returns shouldForceKeyPackageCheck
+            everySuspend {
+                membershipAuditManager.auditIfNeeded(any())
+            } returns Either.Right(Unit)
             withMLSTransactionReturning(Either.Right(Unit))
+            return this to KeyPackageManagerImpl(
+                featureSupport,
+                incrementalSyncRepository,
+                lazy { clientRepository },
+                lazy { refillKeyPackagesUseCase },
+                lazy { keyPackageCountUseCase },
+                lazy { timestampKeyRepository },
+                lazy { membershipAuditManager },
+                cryptoTransactionProvider,
+                TestKaliumDispatcher
+            )
         }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/keypackage/RefillKeyPackageUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/keypackage/RefillKeyPackageUseCaseTest.kt
@@ -19,12 +19,14 @@
 package com.wire.kalium.logic.feature.keypackage
 
 import com.wire.kalium.common.error.NetworkFailure
+import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.client.toCrypto
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.keypackage.KeyPackageLimitsProvider
 import com.wire.kalium.logic.data.keypackage.KeyPackageRepository
+import com.wire.kalium.logic.data.keypackage.MLSMembershipAuditRepository
 import com.wire.kalium.logic.data.mls.CipherSuite
 import com.wire.kalium.logic.framework.TestClient
 import com.wire.kalium.logic.framework.TestUser
@@ -70,6 +72,8 @@ class RefillKeyPackageUseCaseTest {
         }
 
         assertIs<RefillKeyPackagesResult.Success>(actual)
+        assertEquals(keyPackageCount, actual.availableCountBeforeRefill)
+        assertEquals(true, actual.refilled)
     }
 
     @Test
@@ -86,6 +90,69 @@ class RefillKeyPackageUseCaseTest {
         val actual = refillKeyPackagesUseCase(arrangement.mlsContext)
 
         assertIs<RefillKeyPackagesResult.Success>(actual)
+        assertEquals(keyPackageCount, actual.availableCountBeforeRefill)
+        assertEquals(false, actual.refilled)
+    }
+
+    @Test
+    fun givenNoAvailableKeyPackages_whenRefilling_thenAuditIsMarkedRequiredBeforeUpload() = runTest {
+        val (arrangement, refillKeyPackagesUseCase) = Arrangement()
+            .withExistingSelfClientId()
+            .withKeyPackageLimits(true, Arrangement.KEY_PACKAGE_LIMIT)
+            .withKeyPackageCount(0)
+            .withAuditMarkedRequired()
+            .withUploadKeyPackagesSuccessful()
+            .withDefaultCipherSuite(CipherSuite.fromTag(1))
+            .arrange()
+
+        val actual = refillKeyPackagesUseCase(arrangement.mlsContext)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.mlsMembershipAuditRepository.markAuditRequired()
+        }
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.keyPackageRepository.uploadNewKeyPackages(any(), any(), any())
+        }
+        assertEquals(RefillKeyPackagesResult.Success(0, refilled = true), actual)
+    }
+
+    @Test
+    fun givenNoAvailableKeyPackagesAndAuditCannotBePersisted_whenRefilling_thenUploadIsNotAttempted() = runTest {
+        val storageFailure = StorageFailure.Generic(IllegalStateException("storage failure"))
+        val (arrangement, refillKeyPackagesUseCase) = Arrangement()
+            .withExistingSelfClientId()
+            .withKeyPackageLimits(true, Arrangement.KEY_PACKAGE_LIMIT)
+            .withKeyPackageCount(0)
+            .withAuditMarkingFailed(storageFailure)
+            .withDefaultCipherSuite(CipherSuite.fromTag(1))
+            .arrange()
+
+        val actual = refillKeyPackagesUseCase(arrangement.mlsContext)
+
+        verifySuspend(VerifyMode.not) {
+            arrangement.keyPackageRepository.uploadNewKeyPackages(any(), any(), any())
+        }
+        assertEquals(RefillKeyPackagesResult.Failure(storageFailure), actual)
+    }
+
+    @Test
+    fun givenNoAvailableKeyPackagesAndUploadFails_whenRefilling_thenAuditMarkerIsNotCleared() = runTest {
+        val networkFailure = NetworkFailure.NoNetworkConnection(null)
+        val (arrangement, refillKeyPackagesUseCase) = Arrangement()
+            .withExistingSelfClientId()
+            .withKeyPackageLimits(true, Arrangement.KEY_PACKAGE_LIMIT)
+            .withKeyPackageCount(0)
+            .withAuditMarkedRequired()
+            .withUploadKeyPackagesFailed(networkFailure)
+            .withDefaultCipherSuite(CipherSuite.fromTag(1))
+            .arrange()
+
+        val actual = refillKeyPackagesUseCase(arrangement.mlsContext)
+
+        verifySuspend(VerifyMode.not) {
+            arrangement.mlsMembershipAuditRepository.clearAuditRequired()
+        }
+        assertEquals(RefillKeyPackagesResult.Failure(networkFailure), actual)
     }
 
     @Test
@@ -109,6 +176,7 @@ class RefillKeyPackageUseCaseTest {
         val keyPackageRepository: KeyPackageRepository = mock()
         val keyPackageLimitsProvider: KeyPackageLimitsProvider = mock()
         val currentClientIdProvider: CurrentClientIdProvider = mock()
+        val mlsMembershipAuditRepository: MLSMembershipAuditRepository = mock()
 
         private var refillKeyPackageUseCase = RefillKeyPackagesUseCaseImpl(
             keyPackageRepository,
@@ -116,6 +184,7 @@ class RefillKeyPackageUseCaseTest {
             currentClientIdProvider,
             TestUser.SELF.id,
             NoOpCryptoStateChangeHookNotifier,
+            mlsMembershipAuditRepository,
         )
 
         fun withDefaultCipherSuite(cipherSuite: CipherSuite) = apply {
@@ -149,6 +218,24 @@ class RefillKeyPackageUseCaseTest {
             everySuspend {
                 keyPackageRepository.uploadNewKeyPackages(any(), eq(TestClient.CLIENT_ID), any())
             } returns Either.Right(Unit)
+        }
+
+        suspend fun withUploadKeyPackagesFailed(failure: NetworkFailure) = apply {
+            everySuspend {
+                keyPackageRepository.uploadNewKeyPackages(any(), eq(TestClient.CLIENT_ID), any())
+            } returns Either.Left(failure)
+        }
+
+        suspend fun withAuditMarkedRequired() = apply {
+            everySuspend {
+                mlsMembershipAuditRepository.markAuditRequired()
+            } returns Either.Right(Unit)
+        }
+
+        suspend fun withAuditMarkingFailed(failure: StorageFailure) = apply {
+            everySuspend {
+                mlsMembershipAuditRepository.markAuditRequired()
+            } returns Either.Left(failure)
         }
 
         suspend fun withGetAvailableKeyPackagesFailing(failure: NetworkFailure) = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandlerTest.kt
@@ -110,7 +110,7 @@ class MLSWelcomeEventHandlerTest {
     @Test
     fun givenProcessingOfWelcomeSucceeds_thenShouldFetchConversationIfUnknown() = runTest {
         val (arrangement, mlsWelcomeEventHandler) = arrange {
-            withRefillKeyPackagesReturning(RefillKeyPackagesResult.Success)
+            withRefillKeyPackagesReturning(RefillKeyPackagesResult.Success(1, refilled = false))
             withMLSClientProcessingOfWelcomeMessageReturnsSuccessfully()
             withFetchConversationIfUnknownSucceeding()
             withUpdateGroupStateReturning(Either.Right(Unit))
@@ -127,7 +127,7 @@ class MLSWelcomeEventHandlerTest {
     @Test
     fun givenProcessingOfWelcomeSucceeds_thenShouldMarkConversationAsEstablished() = runTest {
         val (arrangement, mlsWelcomeEventHandler) = arrange {
-            withRefillKeyPackagesReturning(RefillKeyPackagesResult.Success)
+            withRefillKeyPackagesReturning(RefillKeyPackagesResult.Success(1, refilled = false))
             withMLSClientProcessingOfWelcomeMessageReturnsSuccessfully()
             withFetchConversationIfUnknownSucceeding()
             withUpdateGroupStateReturning(Either.Right(Unit))
@@ -147,7 +147,7 @@ class MLSWelcomeEventHandlerTest {
     @Test
     fun givenProcessingOfWelcomeForOneOnOneSucceeds_thenShouldResolveConversation() = runTest {
         val (arrangement, mlsWelcomeEventHandler) = arrange {
-            withRefillKeyPackagesReturning(RefillKeyPackagesResult.Success)
+            withRefillKeyPackagesReturning(RefillKeyPackagesResult.Success(1, refilled = false))
             withMLSClientProcessingOfWelcomeMessageReturnsSuccessfully()
             withFetchConversationIfUnknownSucceeding()
             withUpdateGroupStateReturning(Either.Right(Unit))
@@ -165,7 +165,7 @@ class MLSWelcomeEventHandlerTest {
     @Test
     fun givenProcessingOfWelcomeForGroupSucceeds_thenShouldNotResolveConversation() = runTest {
         val (arrangement, mlsWelcomeEventHandler) = arrange {
-            withRefillKeyPackagesReturning(RefillKeyPackagesResult.Success)
+            withRefillKeyPackagesReturning(RefillKeyPackagesResult.Success(1, refilled = false))
             withMLSClientProcessingOfWelcomeMessageReturnsSuccessfully()
             withFetchConversationIfUnknownSucceeding()
             withUpdateGroupStateReturning(Either.Right(Unit))
@@ -232,7 +232,7 @@ class MLSWelcomeEventHandlerTest {
     @Test
     fun givenAllSucceeds_whenHandlingEvent_thenShouldAttemptToRefillKeyPackages() = runTest {
         val (arrangement, mlsWelcomeEventHandler) = arrange {
-            withRefillKeyPackagesReturning(RefillKeyPackagesResult.Success)
+            withRefillKeyPackagesReturning(RefillKeyPackagesResult.Success(1, refilled = false))
             withMLSClientProcessingOfWelcomeMessageReturnsSuccessfully()
             withFetchConversationIfUnknownSucceeding()
             withUpdateGroupStateReturning(Either.Right(Unit))
@@ -290,7 +290,7 @@ class MLSWelcomeEventHandlerTest {
                 )
             )
             withMLSConversationExists(true)
-            withRefillKeyPackagesReturning(RefillKeyPackagesResult.Success)
+            withRefillKeyPackagesReturning(RefillKeyPackagesResult.Success(1, refilled = false))
         }
 
         mlsWelcomeEventHandler.handle(arrangement.transactionContext, WELCOME_EVENT).shouldSucceed()
@@ -321,7 +321,7 @@ class MLSWelcomeEventHandlerTest {
                 )
             )
             withJoinExistingMLSConversationReturning(Either.Right(Unit))
-            withRefillKeyPackagesReturning(RefillKeyPackagesResult.Success)
+            withRefillKeyPackagesReturning(RefillKeyPackagesResult.Success(1, refilled = false))
         }
 
         mlsWelcomeEventHandler.handle(arrangement.transactionContext, WELCOME_EVENT).shouldSucceed()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-27077
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-27077
----

# What's new in this PR?

### Summary
This PR adds MLS conversation membership recovery for clients that were not added to MLS groups because they had no available key packages or had not yet registered an MLS identity during MLS migration.

After key packages become available and synchronization completes, the client audits its active MLS-capable conversations against CoreCrypto and rejoins any missing groups using external commits.

The implementation keeps normal key-package refill behavior separate from MLS membership-audit orchestration.

### Issues

#### Scenario 1 (MLS):

User has two MLS clients (Client A, Client B)
Client B is offline with no key packages left.
User is added to a new conversation, Client A is added, Client B cannot be added (no key packages).
Client B goes online and refills key packages.

Expected:
Client B joins new MLS conversation

Actual:
Client B cannot receive messages in a new conversation.

#### Scenario 2 (Proteus -> MLS migration):

User has two Proteus clients (Client A, Client B)
Client B is offline.
Proteus to MLS migration is started.
Existing proteus conversation is migrated to MLS.
Client A creates MLS client, uploads key packages and is added to MLS conversation, Client B cannot be added.
Client B goes online and refills key packages.

Expected:
Client B joins migrated MLS conversation.

Actual:
Client B cannot receive messages in migrated conversation.


### Solutions

#### Durable membership-audit state
Added a user-scoped MLSMembershipAuditRepository backed by the existing Metadata table.
The repository supports three states:

- NOT_REQUIRED
- REQUIRED
- REQUIRED_AFTER_SLOW_SYNC

The marker survives application restarts and is removed only after the complete membership audit succeeds.
The existing "true" metadata value remains compatible with the new state representation. No database schema migration is required.


#### Key-package depletion detection
RefillKeyPackagesUseCase now treats backend key packages count of zero as a recovery signal.
When zero packages are observed, it:
- Persists the audit-required marker.
- Aborts the refill if marker persistence fails.
- Uploads replacement key packages only after the marker is durable.
- Leaves the marker set if the upload fails.

RefillKeyPackagesResult.Success now includes:
- availableCountBeforeRefill
- refilled
These values allow the audit flow to determine whether key packages are available after the check:
refilled == true means this pass successfully uploaded replacements.

availableCountBeforeRefill > 0 handles restart recovery where a previous pass uploaded packages before the application stopped. Normal refills from a low but nonzero count do not independently schedule an audit.

#### Post-registration recovery
RegisterMLSClientUseCase now persists REQUIRED_AFTER_SLOW_SYNC before registering the MLS client or uploading its initial key packages.
This prevents the audit from starting while registration or its subsequent slow sync is still in progress.
After the manager observes a real post-registration slow-sync cycle completing and incremental sync returning to Live, it promotes the marker to REQUIRED.
This covers existing Proteus clients that receive their MLS identity only after conversations have already migrated.

#### Dedicated audit orchestration
Added MLSConversationMembershipAuditManager to separate membership recovery from normal key-package management.

The manager:
1. Observes incremental sync, slow sync, and durable audit state.
2. Waits until incremental sync is Live and slow sync is complete.
3. Handles deferred post-registration audit state.
4. Exposes a force-check signal so a pending audit can wake KeyPackageManager even when incremental sync is already Live.
5. Verifies that key packages are available before auditing.
6. Runs the audit in a crypto transaction separate from the key-package refill transaction.
7. Clears the marker only after a successful audit.
8. Retains the marker after refill, audit, transaction, or marker-clear failures.

#### Simplified KeyPackageManager
KeyPackageManager remains focused on its original refill flow:
1. Wait for incremental sync to become Live.
2. Verify that MLS is supported.
3. Verify that this client has registered MLS.
4. Check whether:
- the regular 24-hour interval elapsed;
- the cached count indicates refill is needed; or
- membership recovery requests a forced check.
5. Run the refill/check inside an MLS transaction.
6. Reset the last-check timestamp.
7. Pass the successful result to the membership-audit manager.
Normal refill behavior remains independent of slow-sync status. Slow-sync gating applies only to the audit.

#### Membership audit
Added AuditMLSConversationMembershipUseCase.
The audit queries every active MLS-capable conversation where the self user is still a member:
- MLS conversations
- Mixed-protocol conversations
- All local MLS group states
- Self conversations

It excludes:
- Proteus-only conversations
- Locally deleted conversations
- Conversations the self user has left

For each conversation, the audit:
1. Checks whether its MLS group actually exists in CoreCrypto.
2. Skips groups that already exist.
3. Rejoins missing groups with external-commit joining enabled.
4. Continues auditing remaining conversations after individual failures.
5. Returns overall failure if any conversation could not be checked or repaired.
The operation is idempotent: subsequent attempts skip groups repaired by an earlier partial audit.

#### Stale migration metadata recovery
Updated JoinExistingMLSConversationUseCase to handle migrated conversations whose local metadata incorrectly contains:
```
groupState = ESTABLISHED
epoch = 0
```
Previously, epoch zero caused the use case to establish a new local group instead of joining the already-existing migrated group.
When external-commit recovery is enabled, the use case now refreshes authoritative conversation metadata before choosing the recovery strategy if the local conversation is:
- PENDING_AFTER_RESET; or
- ESTABLISHED at epoch zero.
After refresh, a migrated conversation with a nonzero backend epoch is joined using an external commit.
This additional refresh is restricted to external-commit recovery so normal pending Welcome processing remains unchanged.
