### PR TITLE
refactor(time): reduce internal date conversions PR 6 [WPB-10090]

### DIFF
--- a/changelog.d/use-instant-for-conversation-status-timestamps.md
+++ b/changelog.d/use-instant-for-conversation-status-timestamps.md
@@ -1,0 +1,10 @@
+### Changed
+- Conversation archive and mute use cases now accept `Instant` timestamps instead of epoch-millisecond `Long` values.
+
+### Migration
+Pass an `Instant` directly when supplying a custom status timestamp.
+
+### Compatibility
+ABI: breaking.
+Source: breaking for consumers that pass a custom `Long` timestamp.
+Behavior: no behavior change.

--- a/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/SubConversation.kt
+++ b/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/SubConversation.kt
@@ -20,13 +20,14 @@ package com.wire.kalium.logic.data.conversation
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.SubconversationId
+import kotlinx.datetime.Instant
 
 data class SubConversation(
     val id: SubconversationId,
     val parentId: ConversationId,
     val groupId: GroupID,
     val epoch: ULong,
-    val epochTimestamp: String?,
+    val epochTimestamp: Instant?,
     val mlsCipherSuiteTag: Int?,
 
     val members: List<SubconversationMember>,

--- a/core/util/src/androidMain/kotlin/com.wire.kalium.util/PlatformDateTimeUtil.kt
+++ b/core/util/src/androidMain/kotlin/com.wire.kalium.util/PlatformDateTimeUtil.kt
@@ -18,14 +18,9 @@
 
 package com.wire.kalium.util
 
-import android.os.Build
-import androidx.annotation.RequiresApi
-import com.wire.kalium.util.DateTimeUtil.MILLISECONDS_DIGITS
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
-import kotlinx.datetime.toJavaInstant
 import java.text.SimpleDateFormat
-import java.time.format.DateTimeFormatterBuilder
 import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
@@ -38,9 +33,6 @@ actual open class PlatformDateTimeUtil actual constructor() {
 
     private val secondsDateTimeFormat = SimpleDateFormat(DateTimeUtil.simplePattern, Locale.getDefault())
 
-    @RequiresApi(Build.VERSION_CODES.O)
-    private val isoDateTimeFormatter = DateTimeFormatterBuilder().appendInstant(MILLISECONDS_DIGITS).toFormatter()
-
     /**
      * Parse [kotlinx.datetime.Instant] into date-time string in ISO-8601 format.
      * Regular `.toString()` can return different results on different platforms, for instance jvm uses [java.time.Instant]
@@ -50,19 +42,13 @@ actual open class PlatformDateTimeUtil actual constructor() {
      * @return date in ISO-8601 format (YYYY-MM-DDTHH:mm:ss.SSSZ)
      */
     actual fun fromInstantToIsoDateTimeString(instant: Instant): String =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-            isoDateTimeFormatter.format(instant.toJavaInstant())
-        else
             isoDateTimeFormat.format(Date(instant.toEpochMilliseconds()))
 
     /**
      * Parse [kotlinx.datetime.Instant] into date-time string in simplified format with up to seconds precision.
      * @return date in simplified format (YYYY-MM-DD_HH:mm:ss)
      */
-    actual fun fromInstantToSimpleDateTimeString(instant: Instant): String {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-            secondsDateTimeFormat.format(System.currentTimeMillis())
-        else
-            secondsDateTimeFormat.format(Date(Clock.System.now().toEpochMilliseconds()))
-    }
+    actual fun fromInstantToSimpleDateTimeString(instant: Instant): String =
+        secondsDateTimeFormat.format(Date(Clock.System.now().toEpochMilliseconds()))
+
 }

--- a/core/util/src/androidMain/kotlin/com.wire.kalium.util/PlatformDateTimeUtil.kt
+++ b/core/util/src/androidMain/kotlin/com.wire.kalium.util/PlatformDateTimeUtil.kt
@@ -18,20 +18,18 @@
 
 package com.wire.kalium.util
 
-import kotlinx.datetime.Clock
+import com.wire.kalium.util.DateTimeUtil.MILLISECONDS_DIGITS
 import kotlinx.datetime.Instant
+import kotlinx.datetime.toJavaInstant
 import java.text.SimpleDateFormat
-import java.util.Date
+import java.time.format.DateTimeFormatterBuilder
 import java.util.Locale
-import java.util.TimeZone
 
 actual open class PlatformDateTimeUtil actual constructor() {
 
-    private val isoDateTimeFormat = SimpleDateFormat(DateTimeUtil.iso8601Pattern, Locale.getDefault()).apply {
-        timeZone = TimeZone.getTimeZone("UTC")
-    }
-
     private val secondsDateTimeFormat = SimpleDateFormat(DateTimeUtil.simplePattern, Locale.getDefault())
+
+    private val isoDateTimeFormatter = DateTimeFormatterBuilder().appendInstant(MILLISECONDS_DIGITS).toFormatter()
 
     /**
      * Parse [kotlinx.datetime.Instant] into date-time string in ISO-8601 format.
@@ -42,13 +40,13 @@ actual open class PlatformDateTimeUtil actual constructor() {
      * @return date in ISO-8601 format (YYYY-MM-DDTHH:mm:ss.SSSZ)
      */
     actual fun fromInstantToIsoDateTimeString(instant: Instant): String =
-            isoDateTimeFormat.format(Date(instant.toEpochMilliseconds()))
+        isoDateTimeFormatter.format(instant.toJavaInstant())
 
     /**
      * Parse [kotlinx.datetime.Instant] into date-time string in simplified format with up to seconds precision.
      * @return date in simplified format (YYYY-MM-DD_HH:mm:ss)
      */
     actual fun fromInstantToSimpleDateTimeString(instant: Instant): String =
-        secondsDateTimeFormat.format(Date(Clock.System.now().toEpochMilliseconds()))
+        secondsDateTimeFormat.format(System.currentTimeMillis())
 
 }

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAO.kt
@@ -112,13 +112,13 @@ interface ConversationDAO {
     suspend fun updateConversationMutedStatus(
         conversationId: QualifiedIDEntity,
         mutedStatus: ConversationEntity.MutedStatus,
-        mutedStatusTimestamp: Long
+        mutedStatusTimestamp: Instant
     )
 
     suspend fun updateConversationArchivedStatus(
         conversationId: QualifiedIDEntity,
         isArchived: Boolean,
-        archivedStatusTimestamp: Long
+        archivedStatusTimestamp: Instant
     )
 
     suspend fun updateAccess(

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/conversation/ConversationDAOImpl.kt
@@ -38,7 +38,6 @@ import com.wire.kalium.persistence.util.mapToOne
 import com.wire.kalium.persistence.util.mapToOneOrDefault
 import com.wire.kalium.persistence.util.mapToOneOrNull
 import com.wire.kalium.util.DateTimeUtil
-import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
 import com.wire.kalium.util.DebugKaliumApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
@@ -459,12 +458,12 @@ internal class ConversationDAOImpl internal constructor(
     override suspend fun updateConversationMutedStatus(
         conversationId: QualifiedIDEntity,
         mutedStatus: ConversationEntity.MutedStatus,
-        mutedStatusTimestamp: Long
+        mutedStatusTimestamp: Instant
     ) {
         withContext(writeDispatcher.value) {
             conversationQueries.updateConversationMutingStatus(
                 mutedStatus,
-                mutedStatusTimestamp,
+                mutedStatusTimestamp.toEpochMilliseconds(),
                 conversationId
             )
         }
@@ -473,12 +472,12 @@ internal class ConversationDAOImpl internal constructor(
     override suspend fun updateConversationArchivedStatus(
         conversationId: QualifiedIDEntity,
         isArchived: Boolean,
-        archivedStatusTimestamp: Long
+        archivedStatusTimestamp: Instant
     ) {
         withContext(writeDispatcher.value) {
             conversationQueries.updateConversationArchivingStatus(
                 isArchived,
-                Instant.parse(archivedStatusTimestamp.toIsoDateTimeString()),
+                archivedStatusTimestamp,
                 conversationId
             )
         }

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/reaction/ReactionDAO.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/reaction/ReactionDAO.kt
@@ -96,8 +96,9 @@ class ReactionDAOImpl(
         reactionsQueries.transaction {
             reactionsQueries.doesMessageExist(originalMessageId, conversationId).awaitAsOneOrNull()?.let {
                 reactionsQueries.deleteAllReactionsOnMessageFromUser(originalMessageId, conversationId, senderUserId)
+                val date = instant.toIsoDateTimeString()
                 reactions.forEach {
-                    reactionsQueries.insertReaction(originalMessageId, conversationId, senderUserId, it, instant.toIsoDateTimeString())
+                    reactionsQueries.insertReaction(originalMessageId, conversationId, senderUserId, it, date)
                 }
             }
         }

--- a/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
+++ b/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/ConversationDAOTest.kt
@@ -382,7 +382,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
         conversationDAO.updateConversationMutedStatus(
             conversationId = conversationEntity3.id,
             mutedStatus = ConversationEntity.MutedStatus.ONLY_MENTIONS_AND_REPLIES_ALLOWED,
-            mutedStatusTimestamp = 1649702788L
+            mutedStatusTimestamp = Instant.fromEpochMilliseconds(1649702788L)
         )
 
         val result = conversationDAO.getConversationDetailsById(conversationEntity3.id)
@@ -2585,7 +2585,7 @@ class ConversationDAOTest : BaseDatabaseTest() {
             conversationDAO.updateConversationMutedStatus(
                 conversationEntity1.id,
                 ConversationEntity.MutedStatus.MENTIONS_MUTED,
-                Clock.System.now().toEpochMilliseconds()
+                Clock.System.now()
             )
             val result2 = awaitItem()
             assertEquals(ConversationEntity.MutedStatus.MENTIONS_MUTED, result2?.mutedStatus)

--- a/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageNotificationsTest.kt
+++ b/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/message/MessageNotificationsTest.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 import com.wire.kalium.persistence.utils.stubs.newRegularMessageEntity
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -70,7 +71,11 @@ class MessageNotificationsTest : BaseMessageTest() {
     fun givenMutedConversation_whenNewMessageInserted_thenNotificationEmpty() = runTest {
         val message = OTHER_MESSAGE
         insertInitialData()
-        conversationDAO.updateConversationMutedStatus(TEST_CONVERSATION_1.id, ConversationEntity.MutedStatus.ALL_MUTED, 0L)
+        conversationDAO.updateConversationMutedStatus(
+            TEST_CONVERSATION_1.id,
+            ConversationEntity.MutedStatus.ALL_MUTED,
+            Instant.fromEpochMilliseconds(0L)
+        )
 
         messageDAO.insertOrIgnoreMessage(message)
 
@@ -366,7 +371,7 @@ class MessageNotificationsTest : BaseMessageTest() {
     }
 
     private suspend fun setConversationMutedStatus(conversationId: QualifiedIDEntity, mutedStatus: ConversationEntity.MutedStatus) {
-        conversationDAO.updateConversationMutedStatus(conversationId, mutedStatus, Clock.System.now().toEpochMilliseconds())
+        conversationDAO.updateConversationMutedStatus(conversationId, mutedStatus, Clock.System.now())
     }
 
     override suspend fun insertInitialData() {

--- a/logic/api/jvm/logic.api
+++ b/logic/api/jvm/logic.api
@@ -4231,12 +4231,12 @@ public final class com/wire/kalium/logic/feature/conversation/UpdateConversation
 }
 
 public abstract interface class com/wire/kalium/logic/feature/conversation/UpdateConversationArchivedStatusUseCase {
-	public abstract fun invoke (Lcom/wire/kalium/logic/data/id/QualifiedID;ZZJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun invoke$default (Lcom/wire/kalium/logic/feature/conversation/UpdateConversationArchivedStatusUseCase;Lcom/wire/kalium/logic/data/id/QualifiedID;ZZJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun invoke (Lcom/wire/kalium/logic/data/id/QualifiedID;ZZLkotlinx/datetime/Instant;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun invoke$default (Lcom/wire/kalium/logic/feature/conversation/UpdateConversationArchivedStatusUseCase;Lcom/wire/kalium/logic/data/id/QualifiedID;ZZLkotlinx/datetime/Instant;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/wire/kalium/logic/feature/conversation/UpdateConversationArchivedStatusUseCase$DefaultImpls {
-	public static synthetic fun invoke$default (Lcom/wire/kalium/logic/feature/conversation/UpdateConversationArchivedStatusUseCase;Lcom/wire/kalium/logic/data/id/QualifiedID;ZZJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun invoke$default (Lcom/wire/kalium/logic/feature/conversation/UpdateConversationArchivedStatusUseCase;Lcom/wire/kalium/logic/data/id/QualifiedID;ZZLkotlinx/datetime/Instant;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract class com/wire/kalium/logic/feature/conversation/UpdateConversationMemberRoleResult {
@@ -4261,12 +4261,12 @@ public abstract interface class com/wire/kalium/logic/feature/conversation/Updat
 }
 
 public abstract interface class com/wire/kalium/logic/feature/conversation/UpdateConversationMutedStatusUseCase {
-	public abstract fun invoke (Lcom/wire/kalium/logic/data/id/QualifiedID;Lcom/wire/kalium/logic/data/conversation/MutedConversationStatus;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun invoke$default (Lcom/wire/kalium/logic/feature/conversation/UpdateConversationMutedStatusUseCase;Lcom/wire/kalium/logic/data/id/QualifiedID;Lcom/wire/kalium/logic/data/conversation/MutedConversationStatus;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun invoke (Lcom/wire/kalium/logic/data/id/QualifiedID;Lcom/wire/kalium/logic/data/conversation/MutedConversationStatus;Lkotlinx/datetime/Instant;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun invoke$default (Lcom/wire/kalium/logic/feature/conversation/UpdateConversationMutedStatusUseCase;Lcom/wire/kalium/logic/data/id/QualifiedID;Lcom/wire/kalium/logic/data/conversation/MutedConversationStatus;Lkotlinx/datetime/Instant;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/wire/kalium/logic/feature/conversation/UpdateConversationMutedStatusUseCase$DefaultImpls {
-	public static synthetic fun invoke$default (Lcom/wire/kalium/logic/feature/conversation/UpdateConversationMutedStatusUseCase;Lcom/wire/kalium/logic/data/id/QualifiedID;Lcom/wire/kalium/logic/data/conversation/MutedConversationStatus;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun invoke$default (Lcom/wire/kalium/logic/feature/conversation/UpdateConversationMutedStatusUseCase;Lcom/wire/kalium/logic/data/id/QualifiedID;Lcom/wire/kalium/logic/data/conversation/MutedConversationStatus;Lkotlinx/datetime/Instant;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/wire/kalium/logic/feature/conversation/UpdateConversationReadDateUseCase {

--- a/logic/api/logic.klib.api
+++ b/logic/api/logic.klib.api
@@ -1140,7 +1140,7 @@ abstract interface com.wire.kalium.logic.feature.conversation/UpdateConversation
 }
 
 abstract interface com.wire.kalium.logic.feature.conversation/UpdateConversationArchivedStatusUseCase { // com.wire.kalium.logic.feature.conversation/UpdateConversationArchivedStatusUseCase|null[0]
-    abstract suspend fun invoke(com.wire.kalium.logic.data.id/QualifiedID, kotlin/Boolean, kotlin/Boolean, kotlin/Long = ...): com.wire.kalium.logic.feature.conversation/ArchiveStatusUpdateResult // com.wire.kalium.logic.feature.conversation/UpdateConversationArchivedStatusUseCase.invoke|invoke(com.wire.kalium.logic.data.id.QualifiedID;kotlin.Boolean;kotlin.Boolean;kotlin.Long){}[0]
+    abstract suspend fun invoke(com.wire.kalium.logic.data.id/QualifiedID, kotlin/Boolean, kotlin/Boolean, kotlinx.datetime/Instant = ...): com.wire.kalium.logic.feature.conversation/ArchiveStatusUpdateResult // com.wire.kalium.logic.feature.conversation/UpdateConversationArchivedStatusUseCase.invoke|invoke(com.wire.kalium.logic.data.id.QualifiedID;kotlin.Boolean;kotlin.Boolean;kotlinx.datetime.Instant){}[0]
 }
 
 abstract interface com.wire.kalium.logic.feature.conversation/UpdateConversationMemberRoleUseCase { // com.wire.kalium.logic.feature.conversation/UpdateConversationMemberRoleUseCase|null[0]
@@ -1148,7 +1148,7 @@ abstract interface com.wire.kalium.logic.feature.conversation/UpdateConversation
 }
 
 abstract interface com.wire.kalium.logic.feature.conversation/UpdateConversationMutedStatusUseCase { // com.wire.kalium.logic.feature.conversation/UpdateConversationMutedStatusUseCase|null[0]
-    abstract suspend fun invoke(com.wire.kalium.logic.data.id/QualifiedID, com.wire.kalium.logic.data.conversation/MutedConversationStatus, kotlin/Long = ...): com.wire.kalium.logic.feature.conversation/ConversationUpdateStatusResult // com.wire.kalium.logic.feature.conversation/UpdateConversationMutedStatusUseCase.invoke|invoke(com.wire.kalium.logic.data.id.QualifiedID;com.wire.kalium.logic.data.conversation.MutedConversationStatus;kotlin.Long){}[0]
+    abstract suspend fun invoke(com.wire.kalium.logic.data.id/QualifiedID, com.wire.kalium.logic.data.conversation/MutedConversationStatus, kotlinx.datetime/Instant = ...): com.wire.kalium.logic.feature.conversation/ConversationUpdateStatusResult // com.wire.kalium.logic.feature.conversation/UpdateConversationMutedStatusUseCase.invoke|invoke(com.wire.kalium.logic.data.id.QualifiedID;com.wire.kalium.logic.data.conversation.MutedConversationStatus;kotlinx.datetime.Instant){}[0]
 }
 
 abstract interface com.wire.kalium.logic.feature.conversation/UpdateConversationReceiptModeUseCase { // com.wire.kalium.logic.feature.conversation/UpdateConversationReceiptModeUseCase|null[0]

--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -85,7 +85,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
-import kotlinx.datetime.Instant
 import kotlinx.serialization.json.Json
 import kotlin.time.Duration.Companion.seconds
 import kotlin.uuid.Uuid
@@ -133,7 +132,7 @@ internal class CallManagerImpl internal constructor(
     private val initializeServerTimeOffsetJob: Deferred<Unit> = scope.async(start = CoroutineStart.LAZY) {
         callRepository.fetchServerTime()?.let { serverTime ->
             callingLogger.d("$tagWithUserId: Computing server time offset: $serverTime")
-            serverTimeHandler.computeTimeOffset(Instant.parse(serverTime).epochSeconds)
+            serverTimeHandler.computeTimeOffset(serverTime.epochSeconds)
         } ?: callingLogger.w("$tagWithUserId: Failed to fetch server time for offset computation.")
     }
 

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -94,7 +94,6 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.datetime.Instant
 import java.util.Collections
 import kotlin.io.encoding.Base64
 
@@ -153,7 +152,7 @@ internal class CallManagerImpl internal constructor(
     private val initializeServerTimeOffsetJob: Deferred<Unit> = scope.async(start = CoroutineStart.LAZY) {
         callRepository.fetchServerTime()?.let { serverTime ->
             callingLogger.d("$tagWithUserId: Computing server time offset: $serverTime")
-            serverTimeHandler.computeTimeOffset(Instant.parse(serverTime).epochSeconds)
+            serverTimeHandler.computeTimeOffset(serverTime.epochSeconds)
         } ?: run {
             callingLogger.w("$tagWithUserId: Failed to fetch server time for offset computation.")
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
@@ -95,6 +95,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import kotlin.math.max
 import kotlin.time.toDuration
 import kotlin.uuid.Uuid
@@ -152,7 +153,7 @@ internal interface CallRepository {
 
     suspend fun updateRecentlyEndedCallMetadata(recentlyEndedCallMetadata: RecentlyEndedCallMetadata)
     suspend fun observeRecentlyEndedCallMetadata(): Flow<RecentlyEndedCallMetadata>
-    suspend fun fetchServerTime(): String?
+    suspend fun fetchServerTime(): Instant?
     fun updateCallQualityData(conversationId: ConversationId, callQualityData: CallQualityData)
     fun observeCallQualityData(conversationId: ConversationId): Flow<CallQualityData>
 }
@@ -757,10 +758,10 @@ internal class CallDataSource(
     override fun currentCallProtocol(conversationId: ConversationId): Conversation.ProtocolInfo? =
         _callMetadataProfile[conversationId]?.protocol
 
-    override suspend fun fetchServerTime(): String? {
+    override suspend fun fetchServerTime(): Instant? {
         val result = serverTimeApi.getServerTime()
         return if (result.isSuccessful()) {
-            result.value.time
+            Instant.parse(result.value.time)
         } else {
             null
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepository.kt
@@ -175,25 +175,25 @@ internal interface ConversationRepository {
     suspend fun updateMutedStatusLocally(
         conversationId: ConversationId,
         mutedStatus: MutedConversationStatus,
-        mutedStatusTimestamp: Long
+        mutedStatusTimestamp: Instant
     ): Either<StorageFailure, Unit>
 
     suspend fun updateMutedStatusRemotely(
         conversationId: ConversationId,
         mutedStatus: MutedConversationStatus,
-        mutedStatusTimestamp: Long
+        mutedStatusTimestamp: Instant
     ): Either<NetworkFailure, Unit>
 
     suspend fun updateArchivedStatusLocally(
         conversationId: ConversationId,
         isArchived: Boolean,
-        archivedStatusTimestamp: Long
+        archivedStatusTimestamp: Instant
     ): Either<StorageFailure, Unit>
 
     suspend fun updateArchivedStatusRemotely(
         conversationId: ConversationId,
         isArchived: Boolean,
-        archivedStatusTimestamp: Long
+        archivedStatusTimestamp: Instant
     ): Either<NetworkFailure, Unit>
 
     suspend fun getConversationsByGroupState(
@@ -768,7 +768,7 @@ internal class ConversationDataSource internal constructor(
     override suspend fun updateMutedStatusLocally(
         conversationId: ConversationId,
         mutedStatus: MutedConversationStatus,
-        mutedStatusTimestamp: Long
+        mutedStatusTimestamp: Instant
     ): Either<StorageFailure, Unit> = wrapStorageRequest {
         conversationDAO.updateConversationMutedStatus(
             conversationId = conversationId.toDao(),
@@ -780,7 +780,7 @@ internal class ConversationDataSource internal constructor(
     override suspend fun updateMutedStatusRemotely(
         conversationId: ConversationId,
         mutedStatus: MutedConversationStatus,
-        mutedStatusTimestamp: Long
+        mutedStatusTimestamp: Instant
     ): Either<NetworkFailure, Unit> = wrapApiRequest {
         conversationApi.updateConversationMemberState(
             memberUpdateRequest = conversationStatusMapper.toMutedStatusApiModel(mutedStatus, mutedStatusTimestamp),
@@ -791,7 +791,7 @@ internal class ConversationDataSource internal constructor(
     override suspend fun updateArchivedStatusLocally(
         conversationId: ConversationId,
         isArchived: Boolean,
-        archivedStatusTimestamp: Long
+        archivedStatusTimestamp: Instant
     ): Either<StorageFailure, Unit> = wrapStorageRequest {
         conversationDAO.updateConversationArchivedStatus(
             conversationId = conversationId.toDao(),
@@ -803,7 +803,7 @@ internal class ConversationDataSource internal constructor(
     override suspend fun updateArchivedStatusRemotely(
         conversationId: ConversationId,
         isArchived: Boolean,
-        archivedStatusTimestamp: Long
+        archivedStatusTimestamp: Instant
     ): Either<NetworkFailure, Unit> = wrapApiRequest {
         conversationApi.updateConversationMemberState(
             memberUpdateRequest = conversationStatusMapper.toArchivedStatusApiModel(isArchived, archivedStatusTimestamp),

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapper.kt
@@ -26,18 +26,19 @@ import com.wire.kalium.network.api.authenticated.conversation.MutedStatus
 import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 import com.wire.kalium.util.DateTimeUtil.toIsoDateTimeString
+import kotlinx.datetime.Instant
 
 internal interface ConversationStatusMapper {
-    fun toMutedStatusApiModel(mutedStatus: MutedConversationStatus, mutedStatusTimestamp: Long): MemberUpdateDTO
+    fun toMutedStatusApiModel(mutedStatus: MutedConversationStatus, mutedStatusTimestamp: Instant): MemberUpdateDTO
     fun toMutedStatusDaoModel(mutedStatus: MutedConversationStatus): ConversationEntity.MutedStatus
     fun fromMutedStatusDaoModel(mutedStatus: ConversationEntity.MutedStatus): MutedConversationStatus
     fun fromMutedStatusApiToDaoModel(mutedStatus: MutedStatus?): ConversationEntity.MutedStatus
     fun fromRemovedByToLogicModel(removedBy: UserIDEntity): UserId
-    fun toArchivedStatusApiModel(isArchived: Boolean, archivedStatusTimestamp: Long): MemberUpdateDTO
+    fun toArchivedStatusApiModel(isArchived: Boolean, archivedStatusTimestamp: Instant): MemberUpdateDTO
 }
 
 internal class ConversationStatusMapperImpl(val idMapper: IdMapper) : ConversationStatusMapper {
-    override fun toMutedStatusApiModel(mutedStatus: MutedConversationStatus, mutedStatusTimestamp: Long): MemberUpdateDTO {
+    override fun toMutedStatusApiModel(mutedStatus: MutedConversationStatus, mutedStatusTimestamp: Instant): MemberUpdateDTO {
         return MemberUpdateDTO(
             otrMutedStatus = MutedStatus.fromOrdinal(mutedStatus.status),
             otrMutedRef = mutedStatusTimestamp.toIsoDateTimeString()
@@ -73,7 +74,7 @@ internal class ConversationStatusMapperImpl(val idMapper: IdMapper) : Conversati
     override fun fromRemovedByToLogicModel(removedBy: UserIDEntity): UserId = removedBy.toModel()
     override fun toArchivedStatusApiModel(
         isArchived: Boolean,
-        archivedStatusTimestamp: Long
+        archivedStatusTimestamp: Instant
     ): MemberUpdateDTO = MemberUpdateDTO(
         otrArchived = isArchived,
         otrArchivedRef = archivedStatusTimestamp.toIsoDateTimeString()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinSubconversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinSubconversationUseCase.kt
@@ -29,14 +29,11 @@ import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.cryptography.MlsCoreCryptoContext
 import com.wire.kalium.logic.data.client.CryptoTransactionProvider
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.SubconversationId
 import com.wire.kalium.logic.data.id.toApi
-import com.wire.kalium.logic.data.id.toModel
 import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageFailureHandler
 import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageFailureResolution
 import com.wire.kalium.network.api.authenticated.conversation.SubconversationDeleteRequest
-import com.wire.kalium.network.api.authenticated.conversation.SubconversationResponse
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
@@ -67,12 +64,13 @@ internal class JoinSubconversationUseCaseImpl(
     ): Either<CoreFailure, Unit> = transactionProvider.mlsTransaction("JoinSubconversation") { mlsContext ->
         wrapApiRequest {
             conversationApi.fetchSubconversationDetails(conversationId.toApi(), subconversationId.toApi())
-        }.flatMap { subconversationDetails ->
+        }.flatMap { response ->
+            val subconversationDetails = response.toModel()
             joinOrEstablishWithSubconversationDetails(mlsContext, subconversationDetails).onSuccess {
                 subconversationRepository.insertSubconversation(
                     conversationId,
                     subconversationId,
-                    GroupID(subconversationDetails.groupId)
+                    subconversationDetails.groupId
                 )
             }
         }
@@ -80,36 +78,36 @@ internal class JoinSubconversationUseCaseImpl(
 
     private suspend fun joinOrEstablishWithSubconversationDetails(
         mlsContext: MlsCoreCryptoContext,
-        subconversationDetails: SubconversationResponse
+        subconversationDetails: SubConversation
     ): Either<CoreFailure, Unit> =
         if (subconversationDetails.epoch > INITIAL_EPOCH) {
             if (subconversationDetails.timeElapsedSinceLastEpochChange().inWholeHours > STALE_EPOCH_DURATION_IN_HOURS) {
                 wrapApiRequest {
                     conversationApi.deleteSubconversation(
-                        subconversationDetails.parentId,
-                        subconversationDetails.id,
+                        subconversationDetails.parentId.toApi(),
+                        subconversationDetails.id.toApi(),
                         SubconversationDeleteRequest(
                             subconversationDetails.epoch,
-                            subconversationDetails.groupId
+                            subconversationDetails.groupId.value
                         )
                     )
                 }.flatMap {
                     mlsConversationRepository.establishMLSSubConversationGroup(
                         mlsContext,
-                        GroupID(subconversationDetails.groupId),
-                        subconversationDetails.parentId.toModel()
+                        subconversationDetails.groupId,
+                        subconversationDetails.parentId
                     )
                 }
             } else {
                 wrapApiRequest {
                     conversationApi.fetchSubconversationGroupInfo(
-                        subconversationDetails.parentId,
-                        subconversationDetails.id
+                        subconversationDetails.parentId.toApi(),
+                        subconversationDetails.id.toApi()
                     )
                 }.flatMap { groupInfo ->
                     mlsConversationRepository.joinGroupByExternalCommit(
                         mlsContext,
-                        GroupID(subconversationDetails.groupId),
+                        subconversationDetails.groupId,
                         groupInfo
 
                     ).flatMapLeft {
@@ -124,8 +122,8 @@ internal class JoinSubconversationUseCaseImpl(
         } else {
             mlsConversationRepository.establishMLSSubConversationGroup(
                 mlsContext,
-                GroupID(subconversationDetails.groupId),
-                subconversationDetails.parentId.toModel()
+                subconversationDetails.groupId,
+                subconversationDetails.parentId
             )
         }
 
@@ -153,5 +151,5 @@ internal class JoinSubconversationUseCaseImpl(
 private fun Instant.timeElapsedUntilNow(): Duration =
     Clock.System.now().minus(this)
 
-private fun SubconversationResponse.timeElapsedSinceLastEpochChange(): Duration =
-    epochTimestamp?.let { Instant.parse(it) }?.timeElapsedUntilNow() ?: Duration.ZERO
+private fun SubConversation.timeElapsedSinceLastEpochChange(): Duration =
+    epochTimestamp?.timeElapsedUntilNow() ?: Duration.ZERO

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/SubConversationMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/SubConversationMapper.kt
@@ -21,6 +21,7 @@ import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.toModel
 import com.wire.kalium.network.api.authenticated.conversation.SubconversationMemberDTO
 import com.wire.kalium.network.api.authenticated.conversation.SubconversationResponse
+import kotlinx.datetime.Instant
 
 internal fun SubconversationResponse.toModel(): SubConversation {
     return SubConversation(
@@ -28,7 +29,7 @@ internal fun SubconversationResponse.toModel(): SubConversation {
         parentId = parentId.toModel(),
         groupId = GroupID(groupId),
         epoch = epoch,
-        epochTimestamp = epochTimestamp,
+        epochTimestamp = epochTimestamp?.let(Instant::parse),
         mlsCipherSuiteTag = mlsCipherSuiteTag,
         members = members.map { it.toModel() }
     )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -256,7 +256,7 @@ internal sealed class Event(open val id: String) {
                 override val id: String,
                 override val conversationId: ConversationId,
                 val mutedConversationStatus: MutedConversationStatus,
-                val mutedConversationChangedTime: String
+                val mutedConversationChangedTime: Instant
             ) : MemberChanged(id, conversationId) {
 
                 override fun toLogMap(): Map<String, Any?> = mapOf(
@@ -271,7 +271,7 @@ internal sealed class Event(open val id: String) {
             internal data class MemberArchivedStatusChanged(
                 override val id: String,
                 override val conversationId: ConversationId,
-                val archivedConversationChangedTime: String,
+                val archivedConversationChangedTime: Instant,
                 val isArchiving: Boolean
             ) : MemberChanged(id, conversationId) {
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -482,7 +482,9 @@ internal class EventMapper(
                 Event.Conversation.MemberChanged.MemberMutedStatusChanged(
                     id = id,
                     conversationId = eventContentDTO.qualifiedConversation.toModel(),
-                    mutedConversationChangedTime = eventContentDTO.roleChange.mutedRef.orEmpty(),
+                    mutedConversationChangedTime = eventContentDTO.roleChange.mutedRef
+                        ?.let(Instant::parse)
+                        ?: Instant.parse(eventContentDTO.time),
                     mutedConversationStatus = mapConversationMutedStatus(eventContentDTO.roleChange.mutedStatus)
                 )
             }
@@ -491,7 +493,9 @@ internal class EventMapper(
                 Event.Conversation.MemberChanged.MemberArchivedStatusChanged(
                     id = id,
                     conversationId = eventContentDTO.qualifiedConversation.toModel(),
-                    archivedConversationChangedTime = eventContentDTO.roleChange.archivedRef.orEmpty(),
+                    archivedConversationChangedTime = eventContentDTO.roleChange.archivedRef
+                        ?.let(Instant::parse)
+                        ?: Instant.parse(eventContentDTO.time),
                     isArchiving = eventContentDTO.roleChange.isArchiving ?: false
                 )
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationArchivedStatusUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationArchivedStatusUseCase.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.exceptions.isConversationNotFound
 import com.wire.kalium.util.DateTimeUtil
+import kotlinx.datetime.Instant
 
 public interface UpdateConversationArchivedStatusUseCase {
     /**
@@ -46,7 +47,7 @@ public interface UpdateConversationArchivedStatusUseCase {
         conversationId: ConversationId,
         shouldArchiveConversation: Boolean,
         onlyLocally: Boolean,
-        archivedStatusTimestamp: Long = DateTimeUtil.currentInstant().toEpochMilliseconds()
+        archivedStatusTimestamp: Instant = DateTimeUtil.currentInstant()
     ): ArchiveStatusUpdateResult
 }
 
@@ -58,7 +59,7 @@ internal class UpdateConversationArchivedStatusUseCaseImpl(
         conversationId: ConversationId,
         shouldArchiveConversation: Boolean,
         onlyLocally: Boolean,
-        archivedStatusTimestamp: Long
+        archivedStatusTimestamp: Instant
     ): ArchiveStatusUpdateResult =
         if (!onlyLocally) {
             archiveRemotely(conversationId, shouldArchiveConversation, archivedStatusTimestamp)
@@ -86,7 +87,7 @@ internal class UpdateConversationArchivedStatusUseCaseImpl(
     private suspend fun archiveRemotely(
         conversationId: ConversationId,
         shouldArchiveConversation: Boolean,
-        archivedStatusTimestamp: Long
+        archivedStatusTimestamp: Instant
     ) = conversationRepository.updateArchivedStatusRemotely(conversationId, shouldArchiveConversation, archivedStatusTimestamp)
         .onFailure {
             kaliumLogger.e(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationMutedStatusUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationMutedStatusUseCase.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.common.functional.flatMap
 import com.wire.kalium.common.functional.fold
 import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.util.DateTimeUtil
+import kotlinx.datetime.Instant
 
 public interface UpdateConversationMutedStatusUseCase {
     /**
@@ -38,7 +39,7 @@ public interface UpdateConversationMutedStatusUseCase {
     public suspend operator fun invoke(
         conversationId: ConversationId,
         mutedConversationStatus: MutedConversationStatus,
-        mutedStatusTimestamp: Long = DateTimeUtil.currentInstant().toEpochMilliseconds()
+        mutedStatusTimestamp: Instant = DateTimeUtil.currentInstant()
     ): ConversationUpdateStatusResult
 }
 
@@ -49,7 +50,7 @@ internal class UpdateConversationMutedStatusUseCaseImpl(
     override suspend operator fun invoke(
         conversationId: ConversationId,
         mutedConversationStatus: MutedConversationStatus,
-        mutedStatusTimestamp: Long
+        mutedStatusTimestamp: Instant
     ): ConversationUpdateStatusResult =
         conversationRepository.updateMutedStatusRemotely(conversationId, mutedConversationStatus, mutedStatusTimestamp)
             .flatMap {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandler.kt
@@ -35,7 +35,6 @@ import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.util.EventLoggingStatus
 import com.wire.kalium.logic.util.createEventProcessingLogger
-import com.wire.kalium.util.DateTimeUtil
 import com.wire.kalium.util.serialization.toJsonElement
 
 internal interface MemberChangeEventHandler {
@@ -57,7 +56,7 @@ internal class MemberChangeEventHandlerImpl(
                 conversationRepository.updateMutedStatusLocally(
                     event.conversationId,
                     event.mutedConversationStatus,
-                    DateTimeUtil.currentInstant().toEpochMilliseconds()
+                    event.mutedConversationChangedTime
                 )
                 eventLogger.logSuccess()
             }
@@ -66,7 +65,7 @@ internal class MemberChangeEventHandlerImpl(
                 conversationRepository.updateArchivedStatusLocally(
                     event.conversationId,
                     event.isArchiving,
-                    DateTimeUtil.currentInstant().toEpochMilliseconds()
+                    event.archivedConversationChangedTime
                 )
                 eventLogger.logSuccess()
             }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
@@ -101,6 +101,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.coroutines.yield
 import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -1869,8 +1870,9 @@ class CallRepositoryTest {
 
     @Test
     fun givenAPISucceeds_whenFetchingServerTime_thenReturnTime() = runTest {
+        val expectedTime = Instant.parse("2025-01-01T00:00:00Z")
         val result = NetworkResponse.Success(
-            value = ServerTimeDTO("123434545"),
+            value = ServerTimeDTO(expectedTime.toString()),
             headers = mapOf(),
             httpCode = HttpStatusCode.OK.value
         )
@@ -1880,7 +1882,7 @@ class CallRepositoryTest {
 
         val time = eventRepository.fetchServerTime()
 
-        assertNotNull(time)
+        assertEquals(expectedTime, time)
     }
 
     @Test

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationRepositoryTest.kt
@@ -222,7 +222,7 @@ class ConversationRepositoryTest {
         conversationRepository.updateMutedStatusRemotely(
             TestConversation.ID,
             MutedConversationStatus.AllMuted,
-            DateTimeUtil.currentInstant().toEpochMilliseconds()
+            DateTimeUtil.currentInstant()
         )
 
         verifySuspend(VerifyMode.exactly(1)) {
@@ -244,7 +244,7 @@ class ConversationRepositoryTest {
         conversationRepository.updateArchivedStatusRemotely(
             TestConversation.ID,
             isArchived,
-            DateTimeUtil.currentInstant().toEpochMilliseconds()
+            DateTimeUtil.currentInstant()
         )
 
         verifySuspend(VerifyMode.exactly(1)) {
@@ -265,7 +265,7 @@ class ConversationRepositoryTest {
         conversationRepository.updateMutedStatusLocally(
             TestConversation.ID,
             MutedConversationStatus.AllMuted,
-            DateTimeUtil.currentInstant().toEpochMilliseconds()
+            DateTimeUtil.currentInstant()
         )
 
         verifySuspend(VerifyMode.exactly(1)) {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationStatusMapperTest.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.logic.data.conversation
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.network.api.authenticated.conversation.MutedStatus
 import com.wire.kalium.persistence.dao.conversation.ConversationEntity
+import kotlinx.datetime.Instant
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -36,7 +37,8 @@ class ConversationStatusMapperTest {
 
     @Test
     fun givenAConversationModel_whenMappingToApiModel_thenTheMappingStatusesShouldBeOk() {
-        val result = conversationStatusMapper.toMutedStatusApiModel(MutedConversationStatus.OnlyMentionsAndRepliesAllowed, 1649708697237L)
+        val timestamp = Instant.fromEpochMilliseconds(1649708697237L)
+        val result = conversationStatusMapper.toMutedStatusApiModel(MutedConversationStatus.OnlyMentionsAndRepliesAllowed, timestamp)
 
         assertEquals(MutedStatus.ONLY_MENTIONS_ALLOWED, result.otrMutedStatus)
         assertEquals("2022-04-11T20:24:57.237Z", result.otrMutedRef)
@@ -45,7 +47,8 @@ class ConversationStatusMapperTest {
     @Test
     fun givenAConversationModelWithArchivedField_whenMappingToApiModel_thenTheMappingStatusesShouldBeOk() {
         val isArchived = true
-        val result = conversationStatusMapper.toArchivedStatusApiModel(isArchived = isArchived, 1649708697237L)
+        val timestamp = Instant.fromEpochMilliseconds(1649708697237L)
+        val result = conversationStatusMapper.toArchivedStatusApiModel(isArchived = isArchived, timestamp)
 
         assertEquals(isArchived, result.otrArchived)
         assertEquals("2022-04-11T20:24:57.237Z", result.otrArchivedRef)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/event/EventMapperTest.kt
@@ -82,4 +82,57 @@ class EventMapperTest {
         val event = assertIs<Event.Conversation.MemberChanged.MemberChangedRole>(result)
         assertEquals(timestamp, event.dateTime)
     }
+
+    @Test
+    fun givenMutedStatusUpdateDTO_whenMapping_thenMutedReferenceIsMappedToInstant() {
+        val eventTimestamp = Instant.parse("2026-07-24T12:00:00.000Z")
+        val mutedReference = Instant.parse("2026-07-24T12:01:00.000Z")
+        val mapper = MapperProvider.eventMapper(TestUser.SELF.id)
+        val dto = EventContentDTO.Conversation.MemberUpdateDTO(
+            qualifiedConversation = QualifiedID("conversation-id", "domain"),
+            qualifiedFrom = TestUser.NETWORK_ID,
+            time = eventTimestamp.toString(),
+            from = TestUser.NETWORK_ID.value,
+            roleChange = ConversationRoleChange(
+                user = TestUser.NETWORK_ID.value,
+                qualifiedUserId = TestUser.NETWORK_ID,
+                role = null,
+                mutedRef = mutedReference.toString(),
+                mutedStatus = 3,
+                isArchiving = null,
+                archivedRef = null
+            )
+        )
+
+        val result = mapper.fromEventContentDTO("event-id", dto)
+
+        val event = assertIs<Event.Conversation.MemberChanged.MemberMutedStatusChanged>(result)
+        assertEquals(mutedReference, event.mutedConversationChangedTime)
+    }
+
+    @Test
+    fun givenArchivedStatusUpdateWithoutReference_whenMapping_thenEventTimestampIsUsed() {
+        val eventTimestamp = Instant.parse("2026-07-24T12:00:00.000Z")
+        val mapper = MapperProvider.eventMapper(TestUser.SELF.id)
+        val dto = EventContentDTO.Conversation.MemberUpdateDTO(
+            qualifiedConversation = QualifiedID("conversation-id", "domain"),
+            qualifiedFrom = TestUser.NETWORK_ID,
+            time = eventTimestamp.toString(),
+            from = TestUser.NETWORK_ID.value,
+            roleChange = ConversationRoleChange(
+                user = TestUser.NETWORK_ID.value,
+                qualifiedUserId = TestUser.NETWORK_ID,
+                role = null,
+                mutedRef = null,
+                mutedStatus = null,
+                isArchiving = true,
+                archivedRef = null
+            )
+        )
+
+        val result = mapper.fromEventContentDTO("event-id", dto)
+
+        val event = assertIs<Event.Conversation.MemberChanged.MemberArchivedStatusChanged>(result)
+        assertEquals(eventTimestamp, event.archivedConversationChangedTime)
+    }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationArchivedStatusUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/UpdateConversationArchivedStatusUseCaseTest.kt
@@ -32,6 +32,7 @@ import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -41,7 +42,7 @@ class UpdateConversationArchivedStatusUseCaseTest {
     fun givenAConversationId_whenInvokingAnArchivedStatusChange_thenShouldDelegateTheCallAndReturnASuccessResult() = runTest {
         val conversationId = TestConversation.ID
         val isConversationArchived = true
-        val archivedStatusTimestamp = 123456789L
+        val archivedStatusTimestamp = Instant.fromEpochMilliseconds(123456789L)
         val onlyLocally = false
 
         val (arrangement, updateConversationArchivedStatus) = Arrangement()
@@ -75,7 +76,7 @@ class UpdateConversationArchivedStatusUseCaseTest {
         runTest {
             val conversationId = TestConversation.ID
             val isConversationArchived = true
-            val archivedStatusTimestamp = 123456789L
+            val archivedStatusTimestamp = Instant.fromEpochMilliseconds(123456789L)
             val onlyLocally = true
 
             val (arrangement, updateConversationArchivedStatus) = Arrangement()
@@ -104,7 +105,7 @@ class UpdateConversationArchivedStatusUseCaseTest {
     fun givenAConversationId_whenInvokingAnArchivedStatusChangeAndFails_thenShouldDelegateTheCallAndReturnAFailureResult() = runTest {
         val conversationId = TestConversation.ID
         val isConversationArchived = true
-        val archivedStatusTimestamp = 123456789L
+        val archivedStatusTimestamp = Instant.fromEpochMilliseconds(123456789L)
         val onlyLocally = false
 
         val (arrangement, updateConversationArchivedStatus) = Arrangement()
@@ -137,7 +138,7 @@ class UpdateConversationArchivedStatusUseCaseTest {
     fun givenRemoteNoConversationError_whenInvokingAnArchivedStatusChange_thenShouldArchiveLocallyAndReturnSuccess() = runTest {
         val conversationId = TestConversation.ID
         val isConversationArchived = true
-        val archivedStatusTimestamp = 123456789L
+        val archivedStatusTimestamp = Instant.fromEpochMilliseconds(123456789L)
         val onlyLocally = false
 
         val (arrangement, updateConversationArchivedStatus) = Arrangement()
@@ -170,7 +171,7 @@ class UpdateConversationArchivedStatusUseCaseTest {
     fun givenAConversationId_whenInvokingAnArchivedStatusChangeAndFailsOnlyLocally_thenShouldReturnAFailureResult() = runTest {
         val conversationId = TestConversation.ID
         val isConversationArchived = true
-        val archivedStatusTimestamp = 123456789L
+        val archivedStatusTimestamp = Instant.fromEpochMilliseconds(123456789L)
         val onlyLocally = false
 
         val (arrangement, updateConversationArchivedStatus) = Arrangement()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
@@ -71,14 +71,14 @@ internal object TestEvent {
         eventId,
         TestConversation.ID,
         MutedConversationStatus.AllAllowed,
-        "2022-03-30T15:36:00.000Zp"
+        Instant.parse("2022-03-30T15:36:00.000Z")
     )
 
     fun memberChangeArchivedStatus(eventId: String = "eventId", isArchiving: Boolean = true) =
         Event.Conversation.MemberChanged.MemberArchivedStatusChanged(
             eventId,
             TestConversation.ID,
-            "2022-03-31T16:36:00.000Zp",
+            Instant.parse("2022-03-31T16:36:00.000Z"),
             isArchiving,
         )
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberChangeEventHandlerTest.kt
@@ -79,7 +79,11 @@ class MemberChangeEventHandlerTest {
         eventHandler.handle(arrangement.transactionContext, event)
 
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.conversationRepository.updateMutedStatusLocally(eq(event.conversationId), any(), any())
+            arrangement.conversationRepository.updateMutedStatusLocally(
+                eq(event.conversationId),
+                any(),
+                eq(event.mutedConversationChangedTime)
+            )
         }
     }
 
@@ -100,7 +104,7 @@ class MemberChangeEventHandlerTest {
             arrangement.conversationRepository.updateArchivedStatusLocally(
                 eq(event.conversationId),
                 matches { it == isNewEventArchiving },
-                any()
+                eq(event.archivedConversationChangedTime)
             )
         }
     }

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
@@ -218,7 +218,7 @@ internal class CallManagerTest {
         }
 
         fun withFetchServerTimeReturning() = apply {
-            everySuspend { callRepository.fetchServerTime() } returns "2022-03-30T16:36:00.000Z"
+            everySuspend { callRepository.fetchServerTime() } returns Instant.parse("2022-03-30T16:36:00.000Z")
         }
 
         fun withCallMetadataReturning(conversationId: ConversationId, callMetadata: CallMetadata?) = apply {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-10090
<!--jira-description-action-hidden-marker-end-->
Small cleanup to keep a few more timestamps typed as `Instant` internally and avoid repeated formatting/parsing.

- uses `Instant` for conversation status refs, server time, and subconversation epoch time
- formats reaction timestamps once
- removes the unused Android `DateTimeFormatter` path

No DB migration is needed. Callers passing a custom conversation status timestamp should now pass an `Instant`.

Stacked on #4338.

Checks: Logic and Persistence JVM tests, Detekt, ABI check, and the Android `core:util` compile.
