### PR TITLE
fix: recover from prolonged MLS message buffering (WPB-26421)

### DIFF
--- a/core/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/CryptoTransactionContext.kt
+++ b/core/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/CryptoTransactionContext.kt
@@ -149,12 +149,12 @@ interface MlsCoreCryptoContext {
      * @param groupId MLS group where the message was received
      * @param message application message or handshake message
      *
-     * @return decrypted message bundle, which contains the decrypted message.
+     * @return the decrypted messages or the reason the message was buffered.
      */
    suspend fun decryptMessage(
        groupId: String,
        message: ByteArray
-   ): List<DecryptedMessageBundle>
+   ): MLSDecryptResult
 
     /**
      * Current members of the group.

--- a/core/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/MLSClient.kt
+++ b/core/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/MLSClient.kt
@@ -121,6 +121,12 @@ data class DecryptedMessageBundle(
     }
 }
 
+sealed interface MLSDecryptResult {
+    data class Success(val messages: List<DecryptedMessageBundle>) : MLSDecryptResult
+    data object BufferedFutureMessage : MLSDecryptResult
+    data object BufferedCommit : MLSDecryptResult
+}
+
 @JvmInline
 value class ExternalSenderKey(
     val value: ByteArray

--- a/core/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/MLSClientImpl.kt
+++ b/core/cryptography/src/commonMain/kotlin/com/wire/kalium/cryptography/MLSClientImpl.kt
@@ -24,7 +24,6 @@ import com.wire.crypto.ConversationConfiguration
 import com.wire.crypto.CoreCryptoClient
 import com.wire.crypto.CoreCryptoContext
 import com.wire.crypto.CoreCryptoException
-import com.wire.crypto.DecryptedMessage
 import com.wire.crypto.MlsException
 import com.wire.crypto.toClientId
 import com.wire.crypto.toExternalSenderKey
@@ -154,40 +153,27 @@ class MLSClientImpl(
             return context.encryptMessage(groupId.toCrypto(), message)
         }
 
-        @Suppress("TooGenericExceptionCaught")
         override suspend fun decryptMessage(
             groupId: MLSGroupId,
             message: ByteArray,
-        ): List<DecryptedMessageBundle> {
-            var decryptedMessage: DecryptedMessage? = null
-            try {
-                val result = context.decryptMessage(
-                    groupId.toCrypto(),
-                    message
-                )
-                decryptedMessage = result
-
-            } catch (throwable: Throwable) {
-                val isBufferedFutureError = throwable is CoreCryptoException.Mls
-                        && (
-                        throwable.mlsError is MlsException.BufferedFutureMessage
-                                || throwable.mlsError is MlsException.BufferedCommit
-                        )
-                if (!isBufferedFutureError) {
-                    throw throwable
-                }
-            }
-
-            if (decryptedMessage == null) {
-                return emptyList()
-            }
+        ): MLSDecryptResult = try {
+            val decryptedMessage = context.decryptMessage(
+                groupId.toCrypto(),
+                message
+            )
 
             val mainMessageBundle = listOf(decryptedMessage.toBundle())
             val bufferedBundles = decryptedMessage.bufferedMessages
                 ?.map { it.toBundle() }
                 ?: emptyList()
 
-            return mainMessageBundle + bufferedBundles
+            MLSDecryptResult.Success(mainMessageBundle + bufferedBundles)
+        } catch (throwable: CoreCryptoException.Mls) {
+            when (throwable.mlsError) {
+                is MlsException.BufferedFutureMessage -> MLSDecryptResult.BufferedFutureMessage
+                is MlsException.BufferedCommit -> MLSDecryptResult.BufferedCommit
+                else -> throw throwable
+            }
         }
 
         override suspend fun members(groupId: MLSGroupId): List<CryptoQualifiedClientId> {

--- a/core/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/MLSClientTest.kt
+++ b/core/cryptography/src/commonTest/kotlin/com/wire/kalium/cryptography/MLSClientTest.kt
@@ -109,7 +109,7 @@ class MLSClientTest : BaseMLSClientTest() {
 
         val result = aliceClient.transaction { it.decryptMessage(welcomeBundle.groupId, keyMaterialCommit.first.commit) }
 
-        assertNull(result.first().message)
+        assertNull((result as MLSDecryptResult.Success).messages.first().message)
     }
 
     @Test
@@ -164,7 +164,9 @@ class MLSClientTest : BaseMLSClientTest() {
         val welcomeBundle = aliceClient.transaction { it.processWelcomeMessage(welcome) }
 
         val applicationMessage = aliceClient.transaction { it.encryptMessage(welcomeBundle.groupId, PLAIN_TEXT.encodeToByteArray()) }
-        val bundle = bobClient.transaction { it.decryptMessage(welcomeBundle.groupId, applicationMessage).first() }
+        val bundle = bobClient.transaction {
+            (it.decryptMessage(welcomeBundle.groupId, applicationMessage) as MLSDecryptResult.Success).messages.first()
+        }
 
         assertNotNull(bundle.senderClientId)
         assertEquals(PLAIN_TEXT, bundle.message?.decodeToString())
@@ -237,7 +239,8 @@ class MLSClientTest : BaseMLSClientTest() {
         }
         val commit = bobArrangement.sendCommitBundleFlow.first().first.commit
 
-        assertNull(aliceClient.transaction { it.decryptMessage(MLS_CONVERSATION_ID, commit) }.first().message)
+        val result = aliceClient.transaction { it.decryptMessage(MLS_CONVERSATION_ID, commit) }
+        assertNull((result as MLSDecryptResult.Success).messages.first().message)
     }
 
     @Test
@@ -278,11 +281,12 @@ class MLSClientTest : BaseMLSClientTest() {
         val clientRemovalList = listOf(CAROL1.qualifiedClientId)
         bobClient.transaction { it.removeMember(welcomeBundle.groupId, clientRemovalList) }
         val commit = bobArrangement.sendCommitBundleFlow.first().first.commit
-        assertNull(aliceClient.transaction { it.decryptMessage(welcomeBundle.groupId, commit) }.first().message)
+        val result = aliceClient.transaction { it.decryptMessage(welcomeBundle.groupId, commit) }
+        assertNull((result as MLSDecryptResult.Success).messages.first().message)
     }
 
     @Test
-    fun givenThreeClients_whenProcessingCommitOutOfOrder_shouldCatchBufferedFutureMessageAndBuffer() = runTest {
+    fun givenCommitFromFutureEpoch_whenDecrypting_thenReturnBufferedFutureMessage() = runTest {
         val aliceArrangement = create(
             ALICE1,
             ::createMLSClient,
@@ -328,26 +332,9 @@ class MLSClientTest : BaseMLSClientTest() {
         val commitRemoveCarol = bobArrangement.sendCommitBundleFlow.first().first.commit
 
         // Alice tries to decrypt the removeCarol commit, which references an epoch Alice hasn't seen yet.
-        // In normal MLS logic, this triggers a "buffering" error, typically thrown as MlsException.BufferedFutureMessage
-        // wrapped in CoreCryptoException.Mls. The client code is supposed to swallow that error in a transaction
-        // and return an empty DecryptedMessage list.
+        val result = aliceClient.transaction { it.decryptMessage(MLS_CONVERSATION_ID, commitRemoveCarol) }
 
-        val decryptedBundlesResult = runCatching {
-            aliceClient.transaction { it.decryptMessage(MLS_CONVERSATION_ID, commitRemoveCarol) }
-        }
-
-        // The exception should be caught internally, so from the caller's perspective we succeed with an empty result.
-        // That indicates the message was buffered instead of fully decrypted.
-        assertTrue(
-            decryptedBundlesResult.isSuccess,
-            "Out-of-order commit should not propagate BufferedFutureMessage as an unhandled exception."
-        )
-
-        val decryptedBundles = decryptedBundlesResult.getOrThrow()
-        assertTrue(
-            decryptedBundles.isEmpty(),
-            "Decryption result should be empty for a buffered out-of-order commit."
-        )
+        assertEquals(MLSDecryptResult.BufferedFutureMessage, result)
     }
 
     @Test
@@ -397,10 +384,7 @@ class MLSClientTest : BaseMLSClientTest() {
 
         // Alice tries to decrypt the removeCarol commit first => out-of-order => should buffer
         val removeResult = aliceClient.transaction { it.decryptMessage(MLS_CONVERSATION_ID, commitRemoveCarol) }
-        assertTrue(
-            removeResult.isEmpty(),
-            "Out-of-order remove commit should be buffered and return an empty list."
-        )
+        assertEquals(MLSDecryptResult.BufferedFutureMessage, removeResult)
 
         // Now Alice processes the missing 'addCarol' commit.
         // By processing the addCarol commit, MLS should also flush any previously buffered commits (the removeCarol).
@@ -411,7 +395,7 @@ class MLSClientTest : BaseMLSClientTest() {
         // We expect 2 total commits to be processed now: (1) addCarol, (2) removeCarol.
         assertEquals(
             2,
-            addResult.size,
+            (addResult as MLSDecryptResult.Success).messages.size,
             "Processing the older 'addCarol' commit should also flush the buffered 'removeCarol' commit, resulting in 2 items."
         )
         assertEquals(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepository.kt
@@ -41,6 +41,7 @@ import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.cryptography.CryptoQualifiedClientId
 import com.wire.kalium.cryptography.E2EIClient
 import com.wire.kalium.cryptography.MLSClient
+import com.wire.kalium.cryptography.MLSDecryptResult
 import com.wire.kalium.cryptography.MlsCoreCryptoContext
 import com.wire.kalium.cryptography.WireIdentity
 import com.wire.kalium.logic.data.client.toDao
@@ -348,14 +349,19 @@ internal class MLSConversationDataSource(
                 idMapper.toCryptoModel(groupID),
                 message
             )
-                .let { messages ->
-                    messages.map {
+        }.flatMap { result ->
+            when (result) {
+                MLSDecryptResult.BufferedFutureMessage -> Left(MLSFailure.BufferedFutureMessage)
+                MLSDecryptResult.BufferedCommit -> Left(MLSFailure.BufferedCommit)
+                is MLSDecryptResult.Success -> wrapMLSRequest {
+                    result.messages.map {
                         it.crlNewDistributionPoints?.let { newDistributionPoints ->
                             checkRevocationList(mlsContext, newDistributionPoints)
                         }
                         it.toModel(groupID)
                     }
                 }
+            }
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifier.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifier.kt
@@ -23,7 +23,9 @@ import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
 import com.wire.kalium.common.functional.map
 import com.wire.kalium.common.logger.kaliumLogger
+import com.wire.kalium.common.logger.logStructuredJson
 import com.wire.kalium.cryptography.CryptoTransactionContext
+import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.data.client.wrapInMLSContext
 import com.wire.kalium.logic.data.conversation.Conversation
@@ -50,6 +52,7 @@ internal interface StaleEpochVerifier {
     ): Either<CoreFailure, Unit>
 }
 
+@Suppress("LongParameterList")
 internal class StaleEpochVerifierImpl(
     private val systemMessageInserter: SystemMessageInserter,
     private val fetchConversationUseCase: FetchConversationUseCase,
@@ -67,24 +70,27 @@ internal class StaleEpochVerifierImpl(
         timestamp: Instant?
     ): Either<CoreFailure, Unit> {
         return if (subConversationId != null) {
-            verifySubConversationEpoch(transactionContext, conversationId, subConversationId)
+            verifySubConversationEpoch(transactionContext, conversationId, subConversationId, timestamp)
         } else {
-            verifyConversationEpoch(transactionContext, conversationId)
+            verifyConversationEpoch(transactionContext, conversationId, timestamp)
         }
     }
 
     private suspend fun verifyConversationEpoch(
         transactionContext: CryptoTransactionContext,
-        conversationId: ConversationId
+        conversationId: ConversationId,
+        timestamp: Instant?
     ): Either<CoreFailure, Unit> {
         logger.i("Verifying stale epoch for conversation ${conversationId.toLogString()}")
         return getUpdatedConversationProtocolInfo(transactionContext, conversationId).flatMap { remoteMlsInfo ->
-            transactionContext.wrapInMLSContext {
-                mlsConversationRepository.isLocalGroupEpochStale(it, remoteMlsInfo.groupId, remoteMlsInfo.epoch)
-            }
-                .map { epochIsStale ->
-                    epochIsStale
-                }
+            compareEpochsAndLog(
+                transactionContext = transactionContext,
+                conversationId = conversationId,
+                subConversationId = null,
+                groupId = remoteMlsInfo.groupId,
+                remoteEpoch = remoteMlsInfo.epoch,
+                timestamp = timestamp
+            ).map { it.isLocalEpochStale }
         }.flatMap { hasMissedCommits ->
             if (hasMissedCommits) {
                 logger.w("Epoch stale due to missing commits, re-joining")
@@ -104,17 +110,21 @@ internal class StaleEpochVerifierImpl(
     private suspend fun verifySubConversationEpoch(
         transactionContext: CryptoTransactionContext,
         conversationId: ConversationId,
-        subConversationId: SubconversationId
+        subConversationId: SubconversationId,
+        timestamp: Instant?
     ): Either<CoreFailure, Unit> {
         logger.i("Verifying stale epoch for subconversation ${subConversationId.toLogString()}")
         return subconversationRepository.fetchRemoteSubConversationDetails(conversationId, subConversationId)
             .flatMap { subConversationDetails ->
-                transactionContext.wrapInMLSContext {
-                    mlsConversationRepository.isLocalGroupEpochStale(it, subConversationDetails.groupId, subConversationDetails.epoch)
-                }
-                    .map { epochIsStale ->
-                        epochIsStale
-                    }
+                compareEpochsAndLog(
+                    transactionContext = transactionContext,
+                    conversationId = conversationId,
+                    subConversationId = subConversationId,
+                    groupId = subConversationDetails.groupId,
+                    remoteEpoch = subConversationDetails.epoch,
+                    timestamp = timestamp
+                )
+                    .map { it.isLocalEpochStale }
                     .flatMap { hasMissedCommits ->
                         if (hasMissedCommits) {
                             logger.w("Epoch stale due to missing commits, joining by external commit")
@@ -132,6 +142,40 @@ internal class StaleEpochVerifierImpl(
                         }
                     }
             }
+    }
+
+    private suspend fun compareEpochsAndLog(
+        transactionContext: CryptoTransactionContext,
+        conversationId: ConversationId,
+        subConversationId: SubconversationId?,
+        groupId: GroupID,
+        remoteEpoch: ULong,
+        timestamp: Instant?
+    ): Either<CoreFailure, EpochComparison> = transactionContext.wrapInMLSContext {
+        mlsConversationRepository.getLocalGroupEpoch(it, groupId)
+    }.map { localEpoch ->
+        EpochComparison(localEpoch, remoteEpoch).also { comparison ->
+            logger.logStructuredJson(
+                level = if (comparison.isLocalEpochStale) KaliumLogLevel.WARN else KaliumLogLevel.INFO,
+                leadingMessage = "MLS epoch comparison",
+                jsonStringKeyValues = mapOf(
+                    "conversationId" to conversationId.toLogString(),
+                    "subConversationId" to subConversationId?.toLogString(),
+                    "groupId" to groupId.toLogString(),
+                    "localEpoch" to comparison.localEpoch.toString(),
+                    "remoteEpoch" to comparison.remoteEpoch.toString(),
+                    "epochGap" to comparison.epochGap.toString(),
+                    "epochState" to comparison.state.name,
+                    "trigger" to if (timestamp == null) "SEND_FAILURE" else "RECEIVE_FAILURE",
+                    "messageTimestamp" to timestamp,
+                    "recoveryAction" to when {
+                        !comparison.isLocalEpochStale -> "NONE"
+                        subConversationId == null -> "REJOIN"
+                        else -> "EXTERNAL_COMMIT"
+                    }
+                )
+            )
+        }
     }
 
     @OptIn(ConversationPersistenceApi::class)
@@ -164,4 +208,23 @@ internal class StaleEpochVerifierImpl(
         val groupId: GroupID,
         val epoch: ULong
     )
+
+    private data class EpochComparison(
+        val localEpoch: ULong,
+        val remoteEpoch: ULong
+    ) {
+        val isLocalEpochStale: Boolean = localEpoch < remoteEpoch
+        val epochGap: ULong = if (isLocalEpochStale) remoteEpoch - localEpoch else localEpoch - remoteEpoch
+        val state: State = when {
+            isLocalEpochStale -> State.LOCAL_BEHIND_REMOTE
+            localEpoch > remoteEpoch -> State.LOCAL_AHEAD_OF_REMOTE
+            else -> State.IN_SYNC
+        }
+
+        enum class State {
+            LOCAL_BEHIND_REMOTE,
+            IN_SYNC,
+            LOCAL_AHEAD_OF_REMOTE
+        }
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/BufferedMLSMessageRecoveryTracker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/BufferedMLSMessageRecoveryTracker.kt
@@ -1,0 +1,136 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.sync.receiver.conversation.message
+
+import com.wire.kalium.common.logger.kaliumLogger
+import com.wire.kalium.common.logger.logStructuredJson
+import com.wire.kalium.logger.KaliumLogLevel
+import com.wire.kalium.logger.KaliumLogger
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.SubconversationId
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.datetime.Instant
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * Tracks prolonged CoreCrypto MLS message buffering so the client can initiate stale epoch recovery.
+ *
+ * Buffered event timestamps are tracked per conversation and subconversation. Recovery is requested when
+ * their timestamp span exceeds [recoveryThreshold], allowing short-lived out-of-order delivery to resolve
+ * without intervention. Tracking is kept in memory for the lifetime of the current user session and does not
+ * survive process or session recreation.
+ */
+internal class BufferedMLSMessageRecoveryTracker(
+    private val recoveryThreshold: Duration = DEFAULT_RECOVERY_THRESHOLD
+) {
+    private val bufferedMessageRanges = mutableMapOf<ConversationKey, TimestampRange>()
+    private val mutex = Mutex()
+    private val logger by lazy { kaliumLogger.withFeatureId(KaliumLogger.Companion.ApplicationFlow.EVENT_RECEIVER) }
+
+    suspend fun observeBufferedMessage(
+        conversationId: ConversationId,
+        subConversationId: SubconversationId?,
+        timestamp: Instant
+    ): Boolean = mutex.withLock {
+        val key = ConversationKey(conversationId, subConversationId)
+        val updatedRange = bufferedMessageRanges[key]?.include(timestamp) ?: TimestampRange(timestamp, timestamp)
+        val bufferedTimeSpan = updatedRange.latest - updatedRange.earliest
+        val shouldRecover = bufferedTimeSpan > recoveryThreshold
+
+        logBufferedMessageObserved(key, timestamp, updatedRange, bufferedTimeSpan, shouldRecover)
+
+        if (shouldRecover) {
+            bufferedMessageRanges[key] = TimestampRange(timestamp, timestamp)
+            true
+        } else {
+            bufferedMessageRanges[key] = updatedRange
+            false
+        }
+    }
+
+    suspend fun clear(
+        conversationId: ConversationId,
+        subConversationId: SubconversationId?
+    ): Unit = mutex.withLock {
+        val key = ConversationKey(conversationId, subConversationId)
+        bufferedMessageRanges.remove(key)?.let { removedRange ->
+            logTrackingCleared(key, removedRange)
+        }
+    }
+
+    private data class ConversationKey(
+        val conversationId: ConversationId,
+        val subConversationId: SubconversationId?
+    )
+
+    private data class TimestampRange(
+        val earliest: Instant,
+        val latest: Instant
+    ) {
+        fun include(timestamp: Instant) = TimestampRange(
+            earliest = minOf(earliest, timestamp),
+            latest = maxOf(latest, timestamp)
+        )
+    }
+
+    private fun logBufferedMessageObserved(
+        key: ConversationKey,
+        timestamp: Instant,
+        range: TimestampRange,
+        bufferedTimeSpan: Duration,
+        shouldRecover: Boolean
+    ) {
+        logger.logStructuredJson(
+            level = KaliumLogLevel.DEBUG,
+            leadingMessage = if (shouldRecover) {
+                "Buffered MLS message recovery triggered"
+            } else {
+                "Buffered MLS message recovery tracking updated"
+            },
+            jsonStringKeyValues = mapOf(
+                "conversationId" to key.conversationId.toLogString(),
+                "subConversationId" to key.subConversationId?.toLogString(),
+                "messageTimestamp" to timestamp,
+                "earliestBufferedTimestamp" to range.earliest,
+                "latestBufferedTimestamp" to range.latest,
+                "bufferedTimeSpan" to bufferedTimeSpan.toString(),
+                "recoveryThreshold" to recoveryThreshold.toString()
+            )
+        )
+    }
+
+    private fun logTrackingCleared(key: ConversationKey, range: TimestampRange) {
+        logger.logStructuredJson(
+            level = KaliumLogLevel.DEBUG,
+            leadingMessage = "Buffered MLS message recovery tracking cleared",
+            jsonStringKeyValues = mapOf(
+                "conversationId" to key.conversationId.toLogString(),
+                "subConversationId" to key.subConversationId?.toLogString(),
+                "earliestBufferedTimestamp" to range.earliest,
+                "latestBufferedTimestamp" to range.latest
+            )
+        )
+    }
+
+    private companion object {
+        val DEFAULT_RECOVERY_THRESHOLD = 1.minutes
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageFailureHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageFailureHandler.kt
@@ -28,6 +28,7 @@ import com.wire.kalium.common.error.wrapNetworkMlsFailureIfApplicable
 
 internal sealed class MLSMessageFailureResolution {
     internal data object Ignore : MLSMessageFailureResolution()
+    internal data object Buffered : MLSMessageFailureResolution()
     internal data object InformUser : MLSMessageFailureResolution()
     internal data object OutOfSync : MLSMessageFailureResolution()
     internal data object ResetConversation : MLSMessageFailureResolution()
@@ -54,10 +55,13 @@ internal object MLSMessageFailureHandler {
             is NetworkFailure.MlsMessageRejectedFailure -> handleRejected(failure)
             is MLSFailure.MessageRejected -> handleRejected(failure.cause)
 
+            // Received message was targeting a future epoch and has been buffered.
+            is MLSFailure.BufferedFutureMessage,
+                // Commit arrived out of order and has been buffered.
+            MLSFailure.BufferedCommit -> MLSMessageFailureResolution.Buffered
+
             // Received already sent or received message, can safely be ignored.
             is MLSFailure.DuplicateMessage,
-                // Received message was targeting a future epoch and been buffered, can safely be ignored.
-            is MLSFailure.BufferedFutureMessage,
                 // Received self commit, any unmerged group has know been when merged by CoreCrypto.
             is MLSFailure.SelfCommitIgnored,
                 // Message arrive in an unmerged group, it has been buffered and will be consumed later.
@@ -69,7 +73,6 @@ internal object MLSMessageFailureHandler {
             is MLSFailure.Disabled,
             MLSFailure.CommitForMissingProposal,
             MLSFailure.ConversationNotFound,
-            MLSFailure.BufferedCommit,
             MLSFailure.OrphanWelcome,
             is CoreFailure.DevelopmentAPINotAllowedOnProduction,
             is BackupFailure -> MLSMessageFailureResolution.Ignore

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageUnpacker.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageUnpacker.kt
@@ -19,8 +19,10 @@
 package com.wire.kalium.logic.sync.receiver.conversation.message
 
 import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.MLSFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.common.functional.getOrNull
 import com.wire.kalium.common.functional.map
 import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.common.logger.logStructuredJson
@@ -139,7 +141,7 @@ internal class MLSMessageUnpackerImpl(
                         "groupID" to groupID.toLogString()
                     )
                 )
-                mlsConversationRepository.decryptMessage(mlsContext, Base64.decode(messageEvent.content), groupID)
+                decryptMessageAndLogIfBuffered(mlsContext, messageEvent, groupID)
             }
         } ?: conversationRepository.getConversationProtocolInfo(messageEvent.conversationId).flatMap { protocolInfo ->
             if (protocolInfo is Conversation.ProtocolInfo.MLSCapable) {
@@ -151,9 +153,35 @@ internal class MLSMessageUnpackerImpl(
                         "protocolInfo" to protocolInfo.toLogMap()
                     )
                 )
-                mlsConversationRepository.decryptMessage(mlsContext, Base64.decode(messageEvent.content), protocolInfo.groupId)
+                decryptMessageAndLogIfBuffered(mlsContext, messageEvent, protocolInfo.groupId)
             } else {
                 Either.Left(CoreFailure.NotSupportedByProteus)
             }
         }
+
+    private suspend fun decryptMessageAndLogIfBuffered(
+        mlsContext: MlsCoreCryptoContext,
+        messageEvent: Event.Conversation.NewMLSMessage,
+        groupId: GroupID
+    ): Either<CoreFailure, List<DecryptedMessageBundle>> {
+        val result = mlsConversationRepository.decryptMessage(mlsContext, Base64.decode(messageEvent.content), groupId)
+        val bufferType = when ((result as? Either.Left)?.value) {
+            MLSFailure.BufferedFutureMessage -> "FUTURE_MESSAGE"
+            MLSFailure.BufferedCommit -> "COMMIT"
+            else -> return result
+        }
+        val localEpoch = mlsConversationRepository.getLocalGroupEpoch(mlsContext, groupId).getOrNull()
+        logger.logStructuredJson(
+            level = KaliumLogLevel.WARN,
+            leadingMessage = "MLS message buffered",
+            jsonStringKeyValues = buildMap {
+                putAll(messageEvent.toLogMap())
+                put("subConversationId", messageEvent.subconversationId?.toLogString())
+                put("groupId", groupId.toLogString())
+                put("localEpoch", localEpoch?.toString())
+                put("bufferType", bufferType)
+            }
+        )
+        return result
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandler.kt
@@ -38,6 +38,7 @@ import com.wire.kalium.logic.data.client.wrapInMLSContext
 import com.wire.kalium.logic.data.conversation.ResetMLSConversationUseCase
 import com.wire.kalium.logic.sync.incremental.EventSource
 import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldHandler
+import com.wire.kalium.logic.util.EventProcessingLogger
 import com.wire.kalium.logic.util.createEventProcessingLogger
 import com.wire.kalium.util.serialization.toJsonElement
 
@@ -68,6 +69,7 @@ internal class NewMessageEventHandlerImpl(
     private val selfUserId: UserId,
     private val staleEpochVerifier: StaleEpochVerifier,
     private val resetMLSConversation: ResetMLSConversationUseCase,
+    private val bufferedMLSMessageRecoveryTracker: BufferedMLSMessageRecoveryTracker = BufferedMLSMessageRecoveryTracker(),
 ) : NewMessageEventHandler {
 
     private val logger by lazy { kaliumLogger.withFeatureId(KaliumLogger.Companion.ApplicationFlow.EVENT_RECEIVER) }
@@ -151,46 +153,10 @@ internal class NewMessageEventHandlerImpl(
     ) {
         var eventLogger = logger.createEventProcessingLogger(event)
         transactionContext.wrapInMLSContext { mlsMessageUnpacker.unpackMlsMessage(it, event) }
-            .onFailure {
-                when (MLSMessageFailureHandler.handleFailure(it)) {
-                    is MLSMessageFailureResolution.Ignore -> {
-                        eventLogger.logFailure(it, "protocol" to "MLS", "mlsOutcome" to "IGNORE")
-                    }
-
-                    is MLSMessageFailureResolution.InformUser -> {
-                        eventLogger.logFailure(it, "protocol" to "MLS", "mlsOutcome" to "INFORM_USER")
-                        // messages from subconversations should not send a system message
-                        if (event.subconversationId == null) {
-                            applicationMessageHandler.handleDecryptionError(
-                                eventId = event.id,
-                                conversationId = event.conversationId,
-                                messageInstant = event.messageInstant,
-                                senderUserId = event.senderUserId,
-                                senderClientId = ClientId(""), // TODO(mls): client ID not available for MLS messages
-                                content = MessageContent.FailedDecryption(
-                                    isDecryptionResolved = false,
-                                    senderUserId = event.senderUserId
-                                )
-                            )
-                        }
-                    }
-
-                    is MLSMessageFailureResolution.OutOfSync -> {
-                        eventLogger.logFailure(it, "protocol" to "MLS", "mlsOutcome" to "OUT_OF_SYNC")
-                        staleEpochVerifier.verifyEpoch(
-                            transactionContext,
-                            event.conversationId,
-                            event.subconversationId,
-                            event.messageInstant
-                        )
-                    }
-
-                    MLSMessageFailureResolution.ResetConversation -> {
-                        eventLogger.logFailure(it, "protocol" to "MLS", "mlsOutcome" to "OUT_OF_SYNC")
-                        resetMLSConversation(event.conversationId, transactionContext)
-                    }
-                }
+            .onFailure { failure ->
+                handleMLSFailure(transactionContext, event, failure, eventLogger)
             }.onSuccess { batchResult ->
+                bufferedMLSMessageRecoveryTracker.clear(event.conversationId, event.subconversationId)
                 batchResult.forEach { message ->
                     if (message is MessageUnpackResult.ApplicationMessage) {
                         processApplicationMessage(transactionContext, message, deliveryInfo)
@@ -204,6 +170,87 @@ internal class NewMessageEventHandlerImpl(
                     eventLogger = logger.createEventProcessingLogger(event)
                 }
             }
+    }
+
+    private suspend fun handleMLSFailure(
+        transactionContext: CryptoTransactionContext,
+        event: Event.Conversation.NewMLSMessage,
+        failure: CoreFailure,
+        eventLogger: EventProcessingLogger
+    ) {
+        when (MLSMessageFailureHandler.handleFailure(failure)) {
+            is MLSMessageFailureResolution.Ignore ->
+                eventLogger.logFailure(failure, "protocol" to "MLS", "mlsOutcome" to "IGNORE")
+
+            is MLSMessageFailureResolution.Buffered ->
+                handleBufferedMLSMessage(transactionContext, event, failure, eventLogger)
+
+            is MLSMessageFailureResolution.InformUser ->
+                handleMLSFailureToInformUser(event, failure, eventLogger)
+
+            is MLSMessageFailureResolution.OutOfSync -> {
+                bufferedMLSMessageRecoveryTracker.clear(event.conversationId, event.subconversationId)
+                eventLogger.logFailure(failure, "protocol" to "MLS", "mlsOutcome" to "OUT_OF_SYNC")
+                staleEpochVerifier.verifyEpoch(
+                    transactionContext,
+                    event.conversationId,
+                    event.subconversationId,
+                    event.messageInstant
+                )
+            }
+
+            MLSMessageFailureResolution.ResetConversation -> {
+                bufferedMLSMessageRecoveryTracker.clear(event.conversationId, event.subconversationId)
+                eventLogger.logFailure(failure, "protocol" to "MLS", "mlsOutcome" to "OUT_OF_SYNC")
+                resetMLSConversation(event.conversationId, transactionContext)
+            }
+        }
+    }
+
+    private suspend fun handleBufferedMLSMessage(
+        transactionContext: CryptoTransactionContext,
+        event: Event.Conversation.NewMLSMessage,
+        failure: CoreFailure,
+        eventLogger: EventProcessingLogger
+    ) {
+        val shouldRecover = bufferedMLSMessageRecoveryTracker.observeBufferedMessage(
+            event.conversationId,
+            event.subconversationId,
+            event.messageInstant
+        )
+        if (shouldRecover) {
+            eventLogger.logFailure(failure, "protocol" to "MLS", "mlsOutcome" to "BUFFERED_RECOVERY")
+            staleEpochVerifier.verifyEpoch(
+                transactionContext,
+                event.conversationId,
+                event.subconversationId,
+                event.messageInstant
+            )
+        } else {
+            eventLogger.logFailure(failure, "protocol" to "MLS", "mlsOutcome" to "BUFFERED")
+        }
+    }
+
+    private suspend fun handleMLSFailureToInformUser(
+        event: Event.Conversation.NewMLSMessage,
+        failure: CoreFailure,
+        eventLogger: EventProcessingLogger
+    ) {
+        eventLogger.logFailure(failure, "protocol" to "MLS", "mlsOutcome" to "INFORM_USER")
+        // messages from subconversations should not send a system message
+        if (event.subconversationId == null) {
+            applicationMessageHandler.handleDecryptionError(
+                eventId = event.id,
+                conversationId = event.conversationId,
+                messageInstant = event.messageInstant,
+                senderUserId = event.senderUserId,
+                senderClientId = ClientId(""), // TODO(mls): client ID not available for MLS messages
+                content = MessageContent.FailedDecryption(
+                    isDecryptionResolved = false,
+                    senderUserId = event.senderUserId
+                )
+            )
+        }
     }
 
     private suspend fun processApplicationMessage(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/MLSConversationRepositoryTest.kt
@@ -33,6 +33,7 @@ import com.wire.kalium.cryptography.E2EIClient
 import com.wire.kalium.cryptography.ExternalSenderKey
 import com.wire.kalium.cryptography.GroupInfoBundle
 import com.wire.kalium.cryptography.GroupInfoEncryptionType
+import com.wire.kalium.cryptography.MLSDecryptResult
 import com.wire.kalium.cryptography.RatchetTreeType
 import com.wire.kalium.cryptography.RotateBundle
 import com.wire.kalium.cryptography.WelcomeBundle
@@ -133,6 +134,21 @@ class MLSConversationRepositoryTest {
                 arrangement.certificateRevocationListRepository.addOrUpdateCRL(any(), any())
             }
         }
+
+    @Test
+    fun givenBufferedFutureMessage_whenDecryptingMessage_thenReturnBufferedFutureMessageFailure() = runTest {
+        val (arrangement, mlsConversationRepository) = Arrangement()
+            .withDecryptMLSMessageReturning(MLSDecryptResult.BufferedFutureMessage)
+            .arrange()
+
+        val result = mlsConversationRepository.decryptMessage(
+            arrangement.mlsContext,
+            Arrangement.COMMIT,
+            Arrangement.GROUP_ID
+        )
+
+        result.shouldFail { assertEquals(MLSFailure.BufferedFutureMessage, it) }
+    }
 
     @Test
     fun givenSuccessfulResponses_whenCallingEstablishMLSGroup_thenGroupIsCreatedAndCommitBundleIsSentAndAccepted() = runTest {
@@ -1776,9 +1792,13 @@ class MLSConversationRepositoryTest {
         }
 
         fun withDecryptMLSMessageSuccessful(decryptedMessage: com.wire.kalium.cryptography.DecryptedMessageBundle) = apply {
+            withDecryptMLSMessageReturning(MLSDecryptResult.Success(listOf(decryptedMessage)))
+        }
+
+        fun withDecryptMLSMessageReturning(result: MLSDecryptResult) = apply {
             everySuspend {
                 mlsContext.decryptMessage(any(), any())
-            } returns listOf(decryptedMessage)
+            } returns result
         }
 
         fun withRemoveMemberSuccessful() = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifierTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/StaleEpochVerifierTest.kt
@@ -78,7 +78,7 @@ class StaleEpochVerifierTest {
     @Test
     fun givenMLSConversation_whenHandlingStaleEpoch_thenShouldFetchConversationAgain() = runTest {
         val (arrangement, staleEpochHandler) = arrange {
-            withIsGroupOutOfSync(Either.Right(false))
+            withLocalGroupEpoch(Either.Right(REMOTE_EPOCH))
             withFetchConversationResponse(Either.Right(MLS_CONVERSATION_RESPONSE))
         }
 
@@ -96,7 +96,7 @@ class StaleEpochVerifierTest {
     @Test
     fun givenEpochIsLatest_whenHandlingStaleEpoch_thenShouldNotRejoinTheConversation() = runTest {
         val (arrangement, staleEpochHandler) = arrange {
-            withIsGroupOutOfSync(Either.Right(false))
+            withLocalGroupEpoch(Either.Right(REMOTE_EPOCH))
             withFetchConversationResponse(Either.Right(MLS_CONVERSATION_RESPONSE))
         }
 
@@ -115,7 +115,7 @@ class StaleEpochVerifierTest {
     @Test
     fun givenStaleEpoch_whenHandlingStaleEpoch_thenShouldRejoinTheConversation() = runTest {
         val (arrangement, staleEpochHandler) = arrange {
-            withIsGroupOutOfSync(Either.Right(true))
+            withLocalGroupEpoch(Either.Right(REMOTE_EPOCH - 1UL))
             withFetchConversationResponse(Either.Right(MLS_CONVERSATION_RESPONSE))
             withJoinExistingMLSConversationUseCaseReturning(Either.Right(Unit))
             withInsertLostCommitSystemMessage(Either.Right(Unit))
@@ -136,7 +136,7 @@ class StaleEpochVerifierTest {
     @Test
     fun givenRejoiningFails_whenHandlingStaleEpoch_thenShouldNotInsertLostCommitSystemMessage() = runTest {
         val (arrangement, staleEpochHandler) = arrange {
-            withIsGroupOutOfSync(Either.Right(true))
+            withLocalGroupEpoch(Either.Right(REMOTE_EPOCH - 1UL))
             withFetchConversationResponse(Either.Right(MLS_CONVERSATION_RESPONSE))
             withJoinExistingMLSConversationUseCaseReturning(Either.Left(NetworkFailure.NoNetworkConnection(null)))
         }
@@ -151,7 +151,7 @@ class StaleEpochVerifierTest {
     @Test
     fun givenConversationIsRejoined_whenHandlingStaleEpoch_thenShouldInsertLostCommitSystemMessage() = runTest {
         val (arrangement, staleEpochHandler) = arrange {
-            withIsGroupOutOfSync(Either.Right(true))
+            withLocalGroupEpoch(Either.Right(REMOTE_EPOCH - 1UL))
             withFetchConversationResponse(Either.Right(MLS_CONVERSATION_RESPONSE))
             withJoinExistingMLSConversationUseCaseReturning(Either.Right(Unit))
             withInsertLostCommitSystemMessage(Either.Right(Unit))
@@ -169,7 +169,7 @@ class StaleEpochVerifierTest {
         val subConversationId = SubconversationId("subconversation-id")
         val (arrangement, staleEpochHandler) = arrange {
             withFetchRemoteSubConversationDetails(CONVERSATION_ID, subConversationId, Either.Right(TestSubConversationDetails))
-            withIsGroupOutOfSync(Either.Right(false))
+            withLocalGroupEpoch(Either.Right(TestSubConversationDetails.epoch))
         }
 
         val result = staleEpochHandler.verifyEpoch(arrangement.transactionContext, CONVERSATION_ID, subConversationId, null)
@@ -181,10 +181,9 @@ class StaleEpochVerifierTest {
         }
 
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.mlsConversationRepository.isLocalGroupEpochStale(
+            arrangement.mlsConversationRepository.getLocalGroupEpoch(
                 mokkeryAny(),
-                mokkeryEq(TestSubConversationDetails.groupId),
-                mokkeryEq(TestSubConversationDetails.epoch)
+                mokkeryEq(TestSubConversationDetails.groupId)
             )
         }
     }
@@ -194,7 +193,7 @@ class StaleEpochVerifierTest {
         val subConversationId = SubconversationId("subconversation-id")
         val (arrangement, staleEpochHandler) = arrange {
             withFetchRemoteSubConversationDetails(CONVERSATION_ID, subConversationId, Either.Right(TestSubConversationDetails))
-            withIsGroupOutOfSync(Either.Right(true))
+            withLocalGroupEpoch(Either.Right(TestSubConversationDetails.epoch - 1UL))
             withFetchRemoteSubConversationGroupInfo(CONVERSATION_ID, subConversationId, Either.Right(TestGroupInfo))
             withJoinGroupByExternalCommit(TestSubConversationDetails.groupId, TestGroupInfo, Either.Right(Unit))
         }
@@ -241,7 +240,7 @@ class StaleEpochVerifierTest {
         val subConversationId = SubconversationId("subconversation-id")
         val (arrangement, staleEpochHandler) = arrange {
             withFetchRemoteSubConversationDetails(CONVERSATION_ID, subConversationId, Either.Right(TestSubConversationDetails))
-            withIsGroupOutOfSync(Either.Right(true))
+            withLocalGroupEpoch(Either.Right(TestSubConversationDetails.epoch - 1UL))
             withFetchRemoteSubConversationGroupInfo(CONVERSATION_ID, subConversationId, Either.Right(TestGroupInfo))
             withJoinGroupByExternalCommit(
                 TestSubConversationDetails.groupId,
@@ -270,7 +269,7 @@ class StaleEpochVerifierTest {
         val subConversationId = SubconversationId("subconversation-id")
         val (arrangement, staleEpochHandler) = arrange {
             withFetchRemoteSubConversationDetails(CONVERSATION_ID, subConversationId, Either.Right(TestSubConversationDetails))
-            withIsGroupOutOfSync(Either.Right(false))
+            withLocalGroupEpoch(Either.Right(TestSubConversationDetails.epoch))
         }
 
         val result = staleEpochHandler.verifyEpoch(arrangement.transactionContext, CONVERSATION_ID, subConversationId, null)
@@ -307,7 +306,9 @@ class StaleEpochVerifierTest {
             val localProtocolInfo: Either<StorageFailure, Conversation.ProtocolInfo> = when (result) {
                 is Either.Left -> Either.Left(StorageFailure.Generic(IllegalStateException(result.value.toString())))
                 is Either.Right -> when (result.value.protocol) {
-                    ConvProtocol.MLS -> Either.Right(TestConversation.MLS_PROTOCOL_INFO)
+                    ConvProtocol.MLS -> Either.Right(
+                        TestConversation.MLS_PROTOCOL_INFO.copy(epoch = result.value.epoch ?: 0UL)
+                    )
                     else -> Either.Right(Conversation.ProtocolInfo.Proteus)
                 }
             }
@@ -317,8 +318,8 @@ class StaleEpochVerifierTest {
             } returns localProtocolInfo
         }
 
-        suspend fun withIsGroupOutOfSync(result: Either<CoreFailure, Boolean>) {
-            everySuspend { mlsConversationRepository.isLocalGroupEpochStale(mokkeryAny(), mokkeryAny(), mokkeryAny()) } returns result
+        suspend fun withLocalGroupEpoch(result: Either<CoreFailure, ULong>) {
+            everySuspend { mlsConversationRepository.getLocalGroupEpoch(mokkeryAny(), mokkeryAny()) } returns result
         }
 
         suspend fun withJoinExistingMLSConversationUseCaseReturning(result: Either<CoreFailure, Unit>) {
@@ -372,6 +373,7 @@ class StaleEpochVerifierTest {
         suspend fun arrange(configuration: suspend Arrangement.() -> Unit) = Arrangement(configuration).arrange()
 
         val CONVERSATION_ID = ConversationId("conversation-value", "conversation-domain")
+        const val REMOTE_EPOCH = 10UL
 
         val MLS_CONVERSATION_RESPONSE = ConversationResponse(
             creator = TestUser.USER_ID.value,
@@ -382,7 +384,7 @@ class StaleEpochVerifierTest {
             name = "mls-conversation",
             id = CONVERSATION_ID.toApi(),
             groupId = TestConversation.MLS_PROTOCOL_INFO.groupId.value,
-            epoch = TestConversation.MLS_PROTOCOL_INFO.epoch,
+            epoch = REMOTE_EPOCH,
             type = ConversationResponse.Type.GROUP,
             messageTimer = 0,
             teamId = null,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/BufferedMLSMessageRecoveryTrackerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/BufferedMLSMessageRecoveryTrackerTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.sync.receiver.conversation.message
+
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.SubconversationId
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+class BufferedMLSMessageRecoveryTrackerTest {
+
+    @Test
+    fun givenBufferedMessagesAtThreshold_whenObserving_thenShouldNotRecover() = runTest {
+        val tracker = BufferedMLSMessageRecoveryTracker()
+
+        assertFalse(tracker.observeBufferedMessage(CONVERSATION_ID, null, TIMESTAMP))
+        assertFalse(tracker.observeBufferedMessage(CONVERSATION_ID, null, TIMESTAMP + 1.minutes))
+    }
+
+    @Test
+    fun givenBufferedMessagesBeyondThreshold_whenObserving_thenShouldRecover() = runTest {
+        val tracker = BufferedMLSMessageRecoveryTracker()
+
+        assertFalse(tracker.observeBufferedMessage(CONVERSATION_ID, null, TIMESTAMP))
+        assertTrue(tracker.observeBufferedMessage(CONVERSATION_ID, null, TIMESTAMP + 1.minutes + 1.seconds))
+    }
+
+    @Test
+    fun givenReverseOrderedBufferedMessagesBeyondThreshold_whenObserving_thenShouldRecover() = runTest {
+        val tracker = BufferedMLSMessageRecoveryTracker()
+
+        assertFalse(tracker.observeBufferedMessage(CONVERSATION_ID, null, TIMESTAMP + 2.minutes))
+        assertTrue(tracker.observeBufferedMessage(CONVERSATION_ID, null, TIMESTAMP))
+    }
+
+    @Test
+    fun givenDifferentConversationKeys_whenObserving_thenShouldTrackThemIndependently() = runTest {
+        val tracker = BufferedMLSMessageRecoveryTracker()
+
+        assertFalse(tracker.observeBufferedMessage(CONVERSATION_ID, null, TIMESTAMP))
+        assertFalse(tracker.observeBufferedMessage(OTHER_CONVERSATION_ID, null, TIMESTAMP + 2.minutes))
+        assertFalse(tracker.observeBufferedMessage(CONVERSATION_ID, SUBCONVERSATION_ID, TIMESTAMP + 4.minutes))
+    }
+
+    @Test
+    fun givenTrackedConversation_whenClearing_thenShouldStartANewWindow() = runTest {
+        val tracker = BufferedMLSMessageRecoveryTracker()
+
+        assertFalse(tracker.observeBufferedMessage(CONVERSATION_ID, null, TIMESTAMP))
+        tracker.clear(CONVERSATION_ID, null)
+        assertFalse(tracker.observeBufferedMessage(CONVERSATION_ID, null, TIMESTAMP + 2.minutes))
+    }
+
+    @Test
+    fun givenRecoveryTriggered_whenMoreMessagesAreBuffered_thenShouldUseFreshWindow() = runTest {
+        val tracker = BufferedMLSMessageRecoveryTracker()
+
+        assertFalse(tracker.observeBufferedMessage(CONVERSATION_ID, null, TIMESTAMP))
+        assertTrue(tracker.observeBufferedMessage(CONVERSATION_ID, null, TIMESTAMP + 1.minutes + 1.seconds))
+        assertFalse(tracker.observeBufferedMessage(CONVERSATION_ID, null, TIMESTAMP + 2.minutes + 1.seconds))
+        assertTrue(tracker.observeBufferedMessage(CONVERSATION_ID, null, TIMESTAMP + 2.minutes + 2.seconds))
+    }
+
+    private companion object {
+        val CONVERSATION_ID = ConversationId("conversation-id", "domain")
+        val OTHER_CONVERSATION_ID = ConversationId("other-conversation-id", "domain")
+        val SUBCONVERSATION_ID = SubconversationId("subconversation-id")
+        val TIMESTAMP = Instant.parse("2026-07-21T10:00:00Z")
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.logic.sync.receiver.conversation.message
 import com.wire.kalium.cryptography.exceptions.ProteusException
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.MLSFailure
+import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.common.error.ProteusFailure
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Conversation
@@ -37,6 +38,7 @@ import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.conversation.ResetMLSConversationUseCase
+import com.wire.kalium.logic.data.conversation.ResetMLSConversationResult
 import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldHandler
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMokkeryImpl
@@ -55,6 +57,8 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
 import kotlin.test.Test
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 class NewMessageEventHandlerTest {
 
@@ -476,6 +480,89 @@ class NewMessageEventHandlerTest {
     }
 
     @Test
+    fun givenDifferentBufferedErrorsSpanThreshold_whenHandling_thenVerifyStaleEpoch() = runTest {
+        val subConversationId = SubconversationId("subconversation-id")
+        val firstTimestamp = Instant.parse("2026-07-21T10:00:00Z")
+        val triggeringTimestamp = firstTimestamp + 1.minutes + 1.seconds
+        val firstEvent = TestEvent.newMLSMessageEvent(firstTimestamp, subConversationId)
+        val triggeringEvent = TestEvent.newMLSMessageEvent(triggeringTimestamp, subConversationId)
+        val (arrangement, newMessageEventHandler) = Arrangement()
+            .withMLSUnpackerReturningInOrder(
+                Either.Left(MLSFailure.BufferedFutureMessage),
+                Either.Left(MLSFailure.BufferedCommit)
+            )
+            .withVerifyEpoch(Either.Right(Unit))
+            .arrange()
+
+        newMessageEventHandler.handleNewMLSMessage(arrangement.transactionContext, firstEvent, TestEvent.nonLiveDeliveryInfo)
+        newMessageEventHandler.handleNewMLSMessage(arrangement.transactionContext, triggeringEvent, TestEvent.liveDeliveryInfo)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.staleEpochVerifier.verifyEpoch(
+                any(),
+                eq(triggeringEvent.conversationId),
+                eq(subConversationId),
+                eq(triggeringTimestamp)
+            )
+        }
+    }
+
+    @Test
+    fun givenBufferedMessagesAtThreshold_whenHandling_thenShouldNotVerifyStaleEpoch() = runTest {
+        val firstTimestamp = Instant.parse("2026-07-21T10:00:00Z")
+        val (arrangement, newMessageEventHandler) = Arrangement()
+            .withMLSUnpackerReturning(Either.Left(MLSFailure.BufferedFutureMessage))
+            .arrange()
+
+        newMessageEventHandler.handleNewMLSMessage(
+            arrangement.transactionContext,
+            TestEvent.newMLSMessageEvent(firstTimestamp),
+            TestEvent.liveDeliveryInfo
+        )
+        newMessageEventHandler.handleNewMLSMessage(
+            arrangement.transactionContext,
+            TestEvent.newMLSMessageEvent(firstTimestamp + 1.minutes),
+            TestEvent.liveDeliveryInfo
+        )
+
+        verifySuspend(VerifyMode.not) {
+            arrangement.staleEpochVerifier.verifyEpoch(any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun givenSuccessfulDecryptionBetweenBufferedMessages_whenHandling_thenShouldStartANewWindow() = runTest {
+        val firstTimestamp = Instant.parse("2026-07-21T10:00:00Z")
+        val (arrangement, newMessageEventHandler) = Arrangement()
+            .withMLSUnpackerReturningInOrder(
+                Either.Left(MLSFailure.BufferedCommit),
+                Either.Right(listOf(MessageUnpackResult.HandshakeMessage)),
+                Either.Left(MLSFailure.BufferedCommit)
+            )
+            .arrange()
+
+        newMessageEventHandler.handleNewMLSMessage(
+            arrangement.transactionContext,
+            TestEvent.newMLSMessageEvent(firstTimestamp),
+            TestEvent.liveDeliveryInfo
+        )
+        newMessageEventHandler.handleNewMLSMessage(
+            arrangement.transactionContext,
+            TestEvent.newMLSMessageEvent(firstTimestamp + 2.minutes),
+            TestEvent.liveDeliveryInfo
+        )
+        newMessageEventHandler.handleNewMLSMessage(
+            arrangement.transactionContext,
+            TestEvent.newMLSMessageEvent(firstTimestamp + 4.minutes),
+            TestEvent.liveDeliveryInfo
+        )
+
+        verifySuspend(VerifyMode.not) {
+            arrangement.staleEpochVerifier.verifyEpoch(any(), any(), any(), any())
+        }
+    }
+
+    @Test
     fun givenMLSEventFailsWithWrongEpoch_whenHandling_shouldCallWrongEpochHandler() = runTest {
         val (arrangement, newMessageEventHandler) = Arrangement()
             .withMLSUnpackerReturning(Either.Left(MLSFailure.WrongEpoch))
@@ -512,6 +599,59 @@ class NewMessageEventHandlerTest {
                 arrangement.applicationMessageHandler.handleDecryptionError(any(), any(), any(), any(), any(), any())
             }
         }
+
+    @Test
+    fun givenWrongEpochBetweenBufferedMessages_whenHandling_thenShouldClearBufferedWindow() = runTest {
+        val firstTimestamp = Instant.parse("2026-07-21T10:00:00Z")
+        val (arrangement, newMessageEventHandler) = Arrangement()
+            .withMLSUnpackerReturningInOrder(
+                Either.Left(MLSFailure.BufferedFutureMessage),
+                Either.Left(MLSFailure.WrongEpoch),
+                Either.Left(MLSFailure.BufferedFutureMessage)
+            )
+            .withVerifyEpoch(Either.Right(Unit))
+            .arrange()
+
+        listOf(firstTimestamp, firstTimestamp + 2.minutes, firstTimestamp + 4.minutes).forEach { timestamp ->
+            newMessageEventHandler.handleNewMLSMessage(
+                arrangement.transactionContext,
+                TestEvent.newMLSMessageEvent(timestamp),
+                TestEvent.liveDeliveryInfo
+            )
+        }
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.staleEpochVerifier.verifyEpoch(any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun givenConversationResetBetweenBufferedMessages_whenHandling_thenShouldClearBufferedWindow() = runTest {
+        val firstTimestamp = Instant.parse("2026-07-21T10:00:00Z")
+        val (arrangement, newMessageEventHandler) = Arrangement()
+            .withMLSUnpackerReturningInOrder(
+                Either.Left(MLSFailure.BufferedCommit),
+                Either.Left(NetworkFailure.MlsMessageRejectedFailure.InvalidLeafNodeIndex),
+                Either.Left(MLSFailure.BufferedCommit)
+            )
+            .withResetMLSConversationReturning(ResetMLSConversationResult.Success)
+            .arrange()
+
+        listOf(firstTimestamp, firstTimestamp + 2.minutes, firstTimestamp + 4.minutes).forEach { timestamp ->
+            newMessageEventHandler.handleNewMLSMessage(
+                arrangement.transactionContext,
+                TestEvent.newMLSMessageEvent(timestamp),
+                TestEvent.liveDeliveryInfo
+            )
+        }
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.resetMlsConversation(any(), any())
+        }
+        verifySuspend(VerifyMode.not) {
+            arrangement.staleEpochVerifier.verifyEpoch(any(), any(), any(), any())
+        }
+    }
 
     @Test
     fun givenSubconversationId_whenHandlingInformUserFailure_thenShouldNotSendSystemMessage() = runTest {
@@ -595,9 +735,26 @@ class NewMessageEventHandlerTest {
                 }.returns(result)
             }
 
+        suspend fun withMLSUnpackerReturningInOrder(
+            vararg results: Either<CoreFailure, List<MessageUnpackResult>>
+        ) = apply {
+            var nextResult = 0
+            everySuspend {
+                mlsMessageUnpacker.unpackMlsMessage(any(), any())
+            } calls {
+                results[nextResult++]
+            }
+        }
+
         suspend fun withVerifyEpoch(result: Either<CoreFailure, Unit>) = apply {
             everySuspend {
                 staleEpochVerifier.verifyEpoch(any(), any(), any(), any())
+            }.returns(result)
+        }
+
+        suspend fun withResetMLSConversationReturning(result: ResetMLSConversationResult) = apply {
+            everySuspend {
+                resetMlsConversation(any(), any())
             }.returns(result)
         }
 


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26421
<!--jira-description-action-hidden-marker-end-->

https://wearezeta.atlassian.net/browse/WPB-26421

----

# What is new in this PR?

### Issue
If a commit is missed, CoreCrypto can keep buffering later MLS messages indefinitely and the conversation does not recover.

### Solution
- Add `BufferedMLSMessageRecoveryTracker`, scoped by conversation and subconversation, to track the timestamp span of buffered events in memory.
- Trigger stale-epoch verification when the buffered span exceeds one minute; a span exactly at one minute does not recover.
- Clear or restart tracking after successful decryption, out-of-sync handling, conversation reset, or a recovery trigger.

### Dependency
This is stacked on #4316, which surfaces buffered CoreCrypto failures to the event-processing layer. After #4316 merges, this branch will be rebased onto `develop` and the PR base will be retargeted.