### PR TITLE
fix(cells): harden Ktor S3 transfers PR 2  [WPB-26729]

### DIFF
--- a/domain/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/CellsAwsClient.kt
+++ b/domain/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/CellsAwsClient.kt
@@ -61,6 +61,3 @@ internal fun cellsAwsClient(
     },
     fileSystem = FileSystem.SYSTEM,
 )
-
-private suspend fun Deferred<CellsCredentials?>.awaitOrThrow(): CellsCredentials =
-    await() ?: error("Cells credentials are not available")

--- a/domain/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/CellsCredentialsAwait.kt
+++ b/domain/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/CellsCredentialsAwait.kt
@@ -1,0 +1,27 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.cells.data
+
+import com.wire.kalium.cells.domain.model.CellsCredentials
+import kotlinx.coroutines.Deferred
+
+internal suspend fun Deferred<CellsCredentials?>.awaitOrThrow(): CellsCredentials =
+    await() ?: throw CellsCredentialsUnavailableException()
+
+internal class CellsCredentialsUnavailableException :
+    Exception("Cells credentials are not available")

--- a/domain/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/CellsS3Client.kt
+++ b/domain/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/CellsS3Client.kt
@@ -164,9 +164,13 @@ internal class CellsS3Client(
                     signedRequest.headers.forEach { (name, value) -> header(name, value) }
                 }
             },
-            transform = { it.bodyAsText() },
+            transform = { response ->
+                response.bodyAsText().also { body ->
+                    body.throwEmbeddedS3Error("Create multipart upload")
+                }
+            },
         )
-        return responseBody.xmlTagValue("UploadId")
+        return responseBody.multipartUploadId()
             ?: throw IOException("Create multipart upload response did not include an UploadId")
     }
 
@@ -419,32 +423,17 @@ private fun String.escapeXml(): String =
         .replace("\"", "&quot;")
         .replace("'", "&apos;")
 
-private fun String.xmlTagValue(tagName: String): String? {
-    val startTag = "<$tagName>"
-    val endTag = "</$tagName>"
-    val start = indexOf(startTag).takeIf { it >= 0 }?.plus(startTag.length)
-    val end = start?.let { indexOf(endTag, it).takeIf { end -> end >= it } }
-    return if (start != null && end != null) substring(start, end) else null
+private fun String.throwEmbeddedS3Error(operation: String) {
+    val embeddedError = embeddedS3Error() ?: return
+    val message = "$operation failed: ${embeddedError.code ?: "unknown S3 error"}"
+    throw if (embeddedError.isRetryable()) RetryableS3Exception(message) else S3RequestException(message)
 }
-
-private fun String.embeddedS3Error(): S3Error? {
-    if (!S3_ERROR_ELEMENT.containsMatchIn(this)) return null
-    return S3Error(
-        code = xmlTagValue("Code"),
-    )
-}
-
-private fun String.containsCompleteMultipartUploadResult(): Boolean =
-    S3_COMPLETE_MULTIPART_RESULT_ELEMENT.containsMatchIn(this)
 
 private fun validateCompleteMultipartUploadResponse(responseBody: String) {
-    val embeddedError = responseBody.embeddedS3Error()
-    if (embeddedError == null && responseBody.containsCompleteMultipartUploadResult()) return
-    if (embeddedError == null) {
+    responseBody.throwEmbeddedS3Error("Complete multipart upload")
+    if (!responseBody.containsCompleteMultipartUploadResult()) {
         throw RetryableS3Exception("Complete multipart upload returned an invalid response")
     }
-    val message = "Complete multipart upload failed: ${embeddedError.code ?: "unknown S3 error"}"
-    throw if (embeddedError.isRetryable()) RetryableS3Exception(message) else S3RequestException(message)
 }
 
 private fun S3Error.isRetryable(): Boolean = code in RETRYABLE_S3_ERROR_CODES
@@ -453,10 +442,6 @@ private fun s3RetryDelayMillis(retryCount: Int): Long {
     val maximumDelay = S3_RETRY_MAX_DELAYS[retryCount - 1]
     return Random.nextLong(maximumDelay + 1)
 }
-
-private data class S3Error(
-    val code: String?,
-)
 
 private fun HttpStatusCode.isRetryableS3Status(): Boolean = value in RETRYABLE_S3_STATUS_CODES
 
@@ -499,9 +484,6 @@ private val RETRYABLE_S3_STATUS_CODES = setOf(
     HttpStatusCode.ServiceUnavailable.value,
     HttpStatusCode.GatewayTimeout.value,
 )
-private val S3_ERROR_ELEMENT = Regex("""<(?:(?:[A-Za-z_][\w.-]*):)?Error(?:\s[^>]*)?>""")
-private val S3_COMPLETE_MULTIPART_RESULT_ELEMENT =
-    Regex("""<(?:(?:[A-Za-z_][\w.-]*):)?CompleteMultipartUploadResult(?:\s[^>]*)?/?>""")
 private val S3_RETRY_MAX_DELAYS = longArrayOf(
     S3_FIRST_RETRY_MAX_DELAY_MILLIS,
     S3_SECOND_RETRY_MAX_DELAY_MILLIS,

--- a/domain/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/CellsS3Client.kt
+++ b/domain/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/CellsS3Client.kt
@@ -37,6 +37,7 @@ import io.ktor.http.content.OutgoingContent
 import io.ktor.http.content.TextContent
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.ByteWriteChannel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.io.IOException as KtorIOException
 import okio.Buffer
@@ -44,6 +45,7 @@ import okio.BufferedSource
 import okio.FileSystem
 import okio.IOException
 import okio.Path
+import okio.Sink
 import okio.SYSTEM
 import okio.buffer
 import okio.use
@@ -57,9 +59,10 @@ internal class CellsS3Client(
     private val config: CellsS3ClientConfig = CellsS3ClientConfig(),
 ) : CellsAwsClient {
 
+    @Suppress("TooGenericExceptionCaught") // Sink and callback implementations can throw arbitrary exceptions.
     override suspend fun download(
         objectKey: String,
-        outFileSink: okio.Sink,
+        outFileSink: Sink,
         onProgressUpdate: (Long) -> Unit,
     ) {
         requestWithRetry(
@@ -75,10 +78,27 @@ internal class CellsS3Client(
                 }
             },
             transform = { response ->
-                response.bodyAsChannel().copyToSink(
-                    sink = outFileSink,
-                    onProgressUpdate = onProgressUpdate,
-                )
+                val expectedContentLength = response.expectedContentLength()
+                try {
+                    val copiedBytes = response.bodyAsChannel().copyToSink(
+                        sink = outFileSink,
+                        onProgressUpdate = onProgressUpdate,
+                    )
+                    if (expectedContentLength != null && copiedBytes != expectedContentLength) {
+                        throw S3RequestException(
+                            "Download object response body length mismatch: " +
+                                    "expected $expectedContentLength bytes but received $copiedBytes bytes"
+                        )
+                    }
+                } catch (cause: CancellationException) {
+                    throw cause
+                } catch (cause: S3RequestException) {
+                    throw cause
+                } catch (cause: Exception) {
+                    // copyToSink closes the caller-provided sink even if reading fails before the first byte.
+                    // Retrying could therefore replay into a partial or closed destination.
+                    throw S3RequestException("Download object response body could not be copied", cause)
+                }
                 Unit
             },
         )
@@ -445,6 +465,14 @@ private fun s3RetryDelayMillis(retryCount: Int): Long {
 
 private fun HttpStatusCode.isRetryableS3Status(): Boolean = value in RETRYABLE_S3_STATUS_CODES
 
+private fun HttpResponse.expectedContentLength(): Long? {
+    val headerValue = headers[HttpHeaders.ContentLength] ?: return null
+    return headerValue.toLongOrNull()
+        ?.takeIf { it >= 0L }
+        // A structurally invalid response is terminal and is rejected before writing to the caller's sink.
+        ?: throw S3RequestException("Download object response has invalid Content-Length: '$headerValue'")
+}
+
 private suspend fun HttpResponse.discardBody() = bodyAsChannel().cancel(null)
 
 private suspend fun HttpResponse.toS3Failure(operation: String): S3Attempt<Nothing> {
@@ -458,7 +486,7 @@ private suspend fun HttpResponse.toS3Failure(operation: String): S3Attempt<Nothi
     }
 }
 
-private open class S3RequestException(message: String) : IOException(message)
+private open class S3RequestException(message: String, cause: Throwable? = null) : IOException(message, cause)
 
 private class RetryableS3Exception(message: String) : S3RequestException(message)
 

--- a/domain/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/CellsS3Client.kt
+++ b/domain/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/CellsS3Client.kt
@@ -156,7 +156,7 @@ internal class CellsS3Client(
 
         fileSystem.source(path).buffer().use { source ->
             while (uploaded < length) {
-                val partSize = minOf(MULTIPART_CHUNK_SIZE.toLong(), length - uploaded)
+                val partSize = minOf(config.multipartChunkSize, length - uploaded)
                 val partData = source.readPart(partSize)
                 val eTag = uploadPart(node.path, uploadId, partNumber, partData)
                 uploaded += partData.size
@@ -377,7 +377,6 @@ internal class CellsS3Client(
 
     private companion object {
         const val DEFAULT_BUCKET_NAME = "io"
-        const val MULTIPART_CHUNK_SIZE = 10 * 1024 * 1024
         const val STREAM_BUFFER_SIZE = 8 * 1024L
         const val UNSIGNED_PAYLOAD = "UNSIGNED-PAYLOAD"
         const val UPLOADS_QUERY_PARAMETER = "uploads"
@@ -390,7 +389,12 @@ internal data class CellsS3ClientConfig(
     val signer: AwsSigV4Signer = AwsSigV4Signer(DEFAULT_S3_REGION, S3_SERVICE_NAME),
     val dateProvider: () -> AwsSigningDate = { AwsSigningDate.now() },
     val maxRegularUploadSize: Long = DEFAULT_MAX_REGULAR_UPLOAD_SIZE,
-)
+    val multipartChunkSize: Long = DEFAULT_MULTIPART_CHUNK_SIZE,
+) {
+    init {
+        require(multipartChunkSize > 0L) { "Multipart chunk size must be positive" }
+    }
+}
 
 internal data class S3Credentials(
     val accessKeyId: String,
@@ -504,6 +508,7 @@ private const val S3_SECOND_RETRY_MAX_DELAY_MILLIS = 15L
 private const val DEFAULT_S3_REGION = "us-east-1"
 private const val S3_SERVICE_NAME = "s3"
 private const val DEFAULT_MAX_REGULAR_UPLOAD_SIZE = 100 * 1024 * 1024L
+private const val DEFAULT_MULTIPART_CHUNK_SIZE = 10 * 1024 * 1024L
 private val RETRYABLE_S3_STATUS_CODES = setOf(
     HttpStatusCode.RequestTimeout.value,
     HttpStatusCode.TooManyRequests.value,

--- a/domain/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/S3Xml.kt
+++ b/domain/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/S3Xml.kt
@@ -1,0 +1,293 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+@file:Suppress("MatchingDeclarationName")
+
+package com.wire.kalium.cells.data
+
+internal data class S3Error(
+    val code: String?,
+)
+
+internal fun String.multipartUploadId(): String? {
+    val result = parseXmlDocument()?.takeIf { it.localName == "InitiateMultipartUploadResult" } ?: return null
+    return result.children.firstOrNull { it.localName == "UploadId" }?.textValue()
+}
+
+internal fun String.embeddedS3Error(): S3Error? {
+    val error = parseXmlDocument()?.takeIf { it.localName == "Error" } ?: return null
+    return S3Error(code = error.children.firstOrNull { it.localName == "Code" }?.textValue())
+}
+
+internal fun String.containsCompleteMultipartUploadResult(): Boolean =
+    parseXmlDocument()?.localName == "CompleteMultipartUploadResult"
+
+private fun String.parseXmlDocument(): XmlElement? = XmlDocumentParser(this).parse()
+
+private class XmlDocumentParser(
+    private val xml: String,
+) {
+    private var offset = 0
+    private var root: XmlElement? = null
+    private val openElements = mutableListOf<XmlElement>()
+
+    fun parse(): XmlElement? {
+        if (xml.startsWith(XML_BYTE_ORDER_MARK)) offset++
+        while (offset < xml.length) {
+            val parsed = when {
+                xml[offset] != '<' -> parseText()
+                xml.startsWith(XML_COMMENT_START, offset) -> skipDelimited(XML_COMMENT_END)
+                xml.startsWith(XML_PROCESSING_INSTRUCTION_START, offset) ->
+                    skipDelimited(XML_PROCESSING_INSTRUCTION_END)
+                xml.startsWith(XML_CDATA_START, offset) -> parseCData()
+                xml.startsWith("</", offset) -> parseEndElement()
+                xml.startsWith("<!", offset) -> false
+                else -> parseStartElement()
+            }
+            if (!parsed) return null
+        }
+        return root?.takeIf { openElements.isEmpty() }
+    }
+
+    @Suppress("ReturnCount") // Each early return rejects one distinct malformed XML state.
+    private fun parseText(): Boolean {
+        val end = xml.indexOf('<', offset).takeIf { it >= 0 } ?: xml.length
+        val rawText = xml.substring(offset, end)
+        if (XML_CDATA_END in rawText) return false
+        val decoded = rawText.decodeXmlText() ?: return false
+        if (openElements.isEmpty()) {
+            if (decoded.isNotBlank()) return false
+        } else {
+            openElements.last().text.append(decoded)
+        }
+        offset = end
+        return true
+    }
+
+    @Suppress("ReturnCount") // Each early return rejects one distinct malformed XML state.
+    private fun parseCData(): Boolean {
+        val contentStart = offset + XML_CDATA_START.length
+        val end = xml.indexOf(XML_CDATA_END, contentStart)
+        if (end < 0 || openElements.isEmpty()) return false
+        val content = xml.substring(contentStart, end)
+        if (!content.hasOnlyValidXmlCharacters()) return false
+        openElements.last().text.append(content)
+        offset = end + XML_CDATA_END.length
+        return true
+    }
+
+    private fun skipDelimited(endDelimiter: String): Boolean {
+        val end = xml.indexOf(endDelimiter, offset)
+        if (end < 0) return false
+        offset = end + endDelimiter.length
+        return true
+    }
+
+    @Suppress("ReturnCount") // Each early return rejects one distinct malformed XML state.
+    private fun parseStartElement(): Boolean {
+        val end = findStartElementEnd() ?: return false
+        var markup = xml.substring(offset + 1, end).trimEnd()
+        val selfClosing = markup.endsWith('/')
+        if (selfClosing) markup = markup.dropLast(1).trimEnd()
+        val nameEnd = markup.indexOfFirst { it.isWhitespace() }.takeIf { it >= 0 } ?: markup.length
+        val qualifiedName = markup.substring(0, nameEnd)
+        if (!XML_QUALIFIED_NAME.matches(qualifiedName) || !hasValidAttributes(markup, nameEnd)) return false
+
+        val element = XmlElement(qualifiedName)
+        if (openElements.isEmpty()) {
+            if (root != null) return false
+            root = element
+        } else {
+            openElements.last().children += element
+        }
+        if (!selfClosing) openElements += element
+        offset = end + 1
+        return true
+    }
+
+    private fun findStartElementEnd(): Int? {
+        var quote: Char? = null
+        for (index in offset + 1 until xml.length) {
+            val character = xml[index]
+            when {
+                quote != null && character == quote -> quote = null
+                quote == null && (character == '"' || character == '\'') -> quote = character
+                quote == null && character == '>' -> return index
+            }
+        }
+        return null
+    }
+
+    @Suppress(
+        "ReturnCount",
+        "CyclomaticComplexMethod",
+        // Attribute parsing is a validation state machine; early rejection keeps invalid states from leaking forward.
+    )
+    private fun hasValidAttributes(markup: String, nameEnd: Int): Boolean {
+        var index = nameEnd
+        while (index < markup.length) {
+            if (!markup[index].isWhitespace()) return false
+            while (index < markup.length && markup[index].isWhitespace()) index++
+            if (index == markup.length) return true
+
+            val attributeStart = index
+            while (index < markup.length && !markup[index].isWhitespace() && markup[index] != '=') index++
+            val attributeName = markup.substring(attributeStart, index)
+            if (!XML_QUALIFIED_NAME.matches(attributeName)) return false
+            while (index < markup.length && markup[index].isWhitespace()) index++
+            if (index == markup.length || markup[index] != '=') return false
+            index++
+            while (index < markup.length && markup[index].isWhitespace()) index++
+            if (index == markup.length || (markup[index] != '"' && markup[index] != '\'')) return false
+
+            val quote = markup[index++]
+            val valueStart = index
+            while (index < markup.length && markup[index] != quote) index++
+            if (index == markup.length || '<' in markup.substring(valueStart, index)) return false
+            if (markup.substring(valueStart, index).decodeXmlText() == null) return false
+            index++
+        }
+        return true
+    }
+
+    @Suppress("ReturnCount") // Each early return rejects one distinct malformed XML state.
+    private fun parseEndElement(): Boolean {
+        val end = xml.indexOf('>', offset + 2)
+        if (end < 0) return false
+        val qualifiedName = xml.substring(offset + 2, end).trim()
+        if (!XML_QUALIFIED_NAME.matches(qualifiedName) || openElements.lastOrNull()?.qualifiedName != qualifiedName) {
+            return false
+        }
+        openElements.removeAt(openElements.lastIndex)
+        offset = end + 1
+        return true
+    }
+}
+
+private data class XmlElement(
+    val qualifiedName: String,
+    val text: StringBuilder = StringBuilder(),
+    val children: MutableList<XmlElement> = mutableListOf(),
+) {
+    val localName: String
+        get() = qualifiedName.substringAfter(':')
+
+    fun textValue(): String = text.toString().trim()
+}
+
+@Suppress("ReturnCount") // Each early return rejects one distinct malformed XML entity/text state.
+private fun String.decodeXmlText(): String? {
+    if (!hasOnlyValidXmlCharacters() || XML_CDATA_END in this) return null
+    val decoded = StringBuilder(length)
+    var start = 0
+    while (start < length) {
+        val entityStart = indexOf('&', start)
+        if (entityStart < 0) {
+            decoded.append(substring(start))
+            break
+        }
+        decoded.append(substring(start, entityStart))
+        val entityEnd = indexOf(';', entityStart + 1)
+        if (entityEnd < 0) return null
+        val entity = substring(entityStart + 1, entityEnd)
+        decoded.append(entity.decodeXmlEntity() ?: return null)
+        start = entityEnd + 1
+    }
+    return decoded.toString()
+}
+
+private fun String.decodeXmlEntity(): String? = when (this) {
+    "amp" -> "&"
+    "lt" -> "<"
+    "gt" -> ">"
+    "quot" -> "\""
+    "apos" -> "'"
+    else -> {
+        val codePoint = when {
+            startsWith("#x") -> substring(2).takeIf { digits ->
+                digits.isNotEmpty() && digits.all { it.isAsciiHexDigit() }
+            }?.toIntOrNull(XML_HEXADECIMAL_RADIX)
+            startsWith("#") -> substring(1).takeIf { digits ->
+                digits.isNotEmpty() && digits.all { it in '0'..'9' }
+            }?.toIntOrNull()
+            else -> null
+        }
+        codePoint?.toXmlCodePointString()
+    }
+}
+
+private fun Char.isAsciiHexDigit(): Boolean =
+    this in '0'..'9' || this in 'a'..'f' || this in 'A'..'F'
+
+@Suppress("ReturnCount") // Invalid UTF-16 or XML code points terminate validation immediately.
+private fun String.hasOnlyValidXmlCharacters(): Boolean {
+    var index = 0
+    while (index < length) {
+        val character = this[index]
+        when {
+            character in '\uD800'..'\uDBFF' -> {
+                if (index + 1 >= length || this[index + 1] !in '\uDC00'..'\uDFFF') return false
+                index += 2
+            }
+            character in '\uDC00'..'\uDFFF' || !character.code.isValidXmlCodePoint() -> return false
+            else -> index++
+        }
+    }
+    return true
+}
+
+private fun Int.toXmlCodePointString(): String? = when {
+    this.isValidXmlCodePoint() && this <= XML_MAX_VALID_BMP_CODE_POINT -> toChar().toString()
+    this in XML_MIN_SUPPLEMENTARY_CODE_POINT..XML_MAX_CODE_POINT -> {
+        val supplementary = this - XML_MIN_SUPPLEMENTARY_CODE_POINT
+        val highSurrogate = (UTF16_HIGH_SURROGATE_BASE + (supplementary shr UTF16_SURROGATE_SHIFT)).toChar()
+        val lowSurrogate = (UTF16_LOW_SURROGATE_BASE + (supplementary and UTF16_LOW_SURROGATE_MASK)).toChar()
+        "$highSurrogate$lowSurrogate"
+    }
+    else -> null
+}
+
+private fun Int.isValidXmlCodePoint(): Boolean =
+    this == XML_HORIZONTAL_TAB_CODE_POINT ||
+            this == XML_LINE_FEED_CODE_POINT ||
+            this == XML_CARRIAGE_RETURN_CODE_POINT ||
+            this in XML_MIN_CONTENT_CODE_POINT..XML_PRE_SURROGATE_END_CODE_POINT ||
+            this in XML_POST_SURROGATE_START_CODE_POINT..XML_MAX_VALID_BMP_CODE_POINT ||
+            this in XML_MIN_SUPPLEMENTARY_CODE_POINT..XML_MAX_CODE_POINT
+
+private const val XML_COMMENT_START = "<!--"
+private const val XML_COMMENT_END = "-->"
+private const val XML_PROCESSING_INSTRUCTION_START = "<?"
+private const val XML_PROCESSING_INSTRUCTION_END = "?>"
+private const val XML_CDATA_START = "<![CDATA["
+private const val XML_CDATA_END = "]]>"
+private const val XML_BYTE_ORDER_MARK = '\uFEFF'
+private const val XML_HEXADECIMAL_RADIX = 16
+private const val XML_HORIZONTAL_TAB_CODE_POINT = 0x9
+private const val XML_LINE_FEED_CODE_POINT = 0xA
+private const val XML_CARRIAGE_RETURN_CODE_POINT = 0xD
+private const val XML_MIN_CONTENT_CODE_POINT = 0x20
+private const val XML_PRE_SURROGATE_END_CODE_POINT = 0xD7FF
+private const val XML_POST_SURROGATE_START_CODE_POINT = 0xE000
+private const val XML_MAX_VALID_BMP_CODE_POINT = 0xFFFD
+private const val XML_MIN_SUPPLEMENTARY_CODE_POINT = 0x10000
+private const val XML_MAX_CODE_POINT = 0x10FFFF
+private const val UTF16_HIGH_SURROGATE_BASE = 0xD800
+private const val UTF16_LOW_SURROGATE_BASE = 0xDC00
+private const val UTF16_SURROGATE_SHIFT = 10
+private const val UTF16_LOW_SURROGATE_MASK = 0x3FF
+private val XML_QUALIFIED_NAME = Regex("""[A-Za-z_][\w.-]*(?::[A-Za-z_][\w.-]*)?""")

--- a/domain/cells/src/commonTest/kotlin/com/wire/kalium/cells/data/AwsSigV4SignerTest.kt
+++ b/domain/cells/src/commonTest/kotlin/com/wire/kalium/cells/data/AwsSigV4SignerTest.kt
@@ -18,11 +18,19 @@
 package com.wire.kalium.cells.data
 
 import io.ktor.http.HttpHeaders
+import io.ktor.util.date.GMTDate
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
 class AwsSigV4SignerTest {
+
+    @Test
+    fun givenJanuaryDateWithSingleDigitFields_whenConvertingToAwsSigningDate_thenUsesOneBasedMonthAndZeroPadding() {
+        val result = GMTDate(1_767_323_045_000L).toAwsSigningDate()
+
+        assertEquals(AwsSigningDate(date = "20260102", dateTime = "20260102T030405Z"), result)
+    }
 
     @Test
     fun givenAwsSigV4Example_whenSigning_thenCanonicalRequestAndSignatureMatch() {

--- a/domain/cells/src/commonTest/kotlin/com/wire/kalium/cells/data/CellsCredentialsAwaitTest.kt
+++ b/domain/cells/src/commonTest/kotlin/com/wire/kalium/cells/data/CellsCredentialsAwaitTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.cells.data
+
+import com.wire.kalium.cells.domain.model.CellsCredentials
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class CellsCredentialsAwaitTest {
+
+    @Test
+    fun givenCredentialsArePresent_whenAwaiting_thenReturnsCredentials() = runTest {
+        val credentials = CellsCredentials(
+            serverUrl = "https://cells.example.test",
+            gatewaySecret = "gateway-secret",
+        )
+
+        val result = CompletableDeferred<CellsCredentials?>(credentials).awaitOrThrow()
+
+        assertEquals(credentials, result)
+    }
+
+    @Test
+    fun givenCredentialsAreMissing_whenAwaiting_thenThrowsTypedFailure() = runTest {
+        val credentials = CompletableDeferred<CellsCredentials?>()
+        credentials.complete(null)
+
+        val exception = assertFailsWith<CellsCredentialsUnavailableException> {
+            credentials.awaitOrThrow()
+        }
+
+        assertEquals("Cells credentials are not available", exception.message)
+    }
+
+    @Test
+    fun givenCredentialsAwaitIsCancelled_whenAwaiting_thenPropagatesSameCancellation() = runTest {
+        val cancellation = CancellationException("credentials cancelled")
+        val credentials = CompletableDeferred<CellsCredentials?>()
+        credentials.cancel(cancellation)
+
+        val exception = assertFailsWith<CancellationException> {
+            credentials.awaitOrThrow()
+        }
+
+        assertEquals(cancellation.message, exception.message)
+    }
+}

--- a/domain/cells/src/commonTest/kotlin/com/wire/kalium/cells/data/CellsS3ClientConfigTest.kt
+++ b/domain/cells/src/commonTest/kotlin/com/wire/kalium/cells/data/CellsS3ClientConfigTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.cells.data
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class CellsS3ClientConfigTest {
+
+    @Test
+    fun givenDefaultConfig_whenReadingMultipartChunkSize_thenUsesTenMebibytes() {
+        val config = CellsS3ClientConfig()
+
+        assertEquals(10 * 1024 * 1024L, config.multipartChunkSize)
+    }
+
+    @Test
+    fun givenZeroMultipartChunkSize_whenCreatingConfig_thenRejectsIt() {
+        assertFailsWith<IllegalArgumentException> {
+            CellsS3ClientConfig(multipartChunkSize = 0L)
+        }
+    }
+
+    @Test
+    fun givenNegativeMultipartChunkSize_whenCreatingConfig_thenRejectsIt() {
+        assertFailsWith<IllegalArgumentException> {
+            CellsS3ClientConfig(multipartChunkSize = -1L)
+        }
+    }
+}

--- a/domain/cells/src/commonTest/kotlin/com/wire/kalium/cells/data/CellsS3ClientTest.kt
+++ b/domain/cells/src/commonTest/kotlin/com/wire/kalium/cells/data/CellsS3ClientTest.kt
@@ -31,6 +31,7 @@ import io.ktor.http.headersOf
 import io.ktor.utils.io.ByteChannel
 import io.ktor.utils.io.close
 import io.ktor.utils.io.writeFully
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -359,7 +360,15 @@ class CellsS3ClientTest {
         val progressUpdates = mutableListOf<Long>()
         val sink = okio.Buffer()
         val client = CellsS3Client(
-            httpClient = HttpClient(MockEngine { respond(content = payload, status = HttpStatusCode.OK) }),
+            httpClient = HttpClient(
+                MockEngine {
+                    respond(
+                        content = payload,
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentLength, payload.size.toString()),
+                    )
+                }
+            ),
             endpointProvider = { "https://cells.example.test" },
             credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
             config = fixedDateConfig(),
@@ -369,6 +378,361 @@ class CellsS3ClientTest {
 
         assertEquals(TEST_DOWNLOAD_SIZE.toLong(), progressUpdates.last())
         assertTrue(progressUpdates.zipWithNext().all { (previous, next) -> next > previous })
+    }
+
+    @Test
+    fun givenRetryableStatusBeforeDownloadBody_whenDownloading_thenRetriesAndWritesPayloadOnce() = runTest {
+        val payload = "download".encodeToByteArray()
+        var requestCount = 0
+        val sink = okio.Buffer()
+        val client = CellsS3Client(
+            httpClient = HttpClient(
+                MockEngine {
+                    requestCount++
+                    if (requestCount == 1) {
+                        respond(content = "", status = HttpStatusCode.ServiceUnavailable)
+                    } else {
+                        respond(
+                            content = payload,
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(HttpHeaders.ContentLength, payload.size.toString()),
+                        )
+                    }
+                }
+            ),
+            endpointProvider = { "https://cells.example.test" },
+            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
+            config = fixedDateConfig(),
+        )
+
+        client.download("download.txt", sink, onProgressUpdate = {})
+
+        assertContentEquals(payload, sink.readByteArray())
+        assertEquals(2, requestCount)
+    }
+
+    @Test
+    fun givenBodyFailureAfterBytes_whenDownloading_thenDoesNotRetryOrDuplicateBytes() = runTest {
+        val payload = "partial".encodeToByteArray()
+        var requestCount = 0
+        val progressUpdates = mutableListOf<Long>()
+        val firstChunkCopied = CompletableDeferred<Unit>()
+        val responseChannel = ByteChannel(autoFlush = true)
+        val readFailure = IOException("connection lost")
+        val sink = okio.Buffer()
+        val client = CellsS3Client(
+            httpClient = HttpClient(
+                MockEngine {
+                    requestCount++
+                    respond(content = responseChannel, status = HttpStatusCode.OK)
+                }
+            ),
+            endpointProvider = { "https://cells.example.test" },
+            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
+            config = fixedDateConfig(),
+        )
+
+        var failure: Throwable? = null
+        val download = launch {
+            try {
+                client.download("download.txt", sink) {
+                    progressUpdates += it
+                    firstChunkCopied.complete(Unit)
+                }
+            } catch (cause: Throwable) {
+                failure = cause
+            }
+        }
+        responseChannel.writeFully(payload)
+        withContext(Dispatchers.Default) {
+            withTimeout(STREAM_ASSERTION_TIMEOUT_MILLIS) {
+                firstChunkCopied.await()
+            }
+        }
+        responseChannel.close(readFailure)
+        download.join()
+
+        val exception = assertNotNull(failure)
+        assertContains(exception.message.orEmpty(), "could not be copied")
+        val preservedCause = assertNotNull(exception.cause)
+        assertTrue(preservedCause is IOException)
+        assertContains(preservedCause.message.orEmpty(), readFailure.message.orEmpty())
+        assertContentEquals(payload, sink.readByteArray())
+        assertEquals(listOf(payload.size.toLong()), progressUpdates)
+        assertEquals(1, requestCount)
+    }
+
+    @Test
+    fun givenBodyFailureBeforeBytes_whenDownloading_thenDoesNotRetry() = runTest {
+        var requestCount = 0
+        val readFailure = IOException("connection lost")
+        val sink = okio.Buffer()
+        val client = CellsS3Client(
+            httpClient = HttpClient(
+                MockEngine {
+                    requestCount++
+                    val responseChannel = ByteChannel(autoFlush = true)
+                    responseChannel.close(readFailure)
+                    respond(content = responseChannel, status = HttpStatusCode.OK)
+                }
+            ),
+            endpointProvider = { "https://cells.example.test" },
+            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
+            config = fixedDateConfig(),
+        )
+
+        val exception = assertFailsWith<okio.IOException> {
+            client.download("download.txt", sink, onProgressUpdate = {})
+        }
+
+        assertContains(exception.message.orEmpty(), "could not be copied")
+        val preservedCause = assertNotNull(exception.cause)
+        assertTrue(preservedCause is IOException)
+        assertContains(preservedCause.message.orEmpty(), readFailure.message.orEmpty())
+        assertEquals(0L, sink.size)
+        assertEquals(1, requestCount)
+    }
+
+    @Test
+    fun givenSinkWriteFailureAfterBytes_whenDownloading_thenDoesNotRetryOrDuplicateBytes() = runTest {
+        val payload = "download".encodeToByteArray()
+        var requestCount = 0
+        val sinkFailure = okio.IOException("sink write failed")
+        val destination = okio.Buffer()
+        val failingSink = object : okio.ForwardingSink(destination) {
+            private var writeCount = 0
+
+            override fun write(source: okio.Buffer, byteCount: Long) {
+                writeCount++
+                if (writeCount == 1) {
+                    super.write(source, PARTIAL_SINK_WRITE_SIZE)
+                }
+                throw sinkFailure
+            }
+        }
+        val client = CellsS3Client(
+            httpClient = HttpClient(
+                MockEngine {
+                    requestCount++
+                    respond(content = payload, status = HttpStatusCode.OK)
+                }
+            ),
+            endpointProvider = { "https://cells.example.test" },
+            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
+            config = fixedDateConfig(),
+        )
+
+        val exception = assertFailsWith<okio.IOException> {
+            client.download("download.txt", failingSink, onProgressUpdate = {})
+        }
+
+        assertContains(exception.message.orEmpty(), "could not be copied")
+        assertTrue(exception.cause === sinkFailure)
+        assertContentEquals(payload.copyOf(PARTIAL_SINK_WRITE_SIZE.toInt()), destination.readByteArray())
+        assertEquals(1, requestCount)
+    }
+
+    @Test
+    fun givenCancellationDuringBodyCopy_whenDownloading_thenPropagatesSameCancellationWithoutRetrying() = runTest {
+        val payload = "download".encodeToByteArray()
+        val cancellation = CancellationException("download cancelled")
+        var requestCount = 0
+        val client = CellsS3Client(
+            httpClient = HttpClient(
+                MockEngine {
+                    requestCount++
+                    respond(content = payload, status = HttpStatusCode.OK)
+                }
+            ),
+            endpointProvider = { "https://cells.example.test" },
+            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
+            config = fixedDateConfig(),
+        )
+
+        val exception = assertFailsWith<CancellationException> {
+            client.download("download.txt", okio.Buffer()) {
+                throw cancellation
+            }
+        }
+
+        assertTrue(exception === cancellation)
+        assertEquals(1, requestCount)
+    }
+
+    @Test
+    fun givenShortDownloadResponse_whenDownloading_thenFailsWithoutRetryingOrDuplicatingBody() = runTest {
+        val payload = "short".encodeToByteArray()
+        var requestCount = 0
+        val sink = okio.Buffer()
+        val client = CellsS3Client(
+            httpClient = HttpClient(
+                MockEngine {
+                    requestCount++
+                    respond(
+                        content = payload,
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentLength, (payload.size + 1).toString()),
+                    )
+                }
+            ),
+            endpointProvider = { "https://cells.example.test" },
+            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
+            config = fixedDateConfig(),
+        )
+
+        val exception = assertFailsWith<okio.IOException> {
+            client.download("download.txt", sink, onProgressUpdate = {})
+        }
+
+        assertContains(exception.message.orEmpty(), "expected ${payload.size + 1} bytes")
+        assertContains(exception.message.orEmpty(), "received ${payload.size} bytes")
+        assertContentEquals(payload, sink.readByteArray())
+        assertEquals(1, requestCount)
+    }
+
+    @Test
+    fun givenExcessDownloadResponse_whenDownloading_thenFailsWithoutRetryingOrDuplicatingBody() = runTest {
+        val payload = "too long".encodeToByteArray()
+        var requestCount = 0
+        val sink = okio.Buffer()
+        val client = CellsS3Client(
+            httpClient = HttpClient(
+                MockEngine {
+                    requestCount++
+                    respond(
+                        content = payload,
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentLength, (payload.size - 1).toString()),
+                    )
+                }
+            ),
+            endpointProvider = { "https://cells.example.test" },
+            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
+            config = fixedDateConfig(),
+        )
+
+        val exception = assertFailsWith<okio.IOException> {
+            client.download("download.txt", sink, onProgressUpdate = {})
+        }
+
+        assertContains(exception.message.orEmpty(), "expected ${payload.size - 1} bytes")
+        assertContains(exception.message.orEmpty(), "received ${payload.size} bytes")
+        assertContentEquals(payload, sink.readByteArray())
+        assertEquals(1, requestCount)
+    }
+
+    @Test
+    fun givenMissingContentLength_whenDownloading_thenSucceedsWithoutValidation() = runTest {
+        val payload = "download".encodeToByteArray()
+        var requestCount = 0
+        val sink = okio.Buffer()
+        val client = CellsS3Client(
+            httpClient = HttpClient(
+                MockEngine {
+                    requestCount++
+                    respond(content = payload, status = HttpStatusCode.OK)
+                }
+            ),
+            endpointProvider = { "https://cells.example.test" },
+            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
+            config = fixedDateConfig(),
+        )
+
+        client.download("download.txt", sink, onProgressUpdate = {})
+
+        assertContentEquals(payload, sink.readByteArray())
+        assertEquals(1, requestCount)
+    }
+
+    @Test
+    fun givenMalformedContentLength_whenDownloading_thenFailsWithoutRetrying() = runTest {
+        val payload = "download".encodeToByteArray()
+        var requestCount = 0
+        val sink = okio.Buffer()
+        val client = CellsS3Client(
+            httpClient = HttpClient(
+                MockEngine {
+                    requestCount++
+                    respond(
+                        content = payload,
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentLength, "invalid"),
+                    )
+                }
+            ),
+            endpointProvider = { "https://cells.example.test" },
+            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
+            config = fixedDateConfig(),
+        )
+
+        val exception = assertFailsWith<okio.IOException> {
+            client.download("download.txt", sink, onProgressUpdate = {})
+        }
+
+        assertContains(exception.message.orEmpty(), "invalid Content-Length: 'invalid'")
+        assertEquals(0L, sink.size)
+        assertEquals(1, requestCount)
+    }
+
+    @Test
+    fun givenOverflowedContentLength_whenDownloading_thenFailsWithoutRetrying() = runTest {
+        val payload = "download".encodeToByteArray()
+        val overflowedContentLength = "9223372036854775808"
+        var requestCount = 0
+        val sink = okio.Buffer()
+        val client = CellsS3Client(
+            httpClient = HttpClient(
+                MockEngine {
+                    requestCount++
+                    respond(
+                        content = payload,
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentLength, overflowedContentLength),
+                    )
+                }
+            ),
+            endpointProvider = { "https://cells.example.test" },
+            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
+            config = fixedDateConfig(),
+        )
+
+        val exception = assertFailsWith<okio.IOException> {
+            client.download("download.txt", sink, onProgressUpdate = {})
+        }
+
+        assertContains(exception.message.orEmpty(), "invalid Content-Length: '$overflowedContentLength'")
+        assertEquals(0L, sink.size)
+        assertEquals(1, requestCount)
+    }
+
+    @Test
+    fun givenNegativeContentLength_whenDownloading_thenFailsWithoutRetrying() = runTest {
+        val payload = "download".encodeToByteArray()
+        var requestCount = 0
+        val sink = okio.Buffer()
+        val client = CellsS3Client(
+            httpClient = HttpClient(
+                MockEngine {
+                    requestCount++
+                    respond(
+                        content = payload,
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentLength, "-1"),
+                    )
+                }
+            ),
+            endpointProvider = { "https://cells.example.test" },
+            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
+            config = fixedDateConfig(),
+        )
+
+        val exception = assertFailsWith<okio.IOException> {
+            client.download("download.txt", sink, onProgressUpdate = {})
+        }
+
+        assertContains(exception.message.orEmpty(), "invalid Content-Length: '-1'")
+        assertEquals(0L, sink.size)
+        assertEquals(1, requestCount)
     }
 
     @Test
@@ -437,5 +801,7 @@ class CellsS3ClientTest {
         const val TEST_DOWNLOAD_SIZE = 20 * 1024
         const val TEST_STREAM_CHUNK_SIZE = 1024
         const val STREAM_ASSERTION_TIMEOUT_MILLIS = 5_000L
+        const val PARTIAL_SINK_WRITE_SIZE = 3L
+        const val DEFAULT_TEST_MULTIPART_CHUNK_SIZE = 10 * 1024 * 1024L
     }
 }

--- a/domain/cells/src/commonTest/kotlin/com/wire/kalium/cells/data/CellsS3ClientTest.kt
+++ b/domain/cells/src/commonTest/kotlin/com/wire/kalium/cells/data/CellsS3ClientTest.kt
@@ -42,6 +42,7 @@ import kotlinx.io.IOException
 import okio.FileSystem
 import okio.ForwardingFileSystem
 import okio.Path.Companion.toPath
+import okio.SYSTEM
 import okio.Source
 import okio.fakefilesystem.FakeFileSystem
 import kotlin.test.Test
@@ -51,6 +52,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
 
 class CellsS3ClientTest {
 
@@ -644,16 +646,22 @@ class CellsS3ClientTest {
         var requestCount = 0
         val sinkFailure = okio.IOException("sink write failed")
         val destination = okio.Buffer()
-        val failingSink = object : okio.ForwardingSink(destination) {
+        val failingSink = object : okio.Sink {
             private var writeCount = 0
 
             override fun write(source: okio.Buffer, byteCount: Long) {
                 writeCount++
                 if (writeCount == 1) {
-                    super.write(source, PARTIAL_SINK_WRITE_SIZE)
+                    destination.write(source, PARTIAL_SINK_WRITE_SIZE)
                 }
                 throw sinkFailure
             }
+
+            override fun flush() = destination.flush()
+
+            override fun timeout() = destination.timeout()
+
+            override fun close() = destination.close()
         }
         val client = createClient(
             httpClient = HttpClient(
@@ -867,7 +875,7 @@ class CellsS3ClientTest {
         const val EXPECTED_ATTEMPTS = 3
         const val TEST_DOWNLOAD_SIZE = 20 * 1024
         const val TEST_STREAM_CHUNK_SIZE = 1024
-        const val STREAM_ASSERTION_TIMEOUT_MILLIS = 5_000L
+        val STREAM_ASSERTION_TIMEOUT_MILLIS = 5_000L.milliseconds
         const val PARTIAL_SINK_WRITE_SIZE = 3L
         const val DEFAULT_TEST_MULTIPART_CHUNK_SIZE = 10 * 1024 * 1024L
         val TEST_CREDENTIALS = S3Credentials("access-token", "gateway-secret")

--- a/domain/cells/src/commonTest/kotlin/com/wire/kalium/cells/data/CellsS3ClientTest.kt
+++ b/domain/cells/src/commonTest/kotlin/com/wire/kalium/cells/data/CellsS3ClientTest.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.test.runTest
 import kotlinx.io.IOException
+import okio.FileSystem
 import okio.ForwardingFileSystem
 import okio.Path.Companion.toPath
 import okio.Source
@@ -56,23 +57,17 @@ class CellsS3ClientTest {
     @Test
     fun givenSmallFile_whenUploading_thenPutObjectRequestIsSignedWithDraftMetadata() = runTest {
         var capturedRequest: HttpRequestData? = null
-        val fileSystem = FakeFileSystem()
-        val uploadPath = "/upload.txt".toPath()
-        fileSystem.write(uploadPath) {
-            write("hello cells".encodeToByteArray())
-        }
+        val (fileSystem, uploadPath) = createUploadFile("hello cells".encodeToByteArray())
         val httpClient = HttpClient(
             MockEngine { request ->
                 capturedRequest = request
                 respond(content = "", status = HttpStatusCode.OK)
             }
         )
-        val client = CellsS3Client(
+        val client = createClient(
             httpClient = httpClient,
-            endpointProvider = { "https://cells.example.test/api" },
-            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
             fileSystem = fileSystem,
-            config = fixedDateConfig(),
+            endpoint = "$TEST_ENDPOINT/api",
         )
 
         client.upload(
@@ -101,12 +96,8 @@ class CellsS3ClientTest {
 
     @Test
     fun givenRetryableServerResponses_whenUploading_thenRetriesWithFreshSignatures() = runTest {
-        val fileSystem = FakeFileSystem()
-        val uploadPath = "/upload.txt".toPath()
         val uploadBytes = "hello cells".encodeToByteArray()
-        fileSystem.write(uploadPath) {
-            write(uploadBytes)
-        }
+        val (fileSystem, uploadPath) = createUploadFile(uploadBytes)
         var requestCount = 0
         var credentialsCount = 0
         val authorizationHeaders = mutableListOf<String>()
@@ -130,15 +121,13 @@ class CellsS3ClientTest {
                 )
             }
         )
-        val client = CellsS3Client(
+        val client = createClient(
             httpClient = httpClient,
-            endpointProvider = { "https://cells.example.test" },
             credentialsProvider = {
                 credentialsCount++
                 S3Credentials("access-token-$credentialsCount", "gateway-secret")
             },
             fileSystem = fileSystem,
-            config = fixedDateConfig(),
         )
 
         client.upload(uploadPath, cellNode(path = "upload.txt")) { progressUpdates += it }
@@ -155,23 +144,16 @@ class CellsS3ClientTest {
 
     @Test
     fun givenClientErrorResponse_whenUploading_thenDoesNotRetry() = runTest {
-        val fileSystem = FakeFileSystem()
-        val uploadPath = "/upload.txt".toPath()
-        fileSystem.write(uploadPath) {
-            write("hello cells".encodeToByteArray())
-        }
+        val (fileSystem, uploadPath) = createUploadFile("hello cells".encodeToByteArray())
         var requestCount = 0
-        val client = CellsS3Client(
+        val client = createClient(
             httpClient = HttpClient(
                 MockEngine {
                     requestCount++
                     respond(content = "", status = HttpStatusCode.Forbidden)
                 }
             ),
-            endpointProvider = { "https://cells.example.test" },
-            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
             fileSystem = fileSystem,
-            config = fixedDateConfig(),
         )
 
         assertFailsWith<okio.IOException> {
@@ -183,13 +165,9 @@ class CellsS3ClientTest {
 
     @Test
     fun givenNetworkFailures_whenUploading_thenRetriesAndSucceeds() = runTest {
-        val fileSystem = FakeFileSystem()
-        val uploadPath = "/upload.txt".toPath()
-        fileSystem.write(uploadPath) {
-            write("hello cells".encodeToByteArray())
-        }
+        val (fileSystem, uploadPath) = createUploadFile("hello cells".encodeToByteArray())
         var requestCount = 0
-        val client = CellsS3Client(
+        val client = createClient(
             httpClient = HttpClient(
                 MockEngine {
                     requestCount++
@@ -197,10 +175,7 @@ class CellsS3ClientTest {
                     respond(content = "", status = HttpStatusCode.OK)
                 }
             ),
-            endpointProvider = { "https://cells.example.test" },
-            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
             fileSystem = fileSystem,
-            config = fixedDateConfig(),
         )
 
         client.upload(uploadPath, cellNode(path = "upload.txt"), onProgressUpdate = {})
@@ -219,7 +194,7 @@ class CellsS3ClientTest {
             override fun source(file: okio.Path): Source = throw okio.IOException("read failed")
         }
         var requestCount = 0
-        val client = CellsS3Client(
+        val client = createClient(
             httpClient = HttpClient(
                 MockEngine { request ->
                     requestCount++
@@ -227,10 +202,7 @@ class CellsS3ClientTest {
                     respond(content = "", status = HttpStatusCode.OK)
                 }
             ),
-            endpointProvider = { "https://cells.example.test" },
-            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
             fileSystem = failingFileSystem,
-            config = fixedDateConfig(),
         )
 
         val exception = assertFailsWith<okio.IOException> {
@@ -243,11 +215,7 @@ class CellsS3ClientTest {
 
     @Test
     fun givenNamespacedMultipartResponses_whenUploading_thenParsesAttributedElementsAndXmlEntities() = runTest {
-        val fileSystem = FakeFileSystem()
-        val uploadPath = "/upload.txt".toPath()
-        fileSystem.write(uploadPath) {
-            write("multipart".encodeToByteArray())
-        }
+        val (fileSystem, uploadPath) = createUploadFile("multipart".encodeToByteArray())
         var partUploadId: String? = null
         var completionUploadId: String? = null
         val httpClient = HttpClient(
@@ -288,10 +256,8 @@ class CellsS3ClientTest {
                 }
             }
         )
-        val client = CellsS3Client(
+        val client = createClient(
             httpClient = httpClient,
-            endpointProvider = { "https://cells.example.test" },
-            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
             fileSystem = fileSystem,
             config = fixedDateConfig(maxRegularUploadSize = 1),
         )
@@ -304,12 +270,8 @@ class CellsS3ClientTest {
 
     @Test
     fun givenFileSpanningSeveralMultipartChunks_whenUploading_thenSendsSequentialExactPartsAndEscapedCompletionXml() = runTest {
-        val fileSystem = FakeFileSystem()
-        val uploadPath = "/upload.txt".toPath()
         val uploadBytes = ByteArray(10) { it.toByte() }
-        fileSystem.write(uploadPath) {
-            write(uploadBytes)
-        }
+        val (fileSystem, uploadPath) = createUploadFile(uploadBytes)
         val partNumbers = mutableListOf<Int>()
         val partBodies = mutableListOf<ByteArray>()
         val eTags = listOf("\"first&\"", "<second>", "third'")
@@ -346,10 +308,8 @@ class CellsS3ClientTest {
                 }
             }
         )
-        val client = CellsS3Client(
+        val client = createClient(
             httpClient = httpClient,
-            endpointProvider = { "https://cells.example.test" },
-            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
             fileSystem = fileSystem,
             config = fixedDateConfig(
                 maxRegularUploadSize = 1,
@@ -383,11 +343,7 @@ class CellsS3ClientTest {
 
     @Test
     fun givenNamespacedEmbeddedSlowDown_whenCreatingMultipartUpload_thenRetriesOnlyCreation() = runTest {
-        val fileSystem = FakeFileSystem()
-        val uploadPath = "/upload.txt".toPath()
-        fileSystem.write(uploadPath) {
-            write("multipart".encodeToByteArray())
-        }
+        val (fileSystem, uploadPath) = createUploadFile("multipart".encodeToByteArray())
         var createCount = 0
         var partCount = 0
         var completionCount = 0
@@ -428,10 +384,8 @@ class CellsS3ClientTest {
                 }
             }
         )
-        val client = CellsS3Client(
+        val client = createClient(
             httpClient = httpClient,
-            endpointProvider = { "https://cells.example.test" },
-            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
             fileSystem = fileSystem,
             config = fixedDateConfig(maxRegularUploadSize = 1),
         )
@@ -445,11 +399,7 @@ class CellsS3ClientTest {
 
     @Test
     fun givenEmbeddedInternalError_whenCompletingMultipartUpload_thenRetriesOnlyCompletion() = runTest {
-        val fileSystem = FakeFileSystem()
-        val uploadPath = "/upload.txt".toPath()
-        fileSystem.write(uploadPath) {
-            write("multipart".encodeToByteArray())
-        }
+        val (fileSystem, uploadPath) = createUploadFile("multipart".encodeToByteArray())
         var createCount = 0
         var partCount = 0
         var completionCount = 0
@@ -499,10 +449,8 @@ class CellsS3ClientTest {
                 }
             }
         )
-        val client = CellsS3Client(
+        val client = createClient(
             httpClient = httpClient,
-            endpointProvider = { "https://cells.example.test" },
-            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
             fileSystem = fileSystem,
             config = fixedDateConfig(maxRegularUploadSize = 1),
         )
@@ -516,11 +464,7 @@ class CellsS3ClientTest {
 
     @Test
     fun givenEmbeddedValidationError_whenCompletingMultipartUpload_thenDoesNotRetry() = runTest {
-        val fileSystem = FakeFileSystem()
-        val uploadPath = "/upload.txt".toPath()
-        fileSystem.write(uploadPath) {
-            write("multipart".encodeToByteArray())
-        }
+        val (fileSystem, uploadPath) = createUploadFile("multipart".encodeToByteArray())
         var completionCount = 0
         val httpClient = HttpClient(
             MockEngine { request ->
@@ -553,10 +497,8 @@ class CellsS3ClientTest {
                 }
             }
         )
-        val client = CellsS3Client(
+        val client = createClient(
             httpClient = httpClient,
-            endpointProvider = { "https://cells.example.test" },
-            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
             fileSystem = fileSystem,
             config = fixedDateConfig(maxRegularUploadSize = 1),
         )
@@ -574,7 +516,7 @@ class CellsS3ClientTest {
         val payload = ByteArray(TEST_DOWNLOAD_SIZE) { it.toByte() }
         val progressUpdates = mutableListOf<Long>()
         val sink = okio.Buffer()
-        val client = CellsS3Client(
+        val client = createClient(
             httpClient = HttpClient(
                 MockEngine {
                     respond(
@@ -584,9 +526,6 @@ class CellsS3ClientTest {
                     )
                 }
             ),
-            endpointProvider = { "https://cells.example.test" },
-            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
-            config = fixedDateConfig(),
         )
 
         client.download("download.txt", sink) { progressUpdates += it }
@@ -600,7 +539,7 @@ class CellsS3ClientTest {
         val payload = "download".encodeToByteArray()
         var requestCount = 0
         val sink = okio.Buffer()
-        val client = CellsS3Client(
+        val client = createClient(
             httpClient = HttpClient(
                 MockEngine {
                     requestCount++
@@ -615,9 +554,6 @@ class CellsS3ClientTest {
                     }
                 }
             ),
-            endpointProvider = { "https://cells.example.test" },
-            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
-            config = fixedDateConfig(),
         )
 
         client.download("download.txt", sink, onProgressUpdate = {})
@@ -635,16 +571,13 @@ class CellsS3ClientTest {
         val responseChannel = ByteChannel(autoFlush = true)
         val readFailure = IOException("connection lost")
         val sink = okio.Buffer()
-        val client = CellsS3Client(
+        val client = createClient(
             httpClient = HttpClient(
                 MockEngine {
                     requestCount++
                     respond(content = responseChannel, status = HttpStatusCode.OK)
                 }
             ),
-            endpointProvider = { "https://cells.example.test" },
-            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
-            config = fixedDateConfig(),
         )
 
         var failure: Throwable? = null
@@ -682,7 +615,7 @@ class CellsS3ClientTest {
         var requestCount = 0
         val readFailure = IOException("connection lost")
         val sink = okio.Buffer()
-        val client = CellsS3Client(
+        val client = createClient(
             httpClient = HttpClient(
                 MockEngine {
                     requestCount++
@@ -691,9 +624,6 @@ class CellsS3ClientTest {
                     respond(content = responseChannel, status = HttpStatusCode.OK)
                 }
             ),
-            endpointProvider = { "https://cells.example.test" },
-            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
-            config = fixedDateConfig(),
         )
 
         val exception = assertFailsWith<okio.IOException> {
@@ -725,16 +655,13 @@ class CellsS3ClientTest {
                 throw sinkFailure
             }
         }
-        val client = CellsS3Client(
+        val client = createClient(
             httpClient = HttpClient(
                 MockEngine {
                     requestCount++
                     respond(content = payload, status = HttpStatusCode.OK)
                 }
             ),
-            endpointProvider = { "https://cells.example.test" },
-            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
-            config = fixedDateConfig(),
         )
 
         val exception = assertFailsWith<okio.IOException> {
@@ -752,16 +679,13 @@ class CellsS3ClientTest {
         val payload = "download".encodeToByteArray()
         val cancellation = CancellationException("download cancelled")
         var requestCount = 0
-        val client = CellsS3Client(
+        val client = createClient(
             httpClient = HttpClient(
                 MockEngine {
                     requestCount++
                     respond(content = payload, status = HttpStatusCode.OK)
                 }
             ),
-            endpointProvider = { "https://cells.example.test" },
-            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
-            config = fixedDateConfig(),
         )
 
         val exception = assertFailsWith<CancellationException> {
@@ -775,65 +699,33 @@ class CellsS3ClientTest {
     }
 
     @Test
-    fun givenShortDownloadResponse_whenDownloading_thenFailsWithoutRetryingOrDuplicatingBody() = runTest {
-        val payload = "short".encodeToByteArray()
-        var requestCount = 0
-        val sink = okio.Buffer()
-        val client = CellsS3Client(
-            httpClient = HttpClient(
-                MockEngine {
-                    requestCount++
-                    respond(
-                        content = payload,
-                        status = HttpStatusCode.OK,
-                        headers = headersOf(HttpHeaders.ContentLength, (payload.size + 1).toString()),
-                    )
-                }
-            ),
-            endpointProvider = { "https://cells.example.test" },
-            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
-            config = fixedDateConfig(),
-        )
+    fun givenMismatchedDownloadLengths_whenDownloading_thenFailsWithoutRetryingOrDuplicatingBody() = runTest {
+        listOf("short".encodeToByteArray() to 1, "too long".encodeToByteArray() to -1).forEach { (payload, difference) ->
+            val expectedLength = payload.size + difference
+            var requestCount = 0
+            val sink = okio.Buffer()
+            val client = createClient(
+                httpClient = HttpClient(
+                    MockEngine {
+                        requestCount++
+                        respond(
+                            content = payload,
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(HttpHeaders.ContentLength, expectedLength.toString()),
+                        )
+                    }
+                ),
+            )
 
-        val exception = assertFailsWith<okio.IOException> {
-            client.download("download.txt", sink, onProgressUpdate = {})
+            val exception = assertFailsWith<okio.IOException> {
+                client.download("download.txt", sink, onProgressUpdate = {})
+            }
+
+            assertContains(exception.message.orEmpty(), "expected $expectedLength bytes")
+            assertContains(exception.message.orEmpty(), "received ${payload.size} bytes")
+            assertContentEquals(payload, sink.readByteArray())
+            assertEquals(1, requestCount)
         }
-
-        assertContains(exception.message.orEmpty(), "expected ${payload.size + 1} bytes")
-        assertContains(exception.message.orEmpty(), "received ${payload.size} bytes")
-        assertContentEquals(payload, sink.readByteArray())
-        assertEquals(1, requestCount)
-    }
-
-    @Test
-    fun givenExcessDownloadResponse_whenDownloading_thenFailsWithoutRetryingOrDuplicatingBody() = runTest {
-        val payload = "too long".encodeToByteArray()
-        var requestCount = 0
-        val sink = okio.Buffer()
-        val client = CellsS3Client(
-            httpClient = HttpClient(
-                MockEngine {
-                    requestCount++
-                    respond(
-                        content = payload,
-                        status = HttpStatusCode.OK,
-                        headers = headersOf(HttpHeaders.ContentLength, (payload.size - 1).toString()),
-                    )
-                }
-            ),
-            endpointProvider = { "https://cells.example.test" },
-            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
-            config = fixedDateConfig(),
-        )
-
-        val exception = assertFailsWith<okio.IOException> {
-            client.download("download.txt", sink, onProgressUpdate = {})
-        }
-
-        assertContains(exception.message.orEmpty(), "expected ${payload.size - 1} bytes")
-        assertContains(exception.message.orEmpty(), "received ${payload.size} bytes")
-        assertContentEquals(payload, sink.readByteArray())
-        assertEquals(1, requestCount)
     }
 
     @Test
@@ -841,16 +733,13 @@ class CellsS3ClientTest {
         val payload = "download".encodeToByteArray()
         var requestCount = 0
         val sink = okio.Buffer()
-        val client = CellsS3Client(
+        val client = createClient(
             httpClient = HttpClient(
                 MockEngine {
                     requestCount++
                     respond(content = payload, status = HttpStatusCode.OK)
                 }
             ),
-            endpointProvider = { "https://cells.example.test" },
-            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
-            config = fixedDateConfig(),
         )
 
         client.download("download.txt", sink, onProgressUpdate = {})
@@ -860,94 +749,32 @@ class CellsS3ClientTest {
     }
 
     @Test
-    fun givenMalformedContentLength_whenDownloading_thenFailsWithoutRetrying() = runTest {
+    fun givenInvalidContentLengths_whenDownloading_thenFailsWithoutRetrying() = runTest {
         val payload = "download".encodeToByteArray()
-        var requestCount = 0
-        val sink = okio.Buffer()
-        val client = CellsS3Client(
-            httpClient = HttpClient(
-                MockEngine {
-                    requestCount++
-                    respond(
-                        content = payload,
-                        status = HttpStatusCode.OK,
-                        headers = headersOf(HttpHeaders.ContentLength, "invalid"),
-                    )
-                }
-            ),
-            endpointProvider = { "https://cells.example.test" },
-            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
-            config = fixedDateConfig(),
-        )
+        listOf("invalid", "9223372036854775808", "-1").forEach { contentLength ->
+            var requestCount = 0
+            val sink = okio.Buffer()
+            val client = createClient(
+                httpClient = HttpClient(
+                    MockEngine {
+                        requestCount++
+                        respond(
+                            content = payload,
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(HttpHeaders.ContentLength, contentLength),
+                        )
+                    }
+                ),
+            )
 
-        val exception = assertFailsWith<okio.IOException> {
-            client.download("download.txt", sink, onProgressUpdate = {})
+            val exception = assertFailsWith<okio.IOException> {
+                client.download("download.txt", sink, onProgressUpdate = {})
+            }
+
+            assertContains(exception.message.orEmpty(), "invalid Content-Length: '$contentLength'")
+            assertEquals(0L, sink.size)
+            assertEquals(1, requestCount)
         }
-
-        assertContains(exception.message.orEmpty(), "invalid Content-Length: 'invalid'")
-        assertEquals(0L, sink.size)
-        assertEquals(1, requestCount)
-    }
-
-    @Test
-    fun givenOverflowedContentLength_whenDownloading_thenFailsWithoutRetrying() = runTest {
-        val payload = "download".encodeToByteArray()
-        val overflowedContentLength = "9223372036854775808"
-        var requestCount = 0
-        val sink = okio.Buffer()
-        val client = CellsS3Client(
-            httpClient = HttpClient(
-                MockEngine {
-                    requestCount++
-                    respond(
-                        content = payload,
-                        status = HttpStatusCode.OK,
-                        headers = headersOf(HttpHeaders.ContentLength, overflowedContentLength),
-                    )
-                }
-            ),
-            endpointProvider = { "https://cells.example.test" },
-            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
-            config = fixedDateConfig(),
-        )
-
-        val exception = assertFailsWith<okio.IOException> {
-            client.download("download.txt", sink, onProgressUpdate = {})
-        }
-
-        assertContains(exception.message.orEmpty(), "invalid Content-Length: '$overflowedContentLength'")
-        assertEquals(0L, sink.size)
-        assertEquals(1, requestCount)
-    }
-
-    @Test
-    fun givenNegativeContentLength_whenDownloading_thenFailsWithoutRetrying() = runTest {
-        val payload = "download".encodeToByteArray()
-        var requestCount = 0
-        val sink = okio.Buffer()
-        val client = CellsS3Client(
-            httpClient = HttpClient(
-                MockEngine {
-                    requestCount++
-                    respond(
-                        content = payload,
-                        status = HttpStatusCode.OK,
-                        headers = headersOf(HttpHeaders.ContentLength, "-1"),
-                    )
-                }
-            ),
-            endpointProvider = { "https://cells.example.test" },
-            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
-            config = fixedDateConfig(),
-        )
-
-        val exception = assertFailsWith<okio.IOException> {
-            client.download("download.txt", sink, onProgressUpdate = {})
-        }
-
-        assertContains(exception.message.orEmpty(), "invalid Content-Length: '-1'")
-        assertEquals(0L, sink.size)
-        assertEquals(1, requestCount)
     }
 
     @Test
@@ -957,11 +784,8 @@ class CellsS3ClientTest {
         val responseChannel = ByteChannel(autoFlush = true)
         val firstChunkCopied = CompletableDeferred<Unit>()
         val sink = okio.Buffer()
-        val client = CellsS3Client(
+        val client = createClient(
             httpClient = HttpClient(MockEngine { respond(content = responseChannel, status = HttpStatusCode.OK) }),
-            endpointProvider = { "https://cells.example.test" },
-            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
-            config = fixedDateConfig(),
         )
 
         val download = launch {
@@ -984,6 +808,29 @@ class CellsS3ClientTest {
         download.join()
 
         assertContentEquals(firstChunk + secondChunk, sink.readByteArray())
+    }
+
+    private fun createClient(
+        httpClient: HttpClient,
+        fileSystem: FileSystem = FileSystem.SYSTEM,
+        endpoint: String = TEST_ENDPOINT,
+        credentialsProvider: suspend () -> S3Credentials = { TEST_CREDENTIALS },
+        config: CellsS3ClientConfig = fixedDateConfig(),
+    ): CellsS3Client = CellsS3Client(
+        httpClient = httpClient,
+        endpointProvider = { endpoint },
+        credentialsProvider = credentialsProvider,
+        fileSystem = fileSystem,
+        config = config,
+    )
+
+    private fun createUploadFile(bytes: ByteArray): Pair<FakeFileSystem, okio.Path> {
+        val fileSystem = FakeFileSystem()
+        val path = "/upload.txt".toPath()
+        fileSystem.write(path) {
+            write(bytes)
+        }
+        return fileSystem to path
     }
 
     private fun cellNode(path: String): CellNodeDTO = CellNodeDTO(
@@ -1016,11 +863,13 @@ class CellsS3ClientTest {
     )
 
     private companion object {
+        const val TEST_ENDPOINT = "https://cells.example.test"
         const val EXPECTED_ATTEMPTS = 3
         const val TEST_DOWNLOAD_SIZE = 20 * 1024
         const val TEST_STREAM_CHUNK_SIZE = 1024
         const val STREAM_ASSERTION_TIMEOUT_MILLIS = 5_000L
         const val PARTIAL_SINK_WRITE_SIZE = 3L
         const val DEFAULT_TEST_MULTIPART_CHUNK_SIZE = 10 * 1024 * 1024L
+        val TEST_CREDENTIALS = S3Credentials("access-token", "gateway-secret")
     }
 }

--- a/domain/cells/src/commonTest/kotlin/com/wire/kalium/cells/data/CellsS3ClientTest.kt
+++ b/domain/cells/src/commonTest/kotlin/com/wire/kalium/cells/data/CellsS3ClientTest.kt
@@ -242,6 +242,208 @@ class CellsS3ClientTest {
     }
 
     @Test
+    fun givenNamespacedMultipartResponses_whenUploading_thenParsesAttributedElementsAndXmlEntities() = runTest {
+        val fileSystem = FakeFileSystem()
+        val uploadPath = "/upload.txt".toPath()
+        fileSystem.write(uploadPath) {
+            write("multipart".encodeToByteArray())
+        }
+        var partUploadId: String? = null
+        var completionUploadId: String? = null
+        val httpClient = HttpClient(
+            MockEngine { request ->
+                when {
+                    request.method == HttpMethod.Post && request.url.parameters.names().contains("uploads") -> respond(
+                        content = """
+                            <s3:InitiateMultipartUploadResult xmlns:s3="http://s3.amazonaws.com/doc/2006-03-01/">
+                                <s3:UploadId encoding="text"> upload&amp;&#45;id </s3:UploadId>
+                            </s3:InitiateMultipartUploadResult>
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                    )
+
+                    request.method == HttpMethod.Put -> {
+                        partUploadId = request.url.parameters["uploadId"]
+                        respond(
+                            content = "",
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(HttpHeaders.ETag, "etag-1"),
+                        )
+                    }
+
+                    request.method == HttpMethod.Post && request.url.parameters["uploadId"] != null -> {
+                        completionUploadId = request.url.parameters["uploadId"]
+                        respond(
+                            content = """
+                                <s3:CompleteMultipartUploadResult
+                                    xmlns:s3="http://s3.amazonaws.com/doc/2006-03-01/"
+                                    status="complete"
+                                />
+                            """.trimIndent(),
+                            status = HttpStatusCode.OK,
+                        )
+                    }
+
+                    else -> error("Unexpected request: ${request.method} ${request.url}")
+                }
+            }
+        )
+        val client = CellsS3Client(
+            httpClient = httpClient,
+            endpointProvider = { "https://cells.example.test" },
+            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
+            fileSystem = fileSystem,
+            config = fixedDateConfig(maxRegularUploadSize = 1),
+        )
+
+        client.upload(uploadPath, cellNode(path = "upload.txt"), onProgressUpdate = {})
+
+        assertEquals("upload&-id", partUploadId)
+        assertEquals("upload&-id", completionUploadId)
+    }
+
+    @Test
+    fun givenFileSpanningSeveralMultipartChunks_whenUploading_thenSendsSequentialExactPartsAndEscapedCompletionXml() = runTest {
+        val fileSystem = FakeFileSystem()
+        val uploadPath = "/upload.txt".toPath()
+        val uploadBytes = ByteArray(10) { it.toByte() }
+        fileSystem.write(uploadPath) {
+            write(uploadBytes)
+        }
+        val partNumbers = mutableListOf<Int>()
+        val partBodies = mutableListOf<ByteArray>()
+        val eTags = listOf("\"first&\"", "<second>", "third'")
+        val progressUpdates = mutableListOf<Long>()
+        var completionBody: String? = null
+        val httpClient = HttpClient(
+            MockEngine { request ->
+                when {
+                    request.method == HttpMethod.Post && request.url.parameters.names().contains("uploads") -> respond(
+                        content = "<InitiateMultipartUploadResult><UploadId>upload-id</UploadId>" +
+                                "</InitiateMultipartUploadResult>",
+                        status = HttpStatusCode.OK,
+                    )
+
+                    request.method == HttpMethod.Put -> {
+                        val partNumber = assertNotNull(request.url.parameters["partNumber"]).toInt()
+                        assertEquals("upload-id", request.url.parameters["uploadId"])
+                        partNumbers += partNumber
+                        partBodies += request.body.toByteArray()
+                        respond(
+                            content = "",
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(HttpHeaders.ETag, eTags[partNumber - 1]),
+                        )
+                    }
+
+                    request.method == HttpMethod.Post && request.url.parameters["uploadId"] != null -> {
+                        assertEquals("upload-id", request.url.parameters["uploadId"])
+                        completionBody = request.body.toByteArray().decodeToString()
+                        respond(content = "<CompleteMultipartUploadResult/>", status = HttpStatusCode.OK)
+                    }
+
+                    else -> error("Unexpected request: ${request.method} ${request.url}")
+                }
+            }
+        )
+        val client = CellsS3Client(
+            httpClient = httpClient,
+            endpointProvider = { "https://cells.example.test" },
+            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
+            fileSystem = fileSystem,
+            config = fixedDateConfig(
+                maxRegularUploadSize = 1,
+                multipartChunkSize = 4,
+            ),
+        )
+
+        client.upload(uploadPath, cellNode(path = "upload.txt")) { progressUpdates += it }
+
+        assertEquals(listOf(1, 2, 3), partNumbers)
+        val expectedPartBodies = listOf(
+            byteArrayOf(0, 1, 2, 3),
+            byteArrayOf(4, 5, 6, 7),
+            byteArrayOf(8, 9),
+        )
+        assertEquals(expectedPartBodies.size, partBodies.size)
+        expectedPartBodies.forEachIndexed { index, expected ->
+            assertContentEquals(expected, partBodies[index])
+        }
+        assertContentEquals(uploadBytes, partBodies.fold(ByteArray(0)) { result, part -> result + part })
+        assertEquals(listOf(4L, 8L, 10L), progressUpdates)
+        assertEquals(
+            "<CompleteMultipartUpload>" +
+                    "<Part><PartNumber>1</PartNumber><ETag>&quot;first&amp;&quot;</ETag></Part>" +
+                    "<Part><PartNumber>2</PartNumber><ETag>&lt;second&gt;</ETag></Part>" +
+                    "<Part><PartNumber>3</PartNumber><ETag>third&apos;</ETag></Part>" +
+                    "</CompleteMultipartUpload>",
+            completionBody,
+        )
+    }
+
+    @Test
+    fun givenNamespacedEmbeddedSlowDown_whenCreatingMultipartUpload_thenRetriesOnlyCreation() = runTest {
+        val fileSystem = FakeFileSystem()
+        val uploadPath = "/upload.txt".toPath()
+        fileSystem.write(uploadPath) {
+            write("multipart".encodeToByteArray())
+        }
+        var createCount = 0
+        var partCount = 0
+        var completionCount = 0
+        val httpClient = HttpClient(
+            MockEngine { request ->
+                when {
+                    request.method == HttpMethod.Post && request.url.parameters.names().contains("uploads") -> {
+                        createCount++
+                        respond(
+                            content = when (createCount) {
+                                1 -> """
+                                    <s3:Error xmlns:s3="http://s3.amazonaws.com/doc/2006-03-01/" status="503">
+                                        <s3:Code source="server">Slow&#68;own</s3:Code>
+                                    </s3:Error>
+                                """.trimIndent()
+                                else -> "<InitiateMultipartUploadResult><UploadId>upload-id</UploadId>" +
+                                        "</InitiateMultipartUploadResult>"
+                            },
+                            status = HttpStatusCode.OK,
+                        )
+                    }
+
+                    request.method == HttpMethod.Put -> {
+                        partCount++
+                        respond(
+                            content = "",
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(HttpHeaders.ETag, "etag-1"),
+                        )
+                    }
+
+                    request.method == HttpMethod.Post && request.url.parameters["uploadId"] != null -> {
+                        completionCount++
+                        respond(content = "<CompleteMultipartUploadResult/>", status = HttpStatusCode.OK)
+                    }
+
+                    else -> error("Unexpected request: ${request.method} ${request.url}")
+                }
+            }
+        )
+        val client = CellsS3Client(
+            httpClient = httpClient,
+            endpointProvider = { "https://cells.example.test" },
+            credentialsProvider = { S3Credentials("access-token", "gateway-secret") },
+            fileSystem = fileSystem,
+            config = fixedDateConfig(maxRegularUploadSize = 1),
+        )
+
+        client.upload(uploadPath, cellNode(path = "upload.txt"), onProgressUpdate = {})
+
+        assertEquals(2, createCount)
+        assertEquals(1, partCount)
+        assertEquals(1, completionCount)
+    }
+
+    @Test
     fun givenEmbeddedInternalError_whenCompletingMultipartUpload_thenRetriesOnlyCompletion() = runTest {
         val fileSystem = FakeFileSystem()
         val uploadPath = "/upload.txt".toPath()
@@ -276,9 +478,18 @@ class CellsS3ClientTest {
                         completionCount++
                         respond(
                             content = when (completionCount) {
-                                1 -> "<?xml version=\"1.0\"?><Error><Code>InternalError</Code></Error>"
+                                1 -> """
+                                    <s3:Error xmlns:s3="http://s3.amazonaws.com/doc/2006-03-01/" status="500">
+                                        <s3:Code source="server">InternalError</s3:Code>
+                                    </s3:Error>
+                                """.trimIndent()
                                 2 -> ""
-                                else -> "<CompleteMultipartUploadResult/>"
+                                else -> """
+                                    <s3:CompleteMultipartUploadResult
+                                        xmlns:s3="http://s3.amazonaws.com/doc/2006-03-01/"
+                                        status="complete"
+                                    />
+                                """.trimIndent()
                             },
                             status = HttpStatusCode.OK,
                         )
@@ -329,7 +540,11 @@ class CellsS3ClientTest {
                     request.method == HttpMethod.Post && request.url.parameters["uploadId"] != null -> {
                         completionCount++
                         respond(
-                            content = "<Error><Code>InvalidPart</Code></Error>",
+                            content = """
+                                <s3:Error xmlns:s3="http://s3.amazonaws.com/doc/2006-03-01/" status="400">
+                                    <s3:Code source="server">InvalidPart</s3:Code>
+                                </s3:Error>
+                            """.trimIndent(),
                             status = HttpStatusCode.OK,
                         )
                     }

--- a/domain/cells/src/commonTest/kotlin/com/wire/kalium/cells/data/CellsS3ClientTest.kt
+++ b/domain/cells/src/commonTest/kotlin/com/wire/kalium/cells/data/CellsS3ClientTest.kt
@@ -791,9 +791,13 @@ class CellsS3ClientTest {
         dateProvider = { AwsSigningDate(date = "20260701", dateTime = "20260701T120102Z") },
     )
 
-    private fun fixedDateConfig(maxRegularUploadSize: Long): CellsS3ClientConfig = CellsS3ClientConfig(
+    private fun fixedDateConfig(
+        maxRegularUploadSize: Long,
+        multipartChunkSize: Long = DEFAULT_TEST_MULTIPART_CHUNK_SIZE,
+    ): CellsS3ClientConfig = CellsS3ClientConfig(
         dateProvider = { AwsSigningDate(date = "20260701", dateTime = "20260701T120102Z") },
         maxRegularUploadSize = maxRegularUploadSize,
+        multipartChunkSize = multipartChunkSize,
     )
 
     private companion object {

--- a/domain/cells/src/commonTest/kotlin/com/wire/kalium/cells/data/CellsS3XmlTest.kt
+++ b/domain/cells/src/commonTest/kotlin/com/wire/kalium/cells/data/CellsS3XmlTest.kt
@@ -1,0 +1,206 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.cells.data
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class CellsS3XmlTest {
+
+    @Test
+    fun givenLeadingBomBeforeXmlDeclaration_whenReadingMultipartUploadId_thenParsesResponse() {
+        val xml = "\uFEFF<?xml version=\"1.0\"?>" +
+                "<InitiateMultipartUploadResult><UploadId>upload-id</UploadId></InitiateMultipartUploadResult>"
+
+        assertEquals("upload-id", xml.multipartUploadId())
+    }
+
+    @Test
+    fun givenLeadingBom_whenCheckingCompletionResult_thenParsesResponse() {
+        val xml = "\uFEFF<s3:CompleteMultipartUploadResult xmlns:s3=\"urn:s3\"/>"
+
+        assertTrue(xml.containsCompleteMultipartUploadResult())
+    }
+
+    @Test
+    fun givenLeadingBom_whenReadingRootError_thenParsesCode() {
+        val xml = "\uFEFF<s3:Error xmlns:s3=\"urn:s3\"><s3:Code>SlowDown</s3:Code></s3:Error>"
+
+        assertEquals(S3Error("SlowDown"), xml.embeddedS3Error())
+    }
+
+    @Test
+    fun givenBomOutsideLegalDocumentStart_whenReadingXml_thenRejectsResponse() {
+        val validResult = "<CompleteMultipartUploadResult/>"
+        val invalidDocuments = listOf(
+            "\uFEFF\uFEFF$validResult",
+            " \uFEFF$validResult",
+            "$validResult\uFEFF",
+        )
+
+        invalidDocuments.forEach { xml ->
+            assertFalse(xml.containsCompleteMultipartUploadResult())
+        }
+    }
+
+    @Test
+    fun givenGreaterThanInQuotedAttributes_whenReadingTagValue_thenParsesTheCompleteStartElement() {
+        val xml = """
+            <?xml version="1.0"?>
+            <s3:InitiateMultipartUploadResult
+                xmlns:s3="http://s3.amazonaws.com/doc/2006-03-01/"
+                condition="size > 0"
+            >
+                <s3:UploadId description='value > threshold'><![CDATA[upload&raw-id]]></s3:UploadId>
+            </s3:InitiateMultipartUploadResult>
+        """.trimIndent()
+
+        assertEquals("upload&raw-id", xml.multipartUploadId())
+    }
+
+    @Test
+    fun givenCommentedAndNestedErrors_whenReadingEmbeddedError_thenRequiresErrorAtDocumentRoot() {
+        val xml = """
+            <CompleteMultipartUploadResult>
+                <!-- <Error><Code>SlowDown</Code></Error> -->
+                <Metadata><Error><Code>SlowDown</Code></Error></Metadata>
+            </CompleteMultipartUploadResult>
+        """.trimIndent()
+
+        assertNull(xml.embeddedS3Error())
+        assertTrue(xml.containsCompleteMultipartUploadResult())
+    }
+
+    @Test
+    fun givenCDataCodeInsideRootError_whenReadingEmbeddedError_thenReturnsDecodedCode() {
+        val xml = """
+            <s3:Error xmlns:s3="http://s3.amazonaws.com/doc/2006-03-01/">
+                <Metadata><Code>SlowDown</Code></Metadata>
+                <s3:Code><![CDATA[InvalidPart]]></s3:Code>
+            </s3:Error>
+        """.trimIndent()
+
+        assertEquals(S3Error("InvalidPart"), xml.embeddedS3Error())
+    }
+
+    @Test
+    fun givenMismatchedNamespacePrefixes_whenReadingXml_thenRejectsTheDocument() {
+        val xml = """
+            <s3:InitiateMultipartUploadResult>
+                <s3:UploadId>upload-id</other:UploadId>
+            </s3:InitiateMultipartUploadResult>
+        """.trimIndent()
+
+        assertNull(xml.multipartUploadId())
+        assertNull(xml.embeddedS3Error())
+    }
+
+    @Test
+    fun givenMalformedQuotedAttribute_whenReadingXml_thenRejectsTheDocument() {
+        val xml = """
+            <InitiateMultipartUploadResult>
+                <UploadId description="unterminated>upload-id</UploadId>
+            </InitiateMultipartUploadResult>
+        """.trimIndent()
+
+        assertNull(xml.multipartUploadId())
+        assertFalse(xml.containsCompleteMultipartUploadResult())
+    }
+
+    @Test
+    fun givenValidSupplementaryNumericReference_whenReadingTagValue_thenDecodesSurrogatePair() {
+        val xml = """
+            <InitiateMultipartUploadResult>
+                <UploadId>upload-&#x1F600;-id</UploadId>
+            </InitiateMultipartUploadResult>
+        """.trimIndent()
+
+        assertEquals("upload-\uD83D\uDE00-id", xml.multipartUploadId())
+    }
+
+    @Test
+    fun givenInvalidXmlNumericReferences_whenReadingTagValue_thenRejectsTheDocument() {
+        val invalidReferences = listOf("&#0;", "&#xD800;", "&#xFFFE;", "&#x110000;")
+
+        invalidReferences.forEach { reference ->
+            val xml = "<InitiateMultipartUploadResult><UploadId>$reference</UploadId></InitiateMultipartUploadResult>"
+            assertNull(xml.multipartUploadId())
+        }
+    }
+
+    @Test
+    fun givenUploadIdOutsideExpectedRootOrNested_whenReadingMultipartUploadId_thenRejectsIt() {
+        val unrelatedRoot = "<Response><UploadId>upload-id</UploadId></Response>"
+        val nestedUploadId = """
+            <InitiateMultipartUploadResult>
+                <Metadata><UploadId>upload-id</UploadId></Metadata>
+            </InitiateMultipartUploadResult>
+        """.trimIndent()
+
+        assertNull(unrelatedRoot.multipartUploadId())
+        assertNull(nestedUploadId.multipartUploadId())
+    }
+
+    @Test
+    fun givenInvalidLiteralXmlCharacters_whenReadingMultipartUploadId_thenRejectsTheDocument() {
+        val invalidDocuments = listOf(
+            "<InitiateMultipartUploadResult><UploadId>\u0001</UploadId></InitiateMultipartUploadResult>",
+            "<InitiateMultipartUploadResult><UploadId><![CDATA[\uD800]]></UploadId></InitiateMultipartUploadResult>",
+            "<InitiateMultipartUploadResult marker=\"\uFFFE\"><UploadId>id</UploadId></InitiateMultipartUploadResult>",
+        )
+
+        invalidDocuments.forEach { xml ->
+            assertNull(xml.multipartUploadId())
+        }
+    }
+
+    @Test
+    fun givenSignedNumericReferences_whenReadingMultipartUploadId_thenRejectsTheDocument() {
+        val signedReferences = listOf("&#+65;", "&#x+41;")
+
+        signedReferences.forEach { reference ->
+            val xml = "<InitiateMultipartUploadResult><UploadId>$reference</UploadId></InitiateMultipartUploadResult>"
+            assertNull(xml.multipartUploadId())
+        }
+    }
+
+    @Test
+    fun givenCDataTerminatorInRegularText_whenReadingMultipartUploadId_thenRejectsTheDocument() {
+        val xml = """
+            <InitiateMultipartUploadResult>
+                <UploadId>upload]]>id</UploadId>
+            </InitiateMultipartUploadResult>
+        """.trimIndent()
+
+        assertNull(xml.multipartUploadId())
+    }
+
+    @Test
+    fun givenResultMarkupOnlyInComment_whenCheckingCompletionResult_thenDoesNotDetectIt() {
+        val xml = """
+            <Response>
+                <!-- <CompleteMultipartUploadResult status="complete"/> -->
+            </Response>
+        """.trimIndent()
+
+        assertFalse(xml.containsCompleteMultipartUploadResult())
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26729
<!--jira-description-action-hidden-marker-end-->
## Stack

- Depends on #4262.
- Review and merge #4262 before this PR.

## Intent

Keep the shared KMP S3 migration review focused by moving defensive response handling and expanded edge-case coverage into a follow-up layer.

## Changes

- Add strict namespace-aware parsing for S3 XML responses and embedded errors.
- Validate streamed download lengths without replaying partial destinations.
- Use a typed failure when Cells credentials are unavailable.
- Expand multipart, signing, retry, cancellation, and malformed-response coverage.
- Preserve the existing per-request token refresh, retry delay, and multipart cleanup behavior.
