### PR TITLE
feat: ensure MLS is established when joining meeting [WPB-25677]

### DIFF
--- a/changelog.d/ensure-meeting-is-mls-established.md
+++ b/changelog.d/ensure-meeting-is-mls-established.md
@@ -1,0 +1,10 @@
+### Added
+- Added `MeetingScope.ensureMeetingIsMLSEstablished` with `EnsureMeetingIsMLSEstablishedUseCase` to let consumers ensure a meeting conversation's MLS group is established before joining.
+
+### Migration
+No action required unless consumers want to proactively establish MLS for meeting conversations.
+
+### Compatibility
+ABI: additive.
+Source: additive.
+Behavior: no behavior change unless consumers call the new meeting MLS establishment API.

--- a/logic/api/jvm/logic.api
+++ b/logic/api/jvm/logic.api
@@ -5290,6 +5290,10 @@ public final class com/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase$Re
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract interface class com/wire/kalium/logic/feature/meeting/EnsureMeetingIsMLSEstablishedUseCase {
+	public abstract fun invoke (Lcom/wire/kalium/logic/data/id/QualifiedID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public abstract interface class com/wire/kalium/logic/feature/meeting/GetPaginatedMeetingOccurrencesUseCase {
 	public abstract fun invoke (Landroidx/paging/PagingConfig;JLkotlinx/datetime/Instant;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun invoke$default (Lcom/wire/kalium/logic/feature/meeting/GetPaginatedMeetingOccurrencesUseCase;Landroidx/paging/PagingConfig;JLkotlinx/datetime/Instant;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -5301,6 +5305,7 @@ public final class com/wire/kalium/logic/feature/meeting/GetPaginatedMeetingOccu
 
 public final class com/wire/kalium/logic/feature/meeting/MeetingScope {
 	public final fun getDeleteMeeting ()Lcom/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase;
+	public final fun getEnsureMeetingIsMLSEstablished ()Lcom/wire/kalium/logic/feature/meeting/EnsureMeetingIsMLSEstablishedUseCase;
 	public final fun getGetPaginatedMeetingOccurrenceDetails ()Lcom/wire/kalium/logic/feature/meeting/GetPaginatedMeetingOccurrencesUseCase;
 	public final fun getObserveMeetingOccurrence ()Lcom/wire/kalium/logic/feature/meeting/ObserveMeetingOccurrenceUseCase;
 }

--- a/logic/api/logic.klib.api
+++ b/logic/api/logic.klib.api
@@ -1365,6 +1365,10 @@ abstract interface com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase { 
     }
 }
 
+abstract interface com.wire.kalium.logic.feature.meeting/EnsureMeetingIsMLSEstablishedUseCase { // com.wire.kalium.logic.feature.meeting/EnsureMeetingIsMLSEstablishedUseCase|null[0]
+    abstract suspend fun invoke(com.wire.kalium.logic.data.id/QualifiedID): kotlin/Boolean // com.wire.kalium.logic.feature.meeting/EnsureMeetingIsMLSEstablishedUseCase.invoke|invoke(com.wire.kalium.logic.data.id.QualifiedID){}[0]
+}
+
 abstract interface com.wire.kalium.logic.feature.meeting/GetPaginatedMeetingOccurrencesUseCase { // com.wire.kalium.logic.feature.meeting/GetPaginatedMeetingOccurrencesUseCase|null[0]
     abstract suspend fun invoke(androidx.paging/PagingConfig, kotlin/Long, kotlinx.datetime/Instant = ...): kotlinx.coroutines.flow/Flow<androidx.paging/PagingData<com.wire.kalium.logic.data.meeting/MeetingOccurrence>> // com.wire.kalium.logic.feature.meeting/GetPaginatedMeetingOccurrencesUseCase.invoke|invoke(androidx.paging.PagingConfig;kotlin.Long;kotlinx.datetime.Instant){}[0]
 }
@@ -4277,6 +4281,8 @@ final class com.wire.kalium.logic.feature.incallreaction/SendInCallReactionUseCa
 final class com.wire.kalium.logic.feature.meeting/MeetingScope { // com.wire.kalium.logic.feature.meeting/MeetingScope|null[0]
     final val deleteMeeting // com.wire.kalium.logic.feature.meeting/MeetingScope.deleteMeeting|{}deleteMeeting[0]
         final fun <get-deleteMeeting>(): com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase // com.wire.kalium.logic.feature.meeting/MeetingScope.deleteMeeting.<get-deleteMeeting>|<get-deleteMeeting>(){}[0]
+    final val ensureMeetingIsMLSEstablished // com.wire.kalium.logic.feature.meeting/MeetingScope.ensureMeetingIsMLSEstablished|{}ensureMeetingIsMLSEstablished[0]
+        final fun <get-ensureMeetingIsMLSEstablished>(): com.wire.kalium.logic.feature.meeting/EnsureMeetingIsMLSEstablishedUseCase // com.wire.kalium.logic.feature.meeting/MeetingScope.ensureMeetingIsMLSEstablished.<get-ensureMeetingIsMLSEstablished>|<get-ensureMeetingIsMLSEstablished>(){}[0]
     final val getPaginatedMeetingOccurrenceDetails // com.wire.kalium.logic.feature.meeting/MeetingScope.getPaginatedMeetingOccurrenceDetails|{}getPaginatedMeetingOccurrenceDetails[0]
         final fun <get-getPaginatedMeetingOccurrenceDetails>(): com.wire.kalium.logic.feature.meeting/GetPaginatedMeetingOccurrencesUseCase // com.wire.kalium.logic.feature.meeting/MeetingScope.getPaginatedMeetingOccurrenceDetails.<get-getPaginatedMeetingOccurrenceDetails>|<get-getPaginatedMeetingOccurrenceDetails>(){}[0]
     final val observeMeetingOccurrence // com.wire.kalium.logic.feature.meeting/MeetingScope.observeMeetingOccurrence|{}observeMeetingOccurrence[0]

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationUseCase.kt
@@ -45,14 +45,14 @@ import com.wire.kalium.logic.featureFlags.FeatureSupport
 import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageFailureHandler
 import com.wire.kalium.logic.sync.receiver.conversation.message.MLSMessageFailureResolution
 import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
-import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.withContext
 
 /**
- * Send an external commit to join an MLS conversation for which the user is a member,
- * but has not yet joined the corresponding MLS group.
+ * Use case for joining or establishing an MLS group for an existing conversation.
+ * If the conversation is MLS-capable, it checks if it is already established. If not, it establishes the MLS group, otherwise it sends
+ * an external commit to join an MLS conversation for which the user is a member, but has not yet joined the corresponding MLS group.
  */
 internal interface JoinExistingMLSConversationUseCase {
     suspend operator fun invoke(
@@ -287,7 +287,7 @@ internal class JoinExistingMLSConversationUseCaseImpl(
                             leadingMessage = "Establish Group",
                             jsonStringKeyValues = conversation.logData()
                         )
-                    }.map { Unit }
+                    }.map {}
             }
 
             type == Conversation.Type.OneOnOne || type is Conversation.Type.Group -> {
@@ -307,7 +307,7 @@ internal class JoinExistingMLSConversationUseCaseImpl(
                         leadingMessage = "Establish Group",
                         jsonStringKeyValues = conversation.logData()
                     )
-                }.map { Unit }
+                }.map {}
             }
 
             else -> {
@@ -325,30 +325,6 @@ internal class JoinExistingMLSConversationUseCaseImpl(
         put("protocol", CreateConversationParam.Protocol.MLS.name)
         put("protocolInfo", protocol.toLogMap())
         failure?.let { put("errorInfo", "$it") }
-    }
-
-    private suspend fun syncEstablishedConversationMetadata(
-        transactionContext: CryptoTransactionContext,
-        conversation: Conversation
-    ): Either<CoreFailure, Unit> {
-        val protocol = conversation.protocol as? Conversation.ProtocolInfo.MLSCapable ?: return Either.Right(Unit)
-        return transactionContext.wrapInMLSContext { mlsContext ->
-            mlsConversationRepository.getLocalGroupEpoch(mlsContext, protocol.groupId)
-        }.flatMap { localEpoch ->
-            if (protocol.groupState == Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED && protocol.epoch == localEpoch) {
-                Either.Right(Unit)
-            } else {
-                logger.d(
-                    "Updating local MLS metadata for ${conversation.id.toLogString()} to sync DB with local MLS state"
-                )
-                mlsConversationRepository.updateGroupIdAndState(
-                    conversation.id,
-                    protocol.groupId,
-                    localEpoch.toLong(),
-                    ConversationEntity.GroupState.ESTABLISHED
-                )
-            }
-        }
     }
 
     private data class RefreshedConversation(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -2953,6 +2953,9 @@ public class UserSessionScope internal constructor(
         MeetingScope(
             dispatcher = KaliumDispatcherImpl,
             meetingRepository = meetingRepository,
+            conversationRepository = conversationRepository,
+            joinExistingMLSConversation = joinExistingMLSConversationUseCase,
+            transactionProvider = cryptoTransactionProvider
         )
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/meeting/EnsureMeetingIsMLSEstablishedUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/meeting/EnsureMeetingIsMLSEstablishedUseCase.kt
@@ -1,0 +1,57 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.meeting
+
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.common.functional.isRight
+import com.wire.kalium.logic.data.client.CryptoTransactionProvider
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCase
+import com.wire.kalium.logic.data.id.ConversationId
+
+/**
+ * Use case for ensuring that the meeting's MLS conversation group is established.
+ * If the conversation related to the meeting is MLS-capable then tries to establish or join MLS group using dedicated use case.
+ * If the MLS group is already established or if the conversation is not MLS-capable, it does nothing and returns success.
+ */
+public interface EnsureMeetingIsMLSEstablishedUseCase {
+    public suspend operator fun invoke(conversationId: ConversationId): Boolean
+}
+
+internal class EnsureMeetingIsMLSEstablishedUseCaseImpl(
+    private val transactionProvider: CryptoTransactionProvider,
+    private val conversationRepository: ConversationRepository,
+    private val joinExistingMLSConversation: JoinExistingMLSConversationUseCase,
+) : EnsureMeetingIsMLSEstablishedUseCase {
+    override suspend operator fun invoke(conversationId: ConversationId) = conversationRepository.getConversationById(conversationId)
+        .flatMap { conversation ->
+            (conversation.protocol as? Conversation.ProtocolInfo.MLSCapable)?.let { mlsProtocolInfo ->
+                if (mlsProtocolInfo.groupState == Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED) {
+                    Either.Right(Unit) // MLS group is already established, return success
+                } else {
+                    transactionProvider.transaction("ensureMeetingIsMLSEstablished") { transactionContext ->
+                        joinExistingMLSConversation(transactionContext, conversationId)
+                    }
+                }
+            } ?: Either.Right(Unit) // Conversation is not MLS-capable, return success
+        }
+        .isRight()
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/meeting/EnsureMeetingIsMLSEstablishedUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/meeting/EnsureMeetingIsMLSEstablishedUseCase.kt
@@ -41,17 +41,18 @@ internal class EnsureMeetingIsMLSEstablishedUseCaseImpl(
     private val conversationRepository: ConversationRepository,
     private val joinExistingMLSConversation: JoinExistingMLSConversationUseCase,
 ) : EnsureMeetingIsMLSEstablishedUseCase {
-    override suspend operator fun invoke(conversationId: ConversationId) = conversationRepository.getConversationById(conversationId)
-        .flatMap { conversation ->
-            (conversation.protocol as? Conversation.ProtocolInfo.MLSCapable)?.let { mlsProtocolInfo ->
-                if (mlsProtocolInfo.groupState == Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED) {
-                    Either.Right(Unit) // MLS group is already established, return success
-                } else {
-                    transactionProvider.transaction("ensureMeetingIsMLSEstablished") { transactionContext ->
-                        joinExistingMLSConversation(transactionContext, conversationId)
+    override suspend operator fun invoke(conversationId: ConversationId) =
+        conversationRepository.getNonDeletedConversationById(conversationId)
+            .flatMap { conversation ->
+                (conversation.protocol as? Conversation.ProtocolInfo.MLSCapable)?.let { mlsProtocolInfo ->
+                    if (mlsProtocolInfo.groupState == Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED) {
+                        Either.Right(Unit) // MLS group is already established, return success
+                    } else {
+                        transactionProvider.transaction("ensureMeetingIsMLSEstablished") { transactionContext ->
+                            joinExistingMLSConversation(transactionContext, conversationId)
+                        }
                     }
-                }
-            } ?: Either.Right(Unit) // Conversation is not MLS-capable, return success
-        }
-        .isRight()
+                } ?: Either.Right(Unit) // Conversation is not MLS-capable, return success
+            }
+            .isRight()
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/meeting/MeetingScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/meeting/MeetingScope.kt
@@ -18,12 +18,18 @@
 
 package com.wire.kalium.logic.feature.meeting
 
+import com.wire.kalium.logic.data.client.CryptoTransactionProvider
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCase
 import com.wire.kalium.logic.data.meeting.MeetingRepository
 import com.wire.kalium.util.KaliumDispatcher
 
 public class MeetingScope internal constructor(
     private val dispatcher: KaliumDispatcher,
     private val meetingRepository: MeetingRepository,
+    private val conversationRepository: ConversationRepository,
+    private val joinExistingMLSConversation: JoinExistingMLSConversationUseCase,
+    private val transactionProvider: CryptoTransactionProvider,
 ) {
     public val getPaginatedMeetingOccurrenceDetails: GetPaginatedMeetingOccurrencesUseCase
         get() = GetPaginatedMeetingOccurrencesUseCaseImpl(
@@ -40,5 +46,12 @@ public class MeetingScope internal constructor(
     public val deleteMeeting: DeleteMeetingUseCase
         get() = DeleteMeetingUseCaseImpl(
             meetingRepository = meetingRepository,
+        )
+
+    public val ensureMeetingIsMLSEstablished: EnsureMeetingIsMLSEstablishedUseCase
+        get() = EnsureMeetingIsMLSEstablishedUseCaseImpl(
+            transactionProvider = transactionProvider,
+            conversationRepository = conversationRepository,
+            joinExistingMLSConversation = joinExistingMLSConversation,
         )
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/meeting/EnsureMeetingIsMLSEstablishedUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/meeting/EnsureMeetingIsMLSEstablishedUseCaseTest.kt
@@ -1,0 +1,163 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.meeting
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCase
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMokkeryImpl
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.matcher.eq
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class EnsureMeetingIsMLSEstablishedUseCaseTest {
+
+    @Test
+    fun givenGettingConversationFails_whenInvoking_thenReturnsFalseAndDoesNotJoinMLSConversation() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withConversationReturning(Either.Left(StorageFailure.DataNotFound))
+            .arrange()
+
+        val result = useCase(CONVERSATION_ID)
+
+        assertFalse(result)
+        verifySuspend(VerifyMode.not) {
+            arrangement.cryptoTransactionProvider.transaction<Unit>(any(), any())
+        }
+        verifySuspend(VerifyMode.not) {
+            arrangement.joinExistingMLSConversation(any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun givenProteusConversation_whenInvoking_thenReturnsTrueAndDoesNotJoinMLSConversation() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withConversationReturning(Either.Right(TestConversation.GROUP()))
+            .arrange()
+
+        val result = useCase(CONVERSATION_ID)
+
+        assertTrue(result)
+        verifySuspend(VerifyMode.not) {
+            arrangement.cryptoTransactionProvider.transaction<Unit>(any(), any())
+        }
+        verifySuspend(VerifyMode.not) {
+            arrangement.joinExistingMLSConversation(any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun givenEstablishedMLSConversation_whenInvoking_thenReturnsTrueAndDoesNotJoinMLSConversation() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withConversationReturning(Either.Right(mlsConversation(Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED)))
+            .arrange()
+
+        val result = useCase(CONVERSATION_ID)
+
+        assertTrue(result)
+        verifySuspend(VerifyMode.not) {
+            arrangement.cryptoTransactionProvider.transaction<Unit>(any(), any())
+        }
+        verifySuspend(VerifyMode.not) {
+            arrangement.joinExistingMLSConversation(any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun givenPendingMLSConversation_whenInvoking_thenJoinsExistingMLSConversationInTransactionAndReturnsTrue() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withConversationReturning(Either.Right(mlsConversation(Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN)))
+            .withJoinExistingMLSConversationReturning(Either.Right(Unit))
+            .arrange()
+
+        val result = useCase(CONVERSATION_ID)
+
+        assertTrue(result)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.cryptoTransactionProvider.transaction<Unit>(eq("ensureMeetingIsMLSEstablished"), any())
+        }
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.joinExistingMLSConversation(eq(arrangement.transactionContext), eq(CONVERSATION_ID), any(), any())
+        }
+    }
+
+    @Test
+    fun givenPendingMLSConversationAndJoinFails_whenInvoking_thenReturnsFalse() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withConversationReturning(Either.Right(mlsConversation(Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN)))
+            .withJoinExistingMLSConversationReturning(Either.Left(CoreFailure.Unknown(RuntimeException("join failed"))))
+            .arrange()
+
+        val result = useCase(CONVERSATION_ID)
+
+        assertFalse(result)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.joinExistingMLSConversation(eq(arrangement.transactionContext), eq(CONVERSATION_ID), any(), any())
+        }
+    }
+
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMokkeryImpl() {
+        val conversationRepository = mock<ConversationRepository>(mode = MockMode.autoUnit)
+        val joinExistingMLSConversation = mock<JoinExistingMLSConversationUseCase>(mode = MockMode.autoUnit)
+
+        fun withConversationReturning(result: Either<StorageFailure, Conversation>) = apply {
+            everySuspend {
+                conversationRepository.getConversationById(eq(CONVERSATION_ID))
+            } returns result
+        }
+
+        fun withJoinExistingMLSConversationReturning(result: Either<CoreFailure, Unit>) = apply {
+            everySuspend {
+                joinExistingMLSConversation(any(), any(), any(), any())
+            } returns result
+        }
+
+        suspend fun arrange(): Pair<Arrangement, EnsureMeetingIsMLSEstablishedUseCase> {
+            withTransactionReturning(Either.Right(Unit))
+            return this to EnsureMeetingIsMLSEstablishedUseCaseImpl(
+                transactionProvider = cryptoTransactionProvider,
+                conversationRepository = conversationRepository,
+                joinExistingMLSConversation = joinExistingMLSConversation
+            )
+        }
+    }
+
+    private companion object {
+        val CONVERSATION_ID = ConversationId("conversation-id", "domain.example")
+
+        fun mlsConversation(groupState: Conversation.ProtocolInfo.MLSCapable.GroupState): Conversation =
+            TestConversation.GROUP(
+                TestConversation.MLS_PROTOCOL_INFO.copy(groupState = groupState)
+            ).copy(id = CONVERSATION_ID)
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/meeting/EnsureMeetingIsMLSEstablishedUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/meeting/EnsureMeetingIsMLSEstablishedUseCaseTest.kt
@@ -20,18 +20,18 @@ package com.wire.kalium.logic.feature.meeting
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.MockConversation
+import com.wire.kalium.logic.data.MockProtocolInfo
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCase
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMokkeryImpl
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
-import dev.mokkery.matcher.eq
 import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
@@ -62,7 +62,7 @@ class EnsureMeetingIsMLSEstablishedUseCaseTest {
     @Test
     fun givenProteusConversation_whenInvoking_thenReturnsTrueAndDoesNotJoinMLSConversation() = runTest {
         val (arrangement, useCase) = Arrangement()
-            .withConversationReturning(Either.Right(TestConversation.GROUP()))
+            .withConversationReturning(Either.Right(MockConversation.group(id = CONVERSATION_ID)))
             .arrange()
 
         val result = useCase(CONVERSATION_ID)
@@ -104,10 +104,10 @@ class EnsureMeetingIsMLSEstablishedUseCaseTest {
 
         assertTrue(result)
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.cryptoTransactionProvider.transaction<Unit>(eq("ensureMeetingIsMLSEstablished"), any())
+            arrangement.cryptoTransactionProvider.transaction<Unit>("ensureMeetingIsMLSEstablished", any())
         }
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.joinExistingMLSConversation(eq(arrangement.transactionContext), eq(CONVERSATION_ID), any(), any())
+            arrangement.joinExistingMLSConversation(arrangement.transactionContext, CONVERSATION_ID, any(), any())
         }
     }
 
@@ -122,7 +122,7 @@ class EnsureMeetingIsMLSEstablishedUseCaseTest {
 
         assertFalse(result)
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.joinExistingMLSConversation(eq(arrangement.transactionContext), eq(CONVERSATION_ID), any(), any())
+            arrangement.joinExistingMLSConversation(arrangement.transactionContext, CONVERSATION_ID, any(), any())
         }
     }
 
@@ -132,7 +132,7 @@ class EnsureMeetingIsMLSEstablishedUseCaseTest {
 
         fun withConversationReturning(result: Either<StorageFailure, Conversation>) = apply {
             everySuspend {
-                conversationRepository.getConversationById(eq(CONVERSATION_ID))
+                conversationRepository.getConversationById(CONVERSATION_ID)
             } returns result
         }
 
@@ -156,8 +156,9 @@ class EnsureMeetingIsMLSEstablishedUseCaseTest {
         val CONVERSATION_ID = ConversationId("conversation-id", "domain.example")
 
         fun mlsConversation(groupState: Conversation.ProtocolInfo.MLSCapable.GroupState): Conversation =
-            TestConversation.GROUP(
-                TestConversation.MLS_PROTOCOL_INFO.copy(groupState = groupState)
-            ).copy(id = CONVERSATION_ID)
+            MockConversation.group(
+                id = CONVERSATION_ID,
+                protocolInfo = MockProtocolInfo.mls().copy(groupState = groupState)
+            )
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/meeting/EnsureMeetingIsMLSEstablishedUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/meeting/EnsureMeetingIsMLSEstablishedUseCaseTest.kt
@@ -132,7 +132,7 @@ class EnsureMeetingIsMLSEstablishedUseCaseTest {
 
         fun withConversationReturning(result: Either<StorageFailure, Conversation>) = apply {
             everySuspend {
-                conversationRepository.getConversationById(CONVERSATION_ID)
+                conversationRepository.getNonDeletedConversationById(CONVERSATION_ID)
             } returns result
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25677
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Use case for ensuring that the meeting's underlying "meeting" type conversation has established MLS group.
It checks if it's MLS and already established, and if not then it tries again to establish it.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
