### PR TITLE
feat: get next soonest meeting occurrence [WPB-25677]

### DIFF
--- a/changelog.d/get-next-meeting-occurrence-use-case.md
+++ b/changelog.d/get-next-meeting-occurrence-use-case.md
@@ -1,0 +1,10 @@
+### Added
+- Added `MeetingScope.getNextMeetingOccurrence` with `GetNextMeetingOccurrenceUseCase` to get the next occurrence for a given meeting that has not started yet.
+
+### Migration
+No action required unless consumers want to expose the next upcoming occurrence for a specific meeting.
+
+### Compatibility
+ABI: additive.
+Source: additive.
+Behavior: no behavior change unless consumers call the new next meeting occurrence API.

--- a/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Meetings.sq
+++ b/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Meetings.sq
@@ -205,3 +205,14 @@ LEFT JOIN SelfUser
 WHERE Member.conversation IN :conversationIds
     AND User.preview_asset_id IS NOT NULL
 ORDER BY Member.conversation ASC, Member.user ASC;
+
+selectNextMeetingOccurrenceDetailsId:
+SELECT MeetingOccurrence.occurrence_id
+FROM MeetingOccurrence
+JOIN Meeting ON Meeting.meeting_id = MeetingOccurrence.meeting_id
+WHERE MeetingOccurrence.meeting_id = :meetingId
+    AND MeetingOccurrence.occurrence_start > :fromDate
+ORDER BY MeetingOccurrence.occurrence_start ASC,
+    MeetingOccurrence.occurrence_end ASC,
+    Meeting.title ASC
+LIMIT 1;

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/meeting/MeetingDao.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/meeting/MeetingDao.kt
@@ -46,6 +46,7 @@ interface MeetingDao {
         from: Instant,
     ): KaliumPager<MeetingOccurrenceDetailsEntity>
     suspend fun deleteMeeting(meetingId: QualifiedIDEntity)
+    suspend fun getNextMeetingOccurrenceDetailsId(meetingId: QualifiedIDEntity, from: Instant): String?
 }
 
 internal class MeetingDaoImpl(
@@ -135,6 +136,12 @@ internal class MeetingDaoImpl(
             meetingsQueries.deleteMeeting(meetingId)
         }
     }
+
+    override suspend fun getNextMeetingOccurrenceDetailsId(meetingId: QualifiedIDEntity, from: Instant): String? =
+        withContext(readDispatcher.value) {
+            meetingsQueries.selectNextMeetingOccurrenceDetailsId(meetingId = meetingId, fromDate = from)
+                .awaitAsOneOrNull()
+        }
 
     private fun meetingPagingSource(from: Instant, startingOffset: Long, prefetchDistance: Int): MeetingPagingSource =
         MeetingPagingSource(

--- a/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/meeting/MeetingDaoTest.kt
+++ b/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/meeting/MeetingDaoTest.kt
@@ -104,6 +104,40 @@ class MeetingDaoTest : BaseDatabaseTest() {
         }
 
     @Test
+    fun givenRecurringMeeting_whenGettingNextOccurrence_thenReturnsFirstOccurrenceThatHasNotStarted() =
+        runTest(dispatcher) {
+            val meetingStart = Instant.parse("2026-01-02T10:00:00Z")
+            val meeting = newMeeting(
+                startTime = meetingStart,
+                recurrence = MeetingEntity.RecurrenceEntity(frequency = Frequency.DAILY, interval = 1, until = meetingStart + 5.days)
+            )
+            val otherMeeting = newMeeting(
+                meetingId = QualifiedIDEntity("other-meeting", "wire.com"),
+                conversationId = QualifiedIDEntity("other-conversation", "wire.com"),
+                startTime = Instant.parse("2026-01-02T09:45:00Z"),
+                recurrence = MeetingEntity.RecurrenceEntity(frequency = Frequency.DAILY, interval = 1, until = meetingStart + 5.days)
+            )
+            insertMeetingDependencies(meeting)
+            insertMeetingDependencies(otherMeeting)
+            meetingDao.upsertMeetings(listOf(meeting, otherMeeting), GenerationLimit.Window(meetingStart - 1.days, meetingStart + 5.days))
+            val occurrenceIdsByStartTime = occurrencesFor(meeting).associate { it.occurrence_start to it.occurrence_id }
+
+            val beforeTodaysOccurrenceStartId = meetingDao.getNextMeetingOccurrenceDetailsId(
+                meetingId = meeting.meetingId,
+                from = Instant.parse("2026-01-02T09:30:00Z")
+            )
+            val atTodaysOccurrenceStartId = meetingDao.getNextMeetingOccurrenceDetailsId(meetingId = meeting.meetingId, from = meetingStart)
+            val afterTodaysOccurrenceStartId = meetingDao.getNextMeetingOccurrenceDetailsId(
+                meetingId = meeting.meetingId,
+                from = Instant.parse("2026-01-02T10:30:00Z")
+            )
+
+            assertEquals(occurrenceIdsByStartTime.getValue(meetingStart), beforeTodaysOccurrenceStartId)
+            assertEquals(occurrenceIdsByStartTime.getValue(meetingStart + 1.days), atTodaysOccurrenceStartId)
+            assertEquals(occurrenceIdsByStartTime.getValue(meetingStart + 1.days), afterTodaysOccurrenceStartId)
+        }
+
+    @Test
     fun givenGeneratedOccurrences_whenSameMeetingIsUpserted_thenOccurrencesAreNotDuplicated() = runTest(dispatcher) {
         val now = Clock.System.now()
         val meeting = newMeeting(

--- a/logic/api/jvm/logic.api
+++ b/logic/api/jvm/logic.api
@@ -5290,6 +5290,15 @@ public final class com/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase$Re
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract interface class com/wire/kalium/logic/feature/meeting/GetNextMeetingOccurrenceUseCase {
+	public abstract fun invoke (Lcom/wire/kalium/logic/data/id/QualifiedID;Lkotlinx/datetime/Instant;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun invoke$default (Lcom/wire/kalium/logic/feature/meeting/GetNextMeetingOccurrenceUseCase;Lcom/wire/kalium/logic/data/id/QualifiedID;Lkotlinx/datetime/Instant;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/wire/kalium/logic/feature/meeting/GetNextMeetingOccurrenceUseCase$DefaultImpls {
+	public static synthetic fun invoke$default (Lcom/wire/kalium/logic/feature/meeting/GetNextMeetingOccurrenceUseCase;Lcom/wire/kalium/logic/data/id/QualifiedID;Lkotlinx/datetime/Instant;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
 public abstract interface class com/wire/kalium/logic/feature/meeting/GetPaginatedMeetingOccurrencesUseCase {
 	public abstract fun invoke (Landroidx/paging/PagingConfig;JLkotlinx/datetime/Instant;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun invoke$default (Lcom/wire/kalium/logic/feature/meeting/GetPaginatedMeetingOccurrencesUseCase;Landroidx/paging/PagingConfig;JLkotlinx/datetime/Instant;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -5301,6 +5310,7 @@ public final class com/wire/kalium/logic/feature/meeting/GetPaginatedMeetingOccu
 
 public final class com/wire/kalium/logic/feature/meeting/MeetingScope {
 	public final fun getDeleteMeeting ()Lcom/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase;
+	public final fun getGetNextMeetingOccurrence ()Lcom/wire/kalium/logic/feature/meeting/GetNextMeetingOccurrenceUseCase;
 	public final fun getGetPaginatedMeetingOccurrenceDetails ()Lcom/wire/kalium/logic/feature/meeting/GetPaginatedMeetingOccurrencesUseCase;
 	public final fun getObserveMeetingOccurrence ()Lcom/wire/kalium/logic/feature/meeting/ObserveMeetingOccurrenceUseCase;
 }

--- a/logic/api/logic.klib.api
+++ b/logic/api/logic.klib.api
@@ -1365,6 +1365,10 @@ abstract interface com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase { 
     }
 }
 
+abstract interface com.wire.kalium.logic.feature.meeting/GetNextMeetingOccurrenceUseCase { // com.wire.kalium.logic.feature.meeting/GetNextMeetingOccurrenceUseCase|null[0]
+    abstract suspend fun invoke(com.wire.kalium.logic.data.id/QualifiedID, kotlinx.datetime/Instant = ...): com.wire.kalium.logic.data.meeting/MeetingOccurrence? // com.wire.kalium.logic.feature.meeting/GetNextMeetingOccurrenceUseCase.invoke|invoke(com.wire.kalium.logic.data.id.QualifiedID;kotlinx.datetime.Instant){}[0]
+}
+
 abstract interface com.wire.kalium.logic.feature.meeting/GetPaginatedMeetingOccurrencesUseCase { // com.wire.kalium.logic.feature.meeting/GetPaginatedMeetingOccurrencesUseCase|null[0]
     abstract suspend fun invoke(androidx.paging/PagingConfig, kotlin/Long, kotlinx.datetime/Instant = ...): kotlinx.coroutines.flow/Flow<androidx.paging/PagingData<com.wire.kalium.logic.data.meeting/MeetingOccurrence>> // com.wire.kalium.logic.feature.meeting/GetPaginatedMeetingOccurrencesUseCase.invoke|invoke(androidx.paging.PagingConfig;kotlin.Long;kotlinx.datetime.Instant){}[0]
 }
@@ -4277,6 +4281,8 @@ final class com.wire.kalium.logic.feature.incallreaction/SendInCallReactionUseCa
 final class com.wire.kalium.logic.feature.meeting/MeetingScope { // com.wire.kalium.logic.feature.meeting/MeetingScope|null[0]
     final val deleteMeeting // com.wire.kalium.logic.feature.meeting/MeetingScope.deleteMeeting|{}deleteMeeting[0]
         final fun <get-deleteMeeting>(): com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase // com.wire.kalium.logic.feature.meeting/MeetingScope.deleteMeeting.<get-deleteMeeting>|<get-deleteMeeting>(){}[0]
+    final val getNextMeetingOccurrence // com.wire.kalium.logic.feature.meeting/MeetingScope.getNextMeetingOccurrence|{}getNextMeetingOccurrence[0]
+        final fun <get-getNextMeetingOccurrence>(): com.wire.kalium.logic.feature.meeting/GetNextMeetingOccurrenceUseCase // com.wire.kalium.logic.feature.meeting/MeetingScope.getNextMeetingOccurrence.<get-getNextMeetingOccurrence>|<get-getNextMeetingOccurrence>(){}[0]
     final val getPaginatedMeetingOccurrenceDetails // com.wire.kalium.logic.feature.meeting/MeetingScope.getPaginatedMeetingOccurrenceDetails|{}getPaginatedMeetingOccurrenceDetails[0]
         final fun <get-getPaginatedMeetingOccurrenceDetails>(): com.wire.kalium.logic.feature.meeting/GetPaginatedMeetingOccurrencesUseCase // com.wire.kalium.logic.feature.meeting/MeetingScope.getPaginatedMeetingOccurrenceDetails.<get-getPaginatedMeetingOccurrenceDetails>|<get-getPaginatedMeetingOccurrenceDetails>(){}[0]
     final val observeMeetingOccurrence // com.wire.kalium.logic.feature.meeting/MeetingScope.observeMeetingOccurrence|{}observeMeetingOccurrence[0]

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepository.kt
@@ -22,6 +22,7 @@ import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.map
 import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.error.wrapApiRequest
 import com.wire.kalium.common.error.wrapStorageRequest
 import com.wire.kalium.common.functional.Either
@@ -38,6 +39,7 @@ import com.wire.kalium.util.DateTimeUtil.asStartOfDay
 import com.wire.kalium.util.DateTimeUtil.currentInstant
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.datetime.Instant
 import kotlin.time.Duration.Companion.days
@@ -62,6 +64,11 @@ internal interface MeetingRepository {
     ): Flow<PagingData<MeetingOccurrence>>
 
     suspend fun deleteMeeting(meetingId: MeetingId): Either<CoreFailure, Unit>
+
+    suspend fun getNextMeetingOccurrence(
+        meetingId: MeetingId,
+        from: Instant = currentInstant()
+    ): Either<StorageFailure, MeetingOccurrence>
 }
 
 internal class MeetingDataSource(
@@ -120,6 +127,15 @@ internal class MeetingDataSource(
                 meetingDAO.deleteMeeting(meetingId.toDao())
             }
         }
+
+    override suspend fun getNextMeetingOccurrence(
+        meetingId: MeetingId,
+        from: Instant
+    ): Either<StorageFailure, MeetingOccurrence> = wrapStorageRequest {
+        meetingDAO.getNextMeetingOccurrenceDetailsId(meetingId.toDao(), from)?.let { occurrenceId ->
+            meetingDAO.getMeetingOccurrenceDetailsFlow(occurrenceId).firstOrNull()?.let(meetingMapper::fromDaoToModel)
+        }
+    }
 }
 
 private const val OCCURRENCE_GENERATION_WINDOW_DAYS = 90

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/meeting/GetNextMeetingOccurrenceUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/meeting/GetNextMeetingOccurrenceUseCase.kt
@@ -15,36 +15,29 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
-
 package com.wire.kalium.logic.feature.meeting
 
+import com.wire.kalium.common.functional.getOrNull
+import com.wire.kalium.logic.data.id.MeetingId
+import com.wire.kalium.logic.data.meeting.MeetingOccurrence
 import com.wire.kalium.logic.data.meeting.MeetingRepository
+import com.wire.kalium.util.DateTimeUtil.currentInstant
 import com.wire.kalium.util.KaliumDispatcher
+import kotlinx.coroutines.withContext
+import kotlinx.datetime.Instant
 
-public class MeetingScope internal constructor(
+/**
+ * Use case for getting the next soonest occurrence of a meeting after a given point in time.
+ */
+public interface GetNextMeetingOccurrenceUseCase {
+    public suspend operator fun invoke(meetingId: MeetingId, from: Instant = currentInstant()): MeetingOccurrence?
+}
+
+internal class GetNextMeetingOccurrenceUseCaseImpl(
     private val dispatcher: KaliumDispatcher,
     private val meetingRepository: MeetingRepository,
-) {
-    public val getPaginatedMeetingOccurrenceDetails: GetPaginatedMeetingOccurrencesUseCase
-        get() = GetPaginatedMeetingOccurrencesUseCaseImpl(
-            dispatcher = dispatcher,
-            meetingRepository = meetingRepository,
-        )
-
-    public val observeMeetingOccurrence: ObserveMeetingOccurrenceUseCase
-        get() = ObserveMeetingOccurrenceUseCaseImpl(
-            dispatcher = dispatcher,
-            meetingRepository = meetingRepository,
-        )
-
-    public val deleteMeeting: DeleteMeetingUseCase
-        get() = DeleteMeetingUseCaseImpl(
-            meetingRepository = meetingRepository,
-        )
-
-    public val getNextMeetingOccurrence: GetNextMeetingOccurrenceUseCase
-        get() = GetNextMeetingOccurrenceUseCaseImpl(
-            dispatcher = dispatcher,
-            meetingRepository = meetingRepository,
-        )
+) : GetNextMeetingOccurrenceUseCase {
+    override suspend operator fun invoke(meetingId: MeetingId, from: Instant): MeetingOccurrence? = withContext(dispatcher.io) {
+        meetingRepository.getNextMeetingOccurrence(meetingId, from).getOrNull()
+    }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepositoryTest.kt
@@ -18,12 +18,14 @@
 package com.wire.kalium.logic.data.meeting
 
 import com.wire.kalium.common.error.NetworkFailure
+import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.getOrNull
 import com.wire.kalium.common.functional.isRight
 import com.wire.kalium.logic.data.id.MeetingId
 import com.wire.kalium.logic.data.id.toApi
 import com.wire.kalium.logic.data.id.toDao
+import com.wire.kalium.logic.data.id.toModel
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.test_util.TestNetworkException
 import com.wire.kalium.network.api.authenticated.meeting.MeetingDTO
@@ -32,7 +34,12 @@ import com.wire.kalium.network.api.model.ConversationId
 import com.wire.kalium.network.api.model.UserId
 import com.wire.kalium.network.api.model.MeetingId as NetworkMeetingId
 import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.persistence.dao.QualifiedIDEntity
+import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 import com.wire.kalium.persistence.dao.meeting.MeetingDao
+import com.wire.kalium.persistence.dao.meeting.MeetingEntity
+import com.wire.kalium.persistence.dao.meeting.MeetingOccurrenceDetailsEntity
+import com.wire.kalium.persistence.dao.meeting.MeetingOccurrenceEntity
 import com.wire.kalium.persistence.dao.meeting.MeetingOccurrencesGenerator.GenerationLimit
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
@@ -41,10 +48,13 @@ import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
@@ -133,6 +143,42 @@ class MeetingRepositoryTest {
         }
     }
 
+    @Suppress("UnusedFlow")
+    @Test
+    fun givenDaoReturnsOccurrence_whenGetNextMeetingOccurrence_thenReturnsMappedOccurrence() = runTest {
+        val meetingId = MEETING_OCCURRENCE_DETAILS.meeting.meetingId.toModel()
+        val from = Instant.parse("2026-06-01T10:00:00Z")
+        val occurrenceId = MEETING_OCCURRENCE_DETAILS.occurrence.occurrenceId
+        val (arrangement, repository) = Arrangement()
+            .withNextMeetingOccurrenceId(meetingId, from, occurrenceId)
+            .withMeetingOccurrenceDetailsFlow(occurrenceId, flowOf(MEETING_OCCURRENCE_DETAILS))
+            .arrange()
+
+        val result = repository.getNextMeetingOccurrence(meetingId, from)
+
+        assertIs<Either.Right<MeetingOccurrence>>(result).also {
+            assertEquals(arrangement.meetingMapper.fromDaoToModel(MEETING_OCCURRENCE_DETAILS), result.value)
+        }
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingDao.getNextMeetingOccurrenceDetailsId(meetingId.toDao(), from)
+            arrangement.meetingDao.getMeetingOccurrenceDetailsFlow(occurrenceId)
+        }
+    }
+
+    @Test
+    fun givenDaoReturnsNoOccurrenceId_whenGetNextMeetingOccurrence_thenReturnDataNotFound() = runTest {
+        val meetingId = MeetingId("meeting1", "domain")
+        val from = Instant.parse("2026-06-01T10:00:00Z")
+        val (arrangement, repository) = Arrangement()
+            .withNextMeetingOccurrenceId(meetingId, from, null)
+            .arrange()
+
+        val result = repository.getNextMeetingOccurrence(meetingId, from)
+
+        assertIs<Either.Left<StorageFailure.DataNotFound>>(result)
+        verifySuspend(VerifyMode.exactly(1)) { arrangement.meetingDao.getNextMeetingOccurrenceDetailsId(meetingId.toDao(), from) }
+    }
+
     inner class Arrangement {
         internal val meetingDao = mock<MeetingDao>(mode = MockMode.autoUnit)
         internal val meetingApi = mock<MeetingApi>(mode = MockMode.autoUnit)
@@ -150,6 +196,41 @@ class MeetingRepositoryTest {
             everySuspend { meetingApi.deleteMeeting(meetingId.toApi()) } returns NetworkResponse.Error(TestNetworkException.generic)
         }
 
+        internal fun withNextMeetingOccurrenceId(meetingId: MeetingId, from: Instant, result: String?) = apply {
+            everySuspend { meetingDao.getNextMeetingOccurrenceDetailsId(meetingId.toDao(), from) } returns result
+        }
+
+        internal fun withMeetingOccurrenceDetailsFlow(occurrenceId: String, result: Flow<MeetingOccurrenceDetailsEntity?>) = apply {
+            everySuspend { meetingDao.getMeetingOccurrenceDetailsFlow(occurrenceId) } returns result
+        }
+
         internal fun arrange() = this to MeetingDataSource(meetingDAO = meetingDao, meetingApi = meetingApi)
     }
+
+    private val MEETING_ENTITY = MeetingEntity(
+        meetingId = QualifiedIDEntity("meeting1", "domain"),
+        conversationId = QualifiedIDEntity("conversation1", "domain"),
+        creatorId = QualifiedIDEntity("creator1", "domain"),
+        createdAt = Instant.parse("2026-06-01T08:00:00Z"),
+        updatedAt = null,
+        title = "Meeting 1",
+        startTime = Instant.parse("2026-06-01T10:00:00Z"),
+        endTime = Instant.parse("2026-06-01T11:00:00Z"),
+        trial = false,
+        recurrence = null,
+    )
+    private val MEETING_OCCURRENCE_DETAILS = MeetingOccurrenceDetailsEntity(
+        occurrence = MeetingOccurrenceEntity(
+            occurrenceId = "occurrence1",
+            meetingId = MEETING_ENTITY.meetingId,
+            occurrenceStart = Instant.parse("2026-06-01T10:00:00Z"),
+            occurrenceEnd = Instant.parse("2026-06-01T11:00:00Z"),
+        ),
+        meeting = MEETING_ENTITY,
+        conversationName = "Conversation 1",
+        conversationType = ConversationEntity.Type.GROUP,
+        otherUserPreviewAssetId = null,
+        channelAccess = null,
+        selfUserId = MEETING_ENTITY.creatorId,
+    )
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/meeting/GetNextMeetingOccurrenceUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/meeting/GetNextMeetingOccurrenceUseCaseTest.kt
@@ -23,8 +23,10 @@ import com.wire.kalium.common.functional.left
 import com.wire.kalium.common.functional.right
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.MeetingId
+import com.wire.kalium.logic.data.meeting.Meeting
 import com.wire.kalium.logic.data.meeting.MeetingOccurrence
 import com.wire.kalium.logic.data.meeting.MeetingRepository
+import com.wire.kalium.logic.feature.backup.UserId
 import com.wire.kalium.logic.test_util.testKaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcher
 import dev.mokkery.MockMode
@@ -44,28 +46,28 @@ class GetNextMeetingOccurrenceUseCaseTest {
     @Test
     fun givenRepositoryReturnsOccurrence_whenInvoking_thenReturnsOccurrence() = runTest {
         val (arrangement, useCase) = Arrangement(StandardTestDispatcher(testScheduler).testKaliumDispatcher())
-            .withNextMeetingOccurrenceReturning(MEETING_OCCURRENCE.meetingId, FROM, MEETING_OCCURRENCE.right())
+            .withNextMeetingOccurrenceReturning(MEETING.meetingId, FROM, MEETING_OCCURRENCE.right())
             .arrange()
 
-        val result = useCase(MEETING_OCCURRENCE.meetingId, FROM)
+        val result = useCase(MEETING.meetingId, FROM)
 
         assertEquals(MEETING_OCCURRENCE, result)
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.meetingRepository.getNextMeetingOccurrence(MEETING_OCCURRENCE.meetingId, FROM)
+            arrangement.meetingRepository.getNextMeetingOccurrence(MEETING.meetingId, FROM)
         }
     }
 
     @Test
     fun givenRepositoryReturnsNull_whenInvoking_thenReturnsNull() = runTest {
         val (arrangement, useCase) = Arrangement(StandardTestDispatcher(testScheduler).testKaliumDispatcher())
-            .withNextMeetingOccurrenceReturning(MEETING_OCCURRENCE.meetingId, FROM, StorageFailure.DataNotFound.left())
+            .withNextMeetingOccurrenceReturning(MEETING.meetingId, FROM, StorageFailure.DataNotFound.left())
             .arrange()
 
-        val result = useCase(MEETING_OCCURRENCE.meetingId, FROM)
+        val result = useCase(MEETING.meetingId, FROM)
 
         assertEquals(null, result)
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.meetingRepository.getNextMeetingOccurrence(MEETING_OCCURRENCE.meetingId, FROM)
+            arrangement.meetingRepository.getNextMeetingOccurrence(MEETING.meetingId, FROM)
         }
     }
 
@@ -82,19 +84,23 @@ class GetNextMeetingOccurrenceUseCaseTest {
 
     private companion object {
         val FROM: Instant = Instant.parse("2026-06-01T10:00:00Z")
+        val MEETING: Meeting = Meeting(
+            meetingId = MeetingId("meeting1", "domain"),
+            conversationId = ConversationId("conversation1", "domain"),
+            creatorId = UserId("user1", "domain"),
+            title = "Meeting 1",
+            startTime = Instant.parse("2026-06-01T10:30:00Z"),
+            endTime = Instant.parse("2026-06-01T11:30:00Z"),
+            recurrence = null,
+        )
         val MEETING_OCCURRENCE: MeetingOccurrence = MeetingOccurrence(
+            meeting = MEETING,
             selfRole = MeetingOccurrence.SelfRole.Creator,
             conversationName = "Conversation 1",
             conversationType = MeetingOccurrence.ConversationType.Group,
             occurrenceId = "occurrence1",
             occurrenceStartTime = Instant.parse("2026-06-01T10:30:00Z"),
             occurrenceEndTime = Instant.parse("2026-06-01T11:30:00Z"),
-            meetingId = MeetingId("meeting1", "domain"),
-            conversationId = ConversationId("conversation1", "domain"),
-            title = "Meeting 1",
-            startTime = Instant.parse("2026-06-01T10:30:00Z"),
-            endTime = Instant.parse("2026-06-01T11:30:00Z"),
-            recurrence = null,
         )
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/meeting/GetNextMeetingOccurrenceUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/meeting/GetNextMeetingOccurrenceUseCaseTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.meeting
+
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.left
+import com.wire.kalium.common.functional.right
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.MeetingId
+import com.wire.kalium.logic.data.meeting.MeetingOccurrence
+import com.wire.kalium.logic.data.meeting.MeetingRepository
+import com.wire.kalium.logic.test_util.testKaliumDispatcher
+import com.wire.kalium.util.KaliumDispatcher
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GetNextMeetingOccurrenceUseCaseTest {
+
+    @Test
+    fun givenRepositoryReturnsOccurrence_whenInvoking_thenReturnsOccurrence() = runTest {
+        val (arrangement, useCase) = Arrangement(StandardTestDispatcher(testScheduler).testKaliumDispatcher())
+            .withNextMeetingOccurrenceReturning(MEETING_OCCURRENCE.meetingId, FROM, MEETING_OCCURRENCE.right())
+            .arrange()
+
+        val result = useCase(MEETING_OCCURRENCE.meetingId, FROM)
+
+        assertEquals(MEETING_OCCURRENCE, result)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingRepository.getNextMeetingOccurrence(MEETING_OCCURRENCE.meetingId, FROM)
+        }
+    }
+
+    @Test
+    fun givenRepositoryReturnsNull_whenInvoking_thenReturnsNull() = runTest {
+        val (arrangement, useCase) = Arrangement(StandardTestDispatcher(testScheduler).testKaliumDispatcher())
+            .withNextMeetingOccurrenceReturning(MEETING_OCCURRENCE.meetingId, FROM, StorageFailure.DataNotFound.left())
+            .arrange()
+
+        val result = useCase(MEETING_OCCURRENCE.meetingId, FROM)
+
+        assertEquals(null, result)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingRepository.getNextMeetingOccurrence(MEETING_OCCURRENCE.meetingId, FROM)
+        }
+    }
+
+    private class Arrangement(private val dispatcher: KaliumDispatcher) {
+        val meetingRepository = mock<MeetingRepository>(mode = MockMode.autoUnit)
+        fun withNextMeetingOccurrenceReturning(id: MeetingId, from: Instant, result: Either<StorageFailure, MeetingOccurrence>) = apply {
+            everySuspend { meetingRepository.getNextMeetingOccurrence(id, from) } returns result
+        }
+        fun arrange() = this to GetNextMeetingOccurrenceUseCaseImpl(
+            dispatcher = dispatcher,
+            meetingRepository = meetingRepository,
+        )
+    }
+
+    private companion object {
+        val FROM: Instant = Instant.parse("2026-06-01T10:00:00Z")
+        val MEETING_OCCURRENCE: MeetingOccurrence = MeetingOccurrence(
+            selfRole = MeetingOccurrence.SelfRole.Creator,
+            conversationName = "Conversation 1",
+            conversationType = MeetingOccurrence.ConversationType.Group,
+            occurrenceId = "occurrence1",
+            occurrenceStartTime = Instant.parse("2026-06-01T10:30:00Z"),
+            occurrenceEndTime = Instant.parse("2026-06-01T11:30:00Z"),
+            meetingId = MeetingId("meeting1", "domain"),
+            conversationId = ConversationId("conversation1", "domain"),
+            title = "Meeting 1",
+            startTime = Instant.parse("2026-06-01T10:30:00Z"),
+            endTime = Instant.parse("2026-06-01T11:30:00Z"),
+            recurrence = null,
+        )
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25677
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Use case for getting the next soonest occurrence of a meeting after a given point in time.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
