### PR TITLE
test(apple): cover AVS dynamic runtime PR 2 [WPB-27766]

### DIFF
--- a/docs/IOS_BUILD.md
+++ b/docs/IOS_BUILD.md
@@ -332,10 +332,7 @@ git commit -m "Update Kalium submodule"
 
 ### Swift Package Manager (Experimental)
 
-This local wrapper declares only Kalium and is incomplete for AVS-enabled
-builds. Use the submodule integration until the package proposed in
-[ADR 0010](adr/0010-distribute-kalium-and-avs-with-swift-package-manager.md)
-publishes both Kalium and AVS binary targets.
+If you prefer SPM over submodules, you can reference the built XCFramework:
 
 ### Importing in Swift
 

--- a/domain/calling/src/appleTest/kotlin/com/wire/kalium/calling/AppleAvsRuntimeLinkingTest.kt
+++ b/domain/calling/src/appleTest/kotlin/com/wire/kalium/calling/AppleAvsRuntimeLinkingTest.kt
@@ -1,0 +1,32 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.calling
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class AppleAvsRuntimeLinkingTest {
+    @Test
+    fun givenAppleAvsRuntimeLinked_whenStartingRepeatedly_thenStartsSuccessfully() {
+        val flowManager = AppleAvsFlowManager()
+
+        assertTrue(flowManager.startIfAvailable())
+        assertTrue(flowManager.startIfAvailable())
+    }
+}

--- a/plugins/apple-avs-runtime/src/test/kotlin/com/wire/kalium/gradle/avs/AppleAvsRuntimeCacheServiceTest.kt
+++ b/plugins/apple-avs-runtime/src/test/kotlin/com/wire/kalium/gradle/avs/AppleAvsRuntimeCacheServiceTest.kt
@@ -1,0 +1,295 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.gradle.avs
+
+import com.sun.net.httpserver.HttpServer
+import org.gradle.api.GradleException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import java.net.InetSocketAddress
+import java.security.MessageDigest
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.listDirectoryEntries
+import kotlin.io.path.readBytes
+import kotlin.io.path.writeBytes
+import kotlin.io.path.writeText
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class AppleAvsRuntimeCacheServiceTest {
+    @TempDir
+    lateinit var temporaryDirectory: Path
+
+    @Test
+    fun givenValidLocalArchive_whenPreparing_thenPublishesVerifiedArchive() {
+        val source = temporaryDirectory.resolve("source.zip").apply {
+            writeBytes("official avs archive".encodeToByteArray())
+        }
+        val destination = temporaryDirectory.resolve("cache/avs.xcframework.zip")
+
+        AppleAvsRuntimeCacheService.prepareArchive(
+            archiveUrl = "unused",
+            expectedSha256 = source.sha256(),
+            localArchive = source.toFile(),
+            destination = destination.toFile(),
+        )
+
+        assertContentEquals(source.readBytes(), destination.readBytes())
+        assertTrue(isArchiveCacheReady(destination.toFile(), source.sha256()))
+        assertTrue(destination.parent.listDirectoryEntries("*.part-*").isEmpty())
+    }
+
+    @Test
+    fun givenArchiveWithWrongChecksum_whenPreparing_thenRejectsWithoutPublishingPartialContent() {
+        val source = temporaryDirectory.resolve("source.zip").apply {
+            writeBytes("tampered avs archive".encodeToByteArray())
+        }
+        val destination = temporaryDirectory.resolve("cache/avs.xcframework.zip")
+
+        val failure = assertFailsWith<GradleException> {
+            AppleAvsRuntimeCacheService.prepareArchive(
+                archiveUrl = "unused",
+                expectedSha256 = "0".repeat(64),
+                localArchive = source.toFile(),
+                destination = destination.toFile(),
+            )
+        }
+
+        assertTrue(failure.message.orEmpty().contains("checksum mismatch"))
+        assertFalse(destination.exists())
+        assertTrue(destination.parent.listDirectoryEntries("*.part-*").isEmpty())
+    }
+
+    @Test
+    fun givenCorruptedCachedArchive_whenPreparing_thenReplacesItWithVerifiedContent() {
+        val source = temporaryDirectory.resolve("source.zip").apply {
+            writeBytes("official avs archive".encodeToByteArray())
+        }
+        val destination = temporaryDirectory.resolve("cache/avs.xcframework.zip").apply {
+            parent.createDirectories()
+            writeBytes("corrupted cache".encodeToByteArray())
+        }
+
+        AppleAvsRuntimeCacheService.prepareArchive(
+            archiveUrl = "unused",
+            expectedSha256 = source.sha256(),
+            localArchive = source.toFile(),
+            destination = destination.toFile(),
+        )
+
+        assertContentEquals(source.readBytes(), destination.readBytes())
+    }
+
+    @Test
+    fun givenVerifiedRemoteArchiveBehindRedirect_whenPreparing_thenDownloadsAndPublishesIt() {
+        val archiveBytes = "downloaded official archive".encodeToByteArray()
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0).apply {
+            createContext("/redirect") { exchange ->
+                exchange.responseHeaders.add("Location", "/archive")
+                exchange.sendResponseHeaders(302, -1)
+                exchange.close()
+            }
+            createContext("/archive") { exchange ->
+                exchange.sendResponseHeaders(200, archiveBytes.size.toLong())
+                exchange.responseBody.use { it.write(archiveBytes) }
+            }
+            start()
+        }
+        val destination = temporaryDirectory.resolve("cache/avs.xcframework.zip")
+
+        try {
+            AppleAvsRuntimeCacheService.prepareArchive(
+                archiveUrl = "http://127.0.0.1:${server.address.port}/redirect",
+                expectedSha256 = archiveBytes.sha256(),
+                localArchive = null,
+                destination = destination.toFile(),
+            )
+        } finally {
+            server.stop(0)
+        }
+
+        assertContentEquals(archiveBytes, destination.readBytes())
+    }
+
+    @Test
+    fun givenRemoteServerFailure_whenPreparing_thenFailsWithoutPublishingPartialContent() {
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0).apply {
+            createContext("/archive") { exchange ->
+                exchange.sendResponseHeaders(503, -1)
+                exchange.close()
+            }
+            start()
+        }
+        val destination = temporaryDirectory.resolve("cache/avs.xcframework.zip")
+
+        val failure = try {
+            assertFailsWith<GradleException> {
+                AppleAvsRuntimeCacheService.prepareArchive(
+                    archiveUrl = "http://127.0.0.1:${server.address.port}/archive",
+                    expectedSha256 = "0".repeat(64),
+                    localArchive = null,
+                    destination = destination.toFile(),
+                )
+            }
+        } finally {
+            server.stop(0)
+        }
+
+        assertTrue(failure.message.orEmpty().contains("HTTP 503"))
+        assertFalse(destination.exists())
+        assertTrue(destination.parent.listDirectoryEntries("*.part-*").isEmpty())
+    }
+
+    @Test
+    fun givenCorruptedCachedArchive_whenVerifying_thenDeletesItBeforeFailing() {
+        val archive = temporaryDirectory.resolve("avs.xcframework.zip").apply {
+            writeBytes("corrupted cache".encodeToByteArray())
+        }
+
+        assertFailsWith<GradleException> {
+            verifyCachedArchive(archive.toFile(), "0".repeat(64))
+        }
+
+        assertFalse(archive.exists())
+    }
+
+    @Test
+    fun givenConcurrentPrepareRequests_whenRunning_thenOnlyACompleteVerifiedEntryIsPublished() {
+        val source = temporaryDirectory.resolve("source.zip").apply {
+            writeBytes(ByteArray(128 * 1024) { index -> (index % 251).toByte() })
+        }
+        val checksum = source.sha256()
+        val destination = temporaryDirectory.resolve("cache/avs.xcframework.zip")
+        val executor = Executors.newFixedThreadPool(4)
+
+        try {
+            val requests = List(8) {
+                Callable {
+                    AppleAvsRuntimeCacheService.prepareArchive(
+                        archiveUrl = "unused",
+                        expectedSha256 = checksum,
+                        localArchive = source.toFile(),
+                        destination = destination.toFile(),
+                    )
+                }
+            }
+            executor.invokeAll(requests).forEach { it.get() }
+        } finally {
+            executor.shutdownNow()
+        }
+
+        assertEquals(checksum, destination.sha256())
+        assertTrue(destination.parent.listDirectoryEntries("*.part-*").isEmpty())
+    }
+
+    @Test
+    fun givenVerifiedFrameworkCache_whenRuntimeBinaryIsModified_thenCacheIsRejected() {
+        val cache = createCompleteFrameworkCache()
+        val checksum = "a".repeat(64)
+        cache.resolve(AVS_CACHE_READY_MARKER).writeText(
+            frameworkCacheMarker(cache.toFile(), checksum)
+        )
+        assertTrue(isFrameworkCacheReady(cache.toFile(), checksum))
+
+        cache.resolve(
+            "avs.xcframework/${AvsApplePlatform.IOS_DEVICE.xcframeworkSlice}/avs.framework/avs"
+        ).writeText("substituted executable")
+
+        assertFalse(isFrameworkCacheReady(cache.toFile(), checksum))
+    }
+
+    @Test
+    fun givenVerifiedFrameworkCache_whenInfoPlistOrMarkerIsModified_thenCacheIsRejected() {
+        val cache = createCompleteFrameworkCache()
+        val checksum = "b".repeat(64)
+        val marker = cache.resolve(AVS_CACHE_READY_MARKER)
+        marker.writeText(frameworkCacheMarker(cache.toFile(), checksum))
+
+        cache.resolve(
+            "avs.xcframework/${AvsApplePlatform.MACOS.xcframeworkSlice}/avs.framework/Info.plist"
+        ).writeText("substituted plist")
+        assertFalse(isFrameworkCacheReady(cache.toFile(), checksum))
+
+        marker.writeText(frameworkCacheMarker(cache.toFile(), checksum))
+        marker.writeText(marker.toFile().readText().replace("sha256=$checksum", "sha256=${"c".repeat(64)}"))
+        assertFalse(isFrameworkCacheReady(cache.toFile(), checksum))
+    }
+
+    @Test
+    fun givenFrameworkCacheWithEscapingSymlink_whenCreatingIntegrityMarker_thenRejectsIt() {
+        val cache = createCompleteFrameworkCache()
+        val outside = temporaryDirectory.resolve("outside-library").apply {
+            writeText("untrusted executable")
+        }
+        val binary = cache.resolve(
+            "avs.xcframework/${AvsApplePlatform.MACOS.xcframeworkSlice}/avs.framework/avs"
+        )
+        Files.delete(binary)
+        Files.createSymbolicLink(binary, outside)
+
+        val failure = assertFailsWith<IllegalArgumentException> {
+            frameworkCacheMarker(cache.toFile(), "a".repeat(64))
+        }
+
+        assertTrue(failure.message.orEmpty().contains("symlink escapes"))
+    }
+
+    @Test
+    fun givenUppercasePrefixedChecksum_whenNormalizing_thenReturnsLowercaseDigest() {
+        val checksum = "A1".repeat(32)
+
+        assertEquals(checksum.lowercase(), normalizedChecksum("sha256:$checksum"))
+    }
+
+    @Test
+    fun givenMalformedChecksum_whenNormalizing_thenRejectsIt() {
+        assertFailsWith<IllegalArgumentException> {
+            normalizedChecksum("not-a-sha256")
+        }
+    }
+
+    private fun createCompleteFrameworkCache(): Path =
+        temporaryDirectory.resolve("framework-cache").apply {
+            AvsApplePlatform.entries.forEach { platform ->
+                resolve("avs.xcframework/${platform.xcframeworkSlice}/avs.framework").apply {
+                    createDirectories()
+                    resolve("avs").writeText("${platform.name} executable")
+                    resolve("Info.plist").writeText("${platform.name} plist")
+                }
+            }
+        }
+}
+
+private fun Path.sha256(): String {
+    val digest = MessageDigest.getInstance("SHA-256").digest(readBytes())
+    return digest.joinToString("") { byte -> "%02x".format(byte) }
+}
+
+private fun ByteArray.sha256(): String {
+    val digest = MessageDigest.getInstance("SHA-256").digest(this)
+    return digest.joinToString("") { byte -> "%02x".format(byte) }
+}

--- a/plugins/apple-avs-runtime/src/test/kotlin/com/wire/kalium/gradle/avs/AppleAvsRuntimePluginTest.kt
+++ b/plugins/apple-avs-runtime/src/test/kotlin/com/wire/kalium/gradle/avs/AppleAvsRuntimePluginTest.kt
@@ -1,0 +1,184 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.gradle.avs
+
+import org.gradle.testfixtures.ProjectBuilder
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class AppleAvsRuntimePluginTest {
+    @TempDir
+    lateinit var temporaryDirectory: Path
+
+    @Test
+    fun givenPluginApplied_whenConfiguringProject_thenRegistersRuntimeTasksWithPinnedMetadata() {
+        val projectDirectory = temporaryDirectory.resolve("registration-project").apply {
+            createDirectories()
+        }
+        val project = ProjectBuilder.builder().withProjectDir(projectDirectory.toFile()).build()
+
+        AppleAvsRuntimePlugin().apply(project)
+
+        val prepare = project.tasks.named("prepareAvsXcframeworkArchive").get()
+        val extract = project.tasks.named("extractAvsXcframework").get()
+        val generate = project.tasks.named("generateAvsXcodeConfig").get()
+        val embed = project.tasks.named("embedAvsForXcode").get()
+        assertIs<PrepareAvsXcframeworkTask>(prepare)
+        assertIs<ExtractAvsXcframeworkTask>(extract)
+        assertIs<GenerateAvsXcodeConfigTask>(generate)
+        assertIs<EmbedAvsForXcodeTask>(embed)
+        assertIs<ExtractAvsDebugSymbolsTask>(
+            project.tasks.named("extractAvsDebugSymbols").get()
+        )
+        assertEquals(AvsRuntimeArtifact.archiveUrl, prepare.archiveUrl.get())
+        assertEquals(AvsRuntimeArtifact.archiveSha256, prepare.expectedSha256.get())
+        assertEquals(AvsRuntimeArtifact.archiveSha256, extract.expectedSha256.get())
+        assertEquals(AvsRuntimeArtifact.macosMinimumVersion, generate.macosMinimumVersion.get())
+    }
+
+    @Test
+    fun givenAppleTargetsAndRemovedDisableProperty_whenConfiguring_thenEveryBinaryStillLinksVerifiedAvs() {
+        val projectDirectory = temporaryDirectory.resolve("functional-project").apply {
+            createDirectories()
+        }
+        projectDirectory.resolve("settings.gradle.kts").writeText(
+            "rootProject.name = \"apple-avs-functional-test\"\n"
+        )
+        projectDirectory.resolve("build.gradle.kts").writeText(FUNCTIONAL_BUILD_SCRIPT)
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDirectory.toFile())
+            .withPluginClasspath()
+            .withArguments(
+                "inspectAppleAvsWiring",
+                "-Pkalium.disableAppleAvs=true",
+                "--stacktrace",
+            )
+            .build()
+
+        assertLinkWiring(result.output, "IosArm64", AvsApplePlatform.IOS_DEVICE)
+        assertLinkWiring(result.output, "IosSimulatorArm64", AvsApplePlatform.IOS_SIMULATOR)
+        assertLinkWiring(result.output, "MacosArm64", AvsApplePlatform.MACOS)
+        assertTrue(result.output.contains("osVersionMin.macos_arm64=15.0"))
+        assertTrue(result.output.contains("AVS_STAGE:linkDebugExecutableMacosArm64:stageAvsFor"))
+        assertTrue(result.output.contains("AVS_STAGE:linkDebugTestIosSimulatorArm64:stageAvsFor"))
+        assertTrue(
+            result.output.lines().any { line -> line == "AVS_STAGE:linkDebugTestIosArm64:" }
+        )
+    }
+
+    @Test
+    fun givenPublishedAvsDependency_whenLoadingRuntimeMetadata_thenVersionAndTrustInputsRemainConsistent() {
+        val versionCatalog = Path.of(
+            checkNotNull(System.getProperty("kalium.versionCatalog"))
+        ).readText()
+        val catalogAvsVersion = checkNotNull(
+            Regex("(?m)^avs\\s*=\\s*\"([^\"]+)\"")
+                .find(versionCatalog)
+                ?.groupValues
+                ?.get(1)
+        )
+
+        assertEquals(catalogAvsVersion, AvsRuntimeArtifact.version)
+        assertEquals(
+            "https://github.com/wireapp/wire-avs/releases/download/" +
+                "$catalogAvsVersion/avs.xcframework.zip",
+            AvsRuntimeArtifact.archiveUrl,
+        )
+        assertTrue(AvsRuntimeArtifact.archiveSha256.matches(Regex("[0-9a-f]{64}")))
+        assertTrue(AvsRuntimeArtifact.macosMinimumVersion.matches(Regex("[0-9]+\\.[0-9]+")))
+    }
+
+    private fun assertLinkWiring(
+        output: String,
+        taskTargetName: String,
+        platform: AvsApplePlatform,
+    ) {
+        assertTrue(
+            output.lines().any { line ->
+                line.startsWith("AVS_LINK:linkDebugFramework$taskTargetName:") &&
+                    line.contains("/${platform.xcframeworkSlice}|-framework|avs")
+            }
+        )
+        assertTrue(
+            output.lines().any { line ->
+                line.startsWith("AVS_DEP:linkDebugFramework$taskTargetName:") &&
+                    line.contains("extractAvsXcframework")
+            }
+        )
+    }
+
+    private companion object {
+        val FUNCTIONAL_BUILD_SCRIPT =
+            """
+            import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+            import org.jetbrains.kotlin.gradle.tasks.KotlinNativeLink
+
+            plugins {
+                id("com.wire.kalium.apple-avs-runtime")
+            }
+
+            apply(plugin = "org.jetbrains.kotlin.multiplatform")
+
+            extensions.configure<KotlinMultiplatformExtension> {
+                iosArm64 {
+                    binaries.framework()
+                }
+                iosSimulatorArm64 {
+                    binaries.framework()
+                }
+                macosArm64 {
+                    binaries.framework()
+                    binaries.executable()
+                }
+            }
+
+            tasks.register("inspectAppleAvsWiring") {
+                doLast {
+                    tasks.withType<KotlinNativeLink>()
+                        .sortedBy { it.name }
+                        .forEach { linkTask ->
+                            println("AVS_LINK:${'$'}{linkTask.name}:${'$'}{linkTask.linkerOpts.joinToString("|")}")
+                            println(
+                                "AVS_ARGS:${'$'}{linkTask.name}:" +
+                                    linkTask.toolOptions.freeCompilerArgs.get().joinToString("|")
+                            )
+                            println(
+                                "AVS_DEP:${'$'}{linkTask.name}:" +
+                                    linkTask.dependsOn.joinToString("|")
+                            )
+                            println(
+                                "AVS_STAGE:${'$'}{linkTask.name}:" +
+                                    linkTask.finalizedBy.getDependencies(linkTask)
+                                        .joinToString("|") { it.name }
+                            )
+                        }
+                }
+            }
+            """.trimIndent()
+    }
+}

--- a/plugins/apple-avs-runtime/src/test/kotlin/com/wire/kalium/gradle/avs/ExtractAvsDebugSymbolsTaskTest.kt
+++ b/plugins/apple-avs-runtime/src/test/kotlin/com/wire/kalium/gradle/avs/ExtractAvsDebugSymbolsTaskTest.kt
@@ -1,0 +1,122 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.gradle.avs
+
+import org.gradle.api.GradleException
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import java.security.MessageDigest
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.readBytes
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class ExtractAvsDebugSymbolsTaskTest {
+    @TempDir
+    lateinit var temporaryDirectory: Path
+
+    @Test
+    fun givenVerifiedArchive_whenExtractingDebugSymbols_thenCopiesOnlyDsymEntries() {
+        val archive = createArchive(
+            mapOf(
+                "avs.xcframework/ios-arm64/dSYMs/avs.framework.dSYM/Contents/Resources/DWARF/avs" to
+                    "ios symbols",
+                "avs.xcframework/macos-arm64_x86_64/dSYMs/avs.framework.dSYM/Contents/Resources/DWARF/avs" to
+                    "macos symbols",
+                "avs.xcframework/ios-arm64/avs.framework/avs" to "runtime executable",
+                "unrelated.txt" to "unrelated",
+            )
+        )
+        val task = createTask(archive, archive.sha256())
+
+        task.extractVerifiedDebugSymbols()
+
+        val output = task.outputDirectory.get().asFile.toPath()
+        assertEquals(
+            "ios symbols",
+            output.resolve(
+                "avs.xcframework/ios-arm64/dSYMs/avs.framework.dSYM/Contents/Resources/DWARF/avs"
+            ).readText(),
+        )
+        assertEquals(
+            "macos symbols",
+            output.resolve(
+                "avs.xcframework/macos-arm64_x86_64/dSYMs/avs.framework.dSYM/Contents/Resources/DWARF/avs"
+            ).readText(),
+        )
+        assertFalse(output.resolve("avs.xcframework/ios-arm64/avs.framework/avs").exists())
+        assertFalse(output.resolve("unrelated.txt").exists())
+    }
+
+    @Test
+    fun givenCachedArchiveTamperedAfterPreparation_whenExtractingDebugSymbols_thenRejectsAndDeletesIt() {
+        val archive = createArchive(
+            mapOf("avs.xcframework/ios-arm64/dSYMs/avs.dSYM" to "symbols")
+        )
+        val task = createTask(archive, "0".repeat(64))
+
+        val failure = assertFailsWith<GradleException> {
+            task.extractVerifiedDebugSymbols()
+        }
+
+        assertTrue(failure.message.orEmpty().contains("Discarded the cached"))
+        assertFalse(archive.exists())
+        assertFalse(task.outputDirectory.get().asFile.exists())
+    }
+
+    private fun createTask(archive: Path, checksum: String): ExtractAvsDebugSymbolsTask {
+        val projectDirectory = temporaryDirectory.resolve("project").apply { createDirectories() }
+        val project = ProjectBuilder.builder().withProjectDir(projectDirectory.toFile()).build()
+        return project.tasks.register(
+            "extractAvsDebugSymbolsForTest",
+            ExtractAvsDebugSymbolsTask::class.java,
+        ).apply {
+            configure {
+                cachedArchive.set(archive.toFile())
+                expectedSha256.set(checksum)
+                outputDirectory.set(temporaryDirectory.resolve("debug-symbols").toFile())
+            }
+        }.get()
+    }
+
+    private fun createArchive(entries: Map<String, String>): Path =
+        temporaryDirectory.resolve("avs.xcframework.zip").apply {
+            ZipOutputStream(toFile().outputStream()).use { output ->
+                entries.forEach { (name, contents) ->
+                    output.putNextEntry(ZipEntry(name))
+                    output.write(contents.encodeToByteArray())
+                    output.closeEntry()
+                }
+            }
+        }
+}
+
+private fun Path.sha256(): String {
+    val digest = MessageDigest.getInstance("SHA-256").digest(readBytes())
+    return digest.joinToString("") { byte -> "%02x".format(byte) }
+}

--- a/plugins/apple-avs-runtime/src/test/kotlin/com/wire/kalium/gradle/avs/ExtractAvsXcframeworkTaskTest.kt
+++ b/plugins/apple-avs-runtime/src/test/kotlin/com/wire/kalium/gradle/avs/ExtractAvsXcframeworkTaskTest.kt
@@ -1,0 +1,226 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.gradle.avs
+
+import org.gradle.api.GradleException
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import java.security.MessageDigest
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.listDirectoryEntries
+import kotlin.io.path.readBytes
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+import kotlin.test.assertFalse
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+@EnabledOnOs(OS.MAC)
+class ExtractAvsXcframeworkTaskTest {
+    @TempDir
+    lateinit var temporaryDirectory: Path
+
+    @Test
+    fun givenVerifiedArchive_whenExtracting_thenPublishesOnlyCompleteRuntimeSlices() {
+        val archive = createAvsArchive()
+        val task = createExtractionTask(archive)
+
+        task.extractAndNormalize()
+
+        val destination = task.cachedXcframework.get().asFile.toPath()
+        AvsApplePlatform.entries.forEach { platform ->
+            assertTrue(
+                destination.resolve(
+                    "avs.xcframework/${platform.xcframeworkSlice}/avs.framework/avs"
+                ).exists()
+            )
+        }
+        assertFalse(destination.resolve("untrusted/unexpected-file").exists())
+        assertFalse(destination.resolve("avs.xcframework/ios-arm64/dSYMs/avs.dSYM").exists())
+        assertTrue(isFrameworkCacheReady(destination.toFile(), archive.sha256()))
+
+        val macosPlist = destination.resolve(
+            "avs.xcframework/${AvsApplePlatform.MACOS.xcframeworkSlice}/avs.framework/Info.plist"
+        ).readText()
+        assertTrue(macosPlist.contains("MacOSX"))
+        assertFalse(macosPlist.contains("MinimumOSVersion"))
+    }
+
+    @Test
+    fun givenIncompleteArchive_whenExtracting_thenFailsWithoutPublishingCacheEntry() {
+        val archive = createAvsArchive(
+            omittedEntry =
+            "avs.xcframework/${AvsApplePlatform.IOS_SIMULATOR.xcframeworkSlice}/avs.framework/avs"
+        )
+        val task = createExtractionTask(archive)
+
+        val failure = assertFailsWith<GradleException> {
+            task.extractAndNormalize()
+        }
+
+        assertTrue(failure.message.orEmpty().contains("is incomplete"))
+        assertFalse(task.cachedXcframework.get().asFile.exists())
+        assertTrue(
+            task.cachedXcframework.get().asFile.toPath().parent
+                .listDirectoryEntries("*.part-*")
+                .isEmpty()
+        )
+    }
+
+    @Test
+    fun givenArchiveWithTraversalEntries_whenExtracting_thenRejectsArchiveWithoutWritingOutsideCache() {
+        val archive = createAvsArchive(
+            additionalEntries = mapOf(
+                "../../outside-cache" to "escape attempt",
+                "avs.xcframework/../../outside-xcframework" to "escape attempt",
+                "untrusted/unexpected-file" to "unexpected",
+            )
+        )
+        val task = createExtractionTask(archive)
+
+        assertFailsWith<GradleException> {
+            task.extractAndNormalize()
+        }
+
+        assertFalse(temporaryDirectory.resolve("outside-cache").exists())
+        assertFalse(temporaryDirectory.resolve("outside-xcframework").exists())
+        assertFalse(task.cachedXcframework.get().asFile.exists())
+    }
+
+    @Test
+    fun givenCachedArchiveChangedAfterPreparation_whenExtracting_thenDeletesItAndRejectsExtraction() {
+        val archive = createAvsArchive()
+        val expectedChecksum = archive.sha256()
+        val task = createExtractionTask(archive, expectedChecksum)
+        archive.writeText("substituted after preparation")
+
+        assertFailsWith<GradleException> {
+            task.extractAndNormalize()
+        }
+
+        assertFalse(archive.exists())
+        assertFalse(task.cachedXcframework.get().asFile.exists())
+    }
+
+    @Test
+    fun givenConcurrentExtractionRequests_whenRunning_thenPublishesOneCompleteVerifiedCacheEntry() {
+        val archive = createAvsArchive()
+        val checksum = archive.sha256()
+        val tasks = listOf(
+            createExtractionTask(archive, checksum, taskIndex = 1),
+            createExtractionTask(archive, checksum, taskIndex = 2),
+        )
+        val executor = Executors.newFixedThreadPool(tasks.size)
+
+        try {
+            executor.invokeAll(
+                tasks.map { task -> Callable { task.extractAndNormalize() } }
+            ).forEach { it.get() }
+        } finally {
+            executor.shutdownNow()
+        }
+
+        val destination = tasks.first().cachedXcframework.get().asFile
+        assertTrue(isFrameworkCacheReady(destination, checksum))
+        assertTrue(
+            destination.toPath().parent.listDirectoryEntries("*.part-*").isEmpty()
+        )
+    }
+
+    private fun createExtractionTask(
+        archive: Path,
+        expectedChecksum: String = archive.sha256(),
+        taskIndex: Int = 0,
+    ): ExtractAvsXcframeworkTask {
+        val projectDirectory = temporaryDirectory.resolve("project-$taskIndex").apply {
+            createDirectories()
+        }
+        val project = ProjectBuilder.builder()
+            .withProjectDir(projectDirectory.toFile())
+            .build()
+        return project.tasks.register(
+            "extractAvsXcframeworkForTest$taskIndex",
+            ExtractAvsXcframeworkTask::class.java,
+        ).apply {
+            configure {
+                expectedSha256.set(expectedChecksum)
+                cachedArchive.set(archive.toFile())
+                cachedXcframework.set(temporaryDirectory.resolve("framework-cache").toFile())
+                outputMarker.set(temporaryDirectory.resolve("state/frameworks-ready").toFile())
+            }
+        }.get()
+    }
+
+    private fun createAvsArchive(
+        omittedEntry: String? = null,
+        additionalEntries: Map<String, String> = emptyMap(),
+    ): Path {
+        val archive = temporaryDirectory.resolve("avs.xcframework.zip")
+        val entries = buildMap {
+            put("avs.xcframework/Info.plist", validPlist())
+            AvsApplePlatform.entries.forEach { platform ->
+                val framework =
+                    "avs.xcframework/${platform.xcframeworkSlice}/avs.framework"
+                put("$framework/Info.plist", validPlist())
+                put("$framework/avs", "${platform.name} executable")
+            }
+            put("avs.xcframework/ios-arm64/dSYMs/avs.dSYM", "debug symbols")
+            putAll(additionalEntries)
+            remove(omittedEntry)
+        }
+        ZipOutputStream(archive.toFile().outputStream()).use { output ->
+            entries.forEach { (name, contents) ->
+                output.putNextEntry(ZipEntry(name))
+                output.write(contents.encodeToByteArray())
+                output.closeEntry()
+            }
+        }
+        return archive
+    }
+
+    private fun validPlist(): String =
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>CFBundleIdentifier</key>
+            <string>com.wire.avs</string>
+            <key>CFBundleSupportedPlatforms</key>
+            <array><string>iPhoneOS</string></array>
+            <key>MinimumOSVersion</key>
+            <string>14.0</string>
+        </dict>
+        </plist>
+        """.trimIndent()
+}
+
+private fun Path.sha256(): String {
+    val digest = MessageDigest.getInstance("SHA-256").digest(readBytes())
+    return digest.joinToString("") { byte -> "%02x".format(byte) }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-27766
<!--jira-description-action-hidden-marker-end-->
## Stack

- Depends on #4362
- PR 2 of 2

## Goal

Add focused functional and security coverage for the Apple AVS dynamic runtime introduced by the parent PR.

## Changes

- cover local and remote archive verification, redirect handling, cache replacement, and concurrent preparation
- cover extracted-framework integrity, incomplete archives, path traversal rejection, and concurrent extraction
- verify Gradle plugin task registration, pinned metadata, Apple linker wiring, staging, and removal of the AVS opt-out
- verify checksum-protected dSYM extraction
- add a native Apple smoke test that initializes the real AVS runtime repeatedly

## Impact

This PR contains test code only. It validates the parent runtime integration without changing production behavior.
