### PR TITLE
feat: pass meeting flag to AVS when starting call or receiving message [WPB-25067]

### DIFF
--- a/domain/calling/src/appleAvsMain/kotlin/com/wire/kalium/calling/AppleAvs.kt
+++ b/domain/calling/src/appleAvsMain/kotlin/com/wire/kalium/calling/AppleAvs.kt
@@ -308,7 +308,8 @@ private object AppleAvsBridgeImpl : AppleAvsBridge {
         conversationId: String,
         senderUserId: String,
         senderClientId: String,
-        conversationType: Int
+        conversationType: Int,
+        meeting: Boolean
     ): Boolean {
         if (!startIfAvailable()) return false
         if (payload.isEmpty()) return false
@@ -325,7 +326,7 @@ private object AppleAvsBridgeImpl : AppleAvsBridge {
                     userid = senderUserId,
                     clientid = senderClientId,
                     conv_type = conversationType,
-                    meeting = 0
+                    meeting = meeting.toAvsInt()
                 )
             }
             true
@@ -351,8 +352,22 @@ private object AppleAvsBridgeImpl : AppleAvsBridge {
         wcall_config_update(handle, error, json)
     }
 
-    override fun startCall(handle: UInt, conversationId: String, callType: Int, conversationType: Int, audioCbr: Boolean): Int =
-        if (startIfAvailable()) wcall_start(handle, conversationId, callType, conversationType, audioCbr.toAvsInt(), 0) else -1
+    override fun startCall(
+        handle: UInt,
+        conversationId: String,
+        callType: Int,
+        conversationType: Int,
+        audioCbr: Boolean,
+        meeting: Boolean
+    ): Int =
+        if (startIfAvailable()) wcall_start(
+            wuser = handle,
+            convid = conversationId,
+            call_type = callType,
+            conv_type = conversationType,
+            audio_cbr = audioCbr.toAvsInt(),
+            meeting = meeting.toAvsInt()
+        ) else -1
 
     override fun answerCall(handle: UInt, conversationId: String, callType: Int, audioCbr: Boolean): Int =
         if (startIfAvailable()) wcall_answer(handle, conversationId, callType, audioCbr.toAvsInt()) else -1

--- a/domain/calling/src/appleMain/kotlin/com/wire/kalium/calling/AppleAvsBridge.kt
+++ b/domain/calling/src/appleMain/kotlin/com/wire/kalium/calling/AppleAvsBridge.kt
@@ -34,12 +34,13 @@ interface AppleAvsBridge {
         conversationId: String,
         senderUserId: String,
         senderClientId: String,
-        conversationType: Int
+        conversationType: Int,
+        meeting: Boolean
     ): Boolean
     fun respondToSend(handle: UInt, status: Int, reason: String, context: COpaquePointer?)
     fun respondToSft(handle: UInt, error: Int, data: ByteArray, context: COpaquePointer?)
     fun updateConfig(handle: UInt, error: Int, json: String)
-    fun startCall(handle: UInt, conversationId: String, callType: Int, conversationType: Int, audioCbr: Boolean): Int
+    fun startCall(handle: UInt, conversationId: String, callType: Int, conversationType: Int, audioCbr: Boolean, meeting: Boolean): Int
     fun answerCall(handle: UInt, conversationId: String, callType: Int, audioCbr: Boolean): Int
     fun endCall(handle: UInt, conversationId: String)
     fun rejectCall(handle: UInt, conversationId: String): Int

--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -169,7 +169,7 @@ internal class CallManagerImpl internal constructor(
         } else {
             message.conversationId
         }
-        val callConversationType = getCallConversationType(targetConversationId)
+        val (callConversationType, isMeeting) = getCallConversationType(targetConversationId)
         val type = callMapper.toConversationType(callConversationType)
         val received = AppleAvs.bridge.receiveCallingMessage(
             handle = handle,
@@ -179,7 +179,8 @@ internal class CallManagerImpl internal constructor(
             conversationId = federatedIdMapper.parseToFederatedId(targetConversationId),
             senderUserId = federatedIdMapper.parseToFederatedId(message.senderUserId),
             senderClientId = message.senderClientId.value,
-            conversationType = callMapper.toConversationTypeCalling(type).avsValue
+            conversationType = callMapper.toConversationTypeCalling(type).avsValue,
+            meeting = isMeeting
         )
         callingLogger.i("$tagWithUserId: wcall_recv_msg() forwarded=$received")
     }
@@ -188,7 +189,8 @@ internal class CallManagerImpl internal constructor(
         conversationId: ConversationId,
         callType: CallType,
         conversationTypeCalling: ConversationTypeCalling,
-        isAudioCbr: Boolean
+        isAudioCbr: Boolean,
+        isMeeting: Boolean
     ) {
         callingLogger.d("$tagWithUserId: starting call for conversationId: ${conversationId.toLogString()}..")
         val isCameraOn = callType == CallType.VIDEO
@@ -212,7 +214,8 @@ internal class CallManagerImpl internal constructor(
                     conversationId = federatedIdMapper.parseToFederatedId(conversationId),
                     callType = avsCallType.avsValue,
                     conversationType = conversationTypeCalling.avsValue,
-                    audioCbr = isAudioCbr
+                    audioCbr = isAudioCbr,
+                    meeting = isMeeting
                 )
                 callingLogger.d("$tagWithUserId: wcall_start() called -> ${conversationId.toLogString()}")
             }

--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/GlobalCallManager.kt
@@ -145,6 +145,7 @@ private object DisabledAppleCallManager : CallManager {
         callType: CallType,
         conversationTypeCalling: ConversationTypeCalling,
         isAudioCbr: Boolean,
+        isMeeting: Boolean
     ) = Unit
 
     override suspend fun answerCall(conversationId: ConversationId, isAudioCbr: Boolean, isVideoCall: Boolean) = Unit

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -261,7 +261,7 @@ internal class CallManagerImpl internal constructor(
         } else {
             message.conversationId
         }
-        val callConversationType = getCallConversationType(targetConversationId)
+        val (callConversationType, isMeeting) = getCallConversationType(targetConversationId)
         val type = callMapper.toConversationType(callConversationType)
 
         wcall_recv_msg(
@@ -274,7 +274,7 @@ internal class CallManagerImpl internal constructor(
             userId = federatedIdMapper.parseToFederatedId(message.senderUserId),
             clientId = message.senderClientId.value,
             convType = callMapper.toConversationTypeCalling(type).avsValue,
-            meeting = false.toInt()
+            meeting = isMeeting.toInt()
         )
         callingLogger.i("$tagWithUserId: wcall_recv_msg() called")
     }
@@ -283,7 +283,8 @@ internal class CallManagerImpl internal constructor(
         conversationId: ConversationId,
         callType: CallType,
         conversationTypeCalling: ConversationTypeCalling,
-        isAudioCbr: Boolean
+        isAudioCbr: Boolean,
+        isMeeting: Boolean
     ) {
         callingLogger.d(
             "$tagWithUserId: starting call for conversationId: " +
@@ -316,7 +317,7 @@ internal class CallManagerImpl internal constructor(
                             callType = avsCallType.avsValue,
                             convType = conversationTypeCalling.avsValue,
                             audioCbr = isAudioCbr.toInt(),
-                            meeting = false.toInt()
+                            meeting = isMeeting.toInt()
                         )
                         callingLogger.d(
                             "$tagWithUserId: wcall_start() called -> Call for conversationId: " +
@@ -335,7 +336,7 @@ internal class CallManagerImpl internal constructor(
                     callType = avsCallType.avsValue,
                     convType = conversationTypeCalling.avsValue,
                     audioCbr = isAudioCbr.toInt(),
-                    meeting = false.toInt()
+                    meeting = isMeeting.toInt()
                 )
                 callingLogger.d(
                     "$tagWithUserId: wcall_start() called -> Call for conversationId: " +

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/util/DummyCallManager.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/util/DummyCallManager.kt
@@ -37,7 +37,8 @@ internal class DummyCallManager : CallManager {
         conversationId: ConversationId,
         callType: CallType,
         conversationTypeCalling: ConversationTypeCalling,
-        isAudioCbr: Boolean
+        isAudioCbr: Boolean,
+        isMeeting: Boolean
     ) {
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/CallManager.kt
@@ -39,7 +39,8 @@ internal interface CallManager {
         conversationId: ConversationId,
         callType: CallType,
         conversationTypeCalling: ConversationTypeCalling,
-        isAudioCbr: Boolean
+        isAudioCbr: Boolean,
+        isMeeting: Boolean
     )
 
     suspend fun answerCall(conversationId: ConversationId, isAudioCbr: Boolean, isVideoCall: Boolean = false)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetCallConversationTypeProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/GetCallConversationTypeProvider.kt
@@ -21,25 +21,32 @@ import com.wire.kalium.calling.ConversationTypeCalling
 import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
-import com.wire.kalium.logic.configuration.UserConfigRepository
-import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.common.functional.fold
+import com.wire.kalium.common.functional.map
 import com.wire.kalium.common.functional.right
+import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationMetaDataRepository
+import com.wire.kalium.logic.data.id.ConversationId
 
 /**
  * This class is responsible for providing the conversation type for a call.
  */
 internal interface GetCallConversationTypeProvider {
-    suspend operator fun invoke(conversationId: ConversationId): ConversationTypeCalling
+    suspend operator fun invoke(conversationId: ConversationId): Result
+
+    data class Result(val conversationTypeCalling: ConversationTypeCalling, val isMeeting: Boolean) {
+        companion object {
+            val Unknown = Result(ConversationTypeCalling.Unknown, false)
+        }
+    }
 }
 
 internal class GetCallConversationTypeProviderImpl(
     private val userConfigRepository: UserConfigRepository,
     private val conversationMetaDataRepository: ConversationMetaDataRepository,
 ) : GetCallConversationTypeProvider {
-    override suspend fun invoke(conversationId: ConversationId): ConversationTypeCalling {
+    override suspend fun invoke(conversationId: ConversationId): GetCallConversationTypeProvider.Result {
         return conversationMetaDataRepository.getConversationTypeAndProtocolInfo(conversationId)
             .flatMap { (type: Conversation.Type, protocolInfo: Conversation.ProtocolInfo) ->
                 when (type) {
@@ -55,9 +62,14 @@ internal class GetCallConversationTypeProviderImpl(
                     Conversation.Type.Self -> {
                         ConversationTypeCalling.Unknown.right()
                     }
+                }.map { conversationTypeCalling ->
+                    GetCallConversationTypeProvider.Result(
+                        conversationTypeCalling = conversationTypeCalling,
+                        isMeeting = type is Conversation.Type.Group.Meeting
+                    )
                 }
             }.fold(
-                { ConversationTypeCalling.Unknown },
+                { GetCallConversationTypeProvider.Result.Unknown },
                 { it }
             )
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/StartCallUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/StartCallUseCase.kt
@@ -63,13 +63,14 @@ public class StartCallUseCase internal constructor(
                 }
             }
 
-            val callConversationType = getCallConversationType(conversationId)
+            val (callConversationType, isMeeting) = getCallConversationType(conversationId)
 
             callManager.value.startCall(
                 conversationId = conversationId,
                 callType = callType,
                 conversationTypeCalling = callConversationType,
-                isAudioCbr = kaliumConfigs.forceConstantBitrateCalls
+                isAudioCbr = kaliumConfigs.forceConstantBitrateCalls,
+                isMeeting = isMeeting
             )
             return@withContext Result.Success
         })

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/GetCallConversationTypeProviderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/GetCallConversationTypeProviderTest.kt
@@ -33,7 +33,7 @@ class GetCallConversationTypeProviderTest {
                     groupId = GroupID("groupId"),
                     groupState = Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED,
                     epoch = 1.toULong(),
-                    cipherSuite = CipherSuite.Companion.fromTag(1),
+                    cipherSuite = CipherSuite.fromTag(1),
                     keyingMaterialLastUpdate = kotlinx.datetime.Instant.DISTANT_PAST
                 )
             )
@@ -43,7 +43,32 @@ class GetCallConversationTypeProviderTest {
         val result = provider(ConversationId("some-id", "some-domain"))
 
         // Then
-        assertEquals(ConversationTypeCalling.ConferenceMls, result)
+        assertEquals(GetCallConversationTypeProvider.Result(ConversationTypeCalling.ConferenceMls, false), result)
+        verifySuspend(VerifyMode.exactly(1)) { arrangement.conversationMetaDataRepository.getConversationTypeAndProtocolInfo(any()) }
+        verifySuspend(VerifyMode.not) { arrangement.userConfigRepository.shouldUseSFTForOneOnOneCalls() }
+    }
+
+    @Test
+    fun givenMeetingConversationWithMLSProtocol_whenGettingCallType_thenReturnConferenceMlsWithMeetingFlag() = runTest {
+        // Given
+        val (arrangement, provider) = arrange {
+            withGetConversationTypeAndProtocolInfoSuccess(
+                type = Conversation.Type.Group.Meeting,
+                protocolInfo = Conversation.ProtocolInfo.MLS(
+                    groupId = GroupID("groupId"),
+                    groupState = Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED,
+                    epoch = 1.toULong(),
+                    cipherSuite = CipherSuite.fromTag(1),
+                    keyingMaterialLastUpdate = kotlinx.datetime.Instant.DISTANT_PAST
+                )
+            )
+        }
+
+        // When
+        val result = provider(ConversationId("some-id", "some-domain"))
+
+        // Then
+        assertEquals(GetCallConversationTypeProvider.Result(ConversationTypeCalling.ConferenceMls, true), result)
         verifySuspend(VerifyMode.exactly(1)) { arrangement.conversationMetaDataRepository.getConversationTypeAndProtocolInfo(any()) }
         verifySuspend(VerifyMode.not) { arrangement.userConfigRepository.shouldUseSFTForOneOnOneCalls() }
     }
@@ -63,7 +88,7 @@ class GetCallConversationTypeProviderTest {
         val result = provider(ConversationId("some-id", "some-domain"))
 
         // Then
-        assertEquals(ConversationTypeCalling.OneOnOne, result)
+        assertEquals(GetCallConversationTypeProvider.Result(ConversationTypeCalling.OneOnOne, false), result)
         verifySuspend(VerifyMode.exactly(1)) { arrangement.conversationMetaDataRepository.getConversationTypeAndProtocolInfo(any()) }
         verifySuspend(VerifyMode.exactly(1)) { arrangement.userConfigRepository.shouldUseSFTForOneOnOneCalls() }
     }
@@ -83,7 +108,7 @@ class GetCallConversationTypeProviderTest {
         val result = provider(ConversationId("some-id", "some-domain"))
 
         // Then
-        assertEquals(ConversationTypeCalling.Conference, result)
+        assertEquals(GetCallConversationTypeProvider.Result(ConversationTypeCalling.Conference, false), result)
         verifySuspend(VerifyMode.exactly(1)) { arrangement.conversationMetaDataRepository.getConversationTypeAndProtocolInfo(any()) }
         verifySuspend(VerifyMode.exactly(1)) { arrangement.userConfigRepository.shouldUseSFTForOneOnOneCalls() }
     }
@@ -102,7 +127,7 @@ class GetCallConversationTypeProviderTest {
         val result = provider(ConversationId("some-id", "some-domain"))
 
         // Then
-        assertEquals(ConversationTypeCalling.Unknown, result)
+        assertEquals(GetCallConversationTypeProvider.Result.Unknown, result)
         verifySuspend(VerifyMode.exactly(1)) { arrangement.conversationMetaDataRepository.getConversationTypeAndProtocolInfo(any()) }
         verifySuspend(VerifyMode.not) { arrangement.userConfigRepository.shouldUseSFTForOneOnOneCalls() }
     }
@@ -122,7 +147,7 @@ class GetCallConversationTypeProviderTest {
         val result = provider(ConversationId("some-id", "some-domain"))
 
         // Then
-        assertEquals(ConversationTypeCalling.Unknown, result)
+        assertEquals(GetCallConversationTypeProvider.Result.Unknown, result)
         verifySuspend(VerifyMode.exactly(1)) { arrangement.conversationMetaDataRepository.getConversationTypeAndProtocolInfo(any()) }
         verifySuspend(VerifyMode.exactly(1)) { arrangement.userConfigRepository.shouldUseSFTForOneOnOneCalls() }
     }
@@ -141,7 +166,7 @@ class GetCallConversationTypeProviderTest {
         val result = provider(ConversationId("some-id", "some-domain"))
 
         // Then
-        assertEquals(ConversationTypeCalling.Unknown, result)
+        assertEquals(GetCallConversationTypeProvider.Result.Unknown, result)
         verifySuspend(VerifyMode.exactly(1)) { arrangement.conversationMetaDataRepository.getConversationTypeAndProtocolInfo(any()) }
         verifySuspend(VerifyMode.not) { arrangement.userConfigRepository.shouldUseSFTForOneOnOneCalls() }
     }
@@ -156,7 +181,7 @@ class GetCallConversationTypeProviderTest {
                     groupId = GroupID("groupId"),
                     groupState = Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED,
                     epoch = 1.toULong(),
-                    cipherSuite = CipherSuite.Companion.fromTag(1),
+                    cipherSuite = CipherSuite.fromTag(1),
                     keyingMaterialLastUpdate = kotlinx.datetime.Instant.DISTANT_PAST
                 )
             )
@@ -166,14 +191,14 @@ class GetCallConversationTypeProviderTest {
         val result = provider(ConversationId("some-id", "some-domain"))
 
         // Then
-        assertEquals(ConversationTypeCalling.Conference, result)
+        assertEquals(GetCallConversationTypeProvider.Result(ConversationTypeCalling.Conference, false), result)
         verifySuspend(VerifyMode.exactly(1)) { arrangement.conversationMetaDataRepository.getConversationTypeAndProtocolInfo(any()) }
         verifySuspend(VerifyMode.not) { arrangement.userConfigRepository.shouldUseSFTForOneOnOneCalls() }
     }
 
     @Test
     fun givenGroupConversationWithProteusProtocol_whenGettingCallType_thenReturnConference() = runTest {
-        val (arrangement, getCallConversationType) = arrange {
+        val (_, getCallConversationType) = arrange {
             withGetConversationTypeAndProtocolInfoSuccess(
                 type = Conversation.Type.Group.Regular,
                 protocolInfo = Conversation.ProtocolInfo.Proteus
@@ -182,12 +207,12 @@ class GetCallConversationTypeProviderTest {
 
         val result = getCallConversationType(ConversationId("some-id", "some-domain"))
 
-        assertEquals(ConversationTypeCalling.Conference, result)
+        assertEquals(GetCallConversationTypeProvider.Result(ConversationTypeCalling.Conference, false), result)
     }
 
     @Test
     fun givenChannelWithProteusProtocol_whenGettingCallType_thenReturnConference() = runTest {
-        val (arrangement, getCallConversationType) = arrange {
+        val (_, getCallConversationType) = arrange {
             withGetConversationTypeAndProtocolInfoSuccess(
                 type = Conversation.Type.Group.Channel,
                 protocolInfo = Conversation.ProtocolInfo.Proteus
@@ -196,19 +221,19 @@ class GetCallConversationTypeProviderTest {
 
         val result = getCallConversationType(ConversationId("some-id", "some-domain"))
 
-        assertEquals(ConversationTypeCalling.Conference, result)
+        assertEquals(GetCallConversationTypeProvider.Result(ConversationTypeCalling.Conference, false), result)
     }
 
     @Test
     fun givenOneOnOneMLSConversationWithSFTEnabled_whenGettingCallType_thenReturnConferenceMls() = runTest {
-        val (arrangement, getCallConversationType) = arrange {
+        val (_, getCallConversationType) = arrange {
             withGetConversationTypeAndProtocolInfoSuccess(
                 type = Conversation.Type.OneOnOne,
                 protocolInfo = Conversation.ProtocolInfo.MLS(
                     groupId = GroupID("groupId"),
                     groupState = Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED,
                     epoch = 1.toULong(),
-                    cipherSuite = CipherSuite.Companion.fromTag(1),
+                    cipherSuite = CipherSuite.fromTag(1),
                     keyingMaterialLastUpdate = kotlinx.datetime.Instant.DISTANT_PAST
                 )
             )
@@ -217,18 +242,18 @@ class GetCallConversationTypeProviderTest {
 
         val result = getCallConversationType(ConversationId("some-id", "some-domain"))
 
-        assertEquals(ConversationTypeCalling.ConferenceMls, result)
+        assertEquals(GetCallConversationTypeProvider.Result(ConversationTypeCalling.ConferenceMls, false), result)
     }
 
     @Test
     fun givenGetConversationTypeAndProtocolInfoFails_whenGettingCallType_thenReturnUnknown() = runTest {
-        val (arrangement, getCallConversationType) = arrange {
+        val (_, getCallConversationType) = arrange {
             withGetConversationTypeAndProtocolInfoFailure(Either.Left(StorageFailure.DataNotFound))
         }
 
         val result = getCallConversationType(ConversationId("some-id", "some-domain"))
 
-        assertEquals(ConversationTypeCalling.Unknown, result)
+        assertEquals(GetCallConversationTypeProvider.Result.Unknown, result)
     }
 
     private class Arrangement {
@@ -240,15 +265,15 @@ class GetCallConversationTypeProviderTest {
             conversationMetaDataRepository = conversationMetaDataRepository
         )
 
-        suspend fun withShouldUseSFTForOneOnOneCalls() = apply {
+        fun withShouldUseSFTForOneOnOneCalls() = apply {
             everySuspend { userConfigRepository.shouldUseSFTForOneOnOneCalls() } returns (Either.Right(true))
         }
 
-        suspend fun withShouldNotUseSFTForOneOnOneCalls() = apply {
+        fun withShouldNotUseSFTForOneOnOneCalls() = apply {
             everySuspend { userConfigRepository.shouldUseSFTForOneOnOneCalls() } returns (Either.Right(false))
         }
 
-        suspend fun withGetConversationTypeAndProtocolInfoSuccess(
+        fun withGetConversationTypeAndProtocolInfoSuccess(
             type: Conversation.Type,
             protocolInfo: Conversation.ProtocolInfo
         ) = apply {
@@ -257,13 +282,13 @@ class GetCallConversationTypeProviderTest {
             } returns (Either.Right(Pair(type, protocolInfo)))
         }
 
-        suspend fun withSFTCheckFailure() = apply {
+        fun withSFTCheckFailure() = apply {
             everySuspend {
                 userConfigRepository.shouldUseSFTForOneOnOneCalls()
             } returns (Either.Left(StorageFailure.DataNotFound))
         }
 
-        suspend fun withGetConversationTypeAndProtocolInfoFailure(result: Either.Left<StorageFailure>) {
+        fun withGetConversationTypeAndProtocolInfoFailure(result: Either.Left<StorageFailure>) {
             everySuspend {
                 conversationMetaDataRepository.getConversationTypeAndProtocolInfo(any())
             } returns (result)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/StartCallUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/StartCallUseCaseTest.kt
@@ -22,37 +22,39 @@ import com.wire.kalium.calling.ConversationTypeCalling
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.MockConversation
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.CallType
 import com.wire.kalium.logic.feature.call.CallManager
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.framework.TestCall
-import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.sync.SyncStateObserver
-import com.wire.kalium.logic.test_util.TestKaliumDispatcher
 import com.wire.kalium.logic.test_util.testKaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcher
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
-import dev.mokkery.verify.VerifyMode
-import dev.mokkery.matcher.any
 import dev.mokkery.everySuspend
-import dev.mokkery.verifySuspend
-import dev.mokkery.matcher.eq
+import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertIs
 
 class StartCallUseCaseTest {
 
+    private fun TestScope.testDispatcher(): KaliumDispatcher = StandardTestDispatcher(testScheduler).testKaliumDispatcher()
+
     @Test
     fun givenAnIncomingCall_whenStartingANewCall_thenAnswerCallUseCaseShouldBeInvokedOnce() =
         runTest {
-            val conversationId = TestConversation.ID
+            val conversationId = MockConversation.ID
 
-            val (arrangement, startCall) = Arrangement(testKaliumDispatcher)
+            val (arrangement, startCall) = Arrangement(testDispatcher())
                 .withWaitingForSyncSucceeding()
                 .withAnIncomingCall()
                 .withCallConversationTypeUseCaseReturning(ConversationTypeCalling.Conference)
@@ -61,19 +63,19 @@ class StartCallUseCaseTest {
             startCall.invoke(conversationId)
 
             verifySuspend(VerifyMode.exactly(1)) {
-                arrangement.answerCall.invoke(eq(conversationId))
+                arrangement.answerCall.invoke(conversationId)
             }
 
             verifySuspend(VerifyMode.not) {
-                arrangement.callManager.startCall(any(), any(), any(), any())
+                arrangement.callManager.startCall(any(), any(), any(), any(), any())
             }
         }
 
     @Test
     fun givenCallingParamsAndSyncSucceeds_whenRunningUseCase_thenInvokeStartCallOnce() = runTest {
-        val conversationId = TestConversation.ID
+        val conversationId = MockConversation.ID
 
-        val (arrangement, startCall) = Arrangement(testKaliumDispatcher)
+        val (arrangement, startCall) = Arrangement(testDispatcher())
             .withWaitingForSyncSucceeding()
             .withNoIncomingCall()
             .withCallConversationTypeUseCaseReturning(ConversationTypeCalling.Conference)
@@ -82,7 +84,7 @@ class StartCallUseCaseTest {
         startCall.invoke(conversationId, CallType.AUDIO)
 
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.callManager.startCall(eq(conversationId), eq(CallType.AUDIO), any(), eq(false))
+            arrangement.callManager.startCall(conversationId, CallType.AUDIO, any(), false, false)
         }
 
         verifySuspend(VerifyMode.not) {
@@ -92,9 +94,9 @@ class StartCallUseCaseTest {
 
     @Test
     fun givenCallingParamsAndSyncSucceeds_whenRunningUseCase_thenReturnSuccess() = runTest {
-        val conversationId = TestConversation.ID
+        val conversationId = MockConversation.ID
 
-        val (arrangement, startCall) = Arrangement(testKaliumDispatcher)
+        val (arrangement, startCall) = Arrangement(testDispatcher())
             .withWaitingForSyncSucceeding()
             .withNoIncomingCall()
             .withCallConversationTypeUseCaseReturning(ConversationTypeCalling.Conference)
@@ -110,9 +112,9 @@ class StartCallUseCaseTest {
 
     @Test
     fun givenCallingParamsAndSyncFails_whenRunningUseCase_thenStartCallIsNotInvoked() = runTest {
-        val conversationId = TestConversation.ID
+        val conversationId = MockConversation.ID
 
-        val (arrangement, startCall) = Arrangement(testKaliumDispatcher)
+        val (arrangement, startCall) = Arrangement(testDispatcher())
             .withWaitingForSyncFailing()
             .withCallConversationTypeUseCaseReturning(ConversationTypeCalling.OneOnOne)
             .arrange()
@@ -120,15 +122,15 @@ class StartCallUseCaseTest {
         startCall.invoke(conversationId, CallType.AUDIO)
 
         verifySuspend(VerifyMode.not) {
-            arrangement.callManager.startCall(any(), any(), any(), any())
+            arrangement.callManager.startCall(any(), any(), any(), any(), any())
         }
     }
 
     @Test
     fun givenCallingParamsAndSyncFails_whenRunningUseCase_thenShouldReturnSyncFailure() = runTest {
-        val conversationId = TestConversation.ID
+        val conversationId = MockConversation.ID
 
-        val (_, startCall) = Arrangement(testKaliumDispatcher)
+        val (_, startCall) = Arrangement(testDispatcher())
             .withWaitingForSyncFailing()
             .arrange()
 
@@ -138,10 +140,30 @@ class StartCallUseCaseTest {
     }
 
     @Test
-    fun givenCbrEnabled_WhenStartingACall_thenStartTheCallOnCBR() = runTest {
-        val conversationId = TestConversation.ID
+    fun givenMeetingConversation_whenRunningUseCase_thenStartCallReceivesMeetingFlag() = runTest {
+        val conversationId = MockConversation.ID
 
-        val (arrangement, startCall) = Arrangement(testKaliumDispatcher)
+        val (arrangement, startCall) = Arrangement(testDispatcher())
+            .withWaitingForSyncSucceeding()
+            .withNoIncomingCall()
+            .withCallConversationTypeUseCaseReturning(ConversationTypeCalling.ConferenceMls, isMeeting = true)
+            .arrange()
+
+        startCall.invoke(conversationId, CallType.AUDIO)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.callManager.startCall(conversationId, CallType.AUDIO, any(), false, true)
+        }
+        verifySuspend(VerifyMode.not) {
+            arrangement.answerCall.invoke(any())
+        }
+    }
+
+    @Test
+    fun givenCbrEnabled_WhenStartingACall_thenStartTheCallOnCBR() = runTest {
+        val conversationId = MockConversation.ID
+
+        val (arrangement, startCall) = Arrangement(testDispatcher())
             .withWaitingForSyncSucceeding()
             .withNoIncomingCall()
             .withCallConversationTypeUseCaseReturning(ConversationTypeCalling.Conference)
@@ -150,14 +172,14 @@ class StartCallUseCaseTest {
         startCall.invoke(conversationId, CallType.AUDIO)
 
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.callManager.startCall(eq(conversationId), eq(CallType.AUDIO), any(), eq(true))
+            arrangement.callManager.startCall(conversationId, CallType.AUDIO, any(), true, false)
         }
         verifySuspend(VerifyMode.not) {
             arrangement.answerCall.invoke(any())
         }
     }
 
-    private class Arrangement(private var dispatcher: KaliumDispatcher = TestKaliumDispatcher) {
+    private class Arrangement(dispatcher: KaliumDispatcher) {
         val callManager = mock<CallManager>(mode = MockMode.autoUnit)
         val syncStateObserver = mock<SyncStateObserver>(mode = MockMode.autoUnit)
         val answerCall = mock<AnswerCallUseCase>(mode = MockMode.autoUnit)
@@ -186,29 +208,29 @@ class StartCallUseCaseTest {
             dispatcher
         )
 
-        suspend fun withWaitingForSyncSucceeding() = withSyncReturning(Either.Right(Unit))
-        suspend fun withAnIncomingCall() = apply {
+        fun withWaitingForSyncSucceeding() = withSyncReturning(Either.Right(Unit))
+        fun withAnIncomingCall() = apply {
             everySuspend {
                 callRepository.incomingCallsFlow()
-            } returns (flowOf(listOf(TestCall.groupIncomingCall(TestConversation.ID))))
+            } returns (flowOf(listOf(TestCall.groupIncomingCall(MockConversation.ID))))
         }
 
-        suspend fun withCallConversationTypeUseCaseReturning(result: ConversationTypeCalling) = apply {
+        fun withCallConversationTypeUseCaseReturning(type: ConversationTypeCalling, isMeeting: Boolean = false) = apply {
             everySuspend {
                 getCallConversationType.invoke(any())
-            } returns (result)
+            } returns (GetCallConversationTypeProvider.Result(type, isMeeting))
         }
 
-        suspend fun withNoIncomingCall() = apply {
+        fun withNoIncomingCall() = apply {
             everySuspend {
                 callRepository.incomingCallsFlow()
             } returns (flowOf(listOf()))
         }
 
-        suspend fun withWaitingForSyncFailing() =
+        fun withWaitingForSyncFailing() =
             withSyncReturning(Either.Left(NetworkFailure.NoNetworkConnection(null)))
 
-        private suspend fun withSyncReturning(result: Either<CoreFailure, Unit>) = apply {
+        private fun withSyncReturning(result: Either<CoreFailure, Unit>) = apply {
             everySuspend {
                 syncStateObserver.waitUntilLiveOrFailure()
             } returns (result)

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/CallManagerTest.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.logic.feature.call
 
 import com.wire.kalium.calling.Calling
+import com.wire.kalium.calling.CallTypeCalling
 import com.wire.kalium.calling.ConversationTypeCalling
 import com.wire.kalium.calling.callbacks.ReadyHandler
 import com.wire.kalium.calling.types.Handle
@@ -30,6 +31,7 @@ import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.call.CallMetadata
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.CallStatus
+import com.wire.kalium.logic.data.call.CallType
 import com.wire.kalium.logic.data.call.VideoStateChecker
 import com.wire.kalium.logic.data.call.mapper.CallMapperImpl
 import com.wire.kalium.logic.data.conversation.ClientId
@@ -111,8 +113,63 @@ internal class CallManagerTest {
                 CALL_CONV_ID.toString(),
                 USER_ID.toString(),
                 CLIENT_ID.value,
+                ConversationTypeCalling.Conference.avsValue,
+                0
+            )
+        }
+    }
+
+    @Test
+    @Suppress("FunctionNaming") // native function has that name
+    fun givenCallManager_whenCallingMessageIsReceivedForMeeting_then_wcall_recv_msg_IsCalledWithMeetingFlag() = runTest {
+        val (arrangement, callManager) = Arrangement(testDispatcher.testKaliumDispatcher())
+            .onGetCallConversationTypeReturning(ConversationTypeCalling.ConferenceMls, isMeeting = true)
+            .arrange()
+        callManager.waitUntilInitialized()
+
+        callManager.onCallingMessageReceived(content = CALL_CONTENT, message = CALL_MESSAGE,)
+
+        verify(VerifyMode.exactly(1)) {
+            arrangement.calling.wcall_recv_msg(
+                BASE_HANDLE,
+                matches { it.contentEquals(CALL_CONTENT.value.toByteArray()) },
+                CALL_CONTENT.value.toByteArray().size,
                 any(),
-                any()
+                any(),
+                CALL_CONV_ID.toString(),
+                USER_ID.toString(),
+                CLIENT_ID.value,
+                ConversationTypeCalling.ConferenceMls.avsValue,
+                1
+            )
+        }
+    }
+
+    @Test
+    @Suppress("FunctionNaming") // native function has that name
+    fun givenMeetingCallManager_whenStartingCallForMeeting_then_wcall_start_IsCalledWithMeetingFlag() = runTest {
+        val (arrangement, callManager) = Arrangement(testDispatcher.testKaliumDispatcher())
+            .withCreateCallReturning()
+            .withCallMetadataReturning(CALL_CONV_ID, CALL_METADATA)
+            .onWcallStartReturning(0)
+            .arrange()
+
+        callManager.startCall(
+            conversationId = CALL_CONV_ID,
+            callType = CallType.AUDIO,
+            conversationTypeCalling = ConversationTypeCalling.ConferenceMls,
+            isAudioCbr = false,
+            isMeeting = true
+        )
+
+        verify(VerifyMode.exactly(1)) {
+            arrangement.calling.wcall_start(
+                inst = BASE_HANDLE,
+                conversationId = CALL_CONV_ID.toString(),
+                callType = CallTypeCalling.AUDIO.avsValue,
+                convType = ConversationTypeCalling.ConferenceMls.avsValue,
+                audioCbr = 0,
+                meeting = 1
             )
         }
     }
@@ -213,8 +270,18 @@ internal class CallManagerTest {
             every { calling.wcall_recv_msg(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns result
         }
 
-        fun onGetCallConversationTypeReturning(result: ConversationTypeCalling) = apply {
-            everySuspend { getCallConversationType(any()) } returns result
+        fun onWcallStartReturning(result: Int) = apply {
+            every { calling.wcall_start(any(), any(), any(), any(), any(), any()) } returns result
+        }
+
+        fun onGetCallConversationTypeReturning(result: ConversationTypeCalling, isMeeting: Boolean = false) = apply {
+            everySuspend { getCallConversationType(any()) } returns GetCallConversationTypeProvider.Result(result, isMeeting)
+        }
+
+        fun withCreateCallReturning() = apply {
+            everySuspend {
+                callRepository.createCall(any(), any(), any(), any(), any(), any(), any())
+            } returns Unit
         }
 
         fun withFetchServerTimeReturning() = apply {
@@ -225,7 +292,7 @@ internal class CallManagerTest {
             everySuspend { callRepository.getCallMetadata(conversationId) } returns callMetadata
         }
 
-        suspend fun arrange() = this to CallManagerImpl(
+        fun arrange() = this to CallManagerImpl(
             calling = calling,
             callRepository = callRepository,
             currentClientIdProvider = currentClientIdProvider,
@@ -246,7 +313,9 @@ internal class CallManagerTest {
             flowManagerService = flowManagerService,
             createAndPersistRecentlyEndedCallMetadata = createAndPersistRecentlyEndedCallMetadata,
             selfUserId = selfUserId
-        ).also {
+        )
+
+        init {
             onCurrentClientIdReturning(CLIENT_ID.right())
             onParseToFederatedIdReturning(selfUserId, selfUserId.toString())
             onParseToFederatedIdReturning(USER_ID, USER_ID.toString())


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25067
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

In order to handle calls for meetings, we need to pass `meeting: Boolean` flag to AVS when starting a call for a meeting and when receiving and handling a calling message for meeting. This way, it can be handled properly in AVS and client can receive incoming call with proper parameters (i.e. `shouldRing`).

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
