### PR TITLE
fix(calling): forward Apple AVS diagnostic logs [WPB-8645]

### DIFF
--- a/changelog.d/apple-avs-log-callback.added.md
+++ b/changelog.d/apple-avs-log-callback.added.md
@@ -1,0 +1,5 @@
+Added Apple AVS diagnostic log forwarding through Kalium's calling logger.
+
+  - ABI: additive.
+  - Source: additive.
+  - Behavior: Apple AVS logs are emitted with an `[AVS]` prefix.

--- a/domain/calling/src/appleAvsMain/kotlin/com/wire/kalium/calling/AppleAvs.kt
+++ b/domain/calling/src/appleAvsMain/kotlin/com/wire/kalium/calling/AppleAvs.kt
@@ -36,6 +36,7 @@ import avs.wcall_set_background
 import avs.wcall_set_clients_for_conv
 import avs.wcall_set_epoch_info
 import avs.wcall_set_group_changed_handler
+import avs.wcall_set_log_handler
 import avs.wcall_set_mute
 import avs.wcall_set_mute_handler
 import avs.wcall_set_network_quality_handler
@@ -76,6 +77,11 @@ private object AppleAvsBridgeImpl : AppleAvsBridge {
 
     private val readyHandler = staticCFunction { version: Int, arg: COpaquePointer? ->
         callbacks(arg)?.onReady(version)
+        Unit
+    }
+
+    private val logHandler = staticCFunction { level: Int, message: CPointer<ByteVar>?, _: COpaquePointer? ->
+        handles.values.forEach { it.stableRef.get().onLog(level, message.string().orEmpty()) }
         Unit
     }
 
@@ -249,6 +255,7 @@ private object AppleAvsBridgeImpl : AppleAvsBridge {
         return runCatching {
             wcall_setup()
             wcall_run()
+            wcall_set_log_handler(logHandler, null)
             isStarted = true
             true
         }.getOrElse {

--- a/domain/calling/src/appleMain/kotlin/com/wire/kalium/calling/AppleAvsBridge.kt
+++ b/domain/calling/src/appleMain/kotlin/com/wire/kalium/calling/AppleAvsBridge.kt
@@ -56,6 +56,7 @@ interface AppleAvsBridge {
 
 interface AppleAvsCallbacks {
     fun onReady(version: Int)
+    fun onLog(level: Int, message: String)
     fun onSend(
         context: COpaquePointer?,
         conversationId: String?,

--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -357,10 +357,10 @@ internal class CallManagerImpl internal constructor(
 
         override fun onLog(level: Int, message: String) {
             when (level) {
-                0 -> callingLogger.d("[AVS] $message")
-                1 -> callingLogger.i("[AVS] $message")
-                2 -> callingLogger.w("[AVS] $message")
-                3 -> callingLogger.e("[AVS] $message")
+                AVS_LOG_DEBUG_LEVEL -> callingLogger.d("[AVS] $message")
+                AVS_LOG_INFO_LEVEL -> callingLogger.i("[AVS] $message")
+                AVS_LOG_WARNING_LEVEL -> callingLogger.w("[AVS] $message")
+                AVS_LOG_ERROR_LEVEL -> callingLogger.e("[AVS] $message")
             }
         }
 
@@ -687,6 +687,10 @@ internal class CallManagerImpl internal constructor(
         private const val DEFAULT_REQUEST_VIDEO_STREAMS_MODE = 0
         private const val AVS_SEND_SUCCESS_STATUS_CODE = 200
         private const val AVS_SEND_FAILURE_STATUS_CODE = 400
+        private const val AVS_LOG_DEBUG_LEVEL = 0
+        private const val AVS_LOG_INFO_LEVEL = 1
+        private const val AVS_LOG_WARNING_LEVEL = 2
+        private const val AVS_LOG_ERROR_LEVEL = 3
         private const val TAG = "CallManager"
         private val DEFAULT_WAIT_UNTIL_CONNECTED_TIMEOUT = 15.seconds
     }

--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -355,6 +355,15 @@ internal class CallManagerImpl internal constructor(
             onCallingReady()
         }
 
+        override fun onLog(level: Int, message: String) {
+            when (level) {
+                0 -> callingLogger.d("[AVS] $message")
+                1 -> callingLogger.i("[AVS] $message")
+                2 -> callingLogger.w("[AVS] $message")
+                3 -> callingLogger.e("[AVS] $message")
+            }
+        }
+
         override fun onSend(
             context: COpaquePointer?,
             conversationId: String?,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8645
<!--jira-description-action-hidden-marker-end-->
## Summary
- Register the Apple AVS native log handler.
- Route AVS warning and error records through Kalium calling logs.
- Omit informational AVS output, which can contain SDP and ephemeral TURN credentials.

## Validation
- ./gradlew :logic:compileKotlinMacosArm64 -PUSE_UNIFIED_CORE_CRYPTO=true -Pkalium.providerCacheScope=LOCAL

## Context
This exposes native AVS media and conference failures without retaining sensitive signaling material.