### PR TITLE
fix(calling): keep Apple AVS media lifecycle direct [WPB-8645]

### DIFF
--- a/domain/calling/src/appleAvsIosMain/kotlin/com/wire/kalium/calling/AppleAvsFlowManager.kt
+++ b/domain/calling/src/appleAvsIosMain/kotlin/com/wire/kalium/calling/AppleAvsFlowManager.kt
@@ -43,10 +43,5 @@ actual class AppleAvsFlowManager actual constructor() {
         flowManager.setVideoCaptureDevice(deviceId = deviceId, forConversation = forConversation)
     }
 
-    actual fun startAudio() {
-        mediaManager.startAudio()
-        flowManager
-    }
-
     actual fun startIfAvailable(): Boolean = AppleAvs.bridge.startIfAvailable()
 }

--- a/domain/calling/src/appleAvsMacosMain/kotlin/com/wire/kalium/calling/AppleAvsFlowManager.kt
+++ b/domain/calling/src/appleAvsMacosMain/kotlin/com/wire/kalium/calling/AppleAvsFlowManager.kt
@@ -43,10 +43,5 @@ actual class AppleAvsFlowManager actual constructor() {
         flowManager.setVideoCaptureDevice(deviceId = deviceId, forConversation = forConversation)
     }
 
-    actual fun startAudio() {
-        mediaManager.startAudio()
-        flowManager
-    }
-
     actual fun startIfAvailable(): Boolean = AppleAvs.bridge.startIfAvailable()
 }

--- a/domain/calling/src/appleMain/kotlin/com/wire/kalium/calling/AppleAvsFlowManager.kt
+++ b/domain/calling/src/appleMain/kotlin/com/wire/kalium/calling/AppleAvsFlowManager.kt
@@ -21,6 +21,5 @@ package com.wire.kalium.calling
 expect class AppleAvsFlowManager() {
     fun attachVideoView(view: Any?): Boolean
     fun setVideoCaptureDevice(deviceId: String, forConversation: String)
-    fun startAudio()
     fun startIfAvailable(): Boolean
 }

--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/FlowManagerServiceImpl.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/FlowManagerServiceImpl.kt
@@ -60,6 +60,5 @@ internal actual open class FlowManagerServiceImpl(
             kaliumLogger.w("AVS iOS smoke: startFlowManager could not start AVS")
             return
         }
-        flowManager.startAudio()
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8645
<!--jira-description-action-hidden-marker-end-->
## Summary
- Remove the incomplete legacy Apple AVS audio-manager startup path.
- Keep direct wcall_* calls responsible for their media lifecycle.

## Validation
- ./gradlew :logic:compileKotlinMacosArm64 -PUSE_UNIFIED_CORE_CRYPTO=true -Pkalium.providerCacheScope=LOCAL

## Context
The legacy macOS/iOSx manager never reaches ecall_media_start, causing AVS to close established calls after the 10-second media-start timeout.