### PR TITLE
feat(persistence): report user database migration start PR 2

### DIFF
--- a/data/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
+++ b/data/persistence/src/androidMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
@@ -23,7 +23,9 @@ package com.wire.kalium.persistence.db
 import android.content.Context
 import androidx.sqlite.db.SupportSQLiteDatabase
 import app.cash.sqldelight.async.coroutines.synchronous
+import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlSchema
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import com.wire.kalium.persistence.UserDatabase
 import com.wire.kalium.persistence.dao.UserIDEntity
@@ -43,6 +45,44 @@ actual fun userDatabaseBuilder(
     dispatcher: CoroutineDispatcher,
     enableWAL: Boolean,
     dbInvalidationControlEnabled: Boolean
+): UserDatabaseBuilder = createUserDatabaseBuilder(
+    platformDatabaseData = platformDatabaseData,
+    userId = userId,
+    passphrase = passphrase,
+    dispatcher = dispatcher,
+    enableWAL = enableWAL,
+    dbInvalidationControlEnabled = dbInvalidationControlEnabled,
+    schema = UserDatabase.Schema.synchronous()
+)
+
+@Suppress("LongParameterList")
+internal actual fun userDatabaseBuilderWithMigrationObserver(
+    platformDatabaseData: PlatformDatabaseData,
+    userId: UserIDEntity,
+    passphrase: UserDBSecret?,
+    dispatcher: CoroutineDispatcher,
+    enableWAL: Boolean,
+    dbInvalidationControlEnabled: Boolean,
+    onMigrationStarted: () -> Unit
+): UserDatabaseBuilder = createUserDatabaseBuilder(
+    platformDatabaseData = platformDatabaseData,
+    userId = userId,
+    passphrase = passphrase,
+    dispatcher = dispatcher,
+    enableWAL = enableWAL,
+    dbInvalidationControlEnabled = dbInvalidationControlEnabled,
+    schema = UserDatabase.Schema.synchronous().withMigrationObserver(onMigrationStarted)
+)
+
+@Suppress("LongParameterList")
+private fun createUserDatabaseBuilder(
+    platformDatabaseData: PlatformDatabaseData,
+    userId: UserIDEntity,
+    passphrase: UserDBSecret?,
+    dispatcher: CoroutineDispatcher,
+    enableWAL: Boolean,
+    dbInvalidationControlEnabled: Boolean,
+    schema: SqlSchema<QueryResult.Value<Unit>>
 ): UserDatabaseBuilder {
     val dbName = FileNameUtil.userDBName(userId)
     val isEncryptionEnabled = passphrase != null
@@ -50,7 +90,7 @@ actual fun userDatabaseBuilder(
         context = platformDatabaseData.context,
         dbName = dbName,
         passphrase = passphrase?.value,
-        schema = UserDatabase.Schema.synchronous()
+        schema = schema
     ) {
         isWALEnabled = enableWAL
     }

--- a/data/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
+++ b/data/persistence/src/appleMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
@@ -21,7 +21,9 @@
 package com.wire.kalium.persistence.db
 
 import app.cash.sqldelight.async.coroutines.synchronous
+import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlSchema
 import app.cash.sqldelight.driver.native.NativeSqliteDriver
 import com.wire.kalium.persistence.UserDatabase
 import com.wire.kalium.persistence.dao.UserIDEntity
@@ -38,6 +40,44 @@ actual fun userDatabaseBuilder(
     dispatcher: CoroutineDispatcher,
     enableWAL: Boolean,
     dbInvalidationControlEnabled: Boolean
+): UserDatabaseBuilder = createUserDatabaseBuilder(
+    platformDatabaseData = platformDatabaseData,
+    userId = userId,
+    passphrase = passphrase,
+    dispatcher = dispatcher,
+    enableWAL = enableWAL,
+    dbInvalidationControlEnabled = dbInvalidationControlEnabled,
+    schema = UserDatabase.Schema.synchronous()
+)
+
+@Suppress("LongParameterList")
+internal actual fun userDatabaseBuilderWithMigrationObserver(
+    platformDatabaseData: PlatformDatabaseData,
+    userId: UserIDEntity,
+    passphrase: UserDBSecret?,
+    dispatcher: CoroutineDispatcher,
+    enableWAL: Boolean,
+    dbInvalidationControlEnabled: Boolean,
+    onMigrationStarted: () -> Unit
+): UserDatabaseBuilder = createUserDatabaseBuilder(
+    platformDatabaseData = platformDatabaseData,
+    userId = userId,
+    passphrase = passphrase,
+    dispatcher = dispatcher,
+    enableWAL = enableWAL,
+    dbInvalidationControlEnabled = dbInvalidationControlEnabled,
+    schema = UserDatabase.Schema.synchronous().withMigrationObserver(onMigrationStarted)
+)
+
+@Suppress("LongParameterList")
+private fun createUserDatabaseBuilder(
+    platformDatabaseData: PlatformDatabaseData,
+    userId: UserIDEntity,
+    passphrase: UserDBSecret?,
+    dispatcher: CoroutineDispatcher,
+    enableWAL: Boolean,
+    dbInvalidationControlEnabled: Boolean,
+    schema: SqlSchema<QueryResult.Value<Unit>>
 ): UserDatabaseBuilder {
     val rawDriver = when (platformDatabaseData.storageData) {
         is StorageData.FileBacked -> {
@@ -47,14 +87,14 @@ actual fun userDatabaseBuilder(
                 null,
                 null
             )
-            databaseDriver(platformDatabaseData.storageData.storePath, FileNameUtil.userDBName(userId), UserDatabase.Schema.synchronous()) {
+            databaseDriver(platformDatabaseData.storageData.storePath, FileNameUtil.userDBName(userId), schema) {
                 isWALEnabled = enableWAL
                 useGradleSafeSqliterLogging = platformDatabaseData.useGradleSafeSqliterLogging
             }
         }
 
         StorageData.InMemory ->
-            databaseDriver(null, FileNameUtil.userDBName(userId), UserDatabase.Schema.synchronous()) {
+            databaseDriver(null, FileNameUtil.userDBName(userId), schema) {
                 isWALEnabled = false
                 useGradleSafeSqliterLogging = platformDatabaseData.useGradleSafeSqliterLogging
             }

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/UserDatabaseBuilder.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.persistence.db
 
+import app.cash.sqldelight.db.AfterVersion
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlSchema
@@ -146,6 +147,63 @@ expect fun userDatabaseBuilder(
     enableWAL: Boolean = true,
     dbInvalidationControlEnabled: Boolean = false
 ): UserDatabaseBuilder
+
+/**
+ * Creates a user database while reporting when SQLDelight starts a schema migration.
+ *
+ * This uses the same driver and generated schema path as [userDatabaseBuilder]. The callback is
+ * only a lifecycle signal; it does not replace or split SQLDelight migrations.
+ */
+@Suppress("LongParameterList")
+fun userDatabaseBuilder(
+    platformDatabaseData: PlatformDatabaseData,
+    userId: UserIDEntity,
+    passphrase: UserDBSecret?,
+    dispatcher: CoroutineDispatcher,
+    enableWAL: Boolean = true,
+    dbInvalidationControlEnabled: Boolean = false,
+    onMigrationStarted: () -> Unit
+): UserDatabaseBuilder = userDatabaseBuilderWithMigrationObserver(
+    platformDatabaseData = platformDatabaseData,
+    userId = userId,
+    passphrase = passphrase,
+    dispatcher = dispatcher,
+    enableWAL = enableWAL,
+    dbInvalidationControlEnabled = dbInvalidationControlEnabled,
+    onMigrationStarted = onMigrationStarted
+)
+
+@Suppress("LongParameterList")
+internal expect fun userDatabaseBuilderWithMigrationObserver(
+    platformDatabaseData: PlatformDatabaseData,
+    userId: UserIDEntity,
+    passphrase: UserDBSecret?,
+    dispatcher: CoroutineDispatcher,
+    enableWAL: Boolean,
+    dbInvalidationControlEnabled: Boolean,
+    onMigrationStarted: () -> Unit
+): UserDatabaseBuilder
+
+internal fun SqlSchema<QueryResult.Value<Unit>>.withMigrationObserver(
+    onMigrationStarted: () -> Unit
+): SqlSchema<QueryResult.Value<Unit>> {
+    val delegate = this
+    return object : SqlSchema<QueryResult.Value<Unit>> {
+        override val version: Long = delegate.version
+
+        override fun create(driver: SqlDriver): QueryResult.Value<Unit> = delegate.create(driver)
+
+        override fun migrate(
+            driver: SqlDriver,
+            oldVersion: Long,
+            newVersion: Long,
+            vararg callbacks: AfterVersion
+        ): QueryResult.Value<Unit> {
+            onMigrationStarted()
+            return delegate.migrate(driver, oldVersion, newVersion, *callbacks)
+        }
+    }
+}
 
 /**
  * Opens a database driver for an arbitrary path.

--- a/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/db/UserDatabaseMigrationObserverTest.kt
+++ b/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/db/UserDatabaseMigrationObserverTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.persistence.db
+
+import app.cash.sqldelight.db.AfterVersion
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlSchema
+import dev.mokkery.mock
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UserDatabaseMigrationObserverTest {
+    @Test
+    fun givenObservedSchema_whenCreatingDatabase_thenMigrationIsNotReported() {
+        var migrationCount = 0
+        val schema = TestSchema().withMigrationObserver { migrationCount += 1 }
+
+        schema.create(mock<SqlDriver>())
+
+        assertEquals(0, migrationCount)
+    }
+
+    @Test
+    fun givenObservedSchema_whenMigratingDatabase_thenMigrationIsReportedOnce() {
+        var migrationCount = 0
+        val schema = TestSchema().withMigrationObserver { migrationCount += 1 }
+
+        schema.migrate(mock<SqlDriver>(), oldVersion = 1, newVersion = 2)
+
+        assertEquals(1, migrationCount)
+    }
+
+    private class TestSchema : SqlSchema<QueryResult.Value<Unit>> {
+        override val version: Long = 2
+
+        override fun create(driver: SqlDriver): QueryResult.Value<Unit> = QueryResult.Unit
+
+        override fun migrate(
+            driver: SqlDriver,
+            oldVersion: Long,
+            newVersion: Long,
+            vararg callbacks: AfterVersion
+        ): QueryResult.Value<Unit> = QueryResult.Unit
+    }
+}

--- a/data/persistence/src/jsMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
+++ b/data/persistence/src/jsMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
@@ -71,6 +71,24 @@ actual fun userDatabaseBuilder(
     )
 }
 
+@Suppress("LongParameterList")
+internal actual fun userDatabaseBuilderWithMigrationObserver(
+    platformDatabaseData: PlatformDatabaseData,
+    userId: UserIDEntity,
+    passphrase: UserDBSecret?,
+    dispatcher: CoroutineDispatcher,
+    enableWAL: Boolean,
+    dbInvalidationControlEnabled: Boolean,
+    onMigrationStarted: () -> Unit
+): UserDatabaseBuilder = userDatabaseBuilder(
+    platformDatabaseData = platformDatabaseData,
+    userId = userId,
+    passphrase = passphrase,
+    dispatcher = dispatcher,
+    enableWAL = enableWAL,
+    dbInvalidationControlEnabled = dbInvalidationControlEnabled
+)
+
 actual fun userDatabaseDriverByPath(
     platformDatabaseData: PlatformDatabaseData,
     path: String,

--- a/data/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
+++ b/data/persistence/src/jvmMain/kotlin/com/wire/kalium/persistence/db/UserDatabase.kt
@@ -21,7 +21,9 @@
 package com.wire.kalium.persistence.db
 
 import app.cash.sqldelight.async.coroutines.synchronous
+import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlSchema
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.wire.kalium.persistence.UserDatabase
 import com.wire.kalium.persistence.dao.UserIDEntity
@@ -38,6 +40,44 @@ actual fun userDatabaseBuilder(
     dispatcher: CoroutineDispatcher,
     enableWAL: Boolean,
     dbInvalidationControlEnabled: Boolean
+): UserDatabaseBuilder = createUserDatabaseBuilder(
+    platformDatabaseData = platformDatabaseData,
+    userId = userId,
+    passphrase = passphrase,
+    dispatcher = dispatcher,
+    enableWAL = enableWAL,
+    dbInvalidationControlEnabled = dbInvalidationControlEnabled,
+    schema = UserDatabase.Schema.synchronous()
+)
+
+@Suppress("LongParameterList")
+internal actual fun userDatabaseBuilderWithMigrationObserver(
+    platformDatabaseData: PlatformDatabaseData,
+    userId: UserIDEntity,
+    passphrase: UserDBSecret?,
+    dispatcher: CoroutineDispatcher,
+    enableWAL: Boolean,
+    dbInvalidationControlEnabled: Boolean,
+    onMigrationStarted: () -> Unit
+): UserDatabaseBuilder = createUserDatabaseBuilder(
+    platformDatabaseData = platformDatabaseData,
+    userId = userId,
+    passphrase = passphrase,
+    dispatcher = dispatcher,
+    enableWAL = enableWAL,
+    dbInvalidationControlEnabled = dbInvalidationControlEnabled,
+    schema = UserDatabase.Schema.synchronous().withMigrationObserver(onMigrationStarted)
+)
+
+@Suppress("LongParameterList")
+private fun createUserDatabaseBuilder(
+    platformDatabaseData: PlatformDatabaseData,
+    userId: UserIDEntity,
+    passphrase: UserDBSecret?,
+    dispatcher: CoroutineDispatcher,
+    enableWAL: Boolean,
+    dbInvalidationControlEnabled: Boolean,
+    schema: SqlSchema<QueryResult.Value<Unit>>
 ): UserDatabaseBuilder {
     val storageData = platformDatabaseData.storageData
     if (storageData is StorageData.InMemory) {
@@ -50,7 +90,6 @@ actual fun userDatabaseBuilder(
         throw NotImplementedError("Encrypted DB is not supported on JVM")
     }
 
-    val schema = UserDatabase.Schema.synchronous()
     val databasePath = storageData.file.resolve(DATABASE_NAME)
 
     // Make sure all intermediate directories exist

--- a/docs/adr/0011-explicit-user-database-migration-lifecycle.md
+++ b/docs/adr/0011-explicit-user-database-migration-lifecycle.md
@@ -1,0 +1,314 @@
+# 11. Explicit lifecycle for long-running user database migrations
+
+Date: 2026-07-29
+
+## Status
+
+Proposed
+
+## Context
+
+Kalium owns the SQLDelight schema and migrations for `UserDatabase`. Each signed-in account has its
+own user database.
+
+Today, the first call to `CoreLogic.getSessionScope(userId)` creates a `UserSessionScope` and opens
+the database. Opening the database can run pending SQLDelight migrations. The API is synchronous,
+so a slow migration can block the thread that asks for the session. This could be the Android or
+iOS main thread.
+
+Most migrations are quick. Some changes, such as adding an index to a large table or rebuilding a
+table, can take much longer. The app must not use the user session until the database is ready.
+
+Kalium can own database preparation, but it cannot own app UI or platform background rules. Android
+and iOS must decide how to keep the user informed and how to handle the app moving to the
+background.
+
+This ADR covers `UserDatabase`. It does not change `GlobalDatabase` or the backup import flow.
+
+## Decision
+
+### Migration types
+
+Kalium will use two kinds of database work.
+
+#### Required schema migration
+
+A migration is required when the new Kalium code needs the new schema before it can run.
+
+Examples include:
+
+- creating an index used by a current query;
+- rebuilding a table;
+- adding a required constraint;
+- adding a table or column used by current DAOs.
+
+A required migration:
+
+- stays in the SQLDelight `.sqm` files;
+- is also reflected in the `.sq` schema used for a new database;
+- finishes before Kalium exposes the user session;
+- runs on a Kalium I/O dispatcher;
+- commits its SQL changes and schema version together;
+- rolls back when it fails;
+- can be tried again after an interruption.
+
+Data changes that the new schema needs are also required migrations. They must not be moved to a
+background task only to provide percentage progress.
+
+#### Deferred data migration
+
+A migration is deferred only when old and new code can safely work while the data is updated.
+
+A deferred migration:
+
+- handles a limited number of rows per run;
+- saves its checkpoint with the data change;
+- can continue after the process stops;
+- keeps a query fallback until it finishes.
+
+The first implementation does not add a deferred-migration framework. We will add one when there is
+a real use case.
+
+### Public API
+
+`CoreLogic` will expose one operation that prepares the user session and one optional state stream:
+
+```kotlin
+public suspend fun prepareUserSession(
+    userId: UserId
+): PrepareUserSessionResult
+
+public fun observeUserSessionPreparation(
+    userId: UserId
+): Flow<UserSessionPreparationState>
+```
+
+The preparation result is concrete and Swift-friendly, following ADR 7:
+
+```kotlin
+public sealed class PrepareUserSessionResult {
+    public class Success internal constructor(
+        public val sessionScope: UserSessionScope
+    ) : PrepareUserSessionResult()
+
+    public class Failure internal constructor(
+        public val reason: UserSessionPreparationFailure
+    ) : PrepareUserSessionResult()
+}
+```
+
+The app can observe these states:
+
+```kotlin
+public sealed class UserSessionPreparationState {
+    public data object NotStarted : UserSessionPreparationState()
+    public data object OpeningDatabase : UserSessionPreparationState()
+    public data object MigratingDatabase : UserSessionPreparationState()
+    public data object Ready : UserSessionPreparationState()
+
+    public class Failed internal constructor(
+        public val reason: UserSessionPreparationFailure
+    ) : UserSessionPreparationState()
+}
+```
+
+Failures are small and actionable. Kalium does not expose raw database errors, encryption details,
+database paths, or schema versions.
+
+```kotlin
+public sealed class UserSessionPreparationFailure {
+    public data object InsufficientStorage : UserSessionPreparationFailure()
+    public data object TemporarilyUnavailable : UserSessionPreparationFailure()
+    public data object ApplicationUpdateRequired : UserSessionPreparationFailure()
+    public data object SupportRequired : UserSessionPreparationFailure()
+}
+```
+
+`InsufficientStorage` and `TemporarilyUnavailable` may be tried again. The other failures stop
+automatic retries for the current app version.
+
+Observing the state does not start preparation. The state is only for UI. The suspending
+`prepareUserSession` operation is the gate that every database user must call.
+
+`UserStorageProvider` owns one in-process entry per user database. The entry contains the cached
+`UserStorage`, the shared preparation attempt, and the storage lifecycle state flow. The flow is
+passive: collecting it only observes the entry and never opens the database. `:logic` maps that
+storage state to the public session state and creates the `UserSessionScope` after storage is ready.
+
+### How preparation works
+
+Preparation follows this flow:
+
+1. `UserStorageProvider` changes the state to `OpeningDatabase` and moves the work to its I/O
+   dispatcher.
+2. Kalium creates the normal platform SQLDelight driver but does not publish it yet.
+3. Kalium forces the driver to open.
+4. If an upgrade is needed, the driver changes the state to `MigratingDatabase` and runs the
+   generated `UserDatabase.Schema.migrate` path.
+5. When the driver opens successfully, `UserStorageProvider` caches `UserStorage` and changes its
+   state to `Ready`.
+6. `:logic` creates and caches `UserSessionScope` using that same storage and returns `Success` with
+   the ready session scope.
+
+Kalium does not run a general verification pass after the migration. A successful SQLDelight driver
+open is proof that the required schema migration completed.
+
+If one migration needs an extra data check, that check must run inside the migration transaction,
+before the driver commits the new schema version. It is part of that migration, not a separate
+preparation phase.
+
+### SQLDelight owns schema migration
+
+`UserDatabase.Schema` remains the runtime source of truth.
+
+Kalium must:
+
+- run SQLDelight's generated migration path;
+- keep required changes in `.sqm` files;
+- use the existing platform database driver, key handling, and storage protection;
+- let the driver own the migration transaction and schema-version update;
+- test that these rules hold for the Android and Apple drivers;
+- use the same open driver when publishing the normal user database.
+
+Kalium must not copy migration SQL, split it into a second migration engine, or create a plaintext
+database copy.
+
+The whole pending SQLDelight upgrade is one indeterminate `MigratingDatabase` state. Kalium will not
+show percentage progress or treat each `.sqm` file as a durable checkpoint. The database schema
+version committed by the driver is the durable state.
+
+At the time of this decision, Kalium uses the Wire SQLDelight fork based on SQLDelight 2.3.2. Driver
+behavior must be tested when that dependency changes.
+
+Backup import, backup validation, and their existing migration helpers are outside the scope of this
+ADR.
+
+### Planned code changes
+
+The change will follow the current module boundaries:
+
+- `:data:persistence` will provide an internal way to force the normal user database driver to open
+  and report when SQLDelight starts an upgrade.
+- `:domain:userstorage` will own one entry and state flow per user database, coordinate its shared
+  preparation attempt, and cache storage only after preparation succeeds.
+- `:logic` will expose the public API, map internal errors to the public failure types, and create
+  `UserSessionScope` only after storage is ready.
+- Android and iOS will call the new API from startup and every background entry point that needs the
+  user database.
+
+This does not add a dependency or change the dependency direction between modules.
+
+### Concurrency, cancellation, and retry
+
+There is one preparation operation for each physical user database in a process.
+
+- Concurrent callers wait for the same operation.
+- They receive the same cached `UserSessionScope` when it succeeds.
+- A repeated call after `Ready` returns the cached scope immediately.
+- Cancelling one caller only cancels that caller's wait. It does not cancel work used by another
+  caller.
+- A retryable failure allows a later call to start a new attempt.
+- A failure that needs an app update or support does not enter an automatic retry loop.
+
+If the process stops during migration, the next call opens the database again. SQLDelight and the
+platform driver read the stored schema version and run any migration that was not committed. The app
+scheduler is not proof that migration finished.
+
+Each app must list every process and extension that can open the same database. If more than one
+process can open it, preparation also needs an operating-system-backed per-database lock. No process
+may wait for that lock on its main thread.
+
+A failed migration must never cause Kalium to delete or recreate the user database automatically.
+
+### Existing session API
+
+The API will be introduced in steps:
+
+1. Add `prepareUserSession` and the preparation state stream.
+2. Update Android, iOS, workers, services, receivers, and extensions to call it before using a user
+   session.
+3. Deprecate `getSessionScope(userId)` and the `sessionScope` helper.
+4. In a release that allows the behavior change, make the old getter cache-only. Calling it before
+   successful preparation is a programming error and must fail fast instead of opening or migrating
+   the database.
+
+`prepareUserSession` returns the ready scope, so new callers do not need another lookup API.
+
+The additive API and later behavior change must follow the ABI and changelog rules in ADR 9.
+
+### App responsibilities
+
+Each app must prepare the active user before creating database-dependent UI, dependency-injection
+graphs, workers, services, receivers, or extensions.
+
+While a required migration runs, the app must:
+
+- show a migration screen instead of holding the system splash screen;
+- keep database-dependent features closed;
+- show an action the user can take when preparation fails;
+- never delete or recreate the database after a failure;
+- defer incoming work or keep it in a database-independent durable queue.
+
+Android normally starts preparation while the app is visible. A foreground service may be used when
+product requirements say migration should continue in the background. WorkManager state is not
+proof that migration completed.
+
+iOS also starts preparation while the app is visible. It may request finite background time. If iOS
+suspends or ends the process, the next launch tries again. `BGProcessingTask` is better suited to
+deferred work than to required startup migration.
+
+### Release requirements
+
+Before shipping a required migration:
+
+- SQLDelight migration verification must pass for every supported schema snapshot;
+- tests must use the generated SQLDelight migration path;
+- tests must confirm that schema changes and the schema version commit together;
+- tests must cover interruption and retry with the real Android and Apple drivers;
+- concurrency tests must cover two callers and cancellation of one caller;
+- platform tests must show that migration does not run on the main thread;
+- Android and iOS must audit all database entry points;
+- low-storage and database-busy behavior must be tested;
+- rollout must start with internal or beta users.
+
+Metrics may contain only the migration ID, schema versions, duration, result, and approved coarse
+database or device-size buckets.
+
+An index migration must also include the query it improves, query-plan evidence, migration time,
+peak disk use, database growth, read improvement, and write cost on representative database sizes.
+
+## Consequences
+
+**Easier:**
+
+- Slow migration cannot start through the normal synchronous session getter.
+- Android and iOS use the same preparation and failure contract.
+- SQLDelight stays responsible for schema migration.
+- Apps have a clear state for gating UI and background work.
+- Process death is handled by opening the database and checking its committed schema version.
+
+**More difficult:**
+
+- Kalium needs a preparation boundary before it creates `UserSessionScope`.
+- Every app database entry point must move to the new API.
+- Real driver behavior needs platform tests.
+- Multi-process access may need a platform file lock.
+- The transition temporarily supports both explicit and implicit session opening.
+
+## Out of scope
+
+- `GlobalDatabase` preparation;
+- backup import and backup migration helpers;
+- a deferred-migration framework;
+- Android foreground-service implementation;
+- iOS background-task implementation;
+- the minimum supported `UserDatabase` schema version.
+
+## References
+
+- [ADR 3: Database Migration Testing Framework](0003-database-migration-testing-framework.md)
+- [ADR 7: Swift-Friendly Result Types](0007-swift-friendly-result-types.md)
+- [ADR 9: Public API, ABI, and Changelog Governance](0009-public-api-abi-and-changelog-governance.md)
+- [SQLDelight migrations](https://sqldelight.github.io/sqldelight/2.3.2/jvm_sqlite/migrations/)
+- [Android long-running workers](https://developer.android.com/develop/background-work/background-tasks/persistent/how-to/long-running)
+- [Apple `BGProcessingTask`](https://developer.apple.com/documentation/backgroundtasks/bgprocessingtask)


### PR DESCRIPTION
## Intent

Let higher layers distinguish normal database opening from a running SQLDelight migration.

## Changes

- Add a migration-start observer to the user database builder.
- Report migration start consistently on Android, Apple, JVM, and JS.
- Cover the observer contract with a platform-independent test.

## Impact

This provides the persistence signal used by the user-storage lifecycle in the next PR without exposing session behavior yet.

## Stack

- [PR 1](https://github.com/wireapp/kalium/pull/4361)
- PR 2 of 6 (current)

## End-to-end preparation pipeline

All database-dependent entry points converge on one per-user preparation operation. The storage session owns the single in-flight attempt and publishes state for observers.

```mermaid
flowchart TD
    UI_ENTRY["UI or app startup"] --> PREPARE["CoreLogic.prepareUserSession(userId)"]
    APP_ENTRY["Service, receiver, or extension"] --> PREPARE
    WM_ENTRY["Existing WorkManager job"] --> WRAPPER["WrapperWorker"]
    WRAPPER --> PREPARE

    PREPARE --> SCOPE_PROVIDER["UserSessionScopeProvider.prepare"]
    SCOPE_PROVIDER --> STORAGE_PROVIDER["UserStorageProvider.prepare(userId)"]
    STORAGE_PROVIDER --> USER_SESSION["Per-user UserStorageSession<br/>single in-flight attempt"]

    USER_SESSION --> OPENING["OpeningDatabase"]
    OPENING --> DATABASE["UserDatabaseBuilder.open"]
    DATABASE -->|"schema is current"| READY["Ready"]
    DATABASE -->|"migration callback"| MIGRATING["MigratingDatabase"]
    MIGRATING -->|"migration commits"| READY
    DATABASE -->|"open or migration error"| FAILURE["Classify failure"]

    READY --> SESSION_SCOPE["UserSessionScope"]
    SESSION_SCOPE --> CONSUMER["Database-dependent consumer"]
    SESSION_SCOPE --> INNER_WORKER["Create and run inner WorkManager worker"]

    USER_SESSION -.->|"state flow; observation does not start preparation"| OBSERVER["observeUserSessionPreparation(userId)"]
    OBSERVER --> STATE_UI["Migration UI or state observer"]

    FAILURE --> APP_FAILURE["UI, service, or receiver failure handling"]
    FAILURE --> RETRY["Retry policy"]
    RETRY --> PREPARE
    FAILURE --> WORK_FAILURE["WorkManager retry or failure result"]
```

WorkManager is a preparation gate for existing background work; it is not a dedicated migration scheduler.

