### PR TITLE
feat(userstorage): centralize storage preparation PR 3

### DIFF
--- a/domain/userstorage/build.gradle.kts
+++ b/domain/userstorage/build.gradle.kts
@@ -70,25 +70,11 @@ kotlin {
             kotlin.srcDir(generateUserStorageCacheConfig)
             dependencies {
                 implementation(projects.core.data)
+                implementation(projects.core.util)
                 api(projects.data.persistence)
                 implementation(libs.coroutines.core)
                 implementation(libs.concurrentCollections)
                 implementation(libs.statelyCommons)
-            }
-        }
-        val androidMain by getting {
-            dependencies {
-                implementation(projects.core.util)
-            }
-        }
-        val jvmMain by getting {
-            dependencies {
-                implementation(projects.core.util)
-            }
-        }
-        val appleMain by getting {
-            dependencies {
-                implementation(projects.core.util)
             }
         }
     }

--- a/domain/userstorage/src/androidMain/kotlin/com/wire/kalium/userstorage/di/PlatformUserStorageProvider.kt
+++ b/domain/userstorage/src/androidMain/kotlin/com/wire/kalium/userstorage/di/PlatformUserStorageProvider.kt
@@ -30,6 +30,35 @@ public actual class PlatformUserStorageProvider : UserStorageProvider() {
         shouldEncryptData: Boolean,
         platformProperties: PlatformUserStorageProperties,
         dbInvalidationControlEnabled: Boolean
+    ): UserStorage = createUserStorage(
+        userId = userId,
+        shouldEncryptData = shouldEncryptData,
+        platformProperties = platformProperties,
+        dbInvalidationControlEnabled = dbInvalidationControlEnabled,
+        onMigrationStarted = null
+    )
+
+    override fun create(
+        userId: UserId,
+        shouldEncryptData: Boolean,
+        platformProperties: PlatformUserStorageProperties,
+        dbInvalidationControlEnabled: Boolean,
+        onMigrationStarted: () -> Unit
+    ): UserStorage = createUserStorage(
+        userId = userId,
+        shouldEncryptData = shouldEncryptData,
+        platformProperties = platformProperties,
+        dbInvalidationControlEnabled = dbInvalidationControlEnabled,
+        onMigrationStarted = onMigrationStarted
+    )
+
+    @Suppress("LongParameterList")
+    private fun createUserStorage(
+        userId: UserId,
+        shouldEncryptData: Boolean,
+        platformProperties: PlatformUserStorageProperties,
+        dbInvalidationControlEnabled: Boolean,
+        onMigrationStarted: (() -> Unit)?
     ): UserStorage {
         val userIdEntity = UserIDEntity(userId.value, userId.domain)
 
@@ -38,14 +67,26 @@ public actual class PlatformUserStorageProvider : UserStorageProvider() {
         } else {
             null
         }
-        val database = userDatabaseBuilder(
-            platformDatabaseData = PlatformDatabaseData(platformProperties.applicationContext),
-            userId = userIdEntity,
-            passphrase = databasePassphrase,
-            dispatcher = KaliumDispatcherImpl.io,
-            enableWAL = true,
-            dbInvalidationControlEnabled = dbInvalidationControlEnabled
-        )
+        val database = if (onMigrationStarted == null) {
+            userDatabaseBuilder(
+                platformDatabaseData = PlatformDatabaseData(platformProperties.applicationContext),
+                userId = userIdEntity,
+                passphrase = databasePassphrase,
+                dispatcher = KaliumDispatcherImpl.io,
+                enableWAL = true,
+                dbInvalidationControlEnabled = dbInvalidationControlEnabled
+            )
+        } else {
+            userDatabaseBuilder(
+                platformDatabaseData = PlatformDatabaseData(platformProperties.applicationContext),
+                userId = userIdEntity,
+                passphrase = databasePassphrase,
+                dispatcher = KaliumDispatcherImpl.io,
+                enableWAL = true,
+                dbInvalidationControlEnabled = dbInvalidationControlEnabled,
+                onMigrationStarted = onMigrationStarted
+            )
+        }
         return UserStorage(database)
     }
 }

--- a/domain/userstorage/src/appleMain/kotlin/com/wire/kalium/userstorage/di/PlatformUserStorageProvider.kt
+++ b/domain/userstorage/src/appleMain/kotlin/com/wire/kalium/userstorage/di/PlatformUserStorageProvider.kt
@@ -31,16 +31,57 @@ public actual class PlatformUserStorageProvider : UserStorageProvider() {
         shouldEncryptData: Boolean,
         platformProperties: PlatformUserStorageProperties,
         dbInvalidationControlEnabled: Boolean
+    ): UserStorage = createUserStorage(
+        userId = userId,
+        shouldEncryptData = shouldEncryptData,
+        platformProperties = platformProperties,
+        dbInvalidationControlEnabled = dbInvalidationControlEnabled,
+        onMigrationStarted = null
+    )
+
+    override fun create(
+        userId: UserId,
+        shouldEncryptData: Boolean,
+        platformProperties: PlatformUserStorageProperties,
+        dbInvalidationControlEnabled: Boolean,
+        onMigrationStarted: () -> Unit
+    ): UserStorage = createUserStorage(
+        userId = userId,
+        shouldEncryptData = shouldEncryptData,
+        platformProperties = platformProperties,
+        dbInvalidationControlEnabled = dbInvalidationControlEnabled,
+        onMigrationStarted = onMigrationStarted
+    )
+
+    @Suppress("LongParameterList", "UnusedParameter") // User databases are not encrypted on Apple yet.
+    private fun createUserStorage(
+        userId: UserId,
+        shouldEncryptData: Boolean,
+        platformProperties: PlatformUserStorageProperties,
+        dbInvalidationControlEnabled: Boolean,
+        onMigrationStarted: (() -> Unit)?
     ): UserStorage {
         val userIdEntity = UserIDEntity(userId.value, userId.domain)
-        val database = userDatabaseBuilder(
-            platformDatabaseData = PlatformDatabaseData(StorageData.FileBacked(platformProperties.rootStoragePath)),
-            userId = userIdEntity,
-            passphrase = null,
-            dispatcher = KaliumDispatcherImpl.io,
-            enableWAL = true,
-            dbInvalidationControlEnabled = dbInvalidationControlEnabled
-        )
+        val database = if (onMigrationStarted == null) {
+            userDatabaseBuilder(
+                platformDatabaseData = PlatformDatabaseData(StorageData.FileBacked(platformProperties.rootStoragePath)),
+                userId = userIdEntity,
+                passphrase = null,
+                dispatcher = KaliumDispatcherImpl.io,
+                enableWAL = true,
+                dbInvalidationControlEnabled = dbInvalidationControlEnabled
+            )
+        } else {
+            userDatabaseBuilder(
+                platformDatabaseData = PlatformDatabaseData(StorageData.FileBacked(platformProperties.rootStoragePath)),
+                userId = userIdEntity,
+                passphrase = null,
+                dispatcher = KaliumDispatcherImpl.io,
+                enableWAL = true,
+                dbInvalidationControlEnabled = dbInvalidationControlEnabled,
+                onMigrationStarted = onMigrationStarted
+            )
+        }
         return UserStorage(database)
     }
 }

--- a/domain/userstorage/src/commonMain/kotlin/com/wire/kalium/userstorage/di/UserStoragePreparation.kt
+++ b/domain/userstorage/src/commonMain/kotlin/com/wire/kalium/userstorage/di/UserStoragePreparation.kt
@@ -1,0 +1,94 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.userstorage.di
+
+/** Result of opening and, when needed, migrating a user's storage. */
+public sealed interface UserStoragePreparationResult {
+    /** Storage is open and ready to use. */
+    public data class Success(public val storage: UserStorage) : UserStoragePreparationResult
+
+    /** Storage preparation stopped with [reason]. */
+    public class Failure internal constructor(
+        public val reason: UserStoragePreparationFailure,
+        internal val exception: Throwable,
+    ) : UserStoragePreparationResult
+}
+
+/** Current in-process state of a user's storage. */
+public sealed interface UserStorageState {
+    /** Storage has not been requested in this process. */
+    public data object NotStarted : UserStorageState
+
+    /** The database is opening and its schema version is being checked. */
+    public data object OpeningDatabase : UserStorageState
+
+    /** SQLDelight is running the generated migration path. */
+    public data object MigratingDatabase : UserStorageState
+
+    /** Storage is open and ready to use. */
+    public data class Ready(public val storage: UserStorage) : UserStorageState
+
+    /** Storage preparation stopped with [reason]. */
+    public data class Failed(public val reason: UserStoragePreparationFailure) : UserStorageState
+}
+
+/** Storage-level reason why opening the user database failed. */
+public sealed interface UserStoragePreparationFailure {
+    /** The user must free storage before trying again. */
+    public data object InsufficientStorage : UserStoragePreparationFailure
+
+    /** The database is temporarily busy or locked and can be tried again. */
+    public data object TemporarilyUnavailable : UserStoragePreparationFailure
+
+    /** This app version cannot safely open the database. */
+    public data object ApplicationUpdateRequired : UserStoragePreparationFailure
+
+    /** Automatic recovery is unsafe and the user needs support. */
+    public data object SupportRequired : UserStoragePreparationFailure
+}
+
+internal val UserStoragePreparationFailure.canRetry: Boolean
+    get() = this is UserStoragePreparationFailure.InsufficientStorage ||
+        this is UserStoragePreparationFailure.TemporarilyUnavailable
+
+internal fun Throwable.toUserStoragePreparationFailure(): UserStoragePreparationFailure {
+    val messages = generateSequence(this) { it.cause }
+        .mapNotNull { it.message }
+        .joinToString(separator = " ")
+        .lowercase()
+
+    return when {
+        messages.contains("database or disk is full") ||
+            messages.contains("disk full") ||
+            messages.contains("sqlite_full") -> UserStoragePreparationFailure.InsufficientStorage
+
+        messages.contains("database is busy") ||
+            messages.contains("database is locked") ||
+            messages.contains("sqlite_busy") ||
+            messages.contains("sqlite_locked") -> UserStoragePreparationFailure.TemporarilyUnavailable
+
+        messages.contains("downgrade") ||
+            messages.contains("newer database version") ||
+            messages.contains("syntax error") ||
+            messages.contains("no such table") ||
+            messages.contains("no such column") -> UserStoragePreparationFailure.ApplicationUpdateRequired
+
+        else -> UserStoragePreparationFailure.SupportRequired
+    }
+}

--- a/domain/userstorage/src/commonMain/kotlin/com/wire/kalium/userstorage/di/UserStoragePreparation.kt
+++ b/domain/userstorage/src/commonMain/kotlin/com/wire/kalium/userstorage/di/UserStoragePreparation.kt
@@ -23,10 +23,9 @@ public sealed interface UserStoragePreparationResult {
     /** Storage is open and ready to use. */
     public data class Success(public val storage: UserStorage) : UserStoragePreparationResult
 
-    /** Storage preparation stopped with [reason]. */
+    /** Storage preparation stopped with [failure]. */
     public class Failure internal constructor(
-        public val reason: UserStoragePreparationFailure,
-        internal val exception: Throwable,
+        public val failure: UserStoragePreparationFailure,
     ) : UserStoragePreparationResult
 }
 
@@ -44,23 +43,33 @@ public sealed interface UserStorageState {
     /** Storage is open and ready to use. */
     public data class Ready(public val storage: UserStorage) : UserStorageState
 
-    /** Storage preparation stopped with [reason]. */
-    public data class Failed(public val reason: UserStoragePreparationFailure) : UserStorageState
+    /** Storage preparation stopped with [failure]. */
+    public data class Failed(public val failure: UserStoragePreparationFailure) : UserStorageState
 }
 
-/** Storage-level reason why opening the user database failed. */
+/** Typed storage preparation failure that retains the original [exception]. */
 public sealed interface UserStoragePreparationFailure {
+    public val exception: Throwable
+
     /** The user must free storage before trying again. */
-    public data object InsufficientStorage : UserStoragePreparationFailure
+    public class InsufficientStorage internal constructor(
+        public override val exception: Throwable,
+    ) : UserStoragePreparationFailure
 
     /** The database is temporarily busy or locked and can be tried again. */
-    public data object TemporarilyUnavailable : UserStoragePreparationFailure
+    public class TemporarilyUnavailable internal constructor(
+        public override val exception: Throwable,
+    ) : UserStoragePreparationFailure
 
     /** This app version cannot safely open the database. */
-    public data object ApplicationUpdateRequired : UserStoragePreparationFailure
+    public class ApplicationUpdateRequired internal constructor(
+        public override val exception: Throwable,
+    ) : UserStoragePreparationFailure
 
     /** Automatic recovery is unsafe and the user needs support. */
-    public data object SupportRequired : UserStoragePreparationFailure
+    public class SupportRequired internal constructor(
+        public override val exception: Throwable,
+    ) : UserStoragePreparationFailure
 }
 
 internal val UserStoragePreparationFailure.canRetry: Boolean
@@ -76,19 +85,19 @@ internal fun Throwable.toUserStoragePreparationFailure(): UserStoragePreparation
     return when {
         messages.contains("database or disk is full") ||
             messages.contains("disk full") ||
-            messages.contains("sqlite_full") -> UserStoragePreparationFailure.InsufficientStorage
+            messages.contains("sqlite_full") -> UserStoragePreparationFailure.InsufficientStorage(this)
 
         messages.contains("database is busy") ||
             messages.contains("database is locked") ||
             messages.contains("sqlite_busy") ||
-            messages.contains("sqlite_locked") -> UserStoragePreparationFailure.TemporarilyUnavailable
+            messages.contains("sqlite_locked") -> UserStoragePreparationFailure.TemporarilyUnavailable(this)
 
         messages.contains("downgrade") ||
             messages.contains("newer database version") ||
             messages.contains("syntax error") ||
             messages.contains("no such table") ||
-            messages.contains("no such column") -> UserStoragePreparationFailure.ApplicationUpdateRequired
+            messages.contains("no such column") -> UserStoragePreparationFailure.ApplicationUpdateRequired(this)
 
-        else -> UserStoragePreparationFailure.SupportRequired
+        else -> UserStoragePreparationFailure.SupportRequired(this)
     }
 }

--- a/domain/userstorage/src/commonMain/kotlin/com/wire/kalium/userstorage/di/UserStorageProvider.kt
+++ b/domain/userstorage/src/commonMain/kotlin/com/wire/kalium/userstorage/di/UserStorageProvider.kt
@@ -82,7 +82,7 @@ public abstract class UserStorageProvider {
             )
         ) {
             is UserStoragePreparationResult.Success -> result.storage
-            is UserStoragePreparationResult.Failure -> throw result.exception
+            is UserStoragePreparationResult.Failure -> throw result.failure.exception
         }
     }
 
@@ -151,7 +151,7 @@ public abstract class UserStorageProvider {
             if (failure.canRetry) {
                 session.preparation.compareAndSet(preparation, null)
             }
-            UserStoragePreparationResult.Failure(failure, exception)
+            UserStoragePreparationResult.Failure(failure)
         }
     }
 

--- a/domain/userstorage/src/commonMain/kotlin/com/wire/kalium/userstorage/di/UserStorageProvider.kt
+++ b/domain/userstorage/src/commonMain/kotlin/com/wire/kalium/userstorage/di/UserStorageProvider.kt
@@ -18,39 +18,152 @@
 
 package com.wire.kalium.userstorage.di
 
+import co.touchlab.stately.concurrency.AtomicReference
 import co.touchlab.stately.collections.ConcurrentMutableMap
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.persistence.db.UserDatabaseBuilder
+import com.wire.kalium.util.KaliumDispatcherImpl
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.runBlocking
 
 public data class UserStorage(public val database: UserDatabaseBuilder)
 
 /**
- * Provides in-memory caching for [UserStorage] instances keyed by [UserId].
+ * Owns the in-process lifecycle and cache for [UserStorage] instances keyed by [UserId].
  *
  * Cache scope is controlled by the shared provider policy [PROVIDER_CACHE_SCOPE]:
- * - [ProviderCacheScope.GLOBAL]: all [UserStorageProvider] instances share one cache map.
- * - [ProviderCacheScope.LOCAL]: each [UserStorageProvider] instance owns a private cache map.
+ * - [ProviderCacheScope.GLOBAL]: all [UserStorageProvider] instances share the same per-user entries.
+ * - [ProviderCacheScope.LOCAL]: each [UserStorageProvider] instance owns private per-user entries.
  */
 public abstract class UserStorageProvider {
     private companion object {
-        val sharedUserStorageCache: ConcurrentMutableMap<UserId, UserStorage> = ConcurrentMutableMap()
+        val sharedUserStorageSessions: ConcurrentMutableMap<UserId, UserStorageSession> = ConcurrentMutableMap()
     }
 
-    private val providerUserStorageCache: ConcurrentMutableMap<UserId, UserStorage> =
+    private val providerUserStorageSessions: ConcurrentMutableMap<UserId, UserStorageSession> =
         when (PROVIDER_CACHE_SCOPE) {
-            ProviderCacheScope.GLOBAL -> sharedUserStorageCache
+            ProviderCacheScope.GLOBAL -> sharedUserStorageSessions
             ProviderCacheScope.LOCAL -> ConcurrentMutableMap()
         }
 
-    public fun get(userId: UserId): UserStorage? = providerUserStorageCache[userId]
+    private val preparationScope: CoroutineScope = CoroutineScope(SupervisorJob() + KaliumDispatcherImpl.io)
+
+    public fun get(userId: UserId): UserStorage? =
+        (providerUserStorageSessions[userId]?.state?.value as? UserStorageState.Ready)?.storage
+
+    /**
+     * Observes the lifecycle of one user's storage without starting storage preparation.
+     *
+     * The same state flow backs every observer for [userId]. State updates are produced only by
+     * calls to [getOrCreate] or [prepare].
+     */
+    public fun observe(userId: UserId): Flow<UserStorageState> = sessionFor(userId).observableState
 
     public fun getOrCreate(
         userId: UserId,
         platformUserStorageProperties: PlatformUserStorageProperties,
         shouldEncryptData: Boolean = true,
         dbInvalidationControlEnabled: Boolean,
-    ): UserStorage = providerUserStorageCache.computeIfAbsent(userId) {
-        create(userId, shouldEncryptData, platformUserStorageProperties, dbInvalidationControlEnabled)
+    ): UserStorage = get(userId) ?: runBlocking {
+        when (
+            val result = prepare(
+                userId,
+                platformUserStorageProperties,
+                shouldEncryptData,
+                dbInvalidationControlEnabled,
+            )
+        ) {
+            is UserStoragePreparationResult.Success -> result.storage
+            is UserStoragePreparationResult.Failure -> throw result.exception
+        }
+    }
+
+    /**
+     * Opens and, when needed, migrates the user's storage on the storage I/O scope.
+     * Concurrent callers share one preparation attempt.
+     */
+    public suspend fun prepare(
+        userId: UserId,
+        platformUserStorageProperties: PlatformUserStorageProperties,
+        shouldEncryptData: Boolean = true,
+        dbInvalidationControlEnabled: Boolean,
+    ): UserStoragePreparationResult {
+        val session = sessionFor(userId)
+        val preparation = preparationFor(session) {
+            create(
+                userId,
+                shouldEncryptData,
+                platformUserStorageProperties,
+                dbInvalidationControlEnabled,
+                onMigrationStarted = { session.state.value = UserStorageState.MigratingDatabase },
+            )
+        }
+        preparation.start()
+        return preparation.await()
+    }
+
+    private fun preparationFor(
+        session: UserStorageSession,
+        createStorage: () -> UserStorage,
+    ): Deferred<UserStoragePreparationResult> {
+        session.preparation.get()?.let { return it }
+
+        lateinit var candidate: Deferred<UserStoragePreparationResult>
+        candidate = preparationScope.async(start = CoroutineStart.LAZY) {
+            prepareStorage(session, candidate, createStorage)
+        }
+
+        return if (session.preparation.compareAndSet(null, candidate)) {
+            candidate
+        } else {
+            candidate.cancel()
+            requireNotNull(session.preparation.get())
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught") // Database drivers expose platform-specific exception types.
+    private fun prepareStorage(
+        session: UserStorageSession,
+        preparation: Deferred<UserStoragePreparationResult>,
+        createStorage: () -> UserStorage,
+    ): UserStoragePreparationResult {
+        session.state.value = UserStorageState.OpeningDatabase
+
+        return try {
+            val storage = createStorage()
+            session.state.value = UserStorageState.Ready(storage)
+            UserStoragePreparationResult.Success(storage)
+        } catch (exception: CancellationException) {
+            session.preparation.compareAndSet(preparation, null)
+            session.state.value = UserStorageState.NotStarted
+            throw exception
+        } catch (exception: Exception) {
+            val failure = exception.toUserStoragePreparationFailure()
+            session.state.value = UserStorageState.Failed(failure)
+            if (failure.canRetry) {
+                session.preparation.compareAndSet(preparation, null)
+            }
+            UserStoragePreparationResult.Failure(failure, exception)
+        }
+    }
+
+    private fun sessionFor(userId: UserId): UserStorageSession =
+        providerUserStorageSessions.computeIfAbsent(userId) {
+            UserStorageSession()
+        }
+
+    private class UserStorageSession {
+        val state: MutableStateFlow<UserStorageState> = MutableStateFlow(UserStorageState.NotStarted)
+        val observableState: Flow<UserStorageState> = state.asStateFlow()
+        val preparation: AtomicReference<Deferred<UserStoragePreparationResult>?> = AtomicReference(null)
     }
 
     protected abstract fun create(
@@ -60,7 +173,20 @@ public abstract class UserStorageProvider {
         dbInvalidationControlEnabled: Boolean
     ): UserStorage
 
-    public fun remove(userId: UserId): UserStorage? = providerUserStorageCache.remove(userId)
+    @Suppress("LongParameterList")
+    protected open fun create(
+        userId: UserId,
+        shouldEncryptData: Boolean,
+        platformProperties: PlatformUserStorageProperties,
+        dbInvalidationControlEnabled: Boolean,
+        onMigrationStarted: () -> Unit,
+    ): UserStorage = create(userId, shouldEncryptData, platformProperties, dbInvalidationControlEnabled)
+
+    public fun remove(userId: UserId): UserStorage? {
+        val session = providerUserStorageSessions.remove(userId) ?: return null
+        session.preparation.get()?.cancel()
+        return (session.state.value as? UserStorageState.Ready)?.storage
+    }
 }
 
 public expect class PlatformUserStorageProperties

--- a/domain/userstorage/src/jvmMain/kotlin/com/wire/kalium/userstorage/di/PlatformUserStorageProvider.kt
+++ b/domain/userstorage/src/jvmMain/kotlin/com/wire/kalium/userstorage/di/PlatformUserStorageProvider.kt
@@ -32,6 +32,31 @@ public actual class PlatformUserStorageProvider : UserStorageProvider() {
         shouldEncryptData: Boolean,
         platformProperties: PlatformUserStorageProperties,
         dbInvalidationControlEnabled: Boolean
+    ): UserStorage = createUserStorage(
+        userId = userId,
+        platformProperties = platformProperties,
+        dbInvalidationControlEnabled = dbInvalidationControlEnabled,
+        onMigrationStarted = null
+    )
+
+    override fun create(
+        userId: UserId,
+        shouldEncryptData: Boolean,
+        platformProperties: PlatformUserStorageProperties,
+        dbInvalidationControlEnabled: Boolean,
+        onMigrationStarted: () -> Unit
+    ): UserStorage = createUserStorage(
+        userId = userId,
+        platformProperties = platformProperties,
+        dbInvalidationControlEnabled = dbInvalidationControlEnabled,
+        onMigrationStarted = onMigrationStarted
+    )
+
+    private fun createUserStorage(
+        userId: UserId,
+        platformProperties: PlatformUserStorageProperties,
+        dbInvalidationControlEnabled: Boolean,
+        onMigrationStarted: (() -> Unit)?
     ): UserStorage {
         val userIdEntity = UserIDEntity(userId.value, userId.domain)
 
@@ -39,14 +64,26 @@ public actual class PlatformUserStorageProvider : UserStorageProvider() {
         val database = when (databaseInfo) {
             is DatabaseStorageType.FiledBacked -> {
                 val storageData = StorageData.FileBacked(databaseInfo.filePath)
-                userDatabaseBuilder(
-                    platformDatabaseData = PlatformDatabaseData(storageData),
-                    userId = userIdEntity,
-                    passphrase = null,
-                    dispatcher = KaliumDispatcherImpl.io,
-                    enableWAL = true,
-                    dbInvalidationControlEnabled = dbInvalidationControlEnabled
-                )
+                if (onMigrationStarted == null) {
+                    userDatabaseBuilder(
+                        platformDatabaseData = PlatformDatabaseData(storageData),
+                        userId = userIdEntity,
+                        passphrase = null,
+                        dispatcher = KaliumDispatcherImpl.io,
+                        enableWAL = true,
+                        dbInvalidationControlEnabled = dbInvalidationControlEnabled
+                    )
+                } else {
+                    userDatabaseBuilder(
+                        platformDatabaseData = PlatformDatabaseData(storageData),
+                        userId = userIdEntity,
+                        passphrase = null,
+                        dispatcher = KaliumDispatcherImpl.io,
+                        enableWAL = true,
+                        dbInvalidationControlEnabled = dbInvalidationControlEnabled,
+                        onMigrationStarted = onMigrationStarted
+                    )
+                }
             }
 
             is DatabaseStorageType.InMemory -> {

--- a/domain/userstorage/src/jvmTest/kotlin/com/wire/kalium/userstorage/di/UserStorageProviderTest.kt
+++ b/domain/userstorage/src/jvmTest/kotlin/com/wire/kalium/userstorage/di/UserStorageProviderTest.kt
@@ -24,9 +24,19 @@ import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.db.clearInMemoryDatabase
 import com.wire.kalium.persistence.db.inMemoryDatabase
 import com.wire.kalium.util.KaliumDispatcherImpl
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertSame
@@ -134,13 +144,219 @@ class UserStorageProviderTest {
         cleanup(firstProvider, secondProvider)
     }
 
+    @Test
+    fun givenNoPreparation_whenObservingStorage_thenStateIsNotStarted() = runBlocking {
+        val createCount = AtomicInteger(0)
+        val provider = TestUserStorageProvider(createCount)
+        val state = provider.observe(testUserId)
+
+        assertSame(state, provider.observe(testUserId))
+        assertEquals(UserStorageState.NotStarted, state.first())
+        assertEquals(0, createCount.get())
+
+        cleanup(provider)
+    }
+
+    @Test
+    fun givenMigrationStarts_whenPreparingStorage_thenOneStorageFlowReportsLifecycle() = runBlocking {
+        val provider = TestUserStorageProvider(AtomicInteger(0), reportsMigration = true)
+        val states = mutableListOf<UserStorageState>()
+        val observer = launch(Dispatchers.Unconfined, start = CoroutineStart.UNDISPATCHED) {
+            provider.observe(testUserId).take(4).toList(states)
+        }
+
+        val result = provider.prepare(
+            userId = testUserId,
+            platformUserStorageProperties = testProperties,
+            shouldEncryptData = false,
+            dbInvalidationControlEnabled = false,
+        )
+        observer.join()
+
+        val success = assertIs<UserStoragePreparationResult.Success>(result)
+        assertEquals(
+            listOf(
+                UserStorageState.NotStarted,
+                UserStorageState.OpeningDatabase,
+                UserStorageState.MigratingDatabase,
+                UserStorageState.Ready(success.storage),
+            ),
+            states,
+        )
+
+        cleanup(provider)
+    }
+
+    @Test
+    fun givenMigrationStartsThroughSynchronousAccessor_whenCreatingStorage_thenSameFlowReportsLifecycle() = runBlocking {
+        val provider = TestUserStorageProvider(AtomicInteger(0), reportsMigration = true)
+        val states = mutableListOf<UserStorageState>()
+        val observer = launch(Dispatchers.Unconfined, start = CoroutineStart.UNDISPATCHED) {
+            provider.observe(testUserId).take(4).toList(states)
+        }
+
+        val storage = provider.getOrCreate(
+            userId = testUserId,
+            platformUserStorageProperties = testProperties,
+            shouldEncryptData = false,
+            dbInvalidationControlEnabled = false,
+        )
+        observer.join()
+
+        assertEquals(
+            listOf(
+                UserStorageState.NotStarted,
+                UserStorageState.OpeningDatabase,
+                UserStorageState.MigratingDatabase,
+                UserStorageState.Ready(storage),
+            ),
+            states,
+        )
+
+        cleanup(provider)
+    }
+
+    @Test
+    fun givenConcurrentCallers_whenPreparingStorage_thenStorageIsCreatedOnce() = runBlocking {
+        val createCount = AtomicInteger(0)
+        val provider = TestUserStorageProvider(createCount)
+
+        val first = async {
+            provider.prepare(testUserId, testProperties, false, false)
+        }
+        val second = async {
+            provider.prepare(testUserId, testProperties, false, false)
+        }
+
+        assertIs<UserStoragePreparationResult.Success>(first.await())
+        assertIs<UserStoragePreparationResult.Success>(second.await())
+        assertEquals(1, createCount.get())
+
+        cleanup(provider)
+    }
+
+    @Test
+    fun givenConcurrentCallers_whenOneCallerIsCancelled_thenSharedPreparationContinues() = runBlocking {
+        val createCount = AtomicInteger(0)
+        val preparationStarted = CountDownLatch(1)
+        val continuePreparation = CountDownLatch(1)
+        val provider = object : UserStorageProvider() {
+            override fun create(
+                userId: UserId,
+                shouldEncryptData: Boolean,
+                platformProperties: PlatformUserStorageProperties,
+                dbInvalidationControlEnabled: Boolean,
+            ): UserStorage {
+                createCount.incrementAndGet()
+                preparationStarted.countDown()
+                continuePreparation.await()
+                return UserStorage(inMemoryDatabase(testUserIdEntity, KaliumDispatcherImpl.io))
+            }
+        }
+
+        val cancelled = async(start = CoroutineStart.UNDISPATCHED) {
+            provider.prepare(testUserId, testProperties, false, false)
+        }
+        val waiting = async(start = CoroutineStart.UNDISPATCHED) {
+            provider.prepare(testUserId, testProperties, false, false)
+        }
+        preparationStarted.await()
+        cancelled.cancel()
+        continuePreparation.countDown()
+
+        assertIs<UserStoragePreparationResult.Success>(waiting.await())
+        assertEquals(1, createCount.get())
+
+        cleanup(provider)
+    }
+
+    @Test
+    fun givenRetryableFailure_whenPreparingAgain_thenNewAttemptStarts() = runBlocking {
+        val createCount = AtomicInteger(0)
+        val provider = TestUserStorageProvider(createCount, failuresRemaining = AtomicInteger(1))
+
+        val first = provider.prepare(testUserId, testProperties, false, false)
+        val second = provider.prepare(testUserId, testProperties, false, false)
+
+        assertEquals(
+            UserStoragePreparationFailure.TemporarilyUnavailable,
+            assertIs<UserStoragePreparationResult.Failure>(first).reason,
+        )
+        assertIs<UserStoragePreparationResult.Success>(second)
+        assertEquals(2, createCount.get())
+
+        cleanup(provider)
+    }
+
+    @Test
+    fun givenFatalFailure_whenPreparingAgain_thenFailedAttemptIsReused() = runBlocking {
+        val createCount = AtomicInteger(0)
+        val provider = TestUserStorageProvider(
+            createCount,
+            failuresRemaining = AtomicInteger(1),
+            failureMessage = "file is not a database",
+        )
+
+        val first = provider.prepare(testUserId, testProperties, false, false)
+        val second = provider.prepare(testUserId, testProperties, false, false)
+
+        assertEquals(
+            UserStoragePreparationFailure.SupportRequired,
+            assertIs<UserStoragePreparationResult.Failure>(first).reason,
+        )
+        assertEquals(
+            UserStoragePreparationFailure.SupportRequired,
+            assertIs<UserStoragePreparationResult.Failure>(second).reason,
+        )
+        assertEquals(1, createCount.get())
+
+        cleanup(provider)
+    }
+
+    @Test
+    fun givenNestedLockedError_whenClassifyingFailure_thenTemporarilyUnavailableIsReturned() {
+        val result = IllegalStateException(
+            "Could not open database",
+            IllegalStateException("database is locked"),
+        ).toUserStoragePreparationFailure()
+
+        assertEquals(UserStoragePreparationFailure.TemporarilyUnavailable, result)
+    }
+
+    @Test
+    fun givenDiskFullError_whenClassifyingFailure_thenInsufficientStorageIsReturned() {
+        val result = IllegalStateException("SQLITE_FULL: database or disk is full")
+            .toUserStoragePreparationFailure()
+
+        assertEquals(UserStoragePreparationFailure.InsufficientStorage, result)
+    }
+
+    @Test
+    fun givenDowngradeError_whenClassifyingFailure_thenApplicationUpdateRequiredIsReturned() {
+        val result = IllegalStateException("Database downgrade is not supported")
+            .toUserStoragePreparationFailure()
+
+        assertEquals(UserStoragePreparationFailure.ApplicationUpdateRequired, result)
+    }
+
+    @Test
+    fun givenUnknownDatabaseError_whenClassifyingFailure_thenSupportRequiredIsReturned() {
+        val result = IllegalStateException("file is not a database")
+            .toUserStoragePreparationFailure()
+
+        assertEquals(UserStoragePreparationFailure.SupportRequired, result)
+    }
+
     private fun cleanup(vararg providers: UserStorageProvider) {
         providers.forEach { it.remove(testUserId)?.database?.nuke() }
         clearInMemoryDatabase(testUserIdEntity)
     }
 
     private class TestUserStorageProvider(
-        private val createCount: AtomicInteger
+        private val createCount: AtomicInteger,
+        private val reportsMigration: Boolean = false,
+        private val failuresRemaining: AtomicInteger = AtomicInteger(0),
+        private val failureMessage: String = "database is locked",
     ) : UserStorageProvider() {
 
         override fun create(
@@ -150,8 +366,24 @@ class UserStorageProviderTest {
             dbInvalidationControlEnabled: Boolean
         ): UserStorage {
             createCount.incrementAndGet()
+            if (failuresRemaining.getAndUpdate { current -> (current - 1).coerceAtLeast(0) } > 0) {
+                error(failureMessage)
+            }
             val userIdEntity = UserIDEntity(userId.value, userId.domain)
             return UserStorage(inMemoryDatabase(userIdEntity, KaliumDispatcherImpl.io))
+        }
+
+        override fun create(
+            userId: UserId,
+            shouldEncryptData: Boolean,
+            platformProperties: PlatformUserStorageProperties,
+            dbInvalidationControlEnabled: Boolean,
+            onMigrationStarted: () -> Unit,
+        ): UserStorage {
+            if (reportsMigration) {
+                onMigrationStarted()
+            }
+            return create(userId, shouldEncryptData, platformProperties, dbInvalidationControlEnabled)
         }
     }
 }

--- a/domain/userstorage/src/jvmTest/kotlin/com/wire/kalium/userstorage/di/UserStorageProviderTest.kt
+++ b/domain/userstorage/src/jvmTest/kotlin/com/wire/kalium/userstorage/di/UserStorageProviderTest.kt
@@ -172,14 +172,14 @@ class UserStorageProviderTest {
             dbInvalidationControlEnabled = false,
         )
         observer.join()
+        val storage = assertIs<UserStoragePreparationResult.Success>(result).storage
 
-        val success = assertIs<UserStoragePreparationResult.Success>(result)
         assertEquals(
             listOf(
                 UserStorageState.NotStarted,
                 UserStorageState.OpeningDatabase,
                 UserStorageState.MigratingDatabase,
-                UserStorageState.Ready(success.storage),
+                UserStorageState.Ready(storage),
             ),
             states,
         )
@@ -228,8 +228,7 @@ class UserStorageProviderTest {
             provider.prepare(testUserId, testProperties, false, false)
         }
 
-        assertIs<UserStoragePreparationResult.Success>(first.await())
-        assertIs<UserStoragePreparationResult.Success>(second.await())
+        assertSame(first.await(), second.await())
         assertEquals(1, createCount.get())
 
         cleanup(provider)
@@ -273,16 +272,22 @@ class UserStorageProviderTest {
     @Test
     fun givenRetryableFailure_whenPreparingAgain_thenNewAttemptStarts() = runBlocking {
         val createCount = AtomicInteger(0)
-        val provider = TestUserStorageProvider(createCount, failuresRemaining = AtomicInteger(1))
+        val expected = IllegalStateException("database is locked")
+        val provider = TestUserStorageProvider(
+            createCount,
+            failuresRemaining = AtomicInteger(1),
+            failure = expected,
+        )
 
-        val first = provider.prepare(testUserId, testProperties, false, false)
+        val first = assertIs<UserStoragePreparationResult.Failure>(
+            provider.prepare(testUserId, testProperties, false, false)
+        )
         val second = provider.prepare(testUserId, testProperties, false, false)
 
-        assertEquals(
-            UserStoragePreparationFailure.TemporarilyUnavailable,
-            assertIs<UserStoragePreparationResult.Failure>(first).reason,
-        )
-        assertIs<UserStoragePreparationResult.Success>(second)
+        assertIs<UserStoragePreparationFailure.TemporarilyUnavailable>(first.failure)
+        assertSame(expected, first.failure.exception)
+        val storage = assertIs<UserStoragePreparationResult.Success>(second).storage
+        assertSame(storage, provider.get(testUserId))
         assertEquals(2, createCount.get())
 
         cleanup(provider)
@@ -291,60 +296,64 @@ class UserStorageProviderTest {
     @Test
     fun givenFatalFailure_whenPreparingAgain_thenFailedAttemptIsReused() = runBlocking {
         val createCount = AtomicInteger(0)
+        val expected = IllegalStateException("file is not a database")
         val provider = TestUserStorageProvider(
             createCount,
             failuresRemaining = AtomicInteger(1),
-            failureMessage = "file is not a database",
+            failure = expected,
+        )
+        val states = mutableListOf<UserStorageState>()
+        val observer = launch(Dispatchers.Unconfined, start = CoroutineStart.UNDISPATCHED) {
+            provider.observe(testUserId).take(3).toList(states)
+        }
+
+        val first = assertIs<UserStoragePreparationResult.Failure>(
+            provider.prepare(testUserId, testProperties, false, false)
+        )
+        observer.join()
+        val second = assertIs<UserStoragePreparationResult.Failure>(
+            provider.prepare(testUserId, testProperties, false, false)
         )
 
-        val first = provider.prepare(testUserId, testProperties, false, false)
-        val second = provider.prepare(testUserId, testProperties, false, false)
-
-        assertEquals(
-            UserStoragePreparationFailure.SupportRequired,
-            assertIs<UserStoragePreparationResult.Failure>(first).reason,
-        )
-        assertEquals(
-            UserStoragePreparationFailure.SupportRequired,
-            assertIs<UserStoragePreparationResult.Failure>(second).reason,
-        )
+        assertIs<UserStoragePreparationFailure.SupportRequired>(first.failure)
+        assertSame(first.failure, second.failure)
+        assertSame(expected, first.failure.exception)
+        assertEquals(UserStorageState.NotStarted, states[0])
+        assertEquals(UserStorageState.OpeningDatabase, states[1])
+        assertSame(first.failure, assertIs<UserStorageState.Failed>(states[2]).failure)
         assertEquals(1, createCount.get())
 
         cleanup(provider)
     }
 
     @Test
-    fun givenNestedLockedError_whenClassifyingFailure_thenTemporarilyUnavailableIsReturned() {
-        val result = IllegalStateException(
+    fun givenNestedLockedError_whenClassifyingFailure_thenOriginalExceptionIsRetained() {
+        val expected = IllegalStateException(
             "Could not open database",
             IllegalStateException("database is locked"),
-        ).toUserStoragePreparationFailure()
+        )
+        val result = expected.toUserStoragePreparationFailure()
 
-        assertEquals(UserStoragePreparationFailure.TemporarilyUnavailable, result)
+        assertIs<UserStoragePreparationFailure.TemporarilyUnavailable>(result)
+        assertSame(expected, result.exception)
     }
 
     @Test
-    fun givenDiskFullError_whenClassifyingFailure_thenInsufficientStorageIsReturned() {
-        val result = IllegalStateException("SQLITE_FULL: database or disk is full")
-            .toUserStoragePreparationFailure()
+    fun givenDiskFullError_whenClassifyingFailure_thenOriginalExceptionIsRetained() {
+        val expected = IllegalStateException("SQLITE_FULL: database or disk is full")
+        val result = expected.toUserStoragePreparationFailure()
 
-        assertEquals(UserStoragePreparationFailure.InsufficientStorage, result)
+        assertIs<UserStoragePreparationFailure.InsufficientStorage>(result)
+        assertSame(expected, result.exception)
     }
 
     @Test
-    fun givenDowngradeError_whenClassifyingFailure_thenApplicationUpdateRequiredIsReturned() {
-        val result = IllegalStateException("Database downgrade is not supported")
-            .toUserStoragePreparationFailure()
+    fun givenUnknownDatabaseError_whenClassifyingFailure_thenOriginalExceptionIsRetained() {
+        val expected = IllegalStateException("file is not a database")
+        val result = expected.toUserStoragePreparationFailure()
 
-        assertEquals(UserStoragePreparationFailure.ApplicationUpdateRequired, result)
-    }
-
-    @Test
-    fun givenUnknownDatabaseError_whenClassifyingFailure_thenSupportRequiredIsReturned() {
-        val result = IllegalStateException("file is not a database")
-            .toUserStoragePreparationFailure()
-
-        assertEquals(UserStoragePreparationFailure.SupportRequired, result)
+        assertIs<UserStoragePreparationFailure.SupportRequired>(result)
+        assertSame(expected, result.exception)
     }
 
     private fun cleanup(vararg providers: UserStorageProvider) {
@@ -356,7 +365,7 @@ class UserStorageProviderTest {
         private val createCount: AtomicInteger,
         private val reportsMigration: Boolean = false,
         private val failuresRemaining: AtomicInteger = AtomicInteger(0),
-        private val failureMessage: String = "database is locked",
+        private val failure: IllegalStateException = IllegalStateException("database is locked"),
     ) : UserStorageProvider() {
 
         override fun create(
@@ -367,7 +376,7 @@ class UserStorageProviderTest {
         ): UserStorage {
             createCount.incrementAndGet()
             if (failuresRemaining.getAndUpdate { current -> (current - 1).coerceAtLeast(0) } > 0) {
-                error(failureMessage)
+                throw failure
             }
             val userIdEntity = UserIDEntity(userId.value, userId.domain)
             return UserStorage(inMemoryDatabase(userIdEntity, KaliumDispatcherImpl.io))


### PR DESCRIPTION
## Intent

Keep each user's storage lifecycle, preparation attempt, cached storage, and observable state in one place.

## Changes

- Add a per-user storage session that owns the state flow and in-flight preparation.
- Coalesce concurrent preparation calls into one database-open attempt.
- Expose observation without starting preparation.
- Cache successful storage and allow retries for recoverable failures.
- Connect the persistence migration-start signal to the storage lifecycle.
- Cover preparation, observation, concurrency, retry, removal, and cache behavior.

## Impact

Storage consumers no longer need to coordinate database preparation across modules. The user-storage provider is the single source of truth for each user's in-process storage state.

## Stack

- [PR 1](https://github.com/wireapp/kalium/pull/4361)
- [PR 2](https://github.com/wireapp/kalium/pull/4378)
- PR 3 of 6 (current)

## End-to-end preparation pipeline

All database-dependent entry points converge on one per-user preparation operation. The storage session owns the single in-flight attempt and publishes state for observers.

```mermaid
flowchart TD
    UI_ENTRY["UI or app startup"] --> PREPARE["CoreLogic.prepareUserSession(userId)"]
    APP_ENTRY["Service, receiver, or extension"] --> PREPARE
    WM_ENTRY["Existing WorkManager job"] --> WRAPPER["WrapperWorker"]
    WRAPPER --> PREPARE

    PREPARE --> SCOPE_PROVIDER["UserSessionScopeProvider.prepare"]
    SCOPE_PROVIDER --> STORAGE_PROVIDER["UserStorageProvider.prepare(userId)"]
    STORAGE_PROVIDER --> USER_SESSION["Per-user UserStorageSession<br/>single in-flight attempt"]

    USER_SESSION --> OPENING["OpeningDatabase"]
    OPENING --> DATABASE["UserDatabaseBuilder.open"]
    DATABASE -->|"schema is current"| READY["Ready"]
    DATABASE -->|"migration callback"| MIGRATING["MigratingDatabase"]
    MIGRATING -->|"migration commits"| READY
    DATABASE -->|"open or migration error"| FAILURE["Classify failure"]

    READY --> SESSION_SCOPE["UserSessionScope"]
    SESSION_SCOPE --> CONSUMER["Database-dependent consumer"]
    SESSION_SCOPE --> INNER_WORKER["Create and run inner WorkManager worker"]

    USER_SESSION -.->|"state flow; observation does not start preparation"| OBSERVER["observeUserSessionPreparation(userId)"]
    OBSERVER --> STATE_UI["Migration UI or state observer"]

    FAILURE --> APP_FAILURE["UI, service, or receiver failure handling"]
    FAILURE --> RETRY["Retry policy"]
    RETRY --> PREPARE
    FAILURE --> WORK_FAILURE["WorkManager retry or failure result"]
```

WorkManager is a preparation gate for existing background work; it is not a dedicated migration scheduler.

