### PR TITLE
feat(session): expose explicit session preparation PR 4

### DIFF
--- a/changelog.d/user-session-preparation-api.added.md
+++ b/changelog.d/user-session-preparation-api.added.md
@@ -1,5 +1,7 @@
 Added `CoreLogic.prepareUserSession` and `observeUserSessionPreparation` so apps can open and migrate
-user databases away from the main thread before using a session.
+user databases away from the main thread before using a session. Typed preparation failures retain
+the original storage exception, allowing apps to handle the failure category or rethrow the
+underlying exception unchanged.
 
   - ABI: additive.
   - Source: additive.

--- a/changelog.d/user-session-preparation-api.added.md
+++ b/changelog.d/user-session-preparation-api.added.md
@@ -1,0 +1,7 @@
+Added `CoreLogic.prepareUserSession` and `observeUserSessionPreparation` so apps can open and migrate
+user databases away from the main thread before using a session.
+
+  - ABI: additive.
+  - Source: additive.
+  - Behavior: existing `getSessionScope` behavior is unchanged in this release.
+  - Migration: apps may adopt the new preparation API before creating database-dependent UI or work.

--- a/docs/adr/0011-explicit-user-database-migration-lifecycle.md
+++ b/docs/adr/0011-explicit-user-database-migration-lifecycle.md
@@ -83,7 +83,7 @@ public fun observeUserSessionPreparation(
 ): Flow<UserSessionPreparationState>
 ```
 
-The preparation result is concrete and Swift-friendly, following ADR 7:
+The result contains either the ready scope or a typed failure:
 
 ```kotlin
 public sealed class PrepareUserSessionResult {
@@ -92,7 +92,7 @@ public sealed class PrepareUserSessionResult {
     ) : PrepareUserSessionResult()
 
     public class Failure internal constructor(
-        public val reason: UserSessionPreparationFailure
+        public val failure: UserSessionPreparationFailure
     ) : PrepareUserSessionResult()
 }
 ```
@@ -107,25 +107,38 @@ public sealed class UserSessionPreparationState {
     public data object Ready : UserSessionPreparationState()
 
     public class Failed internal constructor(
-        public val reason: UserSessionPreparationFailure
+        public val failure: UserSessionPreparationFailure
     ) : UserSessionPreparationState()
 }
 ```
 
-Failures are small and actionable. Kalium does not expose raw database errors, encryption details,
-database paths, or schema versions.
+Every typed failure retains the exact exception raised while opening or migrating the database:
 
 ```kotlin
 public sealed class UserSessionPreparationFailure {
-    public data object InsufficientStorage : UserSessionPreparationFailure()
-    public data object TemporarilyUnavailable : UserSessionPreparationFailure()
-    public data object ApplicationUpdateRequired : UserSessionPreparationFailure()
-    public data object SupportRequired : UserSessionPreparationFailure()
+    public abstract val exception: Throwable
+
+    public class InsufficientStorage internal constructor(
+        public override val exception: Throwable
+    ) : UserSessionPreparationFailure()
+
+    public class TemporarilyUnavailable internal constructor(
+        public override val exception: Throwable
+    ) : UserSessionPreparationFailure()
+
+    public class ApplicationUpdateRequired internal constructor(
+        public override val exception: Throwable
+    ) : UserSessionPreparationFailure()
+
+    public class SupportRequired internal constructor(
+        public override val exception: Throwable
+    ) : UserSessionPreparationFailure()
 }
 ```
 
-`InsufficientStorage` and `TemporarilyUnavailable` may be tried again. The other failures stop
-automatic retries for the current app version.
+Apps may handle the typed failure or rethrow `failure.exception` without losing its type, message,
+cause chain, or stack trace. They remain responsible for deciding how much diagnostic detail is safe
+to show to users.
 
 Observing the state does not start preparation. The state is only for UI. The suspending
 `prepareUserSession` operation is the gate that every database user must call.
@@ -191,8 +204,8 @@ The change will follow the current module boundaries:
   and report when SQLDelight starts an upgrade.
 - `:domain:userstorage` will own one entry and state flow per user database, coordinate its shared
   preparation attempt, and cache storage only after preparation succeeds.
-- `:logic` will expose the public API, map internal errors to the public failure types, and create
-  `UserSessionScope` only after storage is ready.
+- `:logic` will expose the public API, map storage failure types while retaining their original
+  exceptions, and create `UserSessionScope` only after storage is ready.
 - Android and iOS will call the new API from startup and every background entry point that needs the
   user database.
 
@@ -207,8 +220,9 @@ There is one preparation operation for each physical user database in a process.
 - A repeated call after `Ready` returns the cached scope immediately.
 - Cancelling one caller only cancels that caller's wait. It does not cancel work used by another
   caller.
-- A retryable failure allows a later call to start a new attempt.
-- A failure that needs an app update or support does not enter an automatic retry loop.
+- A transient storage-full, busy, or locked failure allows a later call to start a new attempt.
+- Other failures do not enter an automatic retry loop, but their original exceptions still reach
+  every caller waiting for that preparation attempt.
 
 If the process stops during migration, the next call opens the database again. SQLDelight and the
 platform driver read the stored schema version and run any migration that was not committed. The app
@@ -232,7 +246,8 @@ The API will be introduced in steps:
    successful preparation is a programming error and must fail fast instead of opening or migrating
    the database.
 
-`prepareUserSession` returns the ready scope, so new callers do not need another lookup API.
+`prepareUserSession` returns the ready scope inside `Success`, so new callers do not need another
+lookup API.
 
 The additive API and later behavior change must follow the ABI and changelog rules in ADR 9.
 

--- a/logic/api/jvm/logic.api
+++ b/logic/api/jvm/logic.api
@@ -19,6 +19,8 @@ public abstract class com/wire/kalium/logic/CoreLogicCommon {
 	public abstract fun getSessionScope (Lcom/wire/kalium/logic/data/id/QualifiedID;)Lcom/wire/kalium/logic/feature/UserSessionScope;
 	protected final fun getUserAgent ()Ljava/lang/String;
 	public final fun globalScope (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public final fun observeUserSessionPreparation (Lcom/wire/kalium/logic/data/id/QualifiedID;)Lkotlinx/coroutines/flow/Flow;
+	public final fun prepareUserSession (Lcom/wire/kalium/logic/data/id/QualifiedID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun registerLogger (Lcom/wire/kalium/logger/KaliumLogger$Config;)V
 	public final fun sessionScope (Lcom/wire/kalium/logic/data/id/QualifiedID;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public final fun versionedAuthenticationScope (Lcom/wire/kalium/logic/configuration/server/ServerConfig$Links;)Lcom/wire/kalium/logic/feature/auth/autoVersioningAuth/AutoVersionAuthScopeUseCase;
@@ -54,6 +56,83 @@ public final class com/wire/kalium/logic/GlobalKaliumScope : kotlinx/coroutines/
 	public final fun getValidateUserHandleUseCase ()Lcom/wire/kalium/logic/feature/auth/ValidateUserHandleUseCase;
 	public final fun isCrossBackendLoginBlocked ()Lcom/wire/kalium/logic/feature/server/IsCrossBackendLoginBlockedUseCase;
 	public final fun isCurrentSessionNomadAccount ()Lcom/wire/kalium/logic/feature/session/IsCurrentSessionNomadAccountUseCase;
+}
+
+public abstract class com/wire/kalium/logic/PrepareUserSessionResult {
+}
+
+public final class com/wire/kalium/logic/PrepareUserSessionResult$Failure : com/wire/kalium/logic/PrepareUserSessionResult {
+	public final fun getReason ()Lcom/wire/kalium/logic/UserSessionPreparationFailure;
+}
+
+public final class com/wire/kalium/logic/PrepareUserSessionResult$Success : com/wire/kalium/logic/PrepareUserSessionResult {
+	public final fun getSessionScope ()Lcom/wire/kalium/logic/feature/UserSessionScope;
+}
+
+public abstract class com/wire/kalium/logic/UserSessionPreparationFailure {
+}
+
+public final class com/wire/kalium/logic/UserSessionPreparationFailure$ApplicationUpdateRequired : com/wire/kalium/logic/UserSessionPreparationFailure {
+	public static final field INSTANCE Lcom/wire/kalium/logic/UserSessionPreparationFailure$ApplicationUpdateRequired;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/wire/kalium/logic/UserSessionPreparationFailure$InsufficientStorage : com/wire/kalium/logic/UserSessionPreparationFailure {
+	public static final field INSTANCE Lcom/wire/kalium/logic/UserSessionPreparationFailure$InsufficientStorage;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/wire/kalium/logic/UserSessionPreparationFailure$SupportRequired : com/wire/kalium/logic/UserSessionPreparationFailure {
+	public static final field INSTANCE Lcom/wire/kalium/logic/UserSessionPreparationFailure$SupportRequired;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/wire/kalium/logic/UserSessionPreparationFailure$TemporarilyUnavailable : com/wire/kalium/logic/UserSessionPreparationFailure {
+	public static final field INSTANCE Lcom/wire/kalium/logic/UserSessionPreparationFailure$TemporarilyUnavailable;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/wire/kalium/logic/UserSessionPreparationState {
+}
+
+public final class com/wire/kalium/logic/UserSessionPreparationState$Failed : com/wire/kalium/logic/UserSessionPreparationState {
+	public final fun getReason ()Lcom/wire/kalium/logic/UserSessionPreparationFailure;
+}
+
+public final class com/wire/kalium/logic/UserSessionPreparationState$MigratingDatabase : com/wire/kalium/logic/UserSessionPreparationState {
+	public static final field INSTANCE Lcom/wire/kalium/logic/UserSessionPreparationState$MigratingDatabase;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/wire/kalium/logic/UserSessionPreparationState$NotStarted : com/wire/kalium/logic/UserSessionPreparationState {
+	public static final field INSTANCE Lcom/wire/kalium/logic/UserSessionPreparationState$NotStarted;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/wire/kalium/logic/UserSessionPreparationState$OpeningDatabase : com/wire/kalium/logic/UserSessionPreparationState {
+	public static final field INSTANCE Lcom/wire/kalium/logic/UserSessionPreparationState$OpeningDatabase;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/wire/kalium/logic/UserSessionPreparationState$Ready : com/wire/kalium/logic/UserSessionPreparationState {
+	public static final field INSTANCE Lcom/wire/kalium/logic/UserSessionPreparationState$Ready;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/wire/kalium/logic/configuration/AppLockTeamConfig {

--- a/logic/api/jvm/logic.api
+++ b/logic/api/jvm/logic.api
@@ -62,7 +62,7 @@ public abstract class com/wire/kalium/logic/PrepareUserSessionResult {
 }
 
 public final class com/wire/kalium/logic/PrepareUserSessionResult$Failure : com/wire/kalium/logic/PrepareUserSessionResult {
-	public final fun getReason ()Lcom/wire/kalium/logic/UserSessionPreparationFailure;
+	public final fun getFailure ()Lcom/wire/kalium/logic/UserSessionPreparationFailure;
 }
 
 public final class com/wire/kalium/logic/PrepareUserSessionResult$Success : com/wire/kalium/logic/PrepareUserSessionResult {
@@ -70,41 +70,30 @@ public final class com/wire/kalium/logic/PrepareUserSessionResult$Success : com/
 }
 
 public abstract class com/wire/kalium/logic/UserSessionPreparationFailure {
+	public abstract fun getException ()Ljava/lang/Throwable;
 }
 
 public final class com/wire/kalium/logic/UserSessionPreparationFailure$ApplicationUpdateRequired : com/wire/kalium/logic/UserSessionPreparationFailure {
-	public static final field INSTANCE Lcom/wire/kalium/logic/UserSessionPreparationFailure$ApplicationUpdateRequired;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
+	public fun getException ()Ljava/lang/Throwable;
 }
 
 public final class com/wire/kalium/logic/UserSessionPreparationFailure$InsufficientStorage : com/wire/kalium/logic/UserSessionPreparationFailure {
-	public static final field INSTANCE Lcom/wire/kalium/logic/UserSessionPreparationFailure$InsufficientStorage;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
+	public fun getException ()Ljava/lang/Throwable;
 }
 
 public final class com/wire/kalium/logic/UserSessionPreparationFailure$SupportRequired : com/wire/kalium/logic/UserSessionPreparationFailure {
-	public static final field INSTANCE Lcom/wire/kalium/logic/UserSessionPreparationFailure$SupportRequired;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
+	public fun getException ()Ljava/lang/Throwable;
 }
 
 public final class com/wire/kalium/logic/UserSessionPreparationFailure$TemporarilyUnavailable : com/wire/kalium/logic/UserSessionPreparationFailure {
-	public static final field INSTANCE Lcom/wire/kalium/logic/UserSessionPreparationFailure$TemporarilyUnavailable;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
+	public fun getException ()Ljava/lang/Throwable;
 }
 
 public abstract class com/wire/kalium/logic/UserSessionPreparationState {
 }
 
 public final class com/wire/kalium/logic/UserSessionPreparationState$Failed : com/wire/kalium/logic/UserSessionPreparationState {
-	public final fun getReason ()Lcom/wire/kalium/logic/UserSessionPreparationFailure;
+	public final fun getFailure ()Lcom/wire/kalium/logic/UserSessionPreparationFailure;
 }
 
 public final class com/wire/kalium/logic/UserSessionPreparationState$MigratingDatabase : com/wire/kalium/logic/UserSessionPreparationState {

--- a/logic/api/logic.klib.api
+++ b/logic/api/logic.klib.api
@@ -2567,10 +2567,12 @@ abstract class com.wire.kalium.logic/CoreLogicCommon { // com.wire.kalium.logic/
 
     abstract fun getSessionScope(com.wire.kalium.logic.data.id/QualifiedID): com.wire.kalium.logic.feature/UserSessionScope // com.wire.kalium.logic/CoreLogicCommon.getSessionScope|getSessionScope(com.wire.kalium.logic.data.id.QualifiedID){}[0]
     final fun getGlobalScope(): com.wire.kalium.logic/GlobalKaliumScope // com.wire.kalium.logic/CoreLogicCommon.getGlobalScope|getGlobalScope(){}[0]
+    final fun observeUserSessionPreparation(com.wire.kalium.logic.data.id/QualifiedID): kotlinx.coroutines.flow/Flow<com.wire.kalium.logic/UserSessionPreparationState> // com.wire.kalium.logic/CoreLogicCommon.observeUserSessionPreparation|observeUserSessionPreparation(com.wire.kalium.logic.data.id.QualifiedID){}[0]
     final fun registerLogger(com.wire.kalium.logger/KaliumLogger.Config) // com.wire.kalium.logic/CoreLogicCommon.registerLogger|registerLogger(com.wire.kalium.logger.KaliumLogger.Config){}[0]
     final fun versionedAuthenticationScope(com.wire.kalium.logic.configuration.server/ServerConfig.Links): com.wire.kalium.logic.feature.auth.autoVersioningAuth/AutoVersionAuthScopeUseCase // com.wire.kalium.logic/CoreLogicCommon.versionedAuthenticationScope|versionedAuthenticationScope(com.wire.kalium.logic.configuration.server.ServerConfig.Links){}[0]
     final inline fun <#A1: kotlin/Any?> globalScope(kotlin/Function1<com.wire.kalium.logic/GlobalKaliumScope, #A1>): #A1 // com.wire.kalium.logic/CoreLogicCommon.globalScope|globalScope(kotlin.Function1<com.wire.kalium.logic.GlobalKaliumScope,0:0>){0§<kotlin.Any?>}[0]
     final inline fun <#A1: kotlin/Any?> sessionScope(com.wire.kalium.logic.data.id/QualifiedID, kotlin/Function1<com.wire.kalium.logic.feature/UserSessionScope, #A1>): #A1 // com.wire.kalium.logic/CoreLogicCommon.sessionScope|sessionScope(com.wire.kalium.logic.data.id.QualifiedID;kotlin.Function1<com.wire.kalium.logic.feature.UserSessionScope,0:0>){0§<kotlin.Any?>}[0]
+    final suspend fun prepareUserSession(com.wire.kalium.logic.data.id/QualifiedID): com.wire.kalium.logic/PrepareUserSessionResult // com.wire.kalium.logic/CoreLogicCommon.prepareUserSession|prepareUserSession(com.wire.kalium.logic.data.id.QualifiedID){}[0]
 }
 
 final class com.wire.kalium.logic.configuration.server/ServerConfig { // com.wire.kalium.logic.configuration.server/ServerConfig|null[0]
@@ -8317,6 +8319,75 @@ sealed class com.wire.kalium.logic.sync/SyncRequestResult { // com.wire.kalium.l
     }
 
     final object Success : com.wire.kalium.logic.sync/SyncRequestResult // com.wire.kalium.logic.sync/SyncRequestResult.Success|null[0]
+}
+
+sealed class com.wire.kalium.logic/PrepareUserSessionResult { // com.wire.kalium.logic/PrepareUserSessionResult|null[0]
+    final class Failure : com.wire.kalium.logic/PrepareUserSessionResult { // com.wire.kalium.logic/PrepareUserSessionResult.Failure|null[0]
+        final val reason // com.wire.kalium.logic/PrepareUserSessionResult.Failure.reason|{}reason[0]
+            final fun <get-reason>(): com.wire.kalium.logic/UserSessionPreparationFailure // com.wire.kalium.logic/PrepareUserSessionResult.Failure.reason.<get-reason>|<get-reason>(){}[0]
+    }
+
+    final class Success : com.wire.kalium.logic/PrepareUserSessionResult { // com.wire.kalium.logic/PrepareUserSessionResult.Success|null[0]
+        final val sessionScope // com.wire.kalium.logic/PrepareUserSessionResult.Success.sessionScope|{}sessionScope[0]
+            final fun <get-sessionScope>(): com.wire.kalium.logic.feature/UserSessionScope // com.wire.kalium.logic/PrepareUserSessionResult.Success.sessionScope.<get-sessionScope>|<get-sessionScope>(){}[0]
+    }
+}
+
+sealed class com.wire.kalium.logic/UserSessionPreparationFailure { // com.wire.kalium.logic/UserSessionPreparationFailure|null[0]
+    final object ApplicationUpdateRequired : com.wire.kalium.logic/UserSessionPreparationFailure { // com.wire.kalium.logic/UserSessionPreparationFailure.ApplicationUpdateRequired|null[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic/UserSessionPreparationFailure.ApplicationUpdateRequired.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.wire.kalium.logic/UserSessionPreparationFailure.ApplicationUpdateRequired.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // com.wire.kalium.logic/UserSessionPreparationFailure.ApplicationUpdateRequired.toString|toString(){}[0]
+    }
+
+    final object InsufficientStorage : com.wire.kalium.logic/UserSessionPreparationFailure { // com.wire.kalium.logic/UserSessionPreparationFailure.InsufficientStorage|null[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic/UserSessionPreparationFailure.InsufficientStorage.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.wire.kalium.logic/UserSessionPreparationFailure.InsufficientStorage.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // com.wire.kalium.logic/UserSessionPreparationFailure.InsufficientStorage.toString|toString(){}[0]
+    }
+
+    final object SupportRequired : com.wire.kalium.logic/UserSessionPreparationFailure { // com.wire.kalium.logic/UserSessionPreparationFailure.SupportRequired|null[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic/UserSessionPreparationFailure.SupportRequired.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.wire.kalium.logic/UserSessionPreparationFailure.SupportRequired.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // com.wire.kalium.logic/UserSessionPreparationFailure.SupportRequired.toString|toString(){}[0]
+    }
+
+    final object TemporarilyUnavailable : com.wire.kalium.logic/UserSessionPreparationFailure { // com.wire.kalium.logic/UserSessionPreparationFailure.TemporarilyUnavailable|null[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic/UserSessionPreparationFailure.TemporarilyUnavailable.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.wire.kalium.logic/UserSessionPreparationFailure.TemporarilyUnavailable.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // com.wire.kalium.logic/UserSessionPreparationFailure.TemporarilyUnavailable.toString|toString(){}[0]
+    }
+}
+
+sealed class com.wire.kalium.logic/UserSessionPreparationState { // com.wire.kalium.logic/UserSessionPreparationState|null[0]
+    final class Failed : com.wire.kalium.logic/UserSessionPreparationState { // com.wire.kalium.logic/UserSessionPreparationState.Failed|null[0]
+        final val reason // com.wire.kalium.logic/UserSessionPreparationState.Failed.reason|{}reason[0]
+            final fun <get-reason>(): com.wire.kalium.logic/UserSessionPreparationFailure // com.wire.kalium.logic/UserSessionPreparationState.Failed.reason.<get-reason>|<get-reason>(){}[0]
+    }
+
+    final object MigratingDatabase : com.wire.kalium.logic/UserSessionPreparationState { // com.wire.kalium.logic/UserSessionPreparationState.MigratingDatabase|null[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic/UserSessionPreparationState.MigratingDatabase.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.wire.kalium.logic/UserSessionPreparationState.MigratingDatabase.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // com.wire.kalium.logic/UserSessionPreparationState.MigratingDatabase.toString|toString(){}[0]
+    }
+
+    final object NotStarted : com.wire.kalium.logic/UserSessionPreparationState { // com.wire.kalium.logic/UserSessionPreparationState.NotStarted|null[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic/UserSessionPreparationState.NotStarted.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.wire.kalium.logic/UserSessionPreparationState.NotStarted.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // com.wire.kalium.logic/UserSessionPreparationState.NotStarted.toString|toString(){}[0]
+    }
+
+    final object OpeningDatabase : com.wire.kalium.logic/UserSessionPreparationState { // com.wire.kalium.logic/UserSessionPreparationState.OpeningDatabase|null[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic/UserSessionPreparationState.OpeningDatabase.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.wire.kalium.logic/UserSessionPreparationState.OpeningDatabase.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // com.wire.kalium.logic/UserSessionPreparationState.OpeningDatabase.toString|toString(){}[0]
+    }
+
+    final object Ready : com.wire.kalium.logic/UserSessionPreparationState { // com.wire.kalium.logic/UserSessionPreparationState.Ready|null[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic/UserSessionPreparationState.Ready.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.wire.kalium.logic/UserSessionPreparationState.Ready.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // com.wire.kalium.logic/UserSessionPreparationState.Ready.toString|toString(){}[0]
+    }
 }
 
 final object com.wire.kalium.logic.sync/PendingMessagesForegroundSync { // com.wire.kalium.logic.sync/PendingMessagesForegroundSync|null[0]

--- a/logic/api/logic.klib.api
+++ b/logic/api/logic.klib.api
@@ -8323,8 +8323,8 @@ sealed class com.wire.kalium.logic.sync/SyncRequestResult { // com.wire.kalium.l
 
 sealed class com.wire.kalium.logic/PrepareUserSessionResult { // com.wire.kalium.logic/PrepareUserSessionResult|null[0]
     final class Failure : com.wire.kalium.logic/PrepareUserSessionResult { // com.wire.kalium.logic/PrepareUserSessionResult.Failure|null[0]
-        final val reason // com.wire.kalium.logic/PrepareUserSessionResult.Failure.reason|{}reason[0]
-            final fun <get-reason>(): com.wire.kalium.logic/UserSessionPreparationFailure // com.wire.kalium.logic/PrepareUserSessionResult.Failure.reason.<get-reason>|<get-reason>(){}[0]
+        final val failure // com.wire.kalium.logic/PrepareUserSessionResult.Failure.failure|{}failure[0]
+            final fun <get-failure>(): com.wire.kalium.logic/UserSessionPreparationFailure // com.wire.kalium.logic/PrepareUserSessionResult.Failure.failure.<get-failure>|<get-failure>(){}[0]
     }
 
     final class Success : com.wire.kalium.logic/PrepareUserSessionResult { // com.wire.kalium.logic/PrepareUserSessionResult.Success|null[0]
@@ -8334,35 +8334,34 @@ sealed class com.wire.kalium.logic/PrepareUserSessionResult { // com.wire.kalium
 }
 
 sealed class com.wire.kalium.logic/UserSessionPreparationFailure { // com.wire.kalium.logic/UserSessionPreparationFailure|null[0]
-    final object ApplicationUpdateRequired : com.wire.kalium.logic/UserSessionPreparationFailure { // com.wire.kalium.logic/UserSessionPreparationFailure.ApplicationUpdateRequired|null[0]
-        final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic/UserSessionPreparationFailure.ApplicationUpdateRequired.equals|equals(kotlin.Any?){}[0]
-        final fun hashCode(): kotlin/Int // com.wire.kalium.logic/UserSessionPreparationFailure.ApplicationUpdateRequired.hashCode|hashCode(){}[0]
-        final fun toString(): kotlin/String // com.wire.kalium.logic/UserSessionPreparationFailure.ApplicationUpdateRequired.toString|toString(){}[0]
+    abstract val exception // com.wire.kalium.logic/UserSessionPreparationFailure.exception|{}exception[0]
+        abstract fun <get-exception>(): kotlin/Throwable // com.wire.kalium.logic/UserSessionPreparationFailure.exception.<get-exception>|<get-exception>(){}[0]
+
+    final class ApplicationUpdateRequired : com.wire.kalium.logic/UserSessionPreparationFailure { // com.wire.kalium.logic/UserSessionPreparationFailure.ApplicationUpdateRequired|null[0]
+        final val exception // com.wire.kalium.logic/UserSessionPreparationFailure.ApplicationUpdateRequired.exception|{}exception[0]
+            final fun <get-exception>(): kotlin/Throwable // com.wire.kalium.logic/UserSessionPreparationFailure.ApplicationUpdateRequired.exception.<get-exception>|<get-exception>(){}[0]
     }
 
-    final object InsufficientStorage : com.wire.kalium.logic/UserSessionPreparationFailure { // com.wire.kalium.logic/UserSessionPreparationFailure.InsufficientStorage|null[0]
-        final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic/UserSessionPreparationFailure.InsufficientStorage.equals|equals(kotlin.Any?){}[0]
-        final fun hashCode(): kotlin/Int // com.wire.kalium.logic/UserSessionPreparationFailure.InsufficientStorage.hashCode|hashCode(){}[0]
-        final fun toString(): kotlin/String // com.wire.kalium.logic/UserSessionPreparationFailure.InsufficientStorage.toString|toString(){}[0]
+    final class InsufficientStorage : com.wire.kalium.logic/UserSessionPreparationFailure { // com.wire.kalium.logic/UserSessionPreparationFailure.InsufficientStorage|null[0]
+        final val exception // com.wire.kalium.logic/UserSessionPreparationFailure.InsufficientStorage.exception|{}exception[0]
+            final fun <get-exception>(): kotlin/Throwable // com.wire.kalium.logic/UserSessionPreparationFailure.InsufficientStorage.exception.<get-exception>|<get-exception>(){}[0]
     }
 
-    final object SupportRequired : com.wire.kalium.logic/UserSessionPreparationFailure { // com.wire.kalium.logic/UserSessionPreparationFailure.SupportRequired|null[0]
-        final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic/UserSessionPreparationFailure.SupportRequired.equals|equals(kotlin.Any?){}[0]
-        final fun hashCode(): kotlin/Int // com.wire.kalium.logic/UserSessionPreparationFailure.SupportRequired.hashCode|hashCode(){}[0]
-        final fun toString(): kotlin/String // com.wire.kalium.logic/UserSessionPreparationFailure.SupportRequired.toString|toString(){}[0]
+    final class SupportRequired : com.wire.kalium.logic/UserSessionPreparationFailure { // com.wire.kalium.logic/UserSessionPreparationFailure.SupportRequired|null[0]
+        final val exception // com.wire.kalium.logic/UserSessionPreparationFailure.SupportRequired.exception|{}exception[0]
+            final fun <get-exception>(): kotlin/Throwable // com.wire.kalium.logic/UserSessionPreparationFailure.SupportRequired.exception.<get-exception>|<get-exception>(){}[0]
     }
 
-    final object TemporarilyUnavailable : com.wire.kalium.logic/UserSessionPreparationFailure { // com.wire.kalium.logic/UserSessionPreparationFailure.TemporarilyUnavailable|null[0]
-        final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic/UserSessionPreparationFailure.TemporarilyUnavailable.equals|equals(kotlin.Any?){}[0]
-        final fun hashCode(): kotlin/Int // com.wire.kalium.logic/UserSessionPreparationFailure.TemporarilyUnavailable.hashCode|hashCode(){}[0]
-        final fun toString(): kotlin/String // com.wire.kalium.logic/UserSessionPreparationFailure.TemporarilyUnavailable.toString|toString(){}[0]
+    final class TemporarilyUnavailable : com.wire.kalium.logic/UserSessionPreparationFailure { // com.wire.kalium.logic/UserSessionPreparationFailure.TemporarilyUnavailable|null[0]
+        final val exception // com.wire.kalium.logic/UserSessionPreparationFailure.TemporarilyUnavailable.exception|{}exception[0]
+            final fun <get-exception>(): kotlin/Throwable // com.wire.kalium.logic/UserSessionPreparationFailure.TemporarilyUnavailable.exception.<get-exception>|<get-exception>(){}[0]
     }
 }
 
 sealed class com.wire.kalium.logic/UserSessionPreparationState { // com.wire.kalium.logic/UserSessionPreparationState|null[0]
     final class Failed : com.wire.kalium.logic/UserSessionPreparationState { // com.wire.kalium.logic/UserSessionPreparationState.Failed|null[0]
-        final val reason // com.wire.kalium.logic/UserSessionPreparationState.Failed.reason|{}reason[0]
-            final fun <get-reason>(): com.wire.kalium.logic/UserSessionPreparationFailure // com.wire.kalium.logic/UserSessionPreparationState.Failed.reason.<get-reason>|<get-reason>(){}[0]
+        final val failure // com.wire.kalium.logic/UserSessionPreparationState.Failed.failure|{}failure[0]
+            final fun <get-failure>(): com.wire.kalium.logic/UserSessionPreparationFailure // com.wire.kalium.logic/UserSessionPreparationState.Failed.failure.<get-failure>|<get-failure>(){}[0]
     }
 
     final object MigratingDatabase : com.wire.kalium.logic/UserSessionPreparationState { // com.wire.kalium.logic/UserSessionPreparationState.MigratingDatabase|null[0]

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -29,17 +29,14 @@ import com.wire.kalium.userstorage.di.PlatformUserStorageProperties
 import com.wire.kalium.logic.di.RootPathsProvider
 import com.wire.kalium.usernetwork.di.UserAuthenticatedNetworkProvider
 import com.wire.kalium.userstorage.di.UserStorageProvider
+import com.wire.kalium.userstorage.di.UserStorage
 import com.wire.kalium.logic.feature.auth.AuthenticationScopeProvider
 import com.wire.kalium.logic.feature.auth.LogoutCallback
 import com.wire.kalium.logic.feature.call.GlobalCallManager
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
-import com.wire.kalium.logic.util.DatabaseKeyLock
-import com.wire.kalium.logic.util.SecurityHelperImpl
 import com.wire.kalium.network.NetworkStateObserver
-import com.wire.kalium.persistence.dao.UserIDEntity
 import com.wire.kalium.persistence.db.GlobalDatabaseBuilder
 import com.wire.kalium.persistence.kmmSettings.GlobalPrefProvider
-import com.wire.kalium.persistence.util.FileNameUtil
 
 @Suppress("LongParameterList")
 internal fun UserSessionScope(
@@ -54,26 +51,14 @@ internal fun UserSessionScope(
     rootPathsProvider: RootPathsProvider,
     dataStoragePaths: DataStoragePaths,
     kaliumConfigs: KaliumConfigs,
+    userStorage: UserStorage,
     userStorageProvider: UserStorageProvider,
+    platformUserStorageProperties: PlatformUserStorageProperties,
     userAuthenticatedNetworkProvider: UserAuthenticatedNetworkProvider,
     userSessionScopeProvider: UserSessionScopeProvider,
     networkStateObserver: NetworkStateObserver,
     logoutCallback: LogoutCallback,
 ): UserSessionScope {
-    val securityHelper = SecurityHelperImpl(globalPreferences.passphraseStorage)
-    val platformUserStorageProperties =
-        PlatformUserStorageProperties(applicationContext) { userId ->
-            // The existence check has to be inside the lock: it decides whether a legacy or a raw
-            // key is used, so reading it outside would race with a concurrent database creation.
-            DatabaseKeyLock.withLock {
-                val userIdEntity = UserIDEntity(userId.value, userId.domain)
-                val databaseExists = applicationContext
-                    .getDatabasePath(FileNameUtil.userDBName(userIdEntity))
-                    .exists()
-                securityHelper.userDBSecret(userId, databaseExists)
-            }
-        }
-
     val clientConfig: ClientConfig = ClientConfigImpl(applicationContext)
 
     return UserSessionScope(
@@ -88,11 +73,12 @@ internal fun UserSessionScope(
         dataStoragePaths,
         kaliumConfigs,
         userSessionScopeProvider,
+        userStorage,
         userStorageProvider,
         userAuthenticatedNetworkProvider,
         clientConfig,
         platformUserStorageProperties,
         networkStateObserver,
-        logoutCallback
+        logoutCallback,
     )
 }

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
@@ -33,11 +33,14 @@ import com.wire.kalium.logic.feature.auth.AuthenticationScopeProvider
 import com.wire.kalium.logic.feature.auth.LogoutCallback
 import com.wire.kalium.logic.feature.call.GlobalCallManager
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
+import com.wire.kalium.logic.util.DatabaseKeyLock
+import com.wire.kalium.logic.util.SecurityHelperImpl
 import com.wire.kalium.network.NetworkStateObserver
 import com.wire.kalium.persistence.db.GlobalDatabaseBuilder
 import com.wire.kalium.persistence.kmmSettings.GlobalPrefProvider
 import com.wire.kalium.persistence.util.FileNameUtil
 import com.wire.kalium.usernetwork.di.UserAuthenticatedNetworkProvider
+import com.wire.kalium.userstorage.di.PlatformUserStorageProperties
 import com.wire.kalium.userstorage.di.UserStorageProvider
 
 @Suppress("LongParameterList")
@@ -63,7 +66,27 @@ internal actual open class UserSessionScopeProviderImpl(
 ),
     UserSessionScopeProvider {
 
-    override fun create(userId: UserId): UserSessionScope {
+    override fun storageParameters(userId: UserId): UserStorageSessionParameters {
+        val securityHelper = SecurityHelperImpl(globalPreferences.passphraseStorage)
+        val platformProperties = PlatformUserStorageProperties(appContext) { storageUserId ->
+            // The existence check has to be inside the lock: it decides whether a legacy or a raw
+            // key is used, so reading it outside would race with a concurrent database creation.
+            DatabaseKeyLock.withLock {
+                val userIdEntity = storageUserId.toDao()
+                val databaseExists = appContext
+                    .getDatabasePath(FileNameUtil.userDBName(userIdEntity))
+                    .exists()
+                securityHelper.userDBSecret(storageUserId, databaseExists)
+            }
+        }
+        return UserStorageSessionParameters(
+            platformProperties = platformProperties,
+            shouldEncryptData = kaliumConfigs.shouldEncryptData(),
+            dbInvalidationControlEnabled = kaliumConfigs.dbInvalidationControlEnabled,
+        )
+    }
+
+    override fun create(userId: UserId, preparedStorage: PreparedUserStorage): UserSessionScope {
         val userIdEntity = userId.toDao()
         val rootFileSystemPath = AssetsStorageFolder("${appContext.filesDir}/${userId.domain}/${userId.value}")
         val dbPath = DBFolder("${appContext.getDatabasePath(FileNameUtil.userDBName(userIdEntity))}")
@@ -81,7 +104,9 @@ internal actual open class UserSessionScopeProviderImpl(
             rootPathsProvider = rootPathsProvider,
             dataStoragePaths = dataStoragePaths,
             kaliumConfigs = kaliumConfigs,
+            userStorage = preparedStorage.storage,
             userStorageProvider = userStorageProvider,
+            platformUserStorageProperties = preparedStorage.parameters.platformProperties,
             userAuthenticatedNetworkProvider = userAuthenticatedNetworkProvider,
             userSessionScopeProvider = this,
             networkStateObserver = networkStateObserver,

--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.userstorage.di.PlatformUserStorageProperties
 import com.wire.kalium.logic.di.RootPathsProvider
 import com.wire.kalium.usernetwork.di.UserAuthenticatedNetworkProvider
+import com.wire.kalium.userstorage.di.UserStorage
 import com.wire.kalium.userstorage.di.UserStorageProvider
 import com.wire.kalium.logic.feature.auth.AuthenticationScopeProvider
 import com.wire.kalium.logic.feature.auth.LogoutCallback
@@ -48,12 +49,13 @@ internal fun UserSessionScope(
     rootPathsProvider: RootPathsProvider,
     dataStoragePaths: DataStoragePaths,
     kaliumConfigs: KaliumConfigs,
+    userStorage: UserStorage,
     userStorageProvider: UserStorageProvider,
     userAuthenticatedNetworkProvider: UserAuthenticatedNetworkProvider,
     userSessionScopeProvider: UserSessionScopeProvider,
     networkStateObserver: NetworkStateObserver,
     logoutCallback: LogoutCallback,
-    userAgent: String
+    userAgent: String,
 ): UserSessionScope {
 
     val clientConfig: ClientConfig = ClientConfigImpl()
@@ -70,11 +72,12 @@ internal fun UserSessionScope(
         dataStoragePaths,
         kaliumConfigs,
         userSessionScopeProvider,
+        userStorage,
         userStorageProvider,
         userAuthenticatedNetworkProvider,
         clientConfig,
         platformUserStorageProperties,
         networkStateObserver,
-        logoutCallback
+        logoutCallback,
     )
 }

--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
@@ -61,7 +61,14 @@ internal actual open class UserSessionScopeProviderImpl(
         userAgent,
 ),
     UserSessionScopeProvider {
-    override fun create(userId: UserId): UserSessionScope {
+    override fun storageParameters(userId: UserId): UserStorageSessionParameters =
+        UserStorageSessionParameters(
+            platformProperties = createPlatformUserStorageProperties(userId),
+            shouldEncryptData = kaliumConfigs.shouldEncryptData(),
+            dbInvalidationControlEnabled = kaliumConfigs.dbInvalidationControlEnabled,
+        )
+
+    override fun create(userId: UserId, preparedStorage: PreparedUserStorage): UserSessionScope {
         val rootAccountPath = rootPathsProvider.rootAccountPath(userId)
         val rootStoragePath = "$rootAccountPath/storage"
         val rootFileSystemPath = AssetsStorageFolder("$rootStoragePath/files")
@@ -69,11 +76,7 @@ internal actual open class UserSessionScopeProviderImpl(
         val dbPath = DBFolder("$rootAccountPath/database")
         val dataStoragePaths = DataStoragePaths(rootFileSystemPath, rootCachePath, dbPath)
         return UserSessionScope(
-            PlatformUserStorageProperties(
-                rootPath = rootPathsProvider.rootPath,
-                keychainConfig = keychainConfig,
-                rootStoragePath = rootStoragePath,
-            ),
+            preparedStorage.parameters.platformProperties,
             userId,
             globalScope,
             globalCallManager,
@@ -83,13 +86,22 @@ internal actual open class UserSessionScopeProviderImpl(
             rootPathsProvider,
             dataStoragePaths,
             kaliumConfigs,
+            preparedStorage.storage,
             userStorageProvider,
             userAuthenticatedNetworkProvider,
             this,
             networkStateObserver,
             logoutCallback,
-            userAgent
+            userAgent,
         )
     }
 
+    private fun createPlatformUserStorageProperties(userId: UserId): PlatformUserStorageProperties {
+        val rootStoragePath = "${rootPathsProvider.rootAccountPath(userId)}/storage"
+        return PlatformUserStorageProperties(
+            rootPath = rootPathsProvider.rootPath,
+            keychainConfig = keychainConfig,
+            rootStoragePath = rootStoragePath,
+        )
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreLogicCommon.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/CoreLogicCommon.kt
@@ -43,6 +43,7 @@ import com.wire.kalium.persistence.kmmSettings.GlobalPrefProvider
 import com.wire.kalium.persistence.util.configurePersistenceDebug
 import com.wire.kalium.userstorage.di.PlatformUserStorageProvider
 import com.wire.kalium.userstorage.di.UserStorageProvider
+import kotlinx.coroutines.flow.Flow
 
 @Suppress("TooManyFunctions")
 public abstract class CoreLogicCommon internal constructor(
@@ -105,6 +106,18 @@ public abstract class CoreLogicCommon internal constructor(
 
     @Suppress("MemberVisibilityCanBePrivate") // Can be used by other targets like iOS and JS
     public abstract fun getSessionScope(userId: UserId): UserSessionScope
+
+    /**
+     * Opens and migrates the user's database away from the main thread before exposing the session.
+     */
+    public suspend fun prepareUserSession(userId: UserId): PrepareUserSessionResult =
+        userSessionScopeProvider.value.prepare(userId)
+
+    /**
+     * Observes the current in-process preparation state without starting preparation.
+     */
+    public fun observeUserSessionPreparation(userId: UserId): Flow<UserSessionPreparationState> =
+        userSessionScopeProvider.value.observePreparation(userId)
 
     internal abstract suspend fun deleteSessionScope(userId: UserId) // TODO remove when proper use case is ready
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/UserSessionPreparation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/UserSessionPreparation.kt
@@ -1,0 +1,78 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic
+
+import com.wire.kalium.logic.feature.UserSessionScope
+import com.wire.kalium.userstorage.di.UserStoragePreparationFailure
+
+/** Result of preparing a user session for use. */
+public sealed class PrepareUserSessionResult {
+    /** The database is ready and [sessionScope] can be used. */
+    public class Success internal constructor(
+        public val sessionScope: UserSessionScope
+    ) : PrepareUserSessionResult()
+
+    /** Preparation did not complete. */
+    public class Failure internal constructor(
+        public val reason: UserSessionPreparationFailure
+    ) : PrepareUserSessionResult()
+}
+
+/** Current in-process state of user session preparation. */
+public sealed class UserSessionPreparationState {
+    /** Preparation has not been requested in this process. */
+    public data object NotStarted : UserSessionPreparationState()
+
+    /** Kalium is opening the database and checking its schema version. */
+    public data object OpeningDatabase : UserSessionPreparationState()
+
+    /** SQLDelight is running the generated migration path. */
+    public data object MigratingDatabase : UserSessionPreparationState()
+
+    /** The user session is ready to use. */
+    public data object Ready : UserSessionPreparationState()
+
+    /** Preparation stopped with [reason]. */
+    public class Failed internal constructor(
+        public val reason: UserSessionPreparationFailure
+    ) : UserSessionPreparationState()
+}
+
+/** Actionable reason why user session preparation failed. */
+public sealed class UserSessionPreparationFailure {
+    /** The user must free storage before trying again. */
+    public data object InsufficientStorage : UserSessionPreparationFailure()
+
+    /** The database is temporarily busy or locked and can be tried again. */
+    public data object TemporarilyUnavailable : UserSessionPreparationFailure()
+
+    /** This app version cannot safely prepare the database. */
+    public data object ApplicationUpdateRequired : UserSessionPreparationFailure()
+
+    /** Automatic recovery is unsafe and the user needs support. */
+    public data object SupportRequired : UserSessionPreparationFailure()
+}
+
+internal fun UserStoragePreparationFailure.toUserSessionPreparationFailure(): UserSessionPreparationFailure =
+    when (this) {
+        UserStoragePreparationFailure.InsufficientStorage -> UserSessionPreparationFailure.InsufficientStorage
+        UserStoragePreparationFailure.TemporarilyUnavailable -> UserSessionPreparationFailure.TemporarilyUnavailable
+        UserStoragePreparationFailure.ApplicationUpdateRequired -> UserSessionPreparationFailure.ApplicationUpdateRequired
+        UserStoragePreparationFailure.SupportRequired -> UserSessionPreparationFailure.SupportRequired
+    }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/UserSessionPreparation.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/UserSessionPreparation.kt
@@ -28,9 +28,9 @@ public sealed class PrepareUserSessionResult {
         public val sessionScope: UserSessionScope
     ) : PrepareUserSessionResult()
 
-    /** Preparation did not complete. */
+    /** Preparation did not complete; [failure] retains the original exception. */
     public class Failure internal constructor(
-        public val reason: UserSessionPreparationFailure
+        public val failure: UserSessionPreparationFailure
     ) : PrepareUserSessionResult()
 }
 
@@ -48,31 +48,48 @@ public sealed class UserSessionPreparationState {
     /** The user session is ready to use. */
     public data object Ready : UserSessionPreparationState()
 
-    /** Preparation stopped with [reason]. */
+    /** Preparation stopped with [failure]. */
     public class Failed internal constructor(
-        public val reason: UserSessionPreparationFailure
+        public val failure: UserSessionPreparationFailure
     ) : UserSessionPreparationState()
 }
 
-/** Actionable reason why user session preparation failed. */
+/** Actionable preparation failure that retains the original [exception]. */
 public sealed class UserSessionPreparationFailure {
+    public abstract val exception: Throwable
+
     /** The user must free storage before trying again. */
-    public data object InsufficientStorage : UserSessionPreparationFailure()
+    public class InsufficientStorage internal constructor(
+        public override val exception: Throwable,
+    ) : UserSessionPreparationFailure()
 
     /** The database is temporarily busy or locked and can be tried again. */
-    public data object TemporarilyUnavailable : UserSessionPreparationFailure()
+    public class TemporarilyUnavailable internal constructor(
+        public override val exception: Throwable,
+    ) : UserSessionPreparationFailure()
 
     /** This app version cannot safely prepare the database. */
-    public data object ApplicationUpdateRequired : UserSessionPreparationFailure()
+    public class ApplicationUpdateRequired internal constructor(
+        public override val exception: Throwable,
+    ) : UserSessionPreparationFailure()
 
     /** Automatic recovery is unsafe and the user needs support. */
-    public data object SupportRequired : UserSessionPreparationFailure()
+    public class SupportRequired internal constructor(
+        public override val exception: Throwable,
+    ) : UserSessionPreparationFailure()
 }
 
 internal fun UserStoragePreparationFailure.toUserSessionPreparationFailure(): UserSessionPreparationFailure =
     when (this) {
-        UserStoragePreparationFailure.InsufficientStorage -> UserSessionPreparationFailure.InsufficientStorage
-        UserStoragePreparationFailure.TemporarilyUnavailable -> UserSessionPreparationFailure.TemporarilyUnavailable
-        UserStoragePreparationFailure.ApplicationUpdateRequired -> UserSessionPreparationFailure.ApplicationUpdateRequired
-        UserStoragePreparationFailure.SupportRequired -> UserSessionPreparationFailure.SupportRequired
+        is UserStoragePreparationFailure.InsufficientStorage ->
+            UserSessionPreparationFailure.InsufficientStorage(exception)
+
+        is UserStoragePreparationFailure.TemporarilyUnavailable ->
+            UserSessionPreparationFailure.TemporarilyUnavailable(exception)
+
+        is UserStoragePreparationFailure.ApplicationUpdateRequired ->
+            UserSessionPreparationFailure.ApplicationUpdateRequired(exception)
+
+        is UserStoragePreparationFailure.SupportRequired ->
+            UserSessionPreparationFailure.SupportRequired(exception)
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -589,6 +589,7 @@ import com.wire.kalium.persistence.kmmSettings.GlobalPrefProvider
 import com.wire.kalium.usernetwork.di.UserAuthenticatedNetworkApis
 import com.wire.kalium.usernetwork.di.UserAuthenticatedNetworkProvider
 import com.wire.kalium.userstorage.di.PlatformUserStorageProperties
+import com.wire.kalium.userstorage.di.UserStorage
 import com.wire.kalium.userstorage.di.UserStorageProvider
 import com.wire.kalium.util.DebugKaliumApi
 import com.wire.kalium.util.DelicateKaliumApi
@@ -623,6 +624,7 @@ public class UserSessionScope internal constructor(
     dataStoragePaths: DataStoragePaths,
     private val kaliumConfigs: KaliumConfigs,
     private val userSessionScopeProvider: UserSessionScopeProvider,
+    private val userStorage: UserStorage,
     private val userStorageProvider: UserStorageProvider,
     private val userAuthenticatedNetworkProvider: UserAuthenticatedNetworkProvider,
     private val clientConfig: ClientConfig,
@@ -632,13 +634,6 @@ public class UserSessionScope internal constructor(
 ) : CoroutineScope {
 
     override val coroutineContext: CoroutineContext = SupervisorJob()
-
-    private val userStorage = userStorageProvider.getOrCreate(
-        userId,
-        platformUserStorageProperties,
-        kaliumConfigs.shouldEncryptData(),
-        kaliumConfigs.dbInvalidationControlEnabled
-    )
     private var _clientId: ClientId? = null
 
     @OptIn(DelicateKaliumApi::class) // Use the uncached client ID in order to create the cache itself.

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProvider.kt
@@ -19,36 +19,104 @@
 package com.wire.kalium.logic.feature
 
 import co.touchlab.stately.collections.ConcurrentMutableMap
+import com.wire.kalium.logic.PrepareUserSessionResult
+import com.wire.kalium.logic.UserSessionPreparationState
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.userstorage.di.UserStorageProvider
 import com.wire.kalium.logic.feature.call.GlobalCallManager
+import com.wire.kalium.logic.toUserSessionPreparationFailure
+import com.wire.kalium.userstorage.di.PlatformUserStorageProperties
+import com.wire.kalium.userstorage.di.UserStorage
+import com.wire.kalium.userstorage.di.UserStoragePreparationResult
+import com.wire.kalium.userstorage.di.UserStorageProvider
+import com.wire.kalium.userstorage.di.UserStorageState
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 internal interface UserSessionScopeProvider {
     fun get(userId: UserId): UserSessionScope?
     fun getOrCreate(userId: UserId): UserSessionScope
     fun <T> getOrCreate(userId: UserId, action: UserSessionScope.() -> T): T
+    suspend fun prepare(userId: UserId): PrepareUserSessionResult
+    fun observePreparation(userId: UserId): Flow<UserSessionPreparationState>
     suspend fun delete(userId: UserId)
 }
+
+internal data class UserStorageSessionParameters(
+    val platformProperties: PlatformUserStorageProperties,
+    val shouldEncryptData: Boolean,
+    val dbInvalidationControlEnabled: Boolean,
+)
+
+internal data class PreparedUserStorage(
+    val storage: UserStorage,
+    val parameters: UserStorageSessionParameters,
+)
 
 internal abstract class UserSessionScopeProviderCommon(
     private val globalCallManager: GlobalCallManager,
     private val userStorageProvider: UserStorageProvider,
     private val removeAuthenticatedNetworkForUser: suspend (UserId) -> Unit,
-    protected val userAgent: String
+    protected val userAgent: String,
 ) : UserSessionScopeProvider {
 
     private val userScopeStorage: ConcurrentMutableMap<UserId, UserSessionScope> by lazy {
         ConcurrentMutableMap()
     }
 
-    override fun getOrCreate(userId: UserId): UserSessionScope =
-        userScopeStorage.computeIfAbsent(userId) {
-            create(userId)
+    override fun getOrCreate(userId: UserId): UserSessionScope {
+        return userScopeStorage.computeIfAbsent(userId) {
+            val parameters = storageParameters(userId)
+            val storage = userStorageProvider.getOrCreate(
+                userId,
+                parameters.platformProperties,
+                parameters.shouldEncryptData,
+                parameters.dbInvalidationControlEnabled,
+            )
+            create(userId, PreparedUserStorage(storage, parameters))
         }
+    }
 
     override fun <T> getOrCreate(userId: UserId, action: UserSessionScope.() -> T): T = getOrCreate(userId).action()
 
     override fun get(userId: UserId): UserSessionScope? = userScopeStorage.get(userId)
+
+    override suspend fun prepare(userId: UserId): PrepareUserSessionResult {
+        get(userId)?.let {
+            return PrepareUserSessionResult.Success(it)
+        }
+
+        val parameters = storageParameters(userId)
+        return when (
+            val result = userStorageProvider.prepare(
+                userId,
+                parameters.platformProperties,
+                parameters.shouldEncryptData,
+                parameters.dbInvalidationControlEnabled,
+            )
+        ) {
+            is UserStoragePreparationResult.Success -> {
+                val scope = userScopeStorage.computeIfAbsent(userId) {
+                    create(userId, PreparedUserStorage(result.storage, parameters))
+                }
+                PrepareUserSessionResult.Success(scope)
+            }
+
+            is UserStoragePreparationResult.Failure ->
+                PrepareUserSessionResult.Failure(result.reason.toUserSessionPreparationFailure())
+        }
+    }
+
+    override fun observePreparation(userId: UserId): Flow<UserSessionPreparationState> =
+        userStorageProvider.observe(userId).map { state ->
+            when (state) {
+                UserStorageState.NotStarted -> UserSessionPreparationState.NotStarted
+                UserStorageState.OpeningDatabase -> UserSessionPreparationState.OpeningDatabase
+                UserStorageState.MigratingDatabase -> UserSessionPreparationState.MigratingDatabase
+                is UserStorageState.Ready -> UserSessionPreparationState.Ready
+                is UserStorageState.Failed ->
+                    UserSessionPreparationState.Failed(state.reason.toUserSessionPreparationFailure())
+            }
+        }
 
     override suspend fun delete(userId: UserId) {
         globalCallManager.removeInMemoryCallingManagerForUser(userId)
@@ -57,12 +125,16 @@ internal abstract class UserSessionScopeProviderCommon(
         removeAuthenticatedNetworkForUser(userId)
     }
 
-    internal abstract fun create(userId: UserId): UserSessionScope
+    internal abstract fun storageParameters(userId: UserId): UserStorageSessionParameters
+
+    internal abstract fun create(userId: UserId, preparedStorage: PreparedUserStorage): UserSessionScope
 }
 
 internal expect class UserSessionScopeProviderImpl : UserSessionScopeProvider {
     override fun get(userId: UserId): UserSessionScope?
     override fun getOrCreate(userId: UserId): UserSessionScope
     override fun <T> getOrCreate(userId: UserId, action: UserSessionScope.() -> T): T
+    override suspend fun prepare(userId: UserId): PrepareUserSessionResult
+    override fun observePreparation(userId: UserId): Flow<UserSessionPreparationState>
     override suspend fun delete(userId: UserId)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProvider.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProvider.kt
@@ -81,9 +81,7 @@ internal abstract class UserSessionScopeProviderCommon(
     override fun get(userId: UserId): UserSessionScope? = userScopeStorage.get(userId)
 
     override suspend fun prepare(userId: UserId): PrepareUserSessionResult {
-        get(userId)?.let {
-            return PrepareUserSessionResult.Success(it)
-        }
+        get(userId)?.let { return PrepareUserSessionResult.Success(it) }
 
         val parameters = storageParameters(userId)
         return when (
@@ -102,7 +100,7 @@ internal abstract class UserSessionScopeProviderCommon(
             }
 
             is UserStoragePreparationResult.Failure ->
-                PrepareUserSessionResult.Failure(result.reason.toUserSessionPreparationFailure())
+                PrepareUserSessionResult.Failure(result.failure.toUserSessionPreparationFailure())
         }
     }
 
@@ -114,7 +112,7 @@ internal abstract class UserSessionScopeProviderCommon(
                 UserStorageState.MigratingDatabase -> UserSessionPreparationState.MigratingDatabase
                 is UserStorageState.Ready -> UserSessionPreparationState.Ready
                 is UserStorageState.Failed ->
-                    UserSessionPreparationState.Failed(state.reason.toUserSessionPreparationFailure())
+                    UserSessionPreparationState.Failed(state.failure.toUserSessionPreparationFailure())
             }
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/UserSessionPreparationTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/UserSessionPreparationTest.kt
@@ -18,36 +18,33 @@
 
 package com.wire.kalium.logic
 
-import com.wire.kalium.userstorage.di.UserStoragePreparationFailure
 import kotlin.test.Test
-import kotlin.test.assertEquals
+import kotlin.test.assertSame
 
 class UserSessionPreparationTest {
     @Test
-    fun givenInsufficientStorage_whenMappingFailure_thenInsufficientStorageIsReturned() {
-        val result = UserStoragePreparationFailure.InsufficientStorage.toUserSessionPreparationFailure()
+    fun givenTypedFailures_whenCreated_thenEachRetainsOriginalException() {
+        val expected = IllegalStateException("database preparation failed")
+        val failures = listOf(
+            UserSessionPreparationFailure.InsufficientStorage(expected),
+            UserSessionPreparationFailure.TemporarilyUnavailable(expected),
+            UserSessionPreparationFailure.ApplicationUpdateRequired(expected),
+            UserSessionPreparationFailure.SupportRequired(expected),
+        )
 
-        assertEquals(UserSessionPreparationFailure.InsufficientStorage, result)
+        failures.forEach { failure -> assertSame(expected, failure.exception) }
     }
 
     @Test
-    fun givenTemporarilyUnavailable_whenMappingFailure_thenTemporarilyUnavailableIsReturned() {
-        val result = UserStoragePreparationFailure.TemporarilyUnavailable.toUserSessionPreparationFailure()
+    fun givenFailure_whenExposedByResultAndState_thenTypedFailureIsRetained() {
+        val failure = UserSessionPreparationFailure.SupportRequired(
+            IllegalStateException("database preparation failed")
+        )
 
-        assertEquals(UserSessionPreparationFailure.TemporarilyUnavailable, result)
-    }
+        val result = PrepareUserSessionResult.Failure(failure)
+        val state = UserSessionPreparationState.Failed(failure)
 
-    @Test
-    fun givenApplicationUpdateRequired_whenMappingFailure_thenApplicationUpdateRequiredIsReturned() {
-        val result = UserStoragePreparationFailure.ApplicationUpdateRequired.toUserSessionPreparationFailure()
-
-        assertEquals(UserSessionPreparationFailure.ApplicationUpdateRequired, result)
-    }
-
-    @Test
-    fun givenSupportRequired_whenMappingFailure_thenSupportRequiredIsReturned() {
-        val result = UserStoragePreparationFailure.SupportRequired.toUserSessionPreparationFailure()
-
-        assertEquals(UserSessionPreparationFailure.SupportRequired, result)
+        assertSame(failure, result.failure)
+        assertSame(failure, state.failure)
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/UserSessionPreparationTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/UserSessionPreparationTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic
+
+import com.wire.kalium.userstorage.di.UserStoragePreparationFailure
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UserSessionPreparationTest {
+    @Test
+    fun givenInsufficientStorage_whenMappingFailure_thenInsufficientStorageIsReturned() {
+        val result = UserStoragePreparationFailure.InsufficientStorage.toUserSessionPreparationFailure()
+
+        assertEquals(UserSessionPreparationFailure.InsufficientStorage, result)
+    }
+
+    @Test
+    fun givenTemporarilyUnavailable_whenMappingFailure_thenTemporarilyUnavailableIsReturned() {
+        val result = UserStoragePreparationFailure.TemporarilyUnavailable.toUserSessionPreparationFailure()
+
+        assertEquals(UserSessionPreparationFailure.TemporarilyUnavailable, result)
+    }
+
+    @Test
+    fun givenApplicationUpdateRequired_whenMappingFailure_thenApplicationUpdateRequiredIsReturned() {
+        val result = UserStoragePreparationFailure.ApplicationUpdateRequired.toUserSessionPreparationFailure()
+
+        assertEquals(UserSessionPreparationFailure.ApplicationUpdateRequired, result)
+    }
+
+    @Test
+    fun givenSupportRequired_whenMappingFailure_thenSupportRequiredIsReturned() {
+        val result = UserStoragePreparationFailure.SupportRequired.toUserSessionPreparationFailure()
+
+        assertEquals(UserSessionPreparationFailure.SupportRequired, result)
+    }
+}

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.userstorage.di.PlatformUserStorageProperties
 import com.wire.kalium.logic.di.RootPathsProvider
 import com.wire.kalium.usernetwork.di.UserAuthenticatedNetworkProvider
+import com.wire.kalium.userstorage.di.UserStorage
 import com.wire.kalium.userstorage.di.UserStorageProvider
 import com.wire.kalium.logic.feature.auth.AuthenticationScopeProvider
 import com.wire.kalium.logic.feature.auth.LogoutCallback
@@ -48,12 +49,13 @@ internal fun UserSessionScope(
     rootPathsProvider: RootPathsProvider,
     dataStoragePaths: DataStoragePaths,
     kaliumConfigs: KaliumConfigs,
+    userStorage: UserStorage,
     userStorageProvider: UserStorageProvider,
     userAuthenticatedNetworkProvider: UserAuthenticatedNetworkProvider,
     userSessionScopeProvider: UserSessionScopeProvider,
     networkStateObserver: NetworkStateObserver,
     logoutCallback: LogoutCallback,
-    userAgent: String
+    userAgent: String,
 ): UserSessionScope {
 
     val clientConfig: ClientConfig = ClientConfigImpl()
@@ -70,6 +72,7 @@ internal fun UserSessionScope(
         dataStoragePaths,
         kaliumConfigs,
         userSessionScopeProvider,
+        userStorage,
         userStorageProvider,
         userAuthenticatedNetworkProvider,
         clientConfig,

--- a/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
+++ b/logic/src/jvmMain/kotlin/com/wire/kalium/logic/feature/UserSessionScopeProviderImpl.kt
@@ -63,22 +63,22 @@ internal actual open class UserSessionScopeProviderImpl(
 ),
     UserSessionScopeProvider {
 
-    override fun create(userId: UserId): UserSessionScope {
+    override fun storageParameters(userId: UserId): UserStorageSessionParameters =
+        UserStorageSessionParameters(
+            platformProperties = createPlatformUserStorageProperties(userId),
+            shouldEncryptData = kaliumConfigs.shouldEncryptData(),
+            dbInvalidationControlEnabled = kaliumConfigs.dbInvalidationControlEnabled,
+        )
+
+    override fun create(userId: UserId, preparedStorage: PreparedUserStorage): UserSessionScope {
         val rootAccountPath = rootPathsProvider.rootAccountPath(userId)
         val rootStoragePath = "$rootAccountPath/storage"
-        val databaseInfo = if (useInMemoryDatabase) {
-            DatabaseStorageType.InMemory
-        } else {
-            DatabaseStorageType.FiledBacked(
-                File(rootStoragePath)
-            )
-        }
         val rootFileSystemPath = AssetsStorageFolder("$rootStoragePath/files")
         val rootCachePath = CacheFolder("$rootAccountPath/cache")
         val dbPath = DBFolder("$rootAccountPath/database")
         val dataStoragePaths = DataStoragePaths(rootFileSystemPath, rootCachePath, dbPath)
         return UserSessionScope(
-            PlatformUserStorageProperties(rootPathsProvider.rootPath, databaseInfo),
+            preparedStorage.parameters.platformProperties,
             userId,
             globalScope,
             globalCallManager,
@@ -88,12 +88,23 @@ internal actual open class UserSessionScopeProviderImpl(
             rootPathsProvider,
             dataStoragePaths,
             kaliumConfigs,
+            preparedStorage.storage,
             userStorageProvider,
             userAuthenticatedNetworkProvider,
             this,
             networkStateObserver,
             logoutCallback,
-            userAgent
+            userAgent,
         )
+    }
+
+    private fun createPlatformUserStorageProperties(userId: UserId): PlatformUserStorageProperties {
+        val rootStoragePath = "${rootPathsProvider.rootAccountPath(userId)}/storage"
+        val databaseInfo = if (useInMemoryDatabase) {
+            DatabaseStorageType.InMemory
+        } else {
+            DatabaseStorageType.FiledBacked(File(rootStoragePath))
+        }
+        return PlatformUserStorageProperties(rootPathsProvider.rootPath, databaseInfo)
     }
 }


### PR DESCRIPTION
## Intent

Expose explicit asynchronous session preparation while keeping the storage lifecycle implementation behind the public logic API.

## Changes

- Add public session preparation results, states, and failure reasons.
- Add APIs to prepare a user session and observe its preparation state.
- Map storage lifecycle states and failures into logic-level types.
- Update Android, Apple, and JVM session scope providers.
- Record the public API and changelog changes.
- Cover preparation success, failure mapping, and observation.

## Impact

Callers can wait for a usable session without synchronously opening the user database, and can present actionable migration or storage failures.

## Stack

- [PR 1](https://github.com/wireapp/kalium/pull/4361)
- [PR 2](https://github.com/wireapp/kalium/pull/4378)
- [PR 3](https://github.com/wireapp/kalium/pull/4379)
- PR 4 of 6 (current)

## End-to-end preparation pipeline

All database-dependent entry points converge on one per-user preparation operation. The storage session owns the single in-flight attempt and publishes state for observers.

```mermaid
flowchart TD
    UI_ENTRY["UI or app startup"] --> PREPARE["CoreLogic.prepareUserSession(userId)"]
    APP_ENTRY["Service, receiver, or extension"] --> PREPARE
    WM_ENTRY["Existing WorkManager job"] --> WRAPPER["WrapperWorker"]
    WRAPPER --> PREPARE

    PREPARE --> SCOPE_PROVIDER["UserSessionScopeProvider.prepare"]
    SCOPE_PROVIDER --> STORAGE_PROVIDER["UserStorageProvider.prepare(userId)"]
    STORAGE_PROVIDER --> USER_SESSION["Per-user UserStorageSession<br/>single in-flight attempt"]

    USER_SESSION --> OPENING["OpeningDatabase"]
    OPENING --> DATABASE["UserDatabaseBuilder.open"]
    DATABASE -->|"schema is current"| READY["Ready"]
    DATABASE -->|"migration callback"| MIGRATING["MigratingDatabase"]
    MIGRATING -->|"migration commits"| READY
    DATABASE -->|"open or migration error"| FAILURE["Classify failure"]

    READY --> SESSION_SCOPE["UserSessionScope"]
    SESSION_SCOPE --> CONSUMER["Database-dependent consumer"]
    SESSION_SCOPE --> INNER_WORKER["Create and run inner WorkManager worker"]

    USER_SESSION -.->|"state flow; observation does not start preparation"| OBSERVER["observeUserSessionPreparation(userId)"]
    OBSERVER --> STATE_UI["Migration UI or state observer"]

    FAILURE --> APP_FAILURE["UI, service, or receiver failure handling"]
    FAILURE --> RETRY["Retry policy"]
    RETRY --> PREPARE
    FAILURE --> WORK_FAILURE["WorkManager retry or failure result"]
```

WorkManager is a preparation gate for existing background work; it is not a dedicated migration scheduler.

