### PR TITLE
fix(worker): prepare sessions before user work PR 5

### DIFF
--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/sync/WrapperWorker.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/sync/WrapperWorker.kt
@@ -224,7 +224,7 @@ public class WrapperWorkerFactory(
         return runCatching {
             when (val preparation = coreLogic.prepareUserSession(validUserId)) {
                 is PrepareUserSessionResult.Success -> action(preparation.sessionScope)
-                is PrepareUserSessionResult.Failure -> PreparationFailureWorker(preparation.reason)
+                is PrepareUserSessionResult.Failure -> PreparationFailureWorker(preparation.failure)
             }
         }.getOrElse { error ->
             kaliumLogger.logStructuredJson(
@@ -395,13 +395,13 @@ private class MissingWorker(
 }
 
 private class PreparationFailureWorker(
-    private val reason: UserSessionPreparationFailure,
+    private val failure: UserSessionPreparationFailure,
 ) : DefaultWorker {
     override suspend fun doWork(): KaliumResult {
-        kaliumLogger.w("Skipping user worker because session preparation failed: $reason")
+        kaliumLogger.w("Skipping user worker because session preparation failed: ${failure::class.simpleName}")
         return if (
-            reason is UserSessionPreparationFailure.InsufficientStorage ||
-            reason is UserSessionPreparationFailure.TemporarilyUnavailable
+            failure is UserSessionPreparationFailure.InsufficientStorage ||
+            failure is UserSessionPreparationFailure.TemporarilyUnavailable
         ) {
             KaliumResult.Retry
         } else {

--- a/logic/src/androidMain/kotlin/com/wire/kalium/logic/sync/WrapperWorker.kt
+++ b/logic/src/androidMain/kotlin/com/wire/kalium/logic/sync/WrapperWorker.kt
@@ -32,6 +32,8 @@ import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.common.logger.logStructuredJson
 import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.PrepareUserSessionResult
+import com.wire.kalium.logic.UserSessionPreparationFailure
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.UserSessionScope
@@ -40,21 +42,20 @@ import com.wire.kalium.logic.sync.periodic.MeetingOccurrencesSyncWorker
 import com.wire.kalium.logic.sync.periodic.UpdateApiVersionsWorker
 import com.wire.kalium.logic.sync.periodic.UserConfigSyncWorker
 import com.wire.kalium.logic.sync.receiver.asset.AudioNormalizedLoudnessWorker
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlin.reflect.KClass
 import androidx.work.ListenableWorker.Result as AndroidResult
 import com.wire.kalium.logic.sync.Result as KaliumResult
 
 public class WrapperWorker internal constructor(
-    private val innerWorker: DefaultWorker,
+    private val innerWorker: suspend () -> DefaultWorker,
     appContext: Context,
     params: WorkerParameters,
     private val foregroundNotificationDetailsProvider: ForegroundNotificationDetailsProvider
 ) :
     CoroutineWorker(appContext, params) {
 
-    override suspend fun doWork(): AndroidResult = when (innerWorker.doWork()) {
+    override suspend fun doWork(): AndroidResult = when (innerWorker().doWork()) {
         is KaliumResult.Failure -> AndroidResult.failure()
         is KaliumResult.Retry -> AndroidResult.retry()
         is KaliumResult.Success -> AndroidResult.success()
@@ -103,11 +104,15 @@ public class WrapperWorkerFactory(
             return null // delegate to default factory
         }
 
-        val innerWorker = resolveInnerWorker(workerParameters)
-        return WrapperWorker(innerWorker, appContext, workerParameters, foregroundNotificationDetailsProvider)
+        return WrapperWorker(
+            innerWorker = { resolveInnerWorker(workerParameters) },
+            appContext = appContext,
+            params = workerParameters,
+            foregroundNotificationDetailsProvider = foregroundNotificationDetailsProvider,
+        )
     }
 
-    private fun resolveInnerWorker(workerParameters: WorkerParameters): DefaultWorker {
+    private suspend fun resolveInnerWorker(workerParameters: WorkerParameters): DefaultWorker {
         val userId = workerParameters.getSerializable<UserId>(USER_ID_KEY)
         val workerType = workerParameters.inputData.getString(WORKER_TYPE_KEY)
         val innerWorkerClassName = workerParameters.inputData.getString(WORKER_CLASS_KEY)
@@ -191,7 +196,7 @@ public class WrapperWorkerFactory(
         }
     }
 
-    private fun createAudioNormalizedLoudnessWorker(
+    private suspend fun createAudioNormalizedLoudnessWorker(
         userId: UserId?,
         workerParameters: WorkerParameters
     ): DefaultWorker? = withSessionScope(userId) { sessionScope ->
@@ -214,10 +219,13 @@ public class WrapperWorkerFactory(
         }
     }
 
-    private fun withSessionScope(userId: UserId?, action: (UserSessionScope) -> DefaultWorker): DefaultWorker? {
+    private suspend fun withSessionScope(userId: UserId?, action: (UserSessionScope) -> DefaultWorker): DefaultWorker? {
         val validUserId = validateSessionUserId(userId) ?: return null
         return runCatching {
-            action(coreLogic.getSessionScope(validUserId))
+            when (val preparation = coreLogic.prepareUserSession(validUserId)) {
+                is PrepareUserSessionResult.Success -> action(preparation.sessionScope)
+                is PrepareUserSessionResult.Failure -> PreparationFailureWorker(preparation.reason)
+            }
         }.getOrElse { error ->
             kaliumLogger.logStructuredJson(
                 level = KaliumLogLevel.ERROR,
@@ -234,7 +242,7 @@ public class WrapperWorkerFactory(
         }
     }
 
-    private fun validateSessionUserId(userId: UserId?): UserId? = when {
+    private suspend fun validateSessionUserId(userId: UserId?): UserId? = when {
         userId == null -> {
             logSessionScopeUnavailable(KaliumLogLevel.WARN, SESSION_SCOPE_REASON_MISSING_USER_ID)
             null
@@ -257,11 +265,9 @@ public class WrapperWorkerFactory(
         )
     }
 
-    private fun isValidSession(userId: UserId): Boolean = runCatching {
-        runBlocking {
-            coreLogic.globalScope {
-                doesValidSessionExist(userId).let { it is DoesValidSessionExistResult.Success && it.doesValidSessionExist }
-            }
+    private suspend fun isValidSession(userId: UserId): Boolean = runCatching {
+        coreLogic.globalScope {
+            doesValidSessionExist(userId).let { it is DoesValidSessionExistResult.Success && it.doesValidSessionExist }
         }
     }.getOrElse { error ->
         kaliumLogger.logStructuredJson(
@@ -385,6 +391,22 @@ private class MissingWorker(
         )
         kaliumLogger.e("Skipping worker due to wrapper fallback, class: $workerClassName, reason: $fallbackReason")
         return KaliumResult.Failure
+    }
+}
+
+private class PreparationFailureWorker(
+    private val reason: UserSessionPreparationFailure,
+) : DefaultWorker {
+    override suspend fun doWork(): KaliumResult {
+        kaliumLogger.w("Skipping user worker because session preparation failed: $reason")
+        return if (
+            reason is UserSessionPreparationFailure.InsufficientStorage ||
+            reason is UserSessionPreparationFailure.TemporarilyUnavailable
+        ) {
+            KaliumResult.Retry
+        } else {
+            KaliumResult.Failure
+        }
     }
 }
 


### PR DESCRIPTION
## Intent

Prepare a user's session before constructing or running session-scoped Android workers.

## Reproduction

1. Start a user-scoped WorkManager job for a valid session whose database still needs migration or cannot currently be opened.
2. Let WorkManager construct the wrapper worker.
3. The existing factory resolves the session synchronously during construction, so database preparation happens on that path and preparation failures are not mapped to retryable worker results.

## Changes

- Defer inner-worker resolution until the suspending worker execution path.
- Call explicit session preparation before accessing the session scope.
- Retry recoverable storage failures and fail non-recoverable preparation failures.
- Remove the blocking session-validity bridge from worker construction.

## Impact

Background work waits for database preparation and returns an appropriate WorkManager result when the session cannot be prepared.

## Stack

- [PR 1](https://github.com/wireapp/kalium/pull/4361)
- [PR 2](https://github.com/wireapp/kalium/pull/4378)
- [PR 3](https://github.com/wireapp/kalium/pull/4379)
- [PR 4](https://github.com/wireapp/kalium/pull/4380)
- PR 5 of 6 (current)

## End-to-end preparation pipeline

All database-dependent entry points converge on one per-user preparation operation. The storage session owns the single in-flight attempt and publishes state for observers.

```mermaid
flowchart TD
    UI_ENTRY["UI or app startup"] --> PREPARE["CoreLogic.prepareUserSession(userId)"]
    APP_ENTRY["Service, receiver, or extension"] --> PREPARE
    WM_ENTRY["Existing WorkManager job"] --> WRAPPER["WrapperWorker"]
    WRAPPER --> PREPARE

    PREPARE --> SCOPE_PROVIDER["UserSessionScopeProvider.prepare"]
    SCOPE_PROVIDER --> STORAGE_PROVIDER["UserStorageProvider.prepare(userId)"]
    STORAGE_PROVIDER --> USER_SESSION["Per-user UserStorageSession<br/>single in-flight attempt"]

    USER_SESSION --> OPENING["OpeningDatabase"]
    OPENING --> DATABASE["UserDatabaseBuilder.open"]
    DATABASE -->|"schema is current"| READY["Ready"]
    DATABASE -->|"migration callback"| MIGRATING["MigratingDatabase"]
    MIGRATING -->|"migration commits"| READY
    DATABASE -->|"open or migration error"| FAILURE["Classify failure"]

    READY --> SESSION_SCOPE["UserSessionScope"]
    SESSION_SCOPE --> CONSUMER["Database-dependent consumer"]
    SESSION_SCOPE --> INNER_WORKER["Create and run inner WorkManager worker"]

    USER_SESSION -.->|"state flow; observation does not start preparation"| OBSERVER["observeUserSessionPreparation(userId)"]
    OBSERVER --> STATE_UI["Migration UI or state observer"]

    FAILURE --> APP_FAILURE["UI, service, or receiver failure handling"]
    FAILURE --> RETRY["Retry policy"]
    RETRY --> PREPARE
    FAILURE --> WORK_FAILURE["WorkManager retry or failure result"]
```

WorkManager is a preparation gate for existing background work; it is not a dedicated migration scheduler.

