### PR TITLE
docs(adr): map user session preparation flow PR 6

### DIFF
--- a/docs/adr/0011-explicit-user-database-migration-lifecycle.md
+++ b/docs/adr/0011-explicit-user-database-migration-lifecycle.md
@@ -292,6 +292,45 @@ database or device-size buckets.
 An index migration must also include the query it improves, query-plan evidence, migration time,
 peak disk use, database growth, read improvement, and write cost on representative database sizes.
 
+## End-to-end preparation pipeline
+
+All database-dependent entry points converge on the same per-user preparation operation. The
+storage session owns the single in-flight attempt and publishes state for observers.
+
+```mermaid
+flowchart TD
+    UI_ENTRY["UI or app startup"] --> PREPARE["CoreLogic.prepareUserSession(userId)"]
+    APP_ENTRY["Service, receiver, or extension"] --> PREPARE
+    WM_ENTRY["Existing WorkManager job"] --> WRAPPER["WrapperWorker"]
+    WRAPPER --> PREPARE
+
+    PREPARE --> SCOPE_PROVIDER["UserSessionScopeProvider.prepare"]
+    SCOPE_PROVIDER --> STORAGE_PROVIDER["UserStorageProvider.prepare(userId)"]
+    STORAGE_PROVIDER --> USER_SESSION["Per-user UserStorageSession<br/>single in-flight attempt"]
+
+    USER_SESSION --> OPENING["OpeningDatabase"]
+    OPENING --> DATABASE["UserDatabaseBuilder.open"]
+    DATABASE -->|"schema is current"| READY["Ready"]
+    DATABASE -->|"migration callback"| MIGRATING["MigratingDatabase"]
+    MIGRATING -->|"migration commits"| READY
+    DATABASE -->|"open or migration error"| FAILURE["Classify failure"]
+
+    READY --> SESSION_SCOPE["UserSessionScope"]
+    SESSION_SCOPE --> CONSUMER["Database-dependent consumer"]
+    SESSION_SCOPE --> INNER_WORKER["Create and run inner WorkManager worker"]
+
+    USER_SESSION -.->|"state flow; observation does not start preparation"| OBSERVER["observeUserSessionPreparation(userId)"]
+    OBSERVER --> STATE_UI["Migration UI or state observer"]
+
+    FAILURE --> APP_FAILURE["UI, service, or receiver failure handling"]
+    FAILURE --> RETRY["Retry policy"]
+    RETRY --> PREPARE
+    FAILURE --> WORK_FAILURE["WorkManager retry or failure result"]
+```
+
+`WrapperWorker` is a preparation gate for existing background work; it is not a dedicated migration
+worker. Migration starts only when one of the entry points calls `prepareUserSession`.
+
 ## Consequences
 
 **Easier:**


### PR DESCRIPTION
## Intent

Make the complete user-session preparation pipeline visible in one place after the implementation layers land.

## Changes

- Add a Mermaid flow diagram to ADR 0011.
- Show foreground, service/receiver, and existing WorkManager entry points converging on one per-user preparation attempt.
- Show the storage and migration state transitions, observers, failure mapping, and retry paths.
- Clarify that WorkManager gates existing work but does not schedule migration itself.

## Impact

Reviewers and implementers can trace the data flow from an entry point to the ready session or failure handling without reconstructing it across modules.

## Stack

- [PR 1](https://github.com/wireapp/kalium/pull/4361)
- [PR 2](https://github.com/wireapp/kalium/pull/4378)
- [PR 3](https://github.com/wireapp/kalium/pull/4379)
- [PR 4](https://github.com/wireapp/kalium/pull/4380)
- [PR 5](https://github.com/wireapp/kalium/pull/4381)
- PR 6 of 6 (current)

## End-to-end preparation pipeline

All database-dependent entry points converge on one per-user preparation operation. The storage session owns the single in-flight attempt and publishes state for observers.

```mermaid
flowchart TD
    UI_ENTRY["UI or app startup"] --> PREPARE["CoreLogic.prepareUserSession(userId)"]
    APP_ENTRY["Service, receiver, or extension"] --> PREPARE
    WM_ENTRY["Existing WorkManager job"] --> WRAPPER["WrapperWorker"]
    WRAPPER --> PREPARE

    PREPARE --> SCOPE_PROVIDER["UserSessionScopeProvider.prepare"]
    SCOPE_PROVIDER --> STORAGE_PROVIDER["UserStorageProvider.prepare(userId)"]
    STORAGE_PROVIDER --> USER_SESSION["Per-user UserStorageSession<br/>single in-flight attempt"]

    USER_SESSION --> OPENING["OpeningDatabase"]
    OPENING --> DATABASE["UserDatabaseBuilder.open"]
    DATABASE -->|"schema is current"| READY["Ready"]
    DATABASE -->|"migration callback"| MIGRATING["MigratingDatabase"]
    MIGRATING -->|"migration commits"| READY
    DATABASE -->|"open or migration error"| FAILURE["Classify failure"]

    READY --> SESSION_SCOPE["UserSessionScope"]
    SESSION_SCOPE --> CONSUMER["Database-dependent consumer"]
    SESSION_SCOPE --> INNER_WORKER["Create and run inner WorkManager worker"]

    USER_SESSION -.->|"state flow; observation does not start preparation"| OBSERVER["observeUserSessionPreparation(userId)"]
    OBSERVER --> STATE_UI["Migration UI or state observer"]

    FAILURE --> APP_FAILURE["UI, service, or receiver failure handling"]
    FAILURE --> RETRY["Retry policy"]
    RETRY --> PREPARE
    FAILURE --> WORK_FAILURE["WorkManager retry or failure result"]
```

WorkManager is a preparation gate for existing background work; it is not a dedicated migration scheduler.

