### PR TITLE
fix(calling): tolerate new AVS callback fields on Apple [WPB-8645]

### DIFF
--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -57,6 +57,7 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.id.FederatedIdMapper
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.network.tools.KtxSerializer
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.user.UserId
@@ -85,7 +86,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
-import kotlinx.serialization.json.Json
 import kotlin.time.Duration.Companion.seconds
 import kotlin.uuid.Uuid
 
@@ -373,7 +373,7 @@ internal class CallManagerImpl internal constructor(
                     CallingMessageTarget.Self
                 } else {
                     val specificTarget = targetRecipientsJson?.let { recipientsJson ->
-                        callMapper.toClientMessageTarget(Json.decodeFromString<CallClientList>(recipientsJson))
+                        callMapper.toClientMessageTarget(KtxSerializer.json.decodeFromString<CallClientList>(recipientsJson))
                     } ?: MessageTarget.Conversation()
                     CallingMessageTarget.HostConversation(specificTarget)
                 }
@@ -501,7 +501,7 @@ internal class CallManagerImpl internal constructor(
 
         override fun onNetworkQualityChanged(conversationId: String?, userId: String?, clientId: String?, qualityInfoJson: String?) {
             if (conversationId == null || qualityInfoJson == null) return
-            val callQualityData = Json.decodeFromString<com.wire.kalium.logic.data.call.CallQualityData>(qualityInfoJson)
+            val callQualityData = KtxSerializer.json.decodeFromString<com.wire.kalium.logic.data.call.CallQualityData>(qualityInfoJson)
             callRepository.updateCallQualityData(qualifiedIdMapper.fromStringToQualifiedID(conversationId), callQualityData)
         }
 
@@ -521,7 +521,7 @@ internal class CallManagerImpl internal constructor(
 
         override fun onActiveSpeakersChanged(handle: UInt, conversationId: String?, data: String?) {
             if (conversationId == null || data == null) return
-            val callActiveSpeakers = Json.decodeFromString<CallActiveSpeakers>(data)
+            val callActiveSpeakers = KtxSerializer.json.decodeFromString<CallActiveSpeakers>(data)
             val activeSpeakers = callActiveSpeakers.activeSpeakers.filter { activeSpeaker ->
                 activeSpeaker.audioLevel > 0 || activeSpeaker.audioLevelNow > 0
             }.groupBy({ qualifiedIdMapper.fromStringToQualifiedID(it.userId) }) { it.clientId }
@@ -593,7 +593,7 @@ internal class CallManagerImpl internal constructor(
     )
 
     private suspend fun handleParticipantsChanged(conversationId: String, data: String) {
-        val participantsChange = Json.decodeFromString<CallParticipants>(data)
+        val participantsChange = KtxSerializer.json.decodeFromString<CallParticipants>(data)
         val conversationIdWithDomain = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
         val participants = participantsChange.members.map { member ->
             participantMapper.fromCallMemberToParticipantMinimized(member)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8645
<!--jira-description-action-hidden-marker-end-->
## Summary
- Decode Apple AVS callback payloads with KtxSerializer.json.
- Tolerate forward-compatible fields such as pstn in participant updates.
- Apply the canonical serializer consistently to callback JSON decoding.

## Validation
- ./gradlew :logic:compileKotlinMacosArm64 -PUSE_UNIFIED_CORE_CRYPTO=true -Pkalium.providerCacheScope=LOCAL

## Context
A real macOS call reached ESTABLISHED, then AVS sent a participant payload containing pstn. The strict decoder threw JsonDecodingException and cancelled participant callbacks.