### PR TITLE
fix(mls): show unreachable recipient warning

### DIFF
--- a/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/message/SendMLSMessageResponse.kt
+++ b/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/message/SendMLSMessageResponse.kt
@@ -30,6 +30,7 @@ data class SendMLSMessageResponse(
     val time: Instant,
     @SerialName("events")
     val events: List<EventContentDTO>,
+    /** Federated users who could not be reached and did not receive the message. */
     @SerialName("failed_to_send")
     val failedToSend: List<QualifiedID> = emptyList()
 )

--- a/data/network/src/commonTest/kotlin/com/wire/kalium/api/v5/MLSMessageApiV5Test.kt
+++ b/data/network/src/commonTest/kotlin/com/wire/kalium/api/v5/MLSMessageApiV5Test.kt
@@ -84,6 +84,21 @@ internal class MLSMessageApiV5Test : ApiTest() {
         }
 
     @Test
+    fun givenFailedToSendUsers_whenSendingMessage_thenUsersAreParsed() = runTest {
+        val expected = SendMLSMessageResponseJson.validMessageSentWithFailedToSendJson.serializableData
+        val networkClient = mockAuthenticatedNetworkClient(
+            SendMLSMessageResponseJson.validMessageSentWithFailedToSendJson.rawJson,
+            statusCode = HttpStatusCode.Created
+        )
+        val mlsMessageApi: MLSMessageApi = MLSMessageApiV5(networkClient)
+
+        val response = mlsMessageApi.sendMessage(MESSAGE)
+
+        assertTrue(response.isSuccessful())
+        assertEquals(expected, response.value)
+    }
+
+    @Test
     fun givenCommitBundle_whenSendingBundle_theRequestShouldFail() =
         runTest {
             val mlsMessageApi: MLSMessageApi = MLSMessageApiV0()

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/SendMessagePartialFailureMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/message/SendMessagePartialFailureMapper.kt
@@ -51,18 +51,10 @@ internal class SendMessagePartialFailureMapperImpl : SendMessagePartialFailureMa
     }
 
     override fun fromMlsDTO(sendMLSMessageResponse: SendMLSMessageResponse): MessageSent {
-        return when {
-            sendMLSMessageResponse.failedToSend.isNotEmpty() -> MessageSent(
-                time = sendMLSMessageResponse.time,
-                failedToConfirmClients = sendMLSMessageResponse.failedToSend.map { it.toModel() }
-            )
-
-            else -> {
-                MessageSent(
-                    time = sendMLSMessageResponse.time
-                )
-            }
-        }
+        return MessageSent(
+            time = sendMLSMessageResponse.time,
+            missing = sendMLSMessageResponse.failedToSend.map { it.toModel() }
+        )
     }
 
     private fun mapNestedUsersIntoUserIds(nestedUsersMap: QualifiedUserIdToClientMap?) =

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSenderImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSenderImpl.kt
@@ -556,8 +556,25 @@ internal class MessageSenderImpl internal constructor(
         }
 
     private suspend fun handleMlsRecipientsDeliveryFailure(message: Message, messageSent: MessageSent) =
-        if (messageSent.failedToConfirmClients.isEmpty()) Either.Right(Unit)
-        else {
-            messageRepository.persistRecipientsDeliveryFailure(message.conversationId, message.id, messageSent.failedToConfirmClients)
+        (
+            if (messageSent.failedToConfirmClients.isEmpty()) {
+                Either.Right(Unit)
+            } else {
+                messageRepository.persistRecipientsDeliveryFailure(
+                    message.conversationId,
+                    message.id,
+                    messageSent.failedToConfirmClients
+                )
+            }
+        ).flatMap {
+            if (messageSent.missing.isEmpty()) {
+                Either.Right(Unit)
+            } else {
+                messageRepository.persistNoClientsToDeliverFailure(
+                    message.conversationId,
+                    message.id,
+                    messageSent.missing
+                )
+            }
         }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/SendMessagePartialFailureMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/message/SendMessagePartialFailureMapperTest.kt
@@ -44,11 +44,16 @@ class SendMessagePartialFailureMapperTest {
     fun testFromMlsDTOMapping() {
         val expectedUsersFailedToSend = listOf(TEST_USER_ID, OTHER_USER_ID_2)
         assertEquals(
-            MessageSent(Instant.parse("2022-04-21T20:56:22.393Z"), expectedUsersFailedToSend),
+            MessageSent(
+                time = Instant.parse("2022-04-21T20:56:22.393Z"),
+                missing = expectedUsersFailedToSend
+            ),
             mapper.fromMlsDTO(
-                SendMLSMessageResponse(Instant.parse("2022-04-21T20:56:22.393Z"),
-                    emptyList(),
-                    expectedUsersFailedToSend.map { it.toApi() })
+                SendMLSMessageResponse(
+                    time = Instant.parse("2022-04-21T20:56:22.393Z"),
+                    events = emptyList(),
+                    failedToSend = expectedUsersFailedToSend.map { it.toApi() }
+                )
             )
         )
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
@@ -953,15 +953,17 @@ class MessageSenderTest {
     }
 
     @Test
-    fun givenARemoteMlsConversationPartiallyFails_whenSendingAMessage_ThenReturnSuccessAndPersistFailedToSendUsers() {
+    fun givenARemoteMlsConversationPartiallyFails_whenSendingAMessage_thenPersistNoClientsToDeliver() {
         // given
         val (arrangement, messageSender) = arrange {
             withSendMlsMessage(
-                sendMlsMessageWithResult = Either.Right(MessageSent(MESSAGE_SENT_TIME, listOf(TEST_MEMBER_2))),
+                sendMlsMessageWithResult = Either.Right(
+                    MessageSent(time = MESSAGE_SENT_TIME, missing = listOf(TEST_MEMBER_2))
+                ),
             )
             withWaitUntilLiveOrFailure()
             withPromoteMessageToSentUpdatingServerTime()
-            withSendMessagePartialSuccess()
+            withFailedClientsPartialSuccess()
         }
 
         arrangement.testScope.runTest {
@@ -971,7 +973,7 @@ class MessageSenderTest {
             // then
             result.shouldSucceed()
             verifySuspend(VerifyMode.exactly(1)) {
-                arrangement.messageRepository.persistRecipientsDeliveryFailure(any(), any(), eq(listOf(TEST_MEMBER_2)))
+                arrangement.messageRepository.persistNoClientsToDeliverFailure(any(), any(), eq(listOf(TEST_MEMBER_2)))
             }
         }
     }

--- a/test/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/SendMLSMessageResponseJson.kt
+++ b/test/mocks/src/commonMain/kotlin/com/wire/kalium/mocks/responses/SendMLSMessageResponseJson.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.mocks.responses
 
 import com.wire.kalium.network.api.authenticated.message.SendMLSMessageResponse
+import com.wire.kalium.network.api.model.QualifiedID
 import kotlinx.datetime.Instant
 
 object SendMLSMessageResponseJson {
@@ -37,5 +38,27 @@ object SendMLSMessageResponseJson {
     val validMessageSentJson = ValidJsonProvider(
         SendMLSMessageResponse(TIME, emptyList()),
         emptyResponse
+    )
+
+    private val failedToSendResponse = { response: SendMLSMessageResponse ->
+        val failedUser = response.failedToSend.single()
+        """
+        |{
+        |   "time": "${response.time}",
+        |   "events": [],
+        |   "failed_to_send": [
+        |       {"id": "${failedUser.value}", "domain": "${failedUser.domain}"}
+        |   ]
+        |}
+        """.trimMargin()
+    }
+
+    val validMessageSentWithFailedToSendJson = ValidJsonProvider(
+        SendMLSMessageResponse(
+            time = TIME,
+            events = emptyList(),
+            failedToSend = listOf(QualifiedID("failed-user", "unreachable.example.com"))
+        ),
+        failedToSendResponse
     )
 }


### PR DESCRIPTION
## Summary

- Treat MLS `failed_to_send` recipients as users who did not receive the message.
- Persist those recipients as `NO_CLIENTS_TO_DELIVER` while keeping the outgoing message sent.
- Add network decoding, mapping, and sender coverage for partial MLS delivery.

## Root cause

Kalium mapped MLS `failed_to_send` recipients to the temporary delivery-failure state. That prevented Android from showing the existing “won't get your message” warning for an unreachable federated participant.

## Impact

Available participants still receive the message, while the sender sees which unreachable participant will not receive it. This covers testcase C1312852.

## Validation

- Focused Android host tests pass for the MLS response mapper, message sender, and network decoder.
- Static analysis passes.
