### PR TITLE
fix: parser not ignoring unknown "pstn" field [WPB-26383][WPB-26820]

### DIFF
--- a/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallParticipants.kt
+++ b/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallParticipants.kt
@@ -40,5 +40,4 @@ data class CallMember(
     val vrecv: Int,
     @SerialName("muted")
     val isMuted: Int,
-    val pstn: Boolean,
 )

--- a/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallParticipants.kt
+++ b/core/data/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallParticipants.kt
@@ -39,5 +39,6 @@ data class CallMember(
     val aestab: Int,
     val vrecv: Int,
     @SerialName("muted")
-    val isMuted: Int
+    val isMuted: Int,
+    val pstn: Boolean,
 )

--- a/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/appleMain/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -86,6 +86,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.json.Json
 import kotlin.time.Duration.Companion.seconds
 import kotlin.uuid.Uuid
 
@@ -110,7 +111,8 @@ internal class CallManagerImpl internal constructor(
     private val createAndPersistRecentlyEndedCallMetadata: CreateAndPersistRecentlyEndedCallMetadataUseCase,
     private val selfUserId: UserId,
     private val serverTimeHandler: ServerTimeHandler = ServerTimeHandlerImpl(),
-    kaliumDispatchers: KaliumDispatcher = KaliumDispatcherImpl
+    kaliumDispatchers: KaliumDispatcher = KaliumDispatcherImpl,
+    private val jsonDecoder: Json = KtxSerializer.json
 ) : CallManager {
     private val tagWithUserId = "$TAG(${selfUserId.toLogString()})"
     private val job = SupervisorJob()
@@ -373,7 +375,7 @@ internal class CallManagerImpl internal constructor(
                     CallingMessageTarget.Self
                 } else {
                     val specificTarget = targetRecipientsJson?.let { recipientsJson ->
-                        callMapper.toClientMessageTarget(KtxSerializer.json.decodeFromString<CallClientList>(recipientsJson))
+                        callMapper.toClientMessageTarget(jsonDecoder.decodeFromString<CallClientList>(recipientsJson))
                     } ?: MessageTarget.Conversation()
                     CallingMessageTarget.HostConversation(specificTarget)
                 }
@@ -501,7 +503,7 @@ internal class CallManagerImpl internal constructor(
 
         override fun onNetworkQualityChanged(conversationId: String?, userId: String?, clientId: String?, qualityInfoJson: String?) {
             if (conversationId == null || qualityInfoJson == null) return
-            val callQualityData = KtxSerializer.json.decodeFromString<com.wire.kalium.logic.data.call.CallQualityData>(qualityInfoJson)
+            val callQualityData = jsonDecoder.decodeFromString<com.wire.kalium.logic.data.call.CallQualityData>(qualityInfoJson)
             callRepository.updateCallQualityData(qualifiedIdMapper.fromStringToQualifiedID(conversationId), callQualityData)
         }
 
@@ -521,7 +523,7 @@ internal class CallManagerImpl internal constructor(
 
         override fun onActiveSpeakersChanged(handle: UInt, conversationId: String?, data: String?) {
             if (conversationId == null || data == null) return
-            val callActiveSpeakers = KtxSerializer.json.decodeFromString<CallActiveSpeakers>(data)
+            val callActiveSpeakers = jsonDecoder.decodeFromString<CallActiveSpeakers>(data)
             val activeSpeakers = callActiveSpeakers.activeSpeakers.filter { activeSpeaker ->
                 activeSpeaker.audioLevel > 0 || activeSpeaker.audioLevelNow > 0
             }.groupBy({ qualifiedIdMapper.fromStringToQualifiedID(it.userId) }) { it.clientId }
@@ -593,7 +595,7 @@ internal class CallManagerImpl internal constructor(
     )
 
     private suspend fun handleParticipantsChanged(conversationId: String, data: String) {
-        val participantsChange = KtxSerializer.json.decodeFromString<CallParticipants>(data)
+        val participantsChange = jsonDecoder.decodeFromString<CallParticipants>(data)
         val conversationIdWithDomain = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
         val participants = participantsChange.members.map { member ->
             participantMapper.fromCallMemberToParticipantMinimized(member)

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -182,6 +182,7 @@ internal class CallManagerImpl internal constructor(
             runBlocking { callRepository.updateIsCbrEnabled(isEnabled) }
         }.keepingStrongReference()
 
+    @Suppress("LongMethod")
     private fun startHandleAsync(): Deferred<Handle> {
         return scope.async(start = CoroutineStart.LAZY) {
             val mediaManagerStartJob = launch {

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/CallManagerImpl.kt
@@ -82,6 +82,7 @@ import com.wire.kalium.logic.util.ServerTimeHandlerImpl
 import com.wire.kalium.logic.util.toInt
 import com.wire.kalium.messaging.sending.MessageSender
 import com.wire.kalium.network.NetworkStateObserver
+import com.wire.kalium.network.tools.KtxSerializer
 import com.wire.kalium.util.KaliumDispatcher
 import com.wire.kalium.util.KaliumDispatcherImpl
 import kotlinx.coroutines.CoroutineScope
@@ -94,6 +95,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
 import java.util.Collections
 import kotlin.io.encoding.Base64
 
@@ -119,7 +121,8 @@ internal class CallManagerImpl internal constructor(
     private val createAndPersistRecentlyEndedCallMetadata: CreateAndPersistRecentlyEndedCallMetadataUseCase,
     private val selfUserId: UserId,
     private val serverTimeHandler: ServerTimeHandler = ServerTimeHandlerImpl(),
-    kaliumDispatchers: KaliumDispatcher = KaliumDispatcherImpl
+    kaliumDispatchers: KaliumDispatcher = KaliumDispatcherImpl,
+    private val jsonDecoder: Json = KtxSerializer.json
 ) : CallManager {
     private val tagWithUserId = "$TAG(${selfUserId.toLogString()})"
     private val job = SupervisorJob()
@@ -212,6 +215,7 @@ internal class CallManagerImpl internal constructor(
                     selfClientId = selfClientId,
                     callMapper = callMapper,
                     callingMessageSender = callingMessageSender,
+                    jsonDecoder = jsonDecoder
                 ).keepingStrongReference(),
                 sftRequestHandler = OnSFTRequest(deferredHandle, calling, callRepository, scope, networkStateObserver)
                     .keepingStrongReference(),
@@ -571,7 +575,8 @@ internal class CallManagerImpl internal constructor(
                     participantMapper = ParticipantMapperImpl(videoStateChecker, callMapper, qualifiedIdMapper),
                     callHelper = CallHelperImpl(userConfigRepository, callRepository),
                     endCall = { endCall(it) },
-                    callingScope = scope
+                    callingScope = scope,
+                    jsonDecoder = jsonDecoder
                 ).keepingStrongReference()
 
                 wcall_set_participant_changed_handler(
@@ -588,7 +593,8 @@ internal class CallManagerImpl internal constructor(
         withCalling {
             val onNetworkQualityChanged = OnNetworkQualityChanged(
                 callRepository = callRepository,
-                qualifiedIdMapper = qualifiedIdMapper
+                qualifiedIdMapper = qualifiedIdMapper,
+                jsonDecoder = jsonDecoder
             ).keepingStrongReference()
             wcall_set_network_quality_handler(
                 inst = deferredHandle.await(),
@@ -631,7 +637,8 @@ internal class CallManagerImpl internal constructor(
             withCalling {
                 val activeSpeakersHandler = OnActiveSpeakers(
                     callRepository = callRepository,
-                    qualifiedIdMapper = qualifiedIdMapper
+                    qualifiedIdMapper = qualifiedIdMapper,
+                    jsonDecoder = jsonDecoder
                 ).keepingStrongReference()
 
                 wcall_set_active_speaker_handler(

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnActiveSpeakers.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnActiveSpeakers.kt
@@ -28,11 +28,12 @@ import kotlinx.serialization.json.Json
 
 internal class OnActiveSpeakers(
     private val callRepository: CallRepository,
-    private val qualifiedIdMapper: QualifiedIdMapper
+    private val qualifiedIdMapper: QualifiedIdMapper,
+    private val jsonDecoder: Json = Json { ignoreUnknownKeys = true }
 ) : ActiveSpeakersHandler {
 
     override fun onActiveSpeakersChanged(inst: Handle, conversationId: String, data: String, arg: Pointer?) {
-        val callActiveSpeakers = Json.decodeFromString<CallActiveSpeakers>(data)
+        val callActiveSpeakers = jsonDecoder.decodeFromString<CallActiveSpeakers>(data)
         val conversationIdWithDomain = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
 
         val onlyActiveSpeakers = callActiveSpeakers.activeSpeakers.filter { activeSpeaker ->

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnActiveSpeakers.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnActiveSpeakers.kt
@@ -24,13 +24,12 @@ import com.wire.kalium.calling.types.Handle
 import com.wire.kalium.logic.data.call.CallActiveSpeakers
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
-import com.wire.kalium.network.tools.KtxSerializer
 import kotlinx.serialization.json.Json
 
 internal class OnActiveSpeakers(
     private val callRepository: CallRepository,
     private val qualifiedIdMapper: QualifiedIdMapper,
-    private val jsonDecoder: Json = KtxSerializer.json
+    private val jsonDecoder: Json,
 ) : ActiveSpeakersHandler {
 
     override fun onActiveSpeakersChanged(inst: Handle, conversationId: String, data: String, arg: Pointer?) {

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnActiveSpeakers.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnActiveSpeakers.kt
@@ -24,12 +24,13 @@ import com.wire.kalium.calling.types.Handle
 import com.wire.kalium.logic.data.call.CallActiveSpeakers
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.network.tools.KtxSerializer
 import kotlinx.serialization.json.Json
 
 internal class OnActiveSpeakers(
     private val callRepository: CallRepository,
     private val qualifiedIdMapper: QualifiedIdMapper,
-    private val jsonDecoder: Json = Json { ignoreUnknownKeys = true }
+    private val jsonDecoder: Json = KtxSerializer.json
 ) : ActiveSpeakersHandler {
 
     override fun onActiveSpeakersChanged(inst: Handle, conversationId: String, data: String, arg: Pointer?) {

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnNetworkQualityChanged.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnNetworkQualityChanged.kt
@@ -29,7 +29,8 @@ import kotlinx.serialization.json.Json
 
 internal class OnNetworkQualityChanged(
     private val callRepository: CallRepository,
-    private val qualifiedIdMapper: QualifiedIdMapper
+    private val qualifiedIdMapper: QualifiedIdMapper,
+    private val jsonDecoder: Json = Json { ignoreUnknownKeys = true }
 ) : NetworkQualityChangedHandler {
 
     override fun onNetworkQualityChanged(
@@ -41,7 +42,7 @@ internal class OnNetworkQualityChanged(
     ) {
         val conversationIdWithDomain = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
         qualityInfoJson?.let { qualityInfoJson ->
-            val callQualityData = Json.decodeFromString<CallQualityData>(qualityInfoJson)
+            val callQualityData = jsonDecoder.decodeFromString<CallQualityData>(qualityInfoJson)
             callRepository.updateCallQualityData(conversationId = conversationIdWithDomain, callQualityData = callQualityData)
             callingLogger.i(
                 "[OnNetworkQualityChanged] - ConversationId: ${conversationId.obfuscateId()}" +

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnNetworkQualityChanged.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnNetworkQualityChanged.kt
@@ -25,13 +25,12 @@ import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.call.CallQualityData
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
-import com.wire.kalium.network.tools.KtxSerializer
 import kotlinx.serialization.json.Json
 
 internal class OnNetworkQualityChanged(
     private val callRepository: CallRepository,
     private val qualifiedIdMapper: QualifiedIdMapper,
-    private val jsonDecoder: Json = KtxSerializer.json
+    private val jsonDecoder: Json,
 ) : NetworkQualityChangedHandler {
 
     override fun onNetworkQualityChanged(

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnNetworkQualityChanged.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnNetworkQualityChanged.kt
@@ -25,12 +25,13 @@ import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.data.call.CallQualityData
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.network.tools.KtxSerializer
 import kotlinx.serialization.json.Json
 
 internal class OnNetworkQualityChanged(
     private val callRepository: CallRepository,
     private val qualifiedIdMapper: QualifiedIdMapper,
-    private val jsonDecoder: Json = Json { ignoreUnknownKeys = true }
+    private val jsonDecoder: Json = KtxSerializer.json
 ) : NetworkQualityChangedHandler {
 
     override fun onNetworkQualityChanged(

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnParticipantListChanged.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnParticipantListChanged.kt
@@ -30,7 +30,6 @@ import com.wire.kalium.logic.data.call.ParticipantMinimized
 import com.wire.kalium.logic.data.call.mapper.ParticipantMapper
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
-import com.wire.kalium.network.tools.KtxSerializer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
@@ -43,7 +42,7 @@ internal class OnParticipantListChanged internal constructor(
     private val callHelper: CallHelper,
     private val endCall: suspend (conversationId: ConversationId) -> Unit,
     private val callingScope: CoroutineScope,
-    private val jsonDecoder: Json = KtxSerializer.json
+    private val jsonDecoder: Json,
 ) : ParticipantChangedHandler {
 
     override fun onParticipantChanged(remoteConversationId: String, data: String, arg: Pointer?) {

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnParticipantListChanged.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnParticipantListChanged.kt
@@ -30,6 +30,7 @@ import com.wire.kalium.logic.data.call.ParticipantMinimized
 import com.wire.kalium.logic.data.call.mapper.ParticipantMapper
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.network.tools.KtxSerializer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
@@ -42,7 +43,7 @@ internal class OnParticipantListChanged internal constructor(
     private val callHelper: CallHelper,
     private val endCall: suspend (conversationId: ConversationId) -> Unit,
     private val callingScope: CoroutineScope,
-    private val jsonDecoder: Json = Json { ignoreUnknownKeys = true }
+    private val jsonDecoder: Json = KtxSerializer.json
 ) : ParticipantChangedHandler {
 
     override fun onParticipantChanged(remoteConversationId: String, data: String, arg: Pointer?) {

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnParticipantListChanged.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnParticipantListChanged.kt
@@ -42,7 +42,7 @@ internal class OnParticipantListChanged internal constructor(
     private val callHelper: CallHelper,
     private val endCall: suspend (conversationId: ConversationId) -> Unit,
     private val callingScope: CoroutineScope,
-    private val jsonDecoder: Json = Json
+    private val jsonDecoder: Json = Json { ignoreUnknownKeys = true }
 ) : ParticipantChangedHandler {
 
     override fun onParticipantChanged(remoteConversationId: String, data: String, arg: Pointer?) {

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnSendOTR.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnSendOTR.kt
@@ -30,6 +30,7 @@ import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.feature.call.AvsCallBackError
 import com.wire.kalium.logic.feature.call.CallManagerImpl
 import com.wire.kalium.messaging.sending.MessageTarget
+import com.wire.kalium.network.tools.KtxSerializer
 import kotlinx.serialization.json.Json
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -41,7 +42,7 @@ internal class OnSendOTR(
     private val selfClientId: String,
     private val callMapper: CallMapper,
     private val callingMessageSender: CallingMessageSender,
-    private val jsonDecoder: Json = Json { ignoreUnknownKeys = true }
+    private val jsonDecoder: Json = KtxSerializer.json
 ) : SendHandler {
     @Suppress("TooGenericExceptionCaught", "NestedBlockDepth")
     override fun onSend(

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnSendOTR.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnSendOTR.kt
@@ -41,6 +41,7 @@ internal class OnSendOTR(
     private val selfClientId: String,
     private val callMapper: CallMapper,
     private val callingMessageSender: CallingMessageSender,
+    private val jsonDecoder: Json = Json { ignoreUnknownKeys = true }
 ) : SendHandler {
     @Suppress("TooGenericExceptionCaught", "NestedBlockDepth")
     override fun onSend(
@@ -71,7 +72,7 @@ internal class OnSendOTR(
                 } else {
                     callingLogger.i("[OnSendOTR] -> Decoding Recipients")
                     val specificTarget = targetRecipientsJson?.let { recipientsJson ->
-                        val callClientList = Json.decodeFromString<CallClientList>(recipientsJson)
+                        val callClientList = jsonDecoder.decodeFromString<CallClientList>(recipientsJson)
 
                         callingLogger.i("[OnSendOTR] -> Mapping Recipients")
                         callMapper.toClientMessageTarget(callClientList = callClientList)

--- a/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnSendOTR.kt
+++ b/logic/src/commonJvmAndroid/kotlin/com/wire/kalium/logic/feature/call/scenario/OnSendOTR.kt
@@ -30,7 +30,6 @@ import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.feature.call.AvsCallBackError
 import com.wire.kalium.logic.feature.call.CallManagerImpl
 import com.wire.kalium.messaging.sending.MessageTarget
-import com.wire.kalium.network.tools.KtxSerializer
 import kotlinx.serialization.json.Json
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -42,7 +41,7 @@ internal class OnSendOTR(
     private val selfClientId: String,
     private val callMapper: CallMapper,
     private val callingMessageSender: CallingMessageSender,
-    private val jsonDecoder: Json = KtxSerializer.json
+    private val jsonDecoder: Json,
 ) : SendHandler {
     @Suppress("TooGenericExceptionCaught", "NestedBlockDepth")
     override fun onSend(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/ParticipantMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/ParticipantMapperTest.kt
@@ -89,7 +89,8 @@ class ParticipantMapperTest {
             clientId = "dummyClientId",
             aestab = 0,
             vrecv = 0,
-            isMuted = 0
+            isMuted = 0,
+            pstn = false,
         )
 
         private val DUMMY_USER_ID = QualifiedID(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/ParticipantMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/ParticipantMapperTest.kt
@@ -89,8 +89,7 @@ class ParticipantMapperTest {
             clientId = "dummyClientId",
             aestab = 0,
             vrecv = 0,
-            isMuted = 0,
-            pstn = false,
+            isMuted = 0
         )
 
         private val DUMMY_USER_ID = QualifiedID(

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/scenario/OnActiveSpeakersTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/scenario/OnActiveSpeakersTest.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.network.tools.KtxSerializer
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.verify.VerifyMode
@@ -89,6 +90,6 @@ class OnActiveSpeakersTest {
             } returns (Unit)
         }
 
-        fun arrange() = this to OnActiveSpeakers(callRepository, qualifiedIdMapper)
+        fun arrange() = this to OnActiveSpeakers(callRepository, qualifiedIdMapper, KtxSerializer.json)
     }
 }

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/scenario/OnParticipantListChangedTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/scenario/OnParticipantListChangedTest.kt
@@ -120,6 +120,27 @@ class OnParticipantListChangedTest {
             assertFalse { arrangement.isEndCallInvoked }
         }
 
+    @Test
+    fun givenParticipantListHasUnknownKeys_whenParticipantListChangedCallBackHappens_thenUpdateCallParticipants() =
+        testScope.runTest {
+            val (arrangement, onParticipantListChanged) = Arrangement()
+                .withParticipantMapper()
+                .withShouldEndSFTOneOnOneCall(false)
+                .arrange()
+
+            onParticipantListChanged.onParticipantChanged(
+                REMOTE_CONVERSATION_ID, dataWithUnknownKeys, null
+            )
+            yield()
+
+            verify(VerifyMode.exactly(2)) {
+                arrangement.participantMapper.fromCallMemberToParticipantMinimized(any())
+            }
+
+            verifySuspend(VerifyMode.exactly(1)) {
+                arrangement.callRepository.updateCallParticipants(any(), any())
+            }
+        }
 
     internal class Arrangement {
         val callRepository = mock<CallRepository>(mode = MockMode.autoUnit)
@@ -186,6 +207,30 @@ class OnParticipantListChangedTest {
                   "aestab": "1",
                   "vrecv": "1",
                   "muted": "0"
+                }
+              ]
+            }
+        """
+        private val dataWithUnknownKeys = """
+            {
+              "convid": "c9mGRDNE7YRVRbk6jokwXNXPgU1n37iS",
+              "ignored": true,
+              "members": [
+                {
+                  "userid": "userid1",
+                  "clientid": "clientid1",
+                  "aestab": "1",
+                  "vrecv": "1",
+                  "muted": "0",
+                  "unknownfield": false
+                },
+                {
+                  "userid": "userid2",
+                  "clientid": "clientid2",
+                  "aestab": "1",
+                  "vrecv": "1",
+                  "muted": "0",
+                  "unknownfield": false
                 }
               ]
             }

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/scenario/OnParticipantListChangedTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/scenario/OnParticipantListChangedTest.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.mls.CipherSuite
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.network.tools.KtxSerializer
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.verify.VerifyMode
@@ -160,6 +161,7 @@ class OnParticipantListChangedTest {
                 isEndCallInvoked = true
             },
             callingScope = testScope,
+            jsonDecoder = KtxSerializer.json
         )
 
         fun withParticipantMapper() = apply {

--- a/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/scenario/OnSendOTRTest.kt
+++ b/logic/src/jvmTest/kotlin/com/wire/kalium/logic/feature/call/scenario/OnSendOTRTest.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.logic.feature.call.CallManagerImpl
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.test_util.TestKaliumDispatcher
+import com.wire.kalium.network.tools.KtxSerializer
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.verify.VerifyMode
@@ -136,6 +137,7 @@ class OnSendOTRTest {
             "self_client_id",
             callMapper,
             messageSender,
+            KtxSerializer.json
         )
 
         companion object {


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26383
<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In AVS 10.5.8 there were some changes added from 10.4 including the `pstn` field and it's breaking the logic of handling call participants because the parser is not ignoring unknown keys and cannot handle this new field properly.

### Solutions

Change all Json parsers for AVS call handlers to ignore unknown keys, so that it won't break in the future if some other field is added.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Open app that uses AVS 10.5.8 and try to make or answer a call - it should establish properly.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
