### PR TITLE
feat: expose sqlite headers metadata use case (WPB-27928)

### DIFF
--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/DebugExtension.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/db/DebugExtension.kt
@@ -29,6 +29,24 @@ class DebugExtension(
     private val metaDataDao: MetadataDAO,
 ) {
 
+    /**
+     * Reads the SQLCipher version from the already-open database driver. No key material or database
+     * contents are exposed by this query.
+     */
+    fun sqlCipherVersion(): String? =
+        if (!isEncrypted) {
+            null
+        } else {
+            sqlDriver.executeQuery(
+                identifier = null,
+                sql = "PRAGMA cipher_version",
+                mapper = { cursor ->
+                    QueryResult.Value(if (cursor.next().value) cursor.getString(0) else null)
+                },
+                parameters = 0,
+            ).value
+        }
+
     suspend fun observeIsProfilingEnabled(): Flow<Boolean> =
         metaDataDao.valueByKeyFlow(KEY_CIPHER_PROFILE)
             .map { state ->

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/DebugScope.kt
@@ -127,6 +127,10 @@ public class DebugScope internal constructor(
     internal val dispatcher: KaliumDispatcher = KaliumDispatcherImpl,
 ) {
 
+    @DebugKaliumApi("Debug-only API for inspecting the active SQLCipher version.")
+    public val getSqlCipherVersion: GetSqlCipherVersionUseCase
+        get() = GetSqlCipherVersionUseCase(userStorage)
+
     @OptIn(InternalKaliumApi::class)
     public val establishSession: EstablishSessionUseCase
         get() = EstablishSessionUseCaseImpl(sessionEstablisher, transactionProvider)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/GetSqlCipherVersionUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/debug/GetSqlCipherVersionUseCase.kt
@@ -1,0 +1,22 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.wire.kalium.logic.feature.debug
+
+import com.wire.kalium.userstorage.di.UserStorage
+import com.wire.kalium.util.DebugKaliumApi
+
+/** Reads the SQLCipher version through the active user database connection. */
+@DebugKaliumApi("Debug-only API for inspecting the active SQLCipher version.")
+public class GetSqlCipherVersionUseCase internal constructor(
+    private val userStorage: UserStorage,
+) {
+    public operator fun invoke(): String? = userStorage.database.debugExtension.sqlCipherVersion()
+}


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-27928
<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Expose from kalium the SQLite headers for sqlcipher version usage froma public debug use case

### Dependencies (Optional)

- https://github.com/wireapp/wire-android/pull/5169

#### How to Test

Open in a debug build, the debug screen and security providers item, to see the metadata listed.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
