### PR TITLE
fix(backup): exclude self-deleting messages [WPB-28008]

### DIFF
--- a/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
+++ b/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Messages.sq
@@ -441,12 +441,12 @@ selectByConversationIdAndVisibility:
 SELECT * FROM MessageDetailsView WHERE conversationId = :conversationId AND visibility IN :visibility ORDER BY date DESC LIMIT :limit OFFSET :offset;
 
 countBackupMessages:
-SELECT count(*) FROM Message WHERE visibility = "VISIBLE" AND self_deletion_end_date IS NULL AND content_type IN :contentType;
+SELECT count(*) FROM Message WHERE visibility = "VISIBLE" AND expire_after_millis IS NULL AND content_type IN :contentType;
 
 selectForBackup:
 SELECT * FROM MessageDetailsView
 WHERE visibility = "VISIBLE"
-    AND selfDeletionEndDate IS NULL
+    AND expireAfterMillis IS NULL
     AND contentType IN :contentType
     AND id > :afterId
 ORDER BY id ASC

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/backup/BackupDataSourceTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/backup/BackupDataSourceTest.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.datetime.Instant
+import kotlin.time.Duration.Companion.seconds
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -97,6 +98,31 @@ class BackupDataSourceTest {
         // Then
         assertEquals(testMessages.size, result.data.size)
         assertTrue(result.totalPages > 0)
+    }
+
+    @Test
+    fun givenSelfDeletingMessages_whenGettingMessages_thenShouldNotExportThem() = runTest {
+        // Given
+        val conversation = createTestConversation("1")
+        val regularMessage = createTestMessage(conversation.id, "regular", userId)
+        val selfDeletingMessageNotStarted = createTestMessage(conversation.id, "self-deleting-not-started", userId).copy(
+            expirationData = Message.ExpirationData(expireAfter = 10.seconds)
+        )
+        val selfDeletingMessageStarted = createTestMessage(conversation.id, "self-deleting-started", userId).copy(
+            expirationData = Message.ExpirationData(
+                expireAfter = 10.seconds,
+                selfDeletionStatus = Message.ExpirationData.SelfDeletionStatus.Started(Instant.fromEpochMilliseconds(10_000))
+            )
+        )
+        subject.insertUsers(listOf(createTestUser(userId.value)))
+        subject.insertConversations(listOf(conversation))
+        subject.insertMessages(listOf(regularMessage, selfDeletingMessageNotStarted, selfDeletingMessageStarted))
+
+        // When
+        val result = subject.getMessages().first()
+
+        // Then
+        assertEquals(listOf(regularMessage.id), result.data.map { it.id })
     }
 
     @Test


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-28008
<!--jira-description-action-hidden-marker-end-->
## Goal

Backport the multiplatform backup privacy fix from #4387 to Android release 4.22.

## Root cause

The backup queries filtered on `self_deletion_end_date`. That value remains null until the deletion countdown starts, so self-deleting messages whose timer had not started were selected for export. Because expiration metadata is not part of the backup message format, restoring those entries could make them permanent.

## Steps to reproduce

1. Receive a self-deleting message without starting its deletion timer.
2. Create a multiplatform backup.
3. Restore the backup for the same account.
4. Observe that the message is restored without an expiration timer.

## Changes

- Filter backup message counts and pages on `expire_after_millis` instead.
- Add regression coverage for self-deleting messages with both not-started and started timers.
- Verify that regular messages remain eligible for backup.

## Impact

All messages configured for self-deletion are excluded from multiplatform backups, matching the legacy backup behavior.

## Validation

- Focused backup data-source tests pass.
- Static analysis passes.
