### PR TITLE
feat: update conversation name when updating meeting [WPB-27617]

### DIFF
--- a/changelog.d/update-meeting-use-case-failure.changed.md
+++ b/changelog.d/update-meeting-use-case-failure.changed.md
@@ -1,0 +1,6 @@
+Changed `UpdateMeetingUseCase.Result.Failure` to expose specific update failure types.
+
+  - ABI: changed
+  - Source: changed for consumers matching `Failure` as a singleton object.
+  - Behavior: meeting update conversation-name failures now return `UpdateConversationNameFailure`.
+  - Migration: handle `Failure.Other` and `Failure.UpdateConversationNameFailure`.

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/meeting/MeetingDao.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/meeting/MeetingDao.kt
@@ -47,6 +47,7 @@ interface MeetingDao {
     ): KaliumPager<MeetingOccurrenceDetailsEntity>
     suspend fun deleteMeeting(meetingId: QualifiedIDEntity)
     suspend fun getNextMeetingOccurrenceDetailsId(meetingId: QualifiedIDEntity, from: Instant): String?
+    suspend fun getMeeting(meetingId: QualifiedIDEntity): MeetingEntity?
 }
 
 internal class MeetingDaoImpl(
@@ -142,6 +143,11 @@ internal class MeetingDaoImpl(
             meetingsQueries.selectNextMeetingOccurrenceDetailsId(meetingId = meetingId, fromDate = from)
                 .awaitAsOneOrNull()
         }
+
+    override suspend fun getMeeting(meetingId: QualifiedIDEntity): MeetingEntity? = withContext(readDispatcher.value) {
+        meetingsQueries.selectMeetingByIds(listOf(meetingId), MeetingMapper::fromViewToModel)
+            .awaitAsOneOrNull()
+    }
 
     private fun meetingPagingSource(from: Instant, startingOffset: Long, prefetchDistance: Int): MeetingPagingSource =
         MeetingPagingSource(

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/meeting/MeetingMapper.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/meeting/MeetingMapper.kt
@@ -45,7 +45,7 @@ data object MeetingMapper {
         title = title,
         startTime = startDate,
         endTime = endDate,
-        trial = trial,
+        trial = trial.normalized(),
         recurrence = when {
             recurrenceFrequency != null -> MeetingEntity.RecurrenceEntity(
                 frequency = recurrenceFrequency,
@@ -106,4 +106,8 @@ data object MeetingMapper {
         channelAccess = channelAccess,
         selfUserId = selfUserId,
     )
+
+    // SQLDelight's JS driver can return SQLite booleans as 0/1 behind a Boolean unsafeCast.
+    // Rebuilding the value through a branch canonicalizes it back to true/false.
+    private fun Boolean.normalized(): Boolean = if (this) true else false
 }

--- a/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/meeting/MeetingDaoTest.kt
+++ b/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/meeting/MeetingDaoTest.kt
@@ -138,6 +138,47 @@ class MeetingDaoTest : BaseDatabaseTest() {
         }
 
     @Test
+    fun givenStoredMeetings_whenGettingMeeting_thenReturnsMeeting() = runTest(dispatcher) {
+        val meetingStart = Instant.parse("2026-01-03T10:00:00Z")
+        val meeting = newMeeting(
+            meetingId = QualifiedIDEntity("meeting-to-fetch", "wire.com"),
+            conversationId = QualifiedIDEntity("conversation-to-fetch", "wire.com"),
+            startTime = meetingStart,
+            recurrence = MeetingEntity.RecurrenceEntity(frequency = Frequency.WEEKLY, interval = 2, until = meetingStart + 28.days)
+        ).copy(
+            updatedAt = Instant.parse("2026-01-02T12:00:00Z"),
+            title = "Fetched meeting",
+            trial = true
+        )
+        val otherMeeting = newMeeting(
+            meetingId = QualifiedIDEntity("other-meeting", "wire.com"),
+            conversationId = QualifiedIDEntity("other-conversation", "wire.com"),
+            startTime = meetingStart + 1.days
+        )
+        insertMeetingDependencies(meeting)
+        insertMeetingDependencies(otherMeeting)
+        meetingDao.upsertMeetings(
+            listOf(meeting, otherMeeting),
+            GenerationLimit.Window(meetingStart - 1.days, meetingStart + GENERATION_DAYS.days)
+        )
+
+        assertEquals(meeting, meetingDao.getMeeting(meeting.meetingId))
+    }
+
+    @Test
+    fun givenNoStoredMeetingForId_whenGettingMeeting_thenReturnsNull() = runTest(dispatcher) {
+        val meetingStart = Instant.parse("2026-01-03T10:00:00Z")
+        val meeting = newMeeting(startTime = meetingStart)
+        insertMeetingDependencies(meeting)
+        meetingDao.upsertMeetings(
+            listOf(meeting),
+            GenerationLimit.Window(meetingStart - 1.days, meetingStart + GENERATION_DAYS.days)
+        )
+
+        assertEquals(null, meetingDao.getMeeting(QualifiedIDEntity("missing-meeting", "wire.com")))
+    }
+
+    @Test
     fun givenGeneratedOccurrences_whenSameMeetingIsUpserted_thenOccurrencesAreNotDuplicated() = runTest(dispatcher) {
         val now = Clock.System.now()
         val meeting = newMeeting(

--- a/logic/api/jvm/logic.api
+++ b/logic/api/jvm/logic.api
@@ -5390,9 +5390,23 @@ public abstract interface class com/wire/kalium/logic/feature/meeting/UpdateMeet
 public abstract interface class com/wire/kalium/logic/feature/meeting/UpdateMeetingUseCase$Result {
 }
 
-public final class com/wire/kalium/logic/feature/meeting/UpdateMeetingUseCase$Result$Failure : com/wire/kalium/logic/feature/meeting/UpdateMeetingUseCase$Result {
-	public static final field INSTANCE Lcom/wire/kalium/logic/feature/meeting/UpdateMeetingUseCase$Result$Failure;
+public abstract interface class com/wire/kalium/logic/feature/meeting/UpdateMeetingUseCase$Result$Failure : com/wire/kalium/logic/feature/meeting/UpdateMeetingUseCase$Result {
+}
+
+public final class com/wire/kalium/logic/feature/meeting/UpdateMeetingUseCase$Result$Failure$Other : com/wire/kalium/logic/feature/meeting/UpdateMeetingUseCase$Result$Failure {
+	public static final field INSTANCE Lcom/wire/kalium/logic/feature/meeting/UpdateMeetingUseCase$Result$Failure$Other;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/wire/kalium/logic/feature/meeting/UpdateMeetingUseCase$Result$Failure$UpdateConversationNameFailure : com/wire/kalium/logic/feature/meeting/UpdateMeetingUseCase$Result$Failure {
+	public fun <init> (Lcom/wire/kalium/logic/data/id/QualifiedID;)V
+	public final fun component1 ()Lcom/wire/kalium/logic/data/id/QualifiedID;
+	public final fun copy (Lcom/wire/kalium/logic/data/id/QualifiedID;)Lcom/wire/kalium/logic/feature/meeting/UpdateMeetingUseCase$Result$Failure$UpdateConversationNameFailure;
+	public static synthetic fun copy$default (Lcom/wire/kalium/logic/feature/meeting/UpdateMeetingUseCase$Result$Failure$UpdateConversationNameFailure;Lcom/wire/kalium/logic/data/id/QualifiedID;ILjava/lang/Object;)Lcom/wire/kalium/logic/feature/meeting/UpdateMeetingUseCase$Result$Failure$UpdateConversationNameFailure;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConversationId ()Lcom/wire/kalium/logic/data/id/QualifiedID;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/logic/api/logic.klib.api
+++ b/logic/api/logic.klib.api
@@ -1407,10 +1407,25 @@ abstract interface com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase { 
     abstract suspend fun invoke(com.wire.kalium.logic.data.id/QualifiedID, com.wire.kalium.logic.data.meeting/UpsertMeeting): com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.Result // com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.invoke|invoke(com.wire.kalium.logic.data.id.QualifiedID;com.wire.kalium.logic.data.meeting.UpsertMeeting){}[0]
 
     sealed interface Result { // com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.Result|null[0]
-        final object Failure : com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.Result { // com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.Result.Failure|null[0]
-            final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.Result.Failure.equals|equals(kotlin.Any?){}[0]
-            final fun hashCode(): kotlin/Int // com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.Result.Failure.hashCode|hashCode(){}[0]
-            final fun toString(): kotlin/String // com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.Result.Failure.toString|toString(){}[0]
+        sealed interface Failure : com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.Result { // com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.Result.Failure|null[0]
+            final class UpdateConversationNameFailure : com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.Result.Failure { // com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.Result.Failure.UpdateConversationNameFailure|null[0]
+                constructor <init>(com.wire.kalium.logic.data.id/QualifiedID) // com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.Result.Failure.UpdateConversationNameFailure.<init>|<init>(com.wire.kalium.logic.data.id.QualifiedID){}[0]
+
+                final val conversationId // com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.Result.Failure.UpdateConversationNameFailure.conversationId|{}conversationId[0]
+                    final fun <get-conversationId>(): com.wire.kalium.logic.data.id/QualifiedID // com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.Result.Failure.UpdateConversationNameFailure.conversationId.<get-conversationId>|<get-conversationId>(){}[0]
+
+                final fun component1(): com.wire.kalium.logic.data.id/QualifiedID // com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.Result.Failure.UpdateConversationNameFailure.component1|component1(){}[0]
+                final fun copy(com.wire.kalium.logic.data.id/QualifiedID = ...): com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.Result.Failure.UpdateConversationNameFailure // com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.Result.Failure.UpdateConversationNameFailure.copy|copy(com.wire.kalium.logic.data.id.QualifiedID){}[0]
+                final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.Result.Failure.UpdateConversationNameFailure.equals|equals(kotlin.Any?){}[0]
+                final fun hashCode(): kotlin/Int // com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.Result.Failure.UpdateConversationNameFailure.hashCode|hashCode(){}[0]
+                final fun toString(): kotlin/String // com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.Result.Failure.UpdateConversationNameFailure.toString|toString(){}[0]
+            }
+
+            final object Other : com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.Result.Failure { // com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.Result.Failure.Other|null[0]
+                final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.Result.Failure.Other.equals|equals(kotlin.Any?){}[0]
+                final fun hashCode(): kotlin/Int // com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.Result.Failure.Other.hashCode|hashCode(){}[0]
+                final fun toString(): kotlin/String // com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.Result.Failure.Other.toString|toString(){}[0]
+            }
         }
 
         final object Success : com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.Result { // com.wire.kalium.logic.feature.meeting/UpdateMeetingUseCase.Result.Success|null[0]

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepository.kt
@@ -337,7 +337,6 @@ internal class MeetingDataSource(
                 )
             }.flatMap {
                 establishMLSGroupIfNeeded(transactionContext = transactionContext, otherParticipants = otherParticipants)
-                    .mapLeft { EstablishMLSFailure(conversationId = conversation.id.toModel(), reason = it) }
             }
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepository.kt
@@ -218,7 +218,7 @@ internal class MeetingDataSource(
             conversationRepository.getConversationById(conversationId = meetingEntity.conversationId.toModel())
         }.flatMap { conversation ->
             updateMembers(
-                conversationId = conversation.id,
+                conversation = conversation,
                 upsertMeeting = meeting,
                 transactionContext = transactionContext
             ).flatMap { mlsAdditionResult ->
@@ -240,28 +240,26 @@ internal class MeetingDataSource(
         }
 
     private suspend fun updateMembers(
-        conversationId: ConversationId,
+        conversation: Conversation,
         upsertMeeting: UpsertMeeting,
         transactionContext: CryptoTransactionContext,
-    ): Either<CoreFailure, MLSAdditionResult> =
-        conversationRepository.getConversationById(conversationId)
-            .flatMap { conversation ->
-                val mlsCapableProtocol = conversation.protocol as? Conversation.ProtocolInfo.MLSCapable
-                if (mlsCapableProtocol?.groupState == Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED) {
-                    conversationRepository.getConversationMembers(conversation.id)
-                        .map { it.filterNot { it == selfUserId } } // exclude self user from current members
-                        .flatMap { currentMembers ->
-                            updateMembers(
-                                mlsCapableProtocol = mlsCapableProtocol,
-                                membersToAdd = upsertMeeting.otherParticipants.filterNot { it in currentMembers },
-                                membersToRemove = currentMembers.filterNot { it in upsertMeeting.otherParticipants },
-                                transactionContext = transactionContext
-                            )
-                        }
-                } else {
-                    Either.Right(MLSAdditionResult.Empty) // no MLS-capable protocol or not established, so no need to update members
+    ): Either<CoreFailure, MLSAdditionResult> {
+        val mlsCapableProtocol = conversation.protocol as? Conversation.ProtocolInfo.MLSCapable
+        return if (mlsCapableProtocol?.groupState == Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED) {
+            conversationRepository.getConversationMembers(conversation.id)
+                .map { it.filterNot { it == selfUserId } } // exclude self user from current members
+                .flatMap { currentMembers ->
+                    updateMembers(
+                        mlsCapableProtocol = mlsCapableProtocol,
+                        membersToAdd = upsertMeeting.otherParticipants.filterNot { it in currentMembers },
+                        membersToRemove = currentMembers.filterNot { it in upsertMeeting.otherParticipants },
+                        transactionContext = transactionContext
+                    )
                 }
-            }
+        } else {
+            Either.Right(MLSAdditionResult.Empty) // no MLS-capable protocol or not established, so no need to update members
+        }
+    }
 
     private suspend fun updateMembers(
         mlsCapableProtocol: Conversation.ProtocolInfo.MLSCapable,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepository.kt
@@ -29,11 +29,13 @@ import com.wire.kalium.common.error.wrapApiRequest
 import com.wire.kalium.common.error.wrapStorageRequest
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.common.functional.fold
 import com.wire.kalium.common.functional.map
 import com.wire.kalium.common.functional.mapLeft
 import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.cryptography.CryptoTransactionContext
 import com.wire.kalium.logic.data.client.wrapInMLSContext
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationMapper
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.ConversationSyncReason
@@ -47,10 +49,10 @@ import com.wire.kalium.logic.data.id.MeetingId
 import com.wire.kalium.logic.data.id.toApi
 import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.id.toModel
-import com.wire.kalium.logic.data.mls.CipherSuite
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.network.api.authenticated.conversation.ConvProtocol
+import com.wire.kalium.network.api.authenticated.conversation.ConversationRenameResponse
 import com.wire.kalium.network.api.authenticated.meeting.UpsertMeetingResponse
 import com.wire.kalium.network.api.authenticated.meeting.toMeetingDTO
 import com.wire.kalium.network.api.base.authenticated.meeting.MeetingApi
@@ -209,64 +211,112 @@ internal class MeetingDataSource(
         generateOccurrencesFrom: Instant,
         generateOccurrencesUntil: Instant,
         transactionContext: CryptoTransactionContext
-    ): Either<CoreFailure, MLSAdditionResult> = wrapApiRequest {
-        meetingApi.updateMeeting(meetingId = meetingId.toApi(), request = meetingMapper.fromModelToApi(meeting))
-    }.flatMap { response ->
-        response.persist(
-            transactionContext = transactionContext,
-            otherParticipants = meeting.otherParticipants,
-            generateOccurrencesFrom = generateOccurrencesFrom,
-            generateOccurrencesUntil = generateOccurrencesUntil
-        ).flatMap {
-            response.updateMembers(meeting = meeting, transactionContext = transactionContext)
-        }
-    }
-
-    private suspend fun UpsertMeetingResponse.updateMembers(
-        meeting: UpsertMeeting,
-        transactionContext: CryptoTransactionContext,
-    ) = conversationRepository.getConversationMembers(conversationId.toModel())
-        .map { it.filterNot { it == selfUserId } } // exclude self user from current members
-        .flatMap { currentMembers ->
+    ): Either<CoreFailure, MLSAdditionResult> =
+        wrapStorageRequest {
+            meetingDAO.getMeeting(meetingId.toDao())
+        }.flatMap { meetingEntity ->
+            conversationRepository.getConversationById(conversationId = meetingEntity.conversationId.toModel())
+        }.flatMap { conversation ->
             updateMembers(
-                membersToAdd = meeting.otherParticipants.filterNot { it in currentMembers },
-                membersToRemove = currentMembers.filterNot { it in meeting.otherParticipants },
+                conversationId = conversation.id,
+                upsertMeeting = meeting,
                 transactionContext = transactionContext
-            )
+            ).flatMap { mlsAdditionResult ->
+                wrapApiRequest {
+                    meetingApi.updateMeeting(meetingId = meetingId.toApi(), request = meetingMapper.fromModelToApi(meeting))
+                }.flatMap { response ->
+                    response.updateConversationName(conversation = conversation, upsertMeeting = meeting) { response ->
+                        response.persist(
+                            transactionContext = transactionContext,
+                            otherParticipants = meeting.otherParticipants,
+                            generateOccurrencesFrom = generateOccurrencesFrom,
+                            generateOccurrencesUntil = generateOccurrencesUntil
+                        )
+                    }
+                }.map { mlsEstablishmentResult ->
+                    if (mlsEstablishmentResult == MLSAdditionResult.Empty) mlsAdditionResult else mlsEstablishmentResult
+                }
+            }
         }
 
-    private suspend fun UpsertMeetingResponse.updateMembers(
+    private suspend fun updateMembers(
+        conversationId: ConversationId,
+        upsertMeeting: UpsertMeeting,
+        transactionContext: CryptoTransactionContext,
+    ): Either<CoreFailure, MLSAdditionResult> =
+        conversationRepository.getConversationById(conversationId)
+            .flatMap { conversation ->
+                val mlsCapableProtocol = conversation.protocol as? Conversation.ProtocolInfo.MLSCapable
+                if (mlsCapableProtocol?.groupState == Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED) {
+                    conversationRepository.getConversationMembers(conversation.id)
+                        .map { it.filterNot { it == selfUserId } } // exclude self user from current members
+                        .flatMap { currentMembers ->
+                            updateMembers(
+                                mlsCapableProtocol = mlsCapableProtocol,
+                                membersToAdd = upsertMeeting.otherParticipants.filterNot { it in currentMembers },
+                                membersToRemove = currentMembers.filterNot { it in upsertMeeting.otherParticipants },
+                                transactionContext = transactionContext
+                            )
+                        }
+                } else {
+                    Either.Right(MLSAdditionResult.Empty) // no MLS-capable protocol or not established, so no need to update members
+                }
+            }
+
+    private suspend fun updateMembers(
+        mlsCapableProtocol: Conversation.ProtocolInfo.MLSCapable,
         membersToAdd: List<UserId>,
         membersToRemove: List<UserId>,
         transactionContext: CryptoTransactionContext,
     ): Either<CoreFailure, MLSAdditionResult> =
-        if ((membersToAdd + membersToRemove).isNotEmpty() && conversation.groupId != null && conversation.mlsCipherSuiteTag != null) {
-        transactionContext.wrapInMLSContext { mlsContext ->
-            when {
-                membersToRemove.isNotEmpty() -> mlsConversationRepository.removeMembersFromMLSGroup(
-                    mlsContext = mlsContext,
-                    groupID = idMapper.fromGroupIDEntity(conversation.groupId!!),
-                    userIdList = membersToRemove,
-                )
-
-                else -> Either.Right(Unit)
-            }.flatMap {
+        if ((membersToAdd + membersToRemove).isNotEmpty()) {
+            transactionContext.wrapInMLSContext { mlsContext ->
                 when {
-                    membersToAdd.isNotEmpty() -> mlsConversationRepository.addMemberToMLSGroup(
+                    membersToRemove.isNotEmpty() -> mlsConversationRepository.removeMembersFromMLSGroup(
                         mlsContext = mlsContext,
-                        groupID = idMapper.fromGroupIDEntity(conversation.groupId!!),
-                        userIdList = membersToAdd,
-                        cipherSuite = CipherSuite.fromTag(conversation.mlsCipherSuiteTag!!),
-                        allowPartialMemberList = true
+                        groupID = mlsCapableProtocol.groupId,
+                        userIdList = membersToRemove,
                     )
 
-                    else -> Either.Right(MLSAdditionResult.Empty)
+                    else -> Either.Right(Unit)
+                }.flatMap {
+                    when {
+                        membersToAdd.isNotEmpty() -> mlsConversationRepository.addMemberToMLSGroup(
+                            mlsContext = mlsContext,
+                            groupID = mlsCapableProtocol.groupId,
+                            userIdList = membersToAdd,
+                            cipherSuite = mlsCapableProtocol.cipherSuite,
+                            allowPartialMemberList = true
+                        )
+
+                        else -> Either.Right(MLSAdditionResult.Empty)
+                    }
                 }
             }
-        }.mapLeft { EstablishMLSFailure(conversationId = conversation.id.toModel(), reason = it) }
-    } else {
-        // no members to add and remove, or no group ID or cipher suite tag, so nothing to do
-        Either.Right(MLSAdditionResult.Empty)
+        } else {
+            // no members to add and remove, or no group ID or cipher suite tag, so nothing to do
+            Either.Right(MLSAdditionResult.Empty)
+        }
+
+    private suspend fun <T> UpsertMeetingResponse.updateConversationName(
+        conversation: Conversation,
+        upsertMeeting: UpsertMeeting,
+        action: suspend (UpsertMeetingResponse) -> Either<CoreFailure, T>,
+    ): Either<CoreFailure, T> {
+        val changeConversationNameResult = when {
+            conversation.name == upsertMeeting.title -> Either.Right(ConversationRenameResponse.Unchanged) // no need to execute the change
+            else -> conversationRepository.changeConversationName(conversationId = conversation.id, conversationName = upsertMeeting.title)
+        }
+        val updatedResponse = changeConversationNameResult.fold(
+            { this },
+            { this.copy(conversation = this.conversation.copy(name = upsertMeeting.title)) }
+        )
+        return action(updatedResponse).flatMap { actionResult ->
+            changeConversationNameResult.fold(
+                { Either.Left(UpdateConversationNameFailure(conversationId = conversation.id, reason = it)) },
+                { Either.Right(actionResult) }
+            )
+        }
     }
 
     private suspend fun UpsertMeetingResponse.persist(
@@ -314,6 +364,8 @@ internal class MeetingDataSource(
                 if (it.isMLSRetryableError()) {
                     pendingActionsRepository.enqueuePendingMLSGroupJoin(conversationId = conversation.id.toModel())
                 }
+            }.mapLeft {
+                EstablishMLSFailure(conversationId = conversation.id.toModel(), reason = it)
             }
         }
     }
@@ -327,6 +379,7 @@ internal class MeetingDataSource(
     }
 
     data class EstablishMLSFailure(val conversationId: ConversationId, val reason: CoreFailure) : CoreFailure.FeatureFailure()
+    data class UpdateConversationNameFailure(val conversationId: ConversationId, val reason: CoreFailure) : CoreFailure.FeatureFailure()
 }
 
 private const val OCCURRENCE_GENERATION_WINDOW_DAYS = 90

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/meeting/UpdateMeetingUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/meeting/UpdateMeetingUseCase.kt
@@ -32,6 +32,7 @@ import com.wire.kalium.logic.data.conversation.ResetMLSConversationUseCase
 import com.wire.kalium.logic.data.conversation.mls.MLSAdditionResult
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.MeetingId
+import com.wire.kalium.logic.data.meeting.MeetingDataSource
 import com.wire.kalium.logic.data.meeting.UpsertMeeting
 import com.wire.kalium.logic.data.meeting.MeetingDataSource.EstablishMLSFailure
 import com.wire.kalium.logic.data.meeting.MeetingRepository
@@ -47,7 +48,10 @@ public interface UpdateMeetingUseCase {
     public suspend operator fun invoke(meetingId: MeetingId, updateMeeting: UpsertMeeting): Result
     public sealed interface Result {
         public data object Success : Result
-        public data object Failure : Result // TODO: Add more specific error types in the future
+        public sealed interface Failure : Result { // TODO: Add more specific error types in the future
+            public data class UpdateConversationNameFailure(val conversationId: ConversationId) : Failure
+            public data object Other : Failure
+        }
     }
 }
 
@@ -110,10 +114,14 @@ internal class UpdateMeetingUseCaseImpl(
                         }
                     }
             }
-            .onSuccess {
-                refreshUsersWithoutMetadata()
-            }
-            .fold({ UpdateMeetingUseCase.Result.Failure }, { UpdateMeetingUseCase.Result.Success })
+            .onSuccess { refreshUsersWithoutMetadata() }
+            .fold({ it.toResult() }, { UpdateMeetingUseCase.Result.Success })
+
+    private fun CoreFailure.toResult() = when (this) {
+        is MeetingDataSource.UpdateConversationNameFailure ->
+            UpdateMeetingUseCase.Result.Failure.UpdateConversationNameFailure(conversationId)
+        else -> UpdateMeetingUseCase.Result.Failure.Other
+    }
 
     private fun logData(meetingId: MeetingId, conversationId: ConversationId, failure: CoreFailure? = null): Map<String, Any> = buildMap {
         put("meetingId", meetingId.toLogString())

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepositoryTest.kt
@@ -25,10 +25,12 @@ import com.wire.kalium.common.functional.getOrNull
 import com.wire.kalium.common.functional.isRight
 import com.wire.kalium.cryptography.CryptoTransactionContext
 import com.wire.kalium.cryptography.MlsCoreCryptoContext
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepositoryTest
 import com.wire.kalium.logic.data.conversation.ConversationSyncReason
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.conversation.PersistConversationsUseCase
 import com.wire.kalium.logic.data.conversation.mls.MLSAdditionResult
 import com.wire.kalium.logic.data.conversation.mls.PendingActionsRepository
@@ -44,11 +46,12 @@ import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.test_util.TestNetworkException
 import com.wire.kalium.network.api.authenticated.conversation.ConvProtocol
-import com.wire.kalium.network.api.authenticated.meeting.UpsertMeetingResponse
+import com.wire.kalium.network.api.authenticated.conversation.ConversationRenameResponse
 import com.wire.kalium.network.api.authenticated.conversation.ConversationResponse
 import com.wire.kalium.network.api.authenticated.meeting.MeetingDTO
 import com.wire.kalium.network.api.authenticated.meeting.MeetingFrequencyDTO
 import com.wire.kalium.network.api.authenticated.meeting.MeetingRecurrenceDTO
+import com.wire.kalium.network.api.authenticated.meeting.UpsertMeetingResponse
 import com.wire.kalium.network.api.authenticated.meeting.toMeetingDTO
 import com.wire.kalium.network.api.base.authenticated.meeting.MeetingApi
 import com.wire.kalium.network.utils.NetworkResponse
@@ -244,8 +247,6 @@ class MeetingRepositoryTest {
                 meetings = listOf(expectedMeetingEntity),
                 generateOccurrencesWindow = GenerationLimit.Window(generateOccurrencesFrom, generateOccurrencesUntil)
             )
-        }
-        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.mlsConversationRepository.establishMLSGroup(
                 mlsContext = arrangement.mlsContext,
                 groupID = GroupID(groupId),
@@ -296,6 +297,7 @@ class MeetingRepositoryTest {
 
         assertIs<Either.Left<NetworkFailure.NoNetworkConnection>>(result)
         verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingApi.createNewMeeting(arrangement.meetingMapper.fromModelToApi(createMeeting))
             arrangement.persistConversations(
                 transactionContext = arrangement.transactionContext,
                 conversations = listOf(response.conversation),
@@ -319,6 +321,7 @@ class MeetingRepositoryTest {
             .withPersistConversationsSuccess()
             .withPersistMeetingFailure(error)
             .arrange()
+        val expectedMeetingEntity = requireNotNull(arrangement.meetingMapper.fromApiToDao(response.toMeetingDTO()))
 
         val result = repository.createNewMeeting(
             meeting = createMeeting,
@@ -327,7 +330,17 @@ class MeetingRepositoryTest {
 
         assertIs<Either.Left<StorageFailure.Generic>>(result)
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.meetingDao.upsertMeetings(any(), any())
+            arrangement.meetingApi.createNewMeeting(arrangement.meetingMapper.fromModelToApi(createMeeting))
+            arrangement.persistConversations(
+                transactionContext = arrangement.transactionContext,
+                conversations = listOf(response.conversation),
+                invalidateMembers = true,
+                reason = ConversationSyncReason.Other
+            )
+            arrangement.meetingDao.upsertMeetings(
+                meetings = listOf(expectedMeetingEntity),
+                generateOccurrencesWindow = any()
+            )
         }
         verifySuspend(VerifyMode.not) {
             arrangement.mlsConversationRepository.establishMLSGroup(any(), any(), any(), any(), any())
@@ -345,6 +358,7 @@ class MeetingRepositoryTest {
             .withTransactionMlsContext()
             .withMlsGroupEstablishmentFailure(failure)
             .arrange()
+        val expectedMeetingEntity = requireNotNull(arrangement.meetingMapper.fromApiToDao(response.toMeetingDTO()))
 
         val result = repository.createNewMeeting(
             meeting = createMeeting,
@@ -354,6 +368,17 @@ class MeetingRepositoryTest {
         val resultFailure = assertIs<Either.Left<MeetingDataSource.EstablishMLSFailure>>(result).value
         assertEquals(response.conversation.id.toModel(), resultFailure.conversationId)
         verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingApi.createNewMeeting(arrangement.meetingMapper.fromModelToApi(createMeeting))
+            arrangement.persistConversations(
+                transactionContext = arrangement.transactionContext,
+                conversations = listOf(response.conversation),
+                invalidateMembers = true,
+                reason = ConversationSyncReason.Other
+            )
+            arrangement.meetingDao.upsertMeetings(
+                meetings = listOf(expectedMeetingEntity),
+                generateOccurrencesWindow = any()
+            )
             arrangement.mlsConversationRepository.establishMLSGroup(any(), any(), any(), any(), any())
             arrangement.pendingActionsRepository.enqueuePendingMLSGroupJoin(response.conversation.id.toModel())
         }
@@ -367,6 +392,7 @@ class MeetingRepositoryTest {
             .withCreateNewMeetingSuccess(createMeeting, response)
             .withPersistConversationsSuccess()
             .arrange()
+        val expectedMeetingEntity = requireNotNull(arrangement.meetingMapper.fromApiToDao(response.toMeetingDTO()))
 
         val result = repository.createNewMeeting(
             meeting = createMeeting,
@@ -375,6 +401,19 @@ class MeetingRepositoryTest {
 
         assertTrue(result.isRight())
         assertEquals(MLSAdditionResult.Empty, result.getOrNull())
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingApi.createNewMeeting(arrangement.meetingMapper.fromModelToApi(createMeeting))
+            arrangement.persistConversations(
+                transactionContext = arrangement.transactionContext,
+                conversations = listOf(response.conversation),
+                invalidateMembers = true,
+                reason = ConversationSyncReason.Other
+            )
+            arrangement.meetingDao.upsertMeetings(
+                meetings = listOf(expectedMeetingEntity),
+                generateOccurrencesWindow = any()
+            )
+        }
         verifySuspend(VerifyMode.not) {
             arrangement.mlsConversationRepository.establishMLSGroup(any(), any(), any(), any(), any())
             arrangement.pendingActionsRepository.enqueuePendingMLSGroupJoin(any())
@@ -388,13 +427,20 @@ class MeetingRepositoryTest {
         val response = upsertMeetingResponse(epoch = 1UL)
         val generateOccurrencesFrom = Instant.parse("2026-05-01T00:00:00Z")
         val generateOccurrencesUntil = Instant.parse("2026-07-01T00:00:00Z")
+        val conversationId = response.conversationId.toModel()
+        val conversation = meetingConversation(conversationId = conversationId)
         val (arrangement, repository) = Arrangement()
+            .withStoredMeeting(MEETING_ENTITY.copy(meetingId = meetingId.toDao(), conversationId = conversationId.toDao()))
+            .withConversation(conversation)
+            .withConversationMembers(conversationId, listOf(TestUser.SELF.id) + meeting.otherParticipants)
             .withUpdateMeetingSuccess(meetingId, meeting, response)
+            .withChangeConversationNameSuccess(conversationId, meeting.title)
             .withPersistConversationsSuccess()
-            .withMlsContext()
-            .withConversationMembers(response.conversationId.toModel(), emptyList())
             .arrange()
-        val expectedMeetingEntity = requireNotNull(arrangement.meetingMapper.fromApiToDao(response.toMeetingDTO()))
+        val responseWithUpdatedConversationName = response.withConversationName(meeting.title)
+        val expectedMeetingEntity = requireNotNull(
+            arrangement.meetingMapper.fromApiToDao(responseWithUpdatedConversationName.toMeetingDTO())
+        )
 
         val result = repository.updateMeeting(
             meetingId = meetingId,
@@ -407,13 +453,20 @@ class MeetingRepositoryTest {
         assertTrue(result.isRight())
         assertEquals(MLSAdditionResult.Empty, result.getOrNull())
         verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingDao.getMeeting(meetingId.toDao())
+            arrangement.conversationRepository.getConversationById(conversationId)
+            arrangement.conversationRepository.getConversationMembers(conversationId = conversationId)
             arrangement.meetingApi.updateMeeting(
                 meetingId = meetingId.toApi(),
                 request = arrangement.meetingMapper.fromModelToApi(meeting)
             )
+            arrangement.conversationRepository.changeConversationName(
+                conversationId = conversationId,
+                conversationName = meeting.title
+            )
             arrangement.persistConversations(
                 transactionContext = arrangement.transactionContext,
-                conversations = listOf(response.conversation),
+                conversations = listOf(responseWithUpdatedConversationName.conversation),
                 invalidateMembers = true,
                 reason = ConversationSyncReason.Other,
             )
@@ -428,7 +481,12 @@ class MeetingRepositoryTest {
     fun givenApiUpdateFails_whenUpdateMeeting_thenMeetingIsNotPersistedLocally() = runTest {
         val meetingId = MeetingId("meeting1", "domain")
         val meeting = UPSERT_MEETING
+        val conversationId = MEETING_ENTITY.conversationId.toModel()
+        val conversation = meetingConversation(conversationId = conversationId)
         val (arrangement, repository) = Arrangement()
+            .withStoredMeeting(MEETING_ENTITY.copy(meetingId = meetingId.toDao(), conversationId = conversationId.toDao()))
+            .withConversation(conversation)
+            .withConversationMembers(conversationId, listOf(TestUser.SELF.id) + meeting.otherParticipants)
             .withUpdateMeetingFailure(meetingId, meeting)
             .arrange()
 
@@ -440,6 +498,9 @@ class MeetingRepositoryTest {
 
         assertIs<Either.Left<NetworkFailure.ServerMiscommunication>>(result)
         verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingDao.getMeeting(meetingId.toDao())
+            arrangement.conversationRepository.getConversationById(conversationId)
+            arrangement.conversationRepository.getConversationMembers(conversationId = conversationId)
             arrangement.meetingApi.updateMeeting(
                 meetingId = meetingId.toApi(),
                 request = arrangement.meetingMapper.fromModelToApi(meeting)
@@ -448,23 +509,33 @@ class MeetingRepositoryTest {
         verifySuspend(VerifyMode.not) {
             arrangement.persistConversations(any(), any(), any(), any())
             arrangement.meetingDao.upsertMeetings(any(), any())
+            arrangement.conversationRepository.changeConversationName(any(), any())
         }
     }
 
     @Test
-    fun givenPersistingMeetingFails_whenUpdateMeeting_thenReturnsStorageFailureAndDoesNotUpdateMlsMembers() = runTest {
+    fun givenPersistingMeetingFails_whenUpdateMeeting_thenReturnsStorageFailure() = runTest {
         val meetingId = MeetingId("meeting1", "domain")
         val meeting = UPSERT_MEETING
         val response = upsertMeetingResponse(epoch = 1UL)
         val generateOccurrencesFrom = Instant.parse("2026-05-01T00:00:00Z")
         val generateOccurrencesUntil = Instant.parse("2026-07-01T00:00:00Z")
+        val conversationId = response.conversationId.toModel()
+        val conversation = meetingConversation(conversationId = conversationId)
         val persistenceException = RuntimeException("An error occurred persisting the meeting")
         val (arrangement, repository) = Arrangement()
+            .withStoredMeeting(MEETING_ENTITY.copy(meetingId = meetingId.toDao(), conversationId = conversationId.toDao()))
+            .withConversation(conversation)
+            .withConversationMembers(conversationId, listOf(TestUser.SELF.id) + meeting.otherParticipants)
             .withUpdateMeetingSuccess(meetingId, meeting, response)
+            .withChangeConversationNameSuccess(conversationId, meeting.title)
             .withPersistConversationsSuccess()
             .withPersistMeetingFailure(persistenceException)
             .arrange()
-        val expectedMeetingEntity = requireNotNull(arrangement.meetingMapper.fromApiToDao(response.toMeetingDTO()))
+        val responseWithUpdatedConversationName = response.withConversationName(meeting.title)
+        val expectedMeetingEntity = requireNotNull(
+            arrangement.meetingMapper.fromApiToDao(responseWithUpdatedConversationName.toMeetingDTO())
+        )
 
         val result = repository.updateMeeting(
             meetingId = meetingId,
@@ -478,13 +549,20 @@ class MeetingRepositoryTest {
             assertSame(persistenceException, it.value.rootCause)
         }
         verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingDao.getMeeting(meetingId.toDao())
+            arrangement.conversationRepository.getConversationById(conversationId)
+            arrangement.conversationRepository.getConversationMembers(conversationId = conversationId)
             arrangement.meetingApi.updateMeeting(
                 meetingId = meetingId.toApi(),
                 request = arrangement.meetingMapper.fromModelToApi(meeting)
             )
+            arrangement.conversationRepository.changeConversationName(
+                conversationId = conversationId,
+                conversationName = meeting.title
+            )
             arrangement.persistConversations(
                 transactionContext = arrangement.transactionContext,
-                conversations = listOf(response.conversation),
+                conversations = listOf(responseWithUpdatedConversationName.conversation),
                 invalidateMembers = true,
                 reason = ConversationSyncReason.Other,
             )
@@ -493,8 +571,103 @@ class MeetingRepositoryTest {
                 generateOccurrencesWindow = GenerationLimit.Window(generateOccurrencesFrom, generateOccurrencesUntil)
             )
         }
+    }
+
+    @Test
+    fun givenUpdatingMlsMembersFails_whenUpdateMeeting_thenMeetingApiIsNotCalledAndFailureIsReturned() = runTest {
+        val participantToAdd = UserId("participant-add", "domain")
+        val meetingId = MeetingId("meeting1", "domain")
+        val meeting = UPSERT_MEETING.copy(otherParticipants = listOf(participantToAdd))
+        val groupId = GroupID("group-id")
+        val mlsCipherSuiteTag = 1
+        val conversationId = MEETING_ENTITY.conversationId.toModel()
+        val conversation = meetingConversation(
+            conversationId = conversationId,
+            groupId = groupId,
+            cipherSuite = CipherSuite.fromTag(mlsCipherSuiteTag)
+        )
+        val failure = CoreFailure.MissingKeyPackages(setOf(participantToAdd))
+        val (arrangement, repository) = Arrangement()
+            .withStoredMeeting(MEETING_ENTITY.copy(meetingId = meetingId.toDao(), conversationId = conversationId.toDao()))
+            .withConversation(conversation)
+            .withConversationMembers(conversationId, listOf(TestUser.SELF.id))
+            .withMlsContext()
+            .withAddMembersToMlsGroupFailure(groupId, listOf(participantToAdd), failure)
+            .arrange()
+
+        val result = repository.updateMeeting(
+            meetingId = meetingId,
+            meeting = meeting,
+            transactionContext = arrangement.transactionContext,
+        )
+
+        assertEquals(Either.Left(failure), result)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingDao.getMeeting(meetingId.toDao())
+            arrangement.conversationRepository.getConversationById(conversationId)
+            arrangement.conversationRepository.getConversationMembers(conversationId = conversationId)
+            arrangement.mlsConversationRepository.addMemberToMLSGroup(
+                mlsContext = arrangement.mlsContext,
+                groupID = groupId,
+                userIdList = listOf(participantToAdd),
+                cipherSuite = CipherSuite.fromTag(mlsCipherSuiteTag),
+                allowPartialMemberList = true,
+            )
+        }
         verifySuspend(VerifyMode.not) {
-            arrangement.conversationRepository.getConversationMembers(any())
+            arrangement.meetingApi.updateMeeting(any(), any())
+            arrangement.persistConversations(any(), any(), any(), any())
+            arrangement.meetingDao.upsertMeetings(any(), any())
+            arrangement.conversationRepository.changeConversationName(any(), any())
+            arrangement.mlsConversationRepository.establishMLSGroup(any(), any(), any(), any(), any())
+            arrangement.mlsConversationRepository.removeMembersFromMLSGroup(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun givenUpdatingConversationNameFails_whenUpdateMeeting_thenPersistedButUpdateConversationNameFailureIsReturned() = runTest {
+        val meetingId = MeetingId("meeting1", "domain")
+        val meeting = UPSERT_MEETING
+        val response = upsertMeetingResponse(epoch = 1UL)
+        val conversationId = response.conversationId.toModel()
+        val conversation = meetingConversation(conversationId = conversationId)
+        val failure = CoreFailure.Unknown(RuntimeException("An error occurred updating the conversation name"))
+        val (arrangement, repository) = Arrangement()
+            .withStoredMeeting(MEETING_ENTITY.copy(meetingId = meetingId.toDao(), conversationId = conversationId.toDao()))
+            .withConversation(conversation)
+            .withConversationMembers(conversationId, listOf(TestUser.SELF.id) + meeting.otherParticipants)
+            .withUpdateMeetingSuccess(meetingId, meeting, response)
+            .withChangeConversationNameFailure(conversationId, meeting.title, failure)
+            .withPersistConversationsSuccess()
+            .arrange()
+        val expectedMeetingEntity = requireNotNull(arrangement.meetingMapper.fromApiToDao(response.toMeetingDTO()))
+
+        val result = repository.updateMeeting(
+            meetingId = meetingId,
+            meeting = meeting,
+            transactionContext = arrangement.transactionContext,
+        )
+
+        val resultFailure = assertIs<Either.Left<MeetingDataSource.UpdateConversationNameFailure>>(result).value
+        assertEquals(failure, resultFailure.reason)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingDao.getMeeting(meetingId.toDao())
+            arrangement.conversationRepository.getConversationById(conversationId)
+            arrangement.conversationRepository.getConversationMembers(conversationId = conversationId)
+            arrangement.meetingApi.updateMeeting(
+                meetingId = meetingId.toApi(),
+                request = arrangement.meetingMapper.fromModelToApi(meeting)
+            )
+            arrangement.conversationRepository.changeConversationName(conversationId = conversationId, conversationName = meeting.title)
+            arrangement.persistConversations(
+                transactionContext = arrangement.transactionContext,
+                conversations = listOf(response.conversation),
+                invalidateMembers = true,
+                reason = ConversationSyncReason.Other,
+            )
+            arrangement.meetingDao.upsertMeetings(meetings = listOf(expectedMeetingEntity), generateOccurrencesWindow = any())
+        }
+        verifySuspend(VerifyMode.not) {
             arrangement.mlsConversationRepository.establishMLSGroup(any(), any(), any(), any(), any())
             arrangement.mlsConversationRepository.addMemberToMLSGroup(any(), any(), any(), any(), any())
             arrangement.mlsConversationRepository.removeMembersFromMLSGroup(any(), any(), any())
@@ -513,13 +686,27 @@ class MeetingRepositoryTest {
             mlsCipherSuiteTag = 1,
         )
         val expectedMlsAdditionResult = MLSAdditionResult(setOf(TestUser.OTHER.id), emptySet(), emptySet())
+        val conversationId = response.conversationId.toModel()
+        val conversation = meetingConversation(
+            conversationId = conversationId,
+            groupId = groupId,
+            epoch = 0UL,
+            cipherSuite = CipherSuite.fromTag(1),
+            groupState = Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN
+        )
         val (arrangement, repository) = Arrangement()
+            .withStoredMeeting(MEETING_ENTITY.copy(meetingId = meetingId.toDao(), conversationId = conversationId.toDao()))
+            .withConversation(conversation)
             .withUpdateMeetingSuccess(meetingId, meeting, response)
+            .withChangeConversationNameSuccess(conversationId, meeting.title)
             .withPersistConversationsSuccess()
             .withMlsContext()
             .withEstablishMlsGroupSuccess(groupId, meeting.otherParticipants + TestUser.SELF.id, expectedMlsAdditionResult)
-            .withConversationMembers(response.conversationId.toModel(), meeting.otherParticipants)
             .arrange()
+        val responseWithUpdatedConversationName = response.withConversationName(meeting.title)
+        val expectedMeetingEntity = requireNotNull(
+            arrangement.meetingMapper.fromApiToDao(responseWithUpdatedConversationName.toMeetingDTO())
+        )
 
         val result = repository.updateMeeting(
             meetingId = meetingId,
@@ -529,12 +716,23 @@ class MeetingRepositoryTest {
 
         assertTrue(result.isRight())
         verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingDao.getMeeting(meetingId.toDao())
+            arrangement.conversationRepository.getConversationById(conversationId)
+            arrangement.meetingApi.updateMeeting(
+                meetingId = meetingId.toApi(),
+                request = arrangement.meetingMapper.fromModelToApi(meeting)
+            )
+            arrangement.conversationRepository.changeConversationName(
+                conversationId = conversationId,
+                conversationName = meeting.title
+            )
             arrangement.persistConversations(
                 transactionContext = arrangement.transactionContext,
-                conversations = listOf(response.conversation),
+                conversations = listOf(responseWithUpdatedConversationName.conversation),
                 invalidateMembers = true,
                 reason = ConversationSyncReason.Other,
             )
+            arrangement.meetingDao.upsertMeetings(meetings = listOf(expectedMeetingEntity), generateOccurrencesWindow = any())
             arrangement.mlsConversationRepository.establishMLSGroup(
                 mlsContext = arrangement.mlsContext,
                 groupID = groupId,
@@ -542,9 +740,9 @@ class MeetingRepositoryTest {
                 publicKeys = null,
                 allowSkippingUsersWithoutKeyPackages = true
             )
-            arrangement.conversationRepository.getConversationMembers(conversationId = response.conversationId.toModel())
         }
         verifySuspend(VerifyMode.not) {
+            arrangement.conversationRepository.getConversationMembers(any())
             arrangement.mlsConversationRepository.addMemberToMLSGroup(any(), any(), any(), any(), any())
             arrangement.mlsConversationRepository.removeMembersFromMLSGroup(any(), any(), any())
         }
@@ -566,14 +764,27 @@ class MeetingRepositoryTest {
             mlsCipherSuiteTag = mlsCipherSuiteTag
         )
         val expectedMlsAdditionResult = MLSAdditionResult(setOf(participantToAdd), emptySet(), emptySet())
+        val conversationId = response.conversationId.toModel()
+        val conversation = meetingConversation(
+            conversationId = conversationId,
+            groupId = groupId,
+            cipherSuite = CipherSuite.fromTag(mlsCipherSuiteTag)
+        )
         val (arrangement, repository) = Arrangement()
-            .withUpdateMeetingSuccess(meetingId, meeting, response)
-            .withPersistConversationsSuccess()
+            .withStoredMeeting(MEETING_ENTITY.copy(meetingId = meetingId.toDao(), conversationId = conversationId.toDao()))
+            .withConversation(conversation)
+            .withConversationMembers(conversationId, listOf(TestUser.SELF.id, participantToKeep, participantToRemove))
             .withMlsContext()
-            .withConversationMembers(response.conversationId.toModel(), listOf(participantToKeep, participantToRemove))
             .withRemoveMembersFromMlsGroupSuccess(groupId, listOf(participantToRemove))
             .withAddMembersToMlsGroupSuccess(groupId, listOf(participantToAdd), expectedMlsAdditionResult)
+            .withUpdateMeetingSuccess(meetingId, meeting, response)
+            .withChangeConversationNameSuccess(conversationId, meeting.title)
+            .withPersistConversationsSuccess()
             .arrange()
+        val responseWithUpdatedConversationName = response.withConversationName(meeting.title)
+        val expectedMeetingEntity = requireNotNull(
+            arrangement.meetingMapper.fromApiToDao(responseWithUpdatedConversationName.toMeetingDTO())
+        )
 
         val result = repository.updateMeeting(
             meetingId = meetingId,
@@ -584,7 +795,9 @@ class MeetingRepositoryTest {
         assertTrue(result.isRight())
         assertEquals(expectedMlsAdditionResult, result.getOrNull())
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.conversationRepository.getConversationMembers(conversationId = response.conversationId.toModel())
+            arrangement.meetingDao.getMeeting(meetingId.toDao())
+            arrangement.conversationRepository.getConversationById(conversationId)
+            arrangement.conversationRepository.getConversationMembers(conversationId = conversationId)
             arrangement.mlsConversationRepository.removeMembersFromMLSGroup(
                 mlsContext = arrangement.mlsContext,
                 groupID = groupId,
@@ -597,6 +810,98 @@ class MeetingRepositoryTest {
                 cipherSuite = CipherSuite.fromTag(mlsCipherSuiteTag),
                 allowPartialMemberList = true,
             )
+            arrangement.meetingApi.updateMeeting(
+                meetingId = meetingId.toApi(),
+                request = arrangement.meetingMapper.fromModelToApi(meeting)
+            )
+            arrangement.conversationRepository.changeConversationName(
+                conversationId = conversationId,
+                conversationName = meeting.title
+            )
+            arrangement.persistConversations(
+                transactionContext = arrangement.transactionContext,
+                conversations = listOf(responseWithUpdatedConversationName.conversation),
+                invalidateMembers = true,
+                reason = ConversationSyncReason.Other,
+            )
+            arrangement.meetingDao.upsertMeetings(
+                meetings = listOf(expectedMeetingEntity),
+                generateOccurrencesWindow = any()
+            )
+        }
+        verifySuspend(VerifyMode.not) {
+            arrangement.mlsConversationRepository.establishMLSGroup(any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun givenEstablishedMlsGroupAndParticipantsUnchanged_whenUpdateMeeting_thenMlsMembersAreNotUpdated() = runTest {
+        val participantOne = UserId("participant-one", "domain")
+        val participantTwo = UserId("participant-two", "domain")
+        val meetingId = MeetingId("meeting1", "domain")
+        val meeting = UPSERT_MEETING.copy(otherParticipants = listOf(participantOne, participantTwo))
+        val groupId = GroupID("group-id")
+        val mlsCipherSuiteTag = 1
+        val response = upsertMeetingResponse(
+            protocol = ConvProtocol.MLS,
+            groupId = groupId.value,
+            epoch = 1UL,
+            mlsCipherSuiteTag = mlsCipherSuiteTag
+        )
+        val conversationId = response.conversationId.toModel()
+        val conversation = meetingConversation(
+            conversationId = conversationId,
+            groupId = groupId,
+            cipherSuite = CipherSuite.fromTag(mlsCipherSuiteTag)
+        )
+        val (arrangement, repository) = Arrangement()
+            .withStoredMeeting(MEETING_ENTITY.copy(meetingId = meetingId.toDao(), conversationId = conversationId.toDao()))
+            .withConversation(conversation)
+            .withConversationMembers(conversationId, listOf(TestUser.SELF.id, participantOne, participantTwo))
+            .withUpdateMeetingSuccess(meetingId, meeting, response)
+            .withChangeConversationNameSuccess(conversationId, meeting.title)
+            .withPersistConversationsSuccess()
+            .arrange()
+        val responseWithUpdatedConversationName = response.withConversationName(meeting.title)
+        val expectedMeetingEntity = requireNotNull(
+            arrangement.meetingMapper.fromApiToDao(responseWithUpdatedConversationName.toMeetingDTO())
+        )
+
+        val result = repository.updateMeeting(
+            meetingId = meetingId,
+            meeting = meeting,
+            transactionContext = arrangement.transactionContext,
+        )
+
+        assertTrue(result.isRight())
+        assertEquals(MLSAdditionResult.Empty, result.getOrNull())
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingDao.getMeeting(meetingId.toDao())
+            arrangement.conversationRepository.getConversationById(conversationId)
+            arrangement.conversationRepository.getConversationMembers(conversationId = conversationId)
+            arrangement.meetingApi.updateMeeting(
+                meetingId = meetingId.toApi(),
+                request = arrangement.meetingMapper.fromModelToApi(meeting)
+            )
+            arrangement.conversationRepository.changeConversationName(
+                conversationId = conversationId,
+                conversationName = meeting.title
+            )
+            arrangement.persistConversations(
+                transactionContext = arrangement.transactionContext,
+                conversations = listOf(responseWithUpdatedConversationName.conversation),
+                invalidateMembers = true,
+                reason = ConversationSyncReason.Other,
+            )
+            arrangement.meetingDao.upsertMeetings(
+                meetings = listOf(expectedMeetingEntity),
+                generateOccurrencesWindow = any()
+            )
+        }
+        verifySuspend(VerifyMode.not) {
+            arrangement.mlsConversationRepository.establishMLSGroup(any(), any(), any(), any(), any())
+            arrangement.mlsConversationRepository.addMemberToMLSGroup(any(), any(), any(), any(), any())
+            arrangement.mlsConversationRepository.removeMembersFromMLSGroup(any(), any(), any())
         }
     }
 
@@ -640,7 +945,8 @@ class MeetingRepositoryTest {
 
         internal fun withCreateNewMeetingSuccess(meeting: UpsertMeeting, response: UpsertMeetingResponse) = apply {
             everySuspend {
-                meetingApi.createNewMeeting(meetingMapper.fromModelToApi(meeting)) } returns NetworkResponse.Success(
+                meetingApi.createNewMeeting(meetingMapper.fromModelToApi(meeting))
+            } returns NetworkResponse.Success(
                 value = response,
                 headers = mapOf(),
                 httpCode = HttpStatusCode.Created.value
@@ -663,6 +969,10 @@ class MeetingRepositoryTest {
 
         internal fun withPersistMeetingFailure(error: RuntimeException) = apply {
             everySuspend { meetingDao.upsertMeetings(any(), any()) } throws error
+        }
+
+        internal fun withStoredMeeting(storedMeeting: MeetingEntity) = apply {
+            everySuspend { meetingDao.getMeeting(storedMeeting.meetingId) } returns storedMeeting
         }
 
         internal fun withTransactionMlsContext() = apply {
@@ -697,6 +1007,20 @@ class MeetingRepositoryTest {
             everySuspend { conversationRepository.getConversationMembers(conversationId) } returns Either.Right(result)
         }
 
+        internal fun withConversation(conversation: Conversation) = apply {
+            everySuspend { conversationRepository.getConversationById(conversation.id) } returns Either.Right(conversation)
+        }
+
+        internal fun withChangeConversationNameSuccess(conversationId: ConversationId, name: String) = apply {
+            everySuspend {
+                conversationRepository.changeConversationName(conversationId, name)
+            } returns Either.Right(ConversationRenameResponse.Unchanged)
+        }
+
+        internal fun withChangeConversationNameFailure(conversationId: ConversationId, name: String, failure: CoreFailure) = apply {
+            everySuspend { conversationRepository.changeConversationName(conversationId, name) } returns Either.Left(failure)
+        }
+
         internal fun withRemoveMembersFromMlsGroupSuccess(groupId: GroupID, members: List<UserId>) = apply {
             everySuspend {
                 mlsConversationRepository.removeMembersFromMLSGroup(any(), groupId, members)
@@ -707,6 +1031,12 @@ class MeetingRepositoryTest {
             everySuspend {
                 mlsConversationRepository.addMemberToMLSGroup(any(), groupId, members, any(), true)
             } returns Either.Right(result)
+        }
+
+        internal fun withAddMembersToMlsGroupFailure(groupId: GroupID, members: List<UserId>, failure: CoreFailure) = apply {
+            everySuspend {
+                mlsConversationRepository.addMemberToMLSGroup(any(), groupId, members, any(), true)
+            } returns Either.Left(failure)
         }
 
         internal fun withEstablishMlsGroupSuccess(groupId: GroupID, members: List<UserId>, result: MLSAdditionResult) = apply {
@@ -800,5 +1130,44 @@ class MeetingRepositoryTest {
             mlsCipherSuiteTag = mlsCipherSuiteTag,
             conversationGroupType = ConversationResponse.GroupType.Meeting,
         )
+    )
+
+    private fun UpsertMeetingResponse.withConversationName(conversationName: String) =
+        copy(conversation = conversation.copy(name = conversationName))
+
+    private fun meetingConversation(
+        conversationId: ConversationId,
+        groupId: GroupID = GroupID("group-id"),
+        epoch: ULong = 1UL,
+        cipherSuite: CipherSuite = CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
+        groupState: Conversation.ProtocolInfo.MLSCapable.GroupState = Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED,
+    ) = Conversation(
+        id = conversationId,
+        name = "GROUP Name",
+        type = Conversation.Type.Group.Meeting,
+        teamId = null,
+        protocol = Conversation.ProtocolInfo.MLS(
+            groupId = groupId,
+            groupState = groupState,
+            epoch = epoch,
+            keyingMaterialLastUpdate = Instant.parse("2026-06-01T00:00:00Z"),
+            cipherSuite = cipherSuite,
+        ),
+        mutedStatus = MutedConversationStatus.AllAllowed,
+        removedBy = null,
+        lastNotificationDate = null,
+        lastModifiedDate = Instant.parse("2022-03-30T15:36:00.000Z"),
+        lastReadDate = Instant.parse("2022-03-30T15:36:00.000Z"),
+        access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),
+        accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST),
+        creatorId = "someValue",
+        receiptMode = Conversation.ReceiptMode.DISABLED,
+        messageTimer = null,
+        userMessageTimer = null,
+        archived = false,
+        archivedDateTime = null,
+        mlsVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+        proteusVerificationStatus = Conversation.VerificationStatus.NOT_VERIFIED,
+        legalHoldStatus = Conversation.LegalHoldStatus.DISABLED,
     )
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepositoryTest.kt
@@ -367,6 +367,7 @@ class MeetingRepositoryTest {
 
         val resultFailure = assertIs<Either.Left<MeetingDataSource.EstablishMLSFailure>>(result).value
         assertEquals(response.conversation.id.toModel(), resultFailure.conversationId)
+        assertIs<CoreFailure.MissingKeyPackages>(resultFailure.reason)
         verifySuspend(VerifyMode.exactly(1)) {
             arrangement.meetingApi.createNewMeeting(arrangement.meetingMapper.fromModelToApi(createMeeting))
             arrangement.persistConversations(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/meeting/UpdateMeetingUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/meeting/UpdateMeetingUseCaseTest.kt
@@ -96,6 +96,35 @@ class UpdateMeetingUseCaseTest {
         }
     }
 
+    @Test
+    fun givenUpdateMeetingFailsWithUpdateConversationNameFailure_whenInvoking_thenReturnsUpdateConversationNameFailure() = runTest {
+        val updateConversationNameFailure = MeetingDataSource.UpdateConversationNameFailure(
+            conversationId = CONVERSATION_ID,
+            reason = CoreFailure.MissingClientRegistration,
+        )
+        val (arrangement, useCase) = Arrangement()
+            .withInsertIncompleteUsersSuccess(UPSERT_MEETING)
+            .withUpdateMeetingReturning(MEETING_ID, UPSERT_MEETING, Either.Left(updateConversationNameFailure))
+            .arrange()
+
+        val result = useCase(MEETING_ID, UPSERT_MEETING)
+
+        assertEquals(UpdateMeetingUseCase.Result.Failure.UpdateConversationNameFailure(CONVERSATION_ID), result)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingRepository.updateMeeting(
+                meetingId = MEETING_ID,
+                meeting = UPSERT_MEETING,
+                generateOccurrencesFrom = any(),
+                generateOccurrencesUntil = any(),
+                transactionContext = arrangement.transactionContext
+            )
+        }
+        verifySuspend(VerifyMode.not) {
+            arrangement.resetMLSConversation(any(), any())
+            arrangement.refreshUsersWithoutMetadata()
+        }
+    }
+
     private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
         val meetingRepository = mock<MeetingRepository>(mode = MockMode.autoUnit)
         val userRepository = mock<UserRepository>(mode = MockMode.autoUnit)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-27617
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently, when the meeting title is being updated, it's underlying meeting type conversation still keeps the original name so when the call starts, it can show the old name.

### Solutions

Update the conversation name when meeting is updated. When it fails, we intentionally execute the persist action so that meeting is updated locally, but pass the error to the UI to be displayed to the user and then retried - it's not breaking issue if the names are out of sync, we want to keep all other meeting parameters up to date and give user option to retry.
Also, change the order of actions when editing so that it first updates participants (if MLS is already established) so that users that just got removed won't receive the "update" event.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Create a meeting, edit the title of the meeting, start a meeting call and check the name.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
