### PR TITLE
fix: ignore mls group not found error after member removal [WPB-27759]

### DIFF
--- a/common/src/commonJvmAndroid/kotlin/com/wire/kalium/common/error/CoreCryptoExceptionMapper.kt
+++ b/common/src/commonJvmAndroid/kotlin/com/wire/kalium/common/error/CoreCryptoExceptionMapper.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.common.error
 import com.wire.crypto.CoreCryptoException
 import com.wire.crypto.MlsException
 
+@Suppress("CyclomaticComplexMethod")
 actual fun mapMLSException(exception: Exception): MLSFailure =
     if (exception is CoreCryptoException.Mls) {
         when (exception.v1) {
@@ -34,10 +35,11 @@ actual fun mapMLSException(exception: Exception): MLSFailure =
             is MlsException.MessageEpochTooOld -> MLSFailure.MessageEpochTooOld
 
             is MlsException.Other -> {
-                if ((exception.v1 as MlsException.Other).v1
-                        .startsWith(COMMIT_FOR_MISSING_PROPOSAL)
-                ) {
+                val otherError = (exception.v1 as MlsException.Other).v1
+                if (otherError.startsWith(COMMIT_FOR_MISSING_PROPOSAL)) {
                     MLSFailure.CommitForMissingProposal
+                } else if (otherError.startsWith(CONVERSATION_NOT_FOUND)) {
+                    MLSFailure.ConversationNotFound
                 } else {
                     MLSFailure.Other
                 }
@@ -50,3 +52,4 @@ actual fun mapMLSException(exception: Exception): MLSFailure =
     }
 
 private const val COMMIT_FOR_MISSING_PROPOSAL = "Incoming message is a commit for which we have not yet received all the proposals"
+private const val CONVERSATION_NOT_FOUND = "Couldn't find conversation"

--- a/common/src/commonMain/kotlin/com/wire/kalium/common/error/CoreFailure.kt
+++ b/common/src/commonMain/kotlin/com/wire/kalium/common/error/CoreFailure.kt
@@ -203,6 +203,7 @@ sealed interface MLSFailure : CoreFailure {
     data object Other : MLSFailure
     data object CommitForMissingProposal : MLSFailure
     data object OrphanWelcome : MLSFailure
+    data object ConversationNotFound : MLSFailure
     data class Generic(val rootCause: Throwable) : MLSFailure
 }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageFailureHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageFailureHandler.kt
@@ -51,6 +51,7 @@ internal object MLSMessageFailureHandler {
             is MLSFailure.Disabled,
             MLSFailure.CommitForMissingProposal,
             MLSFailure.OrphanWelcome,
+            MLSFailure.ConversationNotFound,
             is CoreFailure.DevelopmentAPINotAllowedOnProduction -> MLSMessageFailureResolution.Ignore
 
             MLSFailure.ConversationAlreadyExists,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27759" title="WPB-27759" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27759</a>  [Android] Wire Gov - Error message received when being removed from a group
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Cherry pick from https://github.com/wireapp/kalium/pull/3389