### PR TITLE
fix: backport support email in server configuration to 4.22 [WPB-27198]

### DIFF
--- a/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/unbound/configuration/ServerConfigDTO.kt
+++ b/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/unbound/configuration/ServerConfigDTO.kt
@@ -32,7 +32,8 @@ data class ServerConfigDTO(
         val website: String,
         val title: String,
         val isOnPremises: Boolean,
-        val apiProxy: ApiProxy?
+        val apiProxy: ApiProxy?,
+        val supportEmail: String? = null,
     )
 
     data class MetaData(

--- a/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/unbound/configuration/ServerConfigResponse.kt
+++ b/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/unbound/configuration/ServerConfigResponse.kt
@@ -28,7 +28,8 @@ import kotlinx.serialization.Serializable
 data class ServerConfigResponse(
     @SerialName("endpoints") val endpoints: EndPoints,
     @SerialName("title") val title: String,
-    @SerialName("apiProxy") val apiProxy: ApiProxy?
+    @SerialName("apiProxy") val apiProxy: ApiProxy? = null,
+    @SerialName("supportEmail") val supportEmail: String? = null,
 )
 
 @Serializable

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unbound/configuration/ServerConfigApi.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/unbound/configuration/ServerConfigApi.kt
@@ -87,7 +87,8 @@ class ServerConfigApiImpl internal constructor(
                     isOnPremises = true,
                     apiProxy = apiProxy?.let { proxy ->
                         ServerConfigDTO.ApiProxy(proxy.needsAuthentication, proxy.host, proxy.port)
-                    }
+                    },
+                    supportEmail = supportEmail
                 )
             }
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfig.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/configuration/server/ServerConfig.kt
@@ -60,7 +60,8 @@ public data class ServerConfig(
         @SerialName("websiteUrl") val website: String,
         @SerialName("title") val title: String,
         @SerialName("is_on_premises") val isOnPremises: Boolean,
-        @SerialName("apiProxy") val apiProxy: ApiProxy?
+        @SerialName("apiProxy") val apiProxy: ApiProxy?,
+        @SerialName("supportEmail") val supportEmail: String? = null,
     ) {
         val forgotPassword: String
             get() = URLBuilder().apply {
@@ -188,15 +189,16 @@ internal class ServerConfigMapperImpl(
         ServerConfigDTO(
             id = id,
             links = ServerConfigDTO.Links(
-                links.api,
-                links.accounts,
-                links.webSocket,
-                links.blackList,
-                links.teams,
-                links.website,
-                links.title,
+                api = links.api,
+                accounts = links.accounts,
+                webSocket = links.webSocket,
+                blackList = links.blackList,
+                teams = links.teams,
+                website = links.website,
+                title = links.title,
                 isOnPremises = links.isOnPremises,
-                apiProxy = links.apiProxy?.let { toDTO(it) }
+                apiProxy = links.apiProxy?.let { toDTO(it) },
+                supportEmail = links.supportEmail,
             ),
             metaData = ServerConfigDTO.MetaData(
                 federation = metaData.federation,
@@ -216,7 +218,8 @@ internal class ServerConfigMapperImpl(
             links.website,
             title,
             isOnPremises,
-            links.apiProxy?.let { toDTO(it) }
+            links.apiProxy?.let { toDTO(it) },
+            links.supportEmail,
         )
     }
 
@@ -262,7 +265,8 @@ internal class ServerConfigMapperImpl(
             teams = teams,
             title = title,
             isOnPremises = isOnPremises,
-            apiProxy = apiProxy?.let { fromDTO(it) }
+            apiProxy = apiProxy?.let { fromDTO(it) },
+            supportEmail = supportEmail,
         )
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigMapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/configuration/ServerConfigMapperTest.kt
@@ -51,6 +51,15 @@ class ServerConfigMapperTest {
     }
 
     @Test
+    fun givenServerConfigDtoWithSupportEmail_whenMappingToLinks_thenSupportEmailIsRetained() {
+        val links = newServerConfigDTO(1).links.copy(supportEmail = "support@example.com")
+
+        val actual = serverConfigMapper.fromDTO(links)
+
+        assertEquals("support@example.com", actual.supportEmail)
+    }
+
+    @Test
     fun givenAServerConfig_whenMappingToBackendConfig_thenValuesAreMappedCorrectly() {
         val serverConfig: ServerConfig = SERVER_CONFIG_TEST
         val expected: ServerConfigDTO =


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-27198
<!--jira-description-action-hidden-marker-end-->
## Summary
- Backports nullable supportEmail from server/deeplink configuration.
- Keeps the 4.22 storage model unchanged, without adding a DB migration.
- Preserves 4.22 API dump layout while applying the develop change.

## Testing
- Covered through Android app 4.22 compile/tests against this submodule update.