### PR TITLE
fix(cells): propagate failed download channels [WPB-8645]

### DIFF
--- a/domain/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/KtorOkioCopy.kt
+++ b/domain/cells/src/commonMain/kotlin/com/wire/kalium/cells/data/KtorOkioCopy.kt
@@ -65,6 +65,7 @@ private suspend fun ByteReadChannel.copyAvailableTo(
         }
         read = readAvailable(buffer)
     }
+    closedCause?.let { throw it }
     return total
 }
 

--- a/domain/cells/src/commonTest/kotlin/com/wire/kalium/cells/data/KtorOkioCopyTest.kt
+++ b/domain/cells/src/commonTest/kotlin/com/wire/kalium/cells/data/KtorOkioCopyTest.kt
@@ -25,13 +25,18 @@ import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteChannel
 import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.close
 import kotlinx.coroutines.test.runTest
+import kotlinx.io.IOException
 import okio.Buffer
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class KtorOkioCopyTest {
@@ -49,6 +54,18 @@ class KtorOkioCopyTest {
         assertTrue(progressUpdates.isNotEmpty())
         assertEquals(input.size.toLong(), progressUpdates.last())
         assertTrue(progressUpdates.zipWithNext().all { (previous, next) -> next > previous })
+    }
+
+    @Test
+    fun givenChannelAlreadyClosedWithFailure_whenCopyingToSink_thenPropagatesFailure() = runTest {
+        val failure = IOException("connection lost")
+        val input = ByteChannel().apply { close(failure) }
+
+        val exception = assertFailsWith<IOException> {
+            input.copyToSink(Buffer())
+        }
+
+        assertSame(failure, exception.cause)
     }
 
     @Test


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8645
<!--jira-description-action-hidden-marker-end-->
## Intent

Prevent failed Cells download channels from being interpreted as clean EOF, which caused a scheduling-dependent JVM CI failure.

## Changes

- Rethrow a response channel's close cause after the copy loop reaches EOF.
- Add regression coverage for a channel already closed with an I/O failure.

## Reproduction

1. Return a mock response backed by a `ByteChannel` that is closed with an `IOException` before any bytes are read.
2. When Ktor closes its wrapped response channel before the consumer starts reading, `readAvailable` returns `-1`.
3. The copy loop treats that value as clean EOF and the download completes successfully instead of propagating the failure.

## Fix

Inspect `closedCause` after reaching EOF so failed channels consistently propagate their error while preserving the original cause.

## Validation

The complete Cells JVM suite passes with 207 tests and no failures.
