### PR TITLE
fix: starting conversation with user without clients (WPB-18997)

### DIFF
--- a/logic/api/jvm/logic.api
+++ b/logic/api/jvm/logic.api
@@ -3522,6 +3522,42 @@ public final class com/wire/kalium/logic/feature/conversation/CheckConversationL
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract interface class com/wire/kalium/logic/feature/conversation/CheckOneToOneConversationIsReadyUseCase {
+	public abstract fun invoke (Lcom/wire/kalium/logic/data/id/QualifiedID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/wire/kalium/logic/feature/conversation/CheckOneToOneConversationIsReadyUseCase$Result {
+}
+
+public final class com/wire/kalium/logic/feature/conversation/CheckOneToOneConversationIsReadyUseCase$Result$Failure : com/wire/kalium/logic/feature/conversation/CheckOneToOneConversationIsReadyUseCase$Result {
+	public fun <init> (Lcom/wire/kalium/common/error/CoreFailure;)V
+	public final fun component1 ()Lcom/wire/kalium/common/error/CoreFailure;
+	public final fun copy (Lcom/wire/kalium/common/error/CoreFailure;)Lcom/wire/kalium/logic/feature/conversation/CheckOneToOneConversationIsReadyUseCase$Result$Failure;
+	public static synthetic fun copy$default (Lcom/wire/kalium/logic/feature/conversation/CheckOneToOneConversationIsReadyUseCase$Result$Failure;Lcom/wire/kalium/common/error/CoreFailure;ILjava/lang/Object;)Lcom/wire/kalium/logic/feature/conversation/CheckOneToOneConversationIsReadyUseCase$Result$Failure;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCoreFailure ()Lcom/wire/kalium/common/error/CoreFailure;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/wire/kalium/logic/feature/conversation/CheckOneToOneConversationIsReadyUseCase$Result$NotReady : com/wire/kalium/logic/feature/conversation/CheckOneToOneConversationIsReadyUseCase$Result {
+	public static final field INSTANCE Lcom/wire/kalium/logic/feature/conversation/CheckOneToOneConversationIsReadyUseCase$Result$NotReady;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/wire/kalium/logic/feature/conversation/CheckOneToOneConversationIsReadyUseCase$Result$Ready : com/wire/kalium/logic/feature/conversation/CheckOneToOneConversationIsReadyUseCase$Result {
+	public fun <init> (Lcom/wire/kalium/logic/data/conversation/Conversation;)V
+	public final fun component1 ()Lcom/wire/kalium/logic/data/conversation/Conversation;
+	public final fun copy (Lcom/wire/kalium/logic/data/conversation/Conversation;)Lcom/wire/kalium/logic/feature/conversation/CheckOneToOneConversationIsReadyUseCase$Result$Ready;
+	public static synthetic fun copy$default (Lcom/wire/kalium/logic/feature/conversation/CheckOneToOneConversationIsReadyUseCase$Result$Ready;Lcom/wire/kalium/logic/data/conversation/Conversation;ILjava/lang/Object;)Lcom/wire/kalium/logic/feature/conversation/CheckOneToOneConversationIsReadyUseCase$Result$Ready;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConversation ()Lcom/wire/kalium/logic/data/conversation/Conversation;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class com/wire/kalium/logic/feature/conversation/ClearConversationContentUseCase {
 	public abstract fun invoke (Lcom/wire/kalium/logic/data/id/QualifiedID;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun invoke$default (Lcom/wire/kalium/logic/feature/conversation/ClearConversationContentUseCase;Lcom/wire/kalium/logic/data/id/QualifiedID;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -3564,6 +3600,7 @@ public final class com/wire/kalium/logic/feature/conversation/ConversationScope 
 	public final fun getChangeAccessForAppsInConversation ()Lcom/wire/kalium/logic/feature/conversation/apps/ChangeAccessForAppsInConversationUseCase;
 	public final fun getCheckConversationLeaveConditions ()Lcom/wire/kalium/logic/feature/conversation/CheckConversationLeaveConditionsUseCase;
 	public final fun getCheckIConversationInviteCode ()Lcom/wire/kalium/logic/feature/conversation/CheckConversationInviteCodeUseCase;
+	public final fun getCheckOneToOneConversationIsReadyUseCase ()Lcom/wire/kalium/logic/feature/conversation/CheckOneToOneConversationIsReadyUseCase;
 	public final fun getClearConversationContent ()Lcom/wire/kalium/logic/feature/conversation/ClearConversationContentUseCase;
 	public final fun getClearUsersTypingEvents ()Lcom/wire/kalium/logic/feature/conversation/ClearUsersTypingEventsUseCase;
 	public final fun getCreateChannel ()Lcom/wire/kalium/logic/feature/conversation/createconversation/CreateChannelUseCase;

--- a/logic/api/logic.klib.api
+++ b/logic/api/logic.klib.api
@@ -864,6 +864,44 @@ abstract interface com.wire.kalium.logic.feature.conversation/CheckConversationL
     }
 }
 
+abstract interface com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase { // com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase|null[0]
+    abstract suspend fun invoke(com.wire.kalium.logic.data.id/QualifiedID): com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result // com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.invoke|invoke(com.wire.kalium.logic.data.id.QualifiedID){}[0]
+
+    sealed interface Result { // com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result|null[0]
+        final class Failure : com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result { // com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result.Failure|null[0]
+            constructor <init>(com.wire.kalium.common.error/CoreFailure) // com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result.Failure.<init>|<init>(com.wire.kalium.common.error.CoreFailure){}[0]
+
+            final val coreFailure // com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result.Failure.coreFailure|{}coreFailure[0]
+                final fun <get-coreFailure>(): com.wire.kalium.common.error/CoreFailure // com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result.Failure.coreFailure.<get-coreFailure>|<get-coreFailure>(){}[0]
+
+            final fun component1(): com.wire.kalium.common.error/CoreFailure // com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result.Failure.component1|component1(){}[0]
+            final fun copy(com.wire.kalium.common.error/CoreFailure = ...): com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result.Failure // com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result.Failure.copy|copy(com.wire.kalium.common.error.CoreFailure){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result.Failure.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result.Failure.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result.Failure.toString|toString(){}[0]
+        }
+
+        final class Ready : com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result { // com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result.Ready|null[0]
+            constructor <init>(com.wire.kalium.logic.data.conversation/Conversation) // com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result.Ready.<init>|<init>(com.wire.kalium.logic.data.conversation.Conversation){}[0]
+
+            final val conversation // com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result.Ready.conversation|{}conversation[0]
+                final fun <get-conversation>(): com.wire.kalium.logic.data.conversation/Conversation // com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result.Ready.conversation.<get-conversation>|<get-conversation>(){}[0]
+
+            final fun component1(): com.wire.kalium.logic.data.conversation/Conversation // com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result.Ready.component1|component1(){}[0]
+            final fun copy(com.wire.kalium.logic.data.conversation/Conversation = ...): com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result.Ready // com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result.Ready.copy|copy(com.wire.kalium.logic.data.conversation.Conversation){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result.Ready.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result.Ready.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result.Ready.toString|toString(){}[0]
+        }
+
+        final object NotReady : com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result { // com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result.NotReady|null[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result.NotReady.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result.NotReady.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase.Result.NotReady.toString|toString(){}[0]
+        }
+    }
+}
+
 abstract interface com.wire.kalium.logic.feature.conversation/ClearConversationContentUseCase { // com.wire.kalium.logic.feature.conversation/ClearConversationContentUseCase|null[0]
     abstract suspend fun invoke(com.wire.kalium.logic.data.id/QualifiedID, kotlin/Boolean = ...): com.wire.kalium.logic.feature.conversation/ClearConversationContentUseCase.Result // com.wire.kalium.logic.feature.conversation/ClearConversationContentUseCase.invoke|invoke(com.wire.kalium.logic.data.id.QualifiedID;kotlin.Boolean){}[0]
 
@@ -3940,6 +3978,8 @@ final class com.wire.kalium.logic.feature.conversation/ConversationScope { // co
         final fun <get-checkConversationLeaveConditions>(): com.wire.kalium.logic.feature.conversation/CheckConversationLeaveConditionsUseCase // com.wire.kalium.logic.feature.conversation/ConversationScope.checkConversationLeaveConditions.<get-checkConversationLeaveConditions>|<get-checkConversationLeaveConditions>(){}[0]
     final val checkIConversationInviteCode // com.wire.kalium.logic.feature.conversation/ConversationScope.checkIConversationInviteCode|{}checkIConversationInviteCode[0]
         final fun <get-checkIConversationInviteCode>(): com.wire.kalium.logic.feature.conversation/CheckConversationInviteCodeUseCase // com.wire.kalium.logic.feature.conversation/ConversationScope.checkIConversationInviteCode.<get-checkIConversationInviteCode>|<get-checkIConversationInviteCode>(){}[0]
+    final val checkOneToOneConversationIsReadyUseCase // com.wire.kalium.logic.feature.conversation/ConversationScope.checkOneToOneConversationIsReadyUseCase|{}checkOneToOneConversationIsReadyUseCase[0]
+        final fun <get-checkOneToOneConversationIsReadyUseCase>(): com.wire.kalium.logic.feature.conversation/CheckOneToOneConversationIsReadyUseCase // com.wire.kalium.logic.feature.conversation/ConversationScope.checkOneToOneConversationIsReadyUseCase.<get-checkOneToOneConversationIsReadyUseCase>|<get-checkOneToOneConversationIsReadyUseCase>(){}[0]
     final val clearConversationContent // com.wire.kalium.logic.feature.conversation/ConversationScope.clearConversationContent|{}clearConversationContent[0]
         final fun <get-clearConversationContent>(): com.wire.kalium.logic.feature.conversation/ClearConversationContentUseCase // com.wire.kalium.logic.feature.conversation/ConversationScope.clearConversationContent.<get-clearConversationContent>|<get-clearConversationContent>(){}[0]
     final val clearUsersTypingEvents // com.wire.kalium.logic.feature.conversation/ConversationScope.clearUsersTypingEvents|{}clearUsersTypingEvents[0]

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1428,7 +1428,8 @@ public class UserSessionScope internal constructor(
         get() = MLSOneOnOneConversationResolverImpl(
             conversationRepository,
             joinExistingMLSConversationUseCase,
-            fetchMLSOneToOneConversationUseCase
+            fetchMLSOneToOneConversationUseCase,
+            mlsConversationRepository,
         )
 
     private val oneOnOneMigrator: OneOnOneMigrator

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/CheckOneToOneConversationIsReadyUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/CheckOneToOneConversationIsReadyUseCase.kt
@@ -1,0 +1,82 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.fold
+import com.wire.kalium.logic.data.client.CryptoTransactionProvider
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.data.user.UserId
+import kotlinx.coroutines.flow.first
+
+/**
+ * Checks whether the active one-to-one conversation with [otherUserId] is ready to be opened.
+ * Proteus conversations are ready once present locally. MLS conversations are ready only when
+ * their group exists in Core Crypto.
+ */
+public interface CheckOneToOneConversationIsReadyUseCase {
+    public suspend operator fun invoke(otherUserId: UserId): Result
+
+    public sealed interface Result {
+        public data class Ready(val conversation: Conversation) : Result
+        public data object NotReady : Result
+        public data class Failure(val coreFailure: CoreFailure) : Result
+    }
+}
+
+internal class CheckOneToOneConversationIsReadyUseCaseImpl(
+    private val conversationRepository: ConversationRepository,
+    private val mlsConversationRepository: MLSConversationRepository,
+    private val transactionProvider: CryptoTransactionProvider,
+) : CheckOneToOneConversationIsReadyUseCase {
+
+    override suspend fun invoke(otherUserId: UserId): CheckOneToOneConversationIsReadyUseCase.Result =
+        when (val result = conversationRepository.observeOneToOneConversationWithOtherUser(otherUserId).first()) {
+            is Either.Left -> if (result.value is StorageFailure.DataNotFound) {
+                CheckOneToOneConversationIsReadyUseCase.Result.NotReady
+            } else {
+                CheckOneToOneConversationIsReadyUseCase.Result.Failure(result.value)
+            }
+            is Either.Right -> checkConversationReadiness(result.value)
+        }
+
+    private suspend fun checkConversationReadiness(
+        conversation: Conversation
+    ): CheckOneToOneConversationIsReadyUseCase.Result = when (val protocol = conversation.protocol) {
+        Conversation.ProtocolInfo.Proteus -> CheckOneToOneConversationIsReadyUseCase.Result.Ready(conversation)
+        is Conversation.ProtocolInfo.MLS ->
+            transactionProvider.mlsTransaction("checkOneToOneConversationIsReady") { mlsContext ->
+                mlsConversationRepository.hasEstablishedMLSGroup(mlsContext, protocol.groupId)
+            }.fold(
+                { failure -> CheckOneToOneConversationIsReadyUseCase.Result.Failure(failure) },
+                { isEstablished ->
+                    if (isEstablished) {
+                        CheckOneToOneConversationIsReadyUseCase.Result.Ready(conversation)
+                    } else {
+                        CheckOneToOneConversationIsReadyUseCase.Result.NotReady
+                    }
+                }
+            )
+        is Conversation.ProtocolInfo.Mixed -> CheckOneToOneConversationIsReadyUseCase.Result.NotReady
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -248,7 +248,15 @@ public class ConversationScope internal constructor(
             conversationRepository,
             userRepository,
             oneOnOneResolver,
-            transactionProvider
+            transactionProvider,
+            checkOneToOneConversationIsReadyUseCase,
+        )
+
+    public val checkOneToOneConversationIsReadyUseCase: CheckOneToOneConversationIsReadyUseCase
+        get() = CheckOneToOneConversationIsReadyUseCaseImpl(
+            conversationRepository,
+            mlsConversationRepository,
+            transactionProvider,
         )
 
     public val isOneToOneConversationCreatedUseCase: IsOneToOneConversationCreatedUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCase.kt
@@ -19,7 +19,6 @@
 package com.wire.kalium.logic.feature.conversation
 
 import com.wire.kalium.common.error.CoreFailure
-import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.user.UserId
@@ -29,7 +28,6 @@ import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
 import com.wire.kalium.common.functional.fold
 import com.wire.kalium.logic.data.client.CryptoTransactionProvider
-import kotlinx.coroutines.flow.first
 
 /**
  * Operation that creates one-to-one Conversation with specific [UserId] (only if it is absent in local DB)
@@ -44,32 +42,26 @@ internal class GetOrCreateOneToOneConversationUseCaseImpl(
     private val userRepository: UserRepository,
     private val oneOnOneResolver: OneOnOneResolver,
     private val transactionProvider: CryptoTransactionProvider,
+    private val checkOneToOneConversationIsReady: CheckOneToOneConversationIsReadyUseCase,
 ) : GetOrCreateOneToOneConversationUseCase {
 
     /**
-     * The use case operation operation params and return type.
+     * The use case params and return type.
      *
      * @param otherUserId [UserId] private conversation with which we are interested in.
      * @return Result with [Conversation] in case of success, or [CoreFailure] if something went wrong:
      * can't get data from local DB, or can't create a conversation.
      */
     override suspend operator fun invoke(otherUserId: UserId): CreateConversationResult {
-        // TODO periodically re-resolve one-on-one
-        return conversationRepository.observeOneToOneConversationWithOtherUser(otherUserId)
-            .first()
-            .fold({ conversationFailure ->
-                if (conversationFailure is StorageFailure.DataNotFound) {
-                    resolveOneOnOneConversationWithUser(otherUserId)
-                        .fold(
-                            CreateConversationResult::Failure,
-                            CreateConversationResult::Success
-                        )
-                } else {
-                    CreateConversationResult.Failure(conversationFailure)
-                }
-            }, { conversation ->
-                CreateConversationResult.Success(conversation)
-            })
+        return when (val result = checkOneToOneConversationIsReady(otherUserId)) {
+            is CheckOneToOneConversationIsReadyUseCase.Result.Ready -> CreateConversationResult.Success(result.conversation)
+            CheckOneToOneConversationIsReadyUseCase.Result.NotReady -> resolveOneOnOneConversationWithUser(otherUserId)
+                .fold(
+                    CreateConversationResult::Failure,
+                    CreateConversationResult::Success
+                )
+            is CheckOneToOneConversationIsReadyUseCase.Result.Failure -> CreateConversationResult.Failure(result.coreFailure)
+        }
     }
 
     /**
@@ -86,12 +78,12 @@ internal class GetOrCreateOneToOneConversationUseCaseImpl(
      */
     private suspend fun resolveOneOnOneConversationWithUser(otherUserId: UserId): Either<CoreFailure, Conversation> =
         userRepository.userById(otherUserId).flatMap { otherUser ->
-            // TODO support lazily establishing mls group for team 1-1
             transactionProvider.transaction("resolveOneOnOneConversationWithUser") { transactionContext ->
                 oneOnOneResolver.resolveOneOnOneConversationWithUser(
                     user = otherUser,
                     invalidateCurrentKnownProtocols = true,
-                    transactionContext = transactionContext
+                    transactionContext = transactionContext,
+                    fallbackToMLS = true,
                 )
             }
         }.flatMap { conversationId -> conversationRepository.getConversationById(conversationId) }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/MLSOneOnOneConversationResolver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/MLSOneOnOneConversationResolver.kt
@@ -21,6 +21,7 @@ import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.Conversation.ProtocolInfo.MLSCapable.GroupState
 import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCase
@@ -29,6 +30,7 @@ import com.wire.kalium.common.functional.flatMap
 import com.wire.kalium.common.functional.map
 import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.cryptography.CryptoTransactionContext
+import com.wire.kalium.logic.data.client.wrapInMLSContext
 import com.wire.kalium.logic.data.conversation.FetchMLSOneToOneConversationUseCase
 
 /**
@@ -55,7 +57,8 @@ internal interface MLSOneOnOneConversationResolver {
 internal class MLSOneOnOneConversationResolverImpl(
     private val conversationRepository: ConversationRepository,
     private val joinExistingMLSConversationUseCase: JoinExistingMLSConversationUseCase,
-    private val fetchMLSOneToOneConversation: FetchMLSOneToOneConversationUseCase
+    private val fetchMLSOneToOneConversation: FetchMLSOneToOneConversationUseCase,
+    private val mlsConversationRepository: MLSConversationRepository,
 ) : MLSOneOnOneConversationResolver {
 
     override suspend fun invoke(
@@ -64,28 +67,45 @@ internal class MLSOneOnOneConversationResolverImpl(
         allowJoinByExternalCommit: Boolean,
     ): Either<CoreFailure, ConversationId> =
         conversationRepository.getConversationsByUserId(userId).flatMap { conversations ->
-            // Look for an existing MLS-capable conversation one-on-one
-            val initializedMLSOneOnOne = conversations.firstOrNull {
+            val establishedMLSOneOnOnes = conversations.filter {
                 val isOneOnOne = it.type == Conversation.Type.OneOnOne
                 val protocol = it.protocol
-                val isMLSInitialized = protocol is Conversation.ProtocolInfo.MLSCapable &&
+                val isMLSInitialized = protocol is Conversation.ProtocolInfo.MLS &&
                         protocol.groupState == GroupState.ESTABLISHED
                 isOneOnOne && isMLSInitialized
             }
 
-            if (initializedMLSOneOnOne != null) {
-                kaliumLogger.d("Already established mls group for one-on-one with ${userId.toLogString()}, skipping.")
-                Either.Right(initializedMLSOneOnOne.id)
-            } else {
-                kaliumLogger.d("Establishing mls group for one-on-one with ${userId.toLogString()}")
-                fetchMLSOneToOneConversation(transactionContext, userId).flatMap { conversation ->
-                    joinExistingMLSConversationUseCase(
-                        transactionContext = transactionContext,
-                        conversationId = conversation.id,
-                        mlsPublicKeys = conversation.mlsPublicKeys,
-                        allowJoinByExternalCommit = allowJoinByExternalCommit
-                    ).map { conversation.id }
+            findEstablishedMLSOneOnOneInCoreCrypto(transactionContext, establishedMLSOneOnOnes).flatMap { establishedConversation ->
+                if (establishedConversation != null) {
+                    kaliumLogger.d("Already established mls group for one-on-one with ${userId.toLogString()}, skipping.")
+                    Either.Right(establishedConversation.id)
+                } else {
+                    kaliumLogger.d("Establishing mls group for one-on-one with ${userId.toLogString()}")
+                    fetchMLSOneToOneConversation(transactionContext, userId).flatMap { conversation ->
+                        joinExistingMLSConversationUseCase(
+                            transactionContext = transactionContext,
+                            conversationId = conversation.id,
+                            mlsPublicKeys = conversation.mlsPublicKeys,
+                            allowJoinByExternalCommit = allowJoinByExternalCommit
+                        ).map { conversation.id }
+                    }
                 }
             }
         }
+
+    private suspend fun findEstablishedMLSOneOnOneInCoreCrypto(
+        transactionContext: CryptoTransactionContext,
+        candidates: List<Conversation>,
+    ): Either<CoreFailure, Conversation?> = if (candidates.isEmpty()) {
+        Either.Right(null)
+    } else transactionContext.wrapInMLSContext { mlsContext ->
+        for (candidate in candidates) {
+            val protocol = candidate.protocol as Conversation.ProtocolInfo.MLS
+            when (val result = mlsConversationRepository.hasEstablishedMLSGroup(mlsContext, protocol.groupId)) {
+                is Either.Left -> return@wrapInMLSContext result
+                is Either.Right -> if (result.value) return@wrapInMLSContext Either.Right(candidate)
+            }
+        }
+        Either.Right(null)
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolver.kt
@@ -90,12 +90,16 @@ internal interface OneOnOneResolver {
      * @param user The other user in the conversation.
      * @param invalidateCurrentKnownProtocols Flag indicating whether to whether it should attempt refreshing the other user's list of
      * supported protocols by fetching from remote. In case of failure, the local result will be used as a fallback.
+     * @param fallbackToMLS Whether a missing common protocol should attempt to establish the canonical MLS conversation instead of
+     * falling back to an existing Proteus conversation. This is used for explicit start-conversation actions so Core Crypto can report
+     * missing key packages for users without clients.
      * @return Either a [CoreFailure] if there is an error or a [ConversationId] if the resolution is successful.
      */
     suspend fun resolveOneOnOneConversationWithUser(
         transactionContext: CryptoTransactionContext,
         user: OtherUser,
         invalidateCurrentKnownProtocols: Boolean,
+        fallbackToMLS: Boolean = false,
     ): Either<CoreFailure, ConversationId>
 }
 
@@ -278,12 +282,14 @@ internal class OneOnOneResolverImpl(
         transactionContext: CryptoTransactionContext,
         user: OtherUser,
         invalidateCurrentKnownProtocols: Boolean,
+        fallbackToMLS: Boolean,
     ): Either<CoreFailure, ConversationId> =
         resolveOneOnOneConversationWithUserInternal(
             transactionContext = transactionContext,
             user = user,
             invalidateCurrentKnownProtocols = invalidateCurrentKnownProtocols,
-            allowJoinByExternalCommit = true
+            allowJoinByExternalCommit = true,
+            fallbackToMLS = fallbackToMLS,
         )
 
     private suspend fun resolveOneOnOneConversationWithUserInternal(
@@ -291,6 +297,7 @@ internal class OneOnOneResolverImpl(
         user: OtherUser,
         invalidateCurrentKnownProtocols: Boolean,
         allowJoinByExternalCommit: Boolean,
+        fallbackToMLS: Boolean = false,
     ): Either<CoreFailure, ConversationId> {
         if (user.deleted) {
             return cleanupDeletedPeerMlsGroup(transactionContext, user.id)
@@ -300,7 +307,14 @@ internal class OneOnOneResolverImpl(
             userRepository.fetchUsersByIds(setOf(user.id))
         }
         return oneOnOneProtocolSelector.getProtocolForUser(user.id).fold({ coreFailure ->
-            if (coreFailure is CoreFailure.NoCommonProtocolFound.OtherNeedToUpdate) {
+            if (coreFailure is CoreFailure.NoCommonProtocolFound.OtherNeedToUpdate && fallbackToMLS) {
+                kaliumLogger.i("No common protocol found; attempting MLS 1:1 for explicit start with: ${user.id.toLogString()}")
+                oneOnOneMigrator.migrateToMLS(
+                    transactionContext = transactionContext,
+                    user = user,
+                    allowJoinByExternalCommit = allowJoinByExternalCommit
+                )
+            } else if (coreFailure is CoreFailure.NoCommonProtocolFound.OtherNeedToUpdate) {
                 kaliumLogger.i("Resolving existing proteus 1:1 as not matching protocol found with: ${user.id.toLogString()}")
                 oneOnOneMigrator.migrateExistingProteus(user)
             } else {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/CheckOneToOneConversationIsReadyUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/CheckOneToOneConversationIsReadyUseCaseTest.kt
@@ -1,0 +1,165 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.conversation
+
+import com.wire.kalium.common.error.MLSFailure
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
+import com.wire.kalium.logic.framework.TestConversation
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class CheckOneToOneConversationIsReadyUseCaseTest {
+
+    @Test
+    fun givenNoActiveConversation_whenCheckingReadiness_thenReturnNotReady() = runTest {
+        val (_, useCase) = arrange {
+            withActiveConversation(Either.Left(StorageFailure.DataNotFound))
+        }
+
+        assertEquals(CheckOneToOneConversationIsReadyUseCase.Result.NotReady, useCase(OTHER_USER_ID))
+    }
+
+    @Test
+    fun givenStorageFailure_whenCheckingReadiness_thenReturnFailure() = runTest {
+        val failure = StorageFailure.Generic(IllegalStateException("failure"))
+        val (_, useCase) = arrange {
+            withActiveConversation(Either.Left(failure))
+        }
+
+        val result = useCase(OTHER_USER_ID)
+
+        assertIs<CheckOneToOneConversationIsReadyUseCase.Result.Failure>(result)
+        assertEquals(failure, result.coreFailure)
+    }
+
+    @Test
+    fun givenActiveProteusConversation_whenCheckingReadiness_thenReturnReadyWithoutCheckingCoreCrypto() = runTest {
+        val (arrangement, useCase) = arrange {
+            withActiveConversation(Either.Right(PROTEUS_CONVERSATION))
+        }
+
+        val result = useCase(OTHER_USER_ID)
+
+        assertIs<CheckOneToOneConversationIsReadyUseCase.Result.Ready>(result)
+        assertEquals(PROTEUS_CONVERSATION, result.conversation)
+        verifySuspend(VerifyMode.not) {
+            arrangement.mlsConversationRepository.hasEstablishedMLSGroup(any(), any())
+        }
+    }
+
+    @Test
+    fun givenActiveMLSConversationWithEstablishedGroup_whenCheckingReadiness_thenReturnReady() = runTest {
+        val (_, useCase) = arrange {
+            withActiveConversation(Either.Right(MLS_CONVERSATION))
+            withEstablishedMLSGroup(Either.Right(true))
+        }
+
+        val result = useCase(OTHER_USER_ID)
+
+        assertIs<CheckOneToOneConversationIsReadyUseCase.Result.Ready>(result)
+        assertEquals(MLS_CONVERSATION, result.conversation)
+    }
+
+    @Test
+    fun givenActiveMLSConversationWithoutEstablishedGroup_whenCheckingReadiness_thenReturnNotReady() = runTest {
+        val (_, useCase) = arrange {
+            withActiveConversation(Either.Right(MLS_CONVERSATION))
+            withEstablishedMLSGroup(Either.Right(false))
+        }
+
+        assertEquals(CheckOneToOneConversationIsReadyUseCase.Result.NotReady, useCase(OTHER_USER_ID))
+    }
+
+    @Test
+    fun givenCoreCryptoFailure_whenCheckingReadiness_thenReturnFailure() = runTest {
+        val (_, useCase) = arrange {
+            withActiveConversation(Either.Right(MLS_CONVERSATION))
+            withEstablishedMLSGroup(Either.Left(MLSFailure.Disabled))
+        }
+
+        val result = useCase(OTHER_USER_ID)
+
+        assertIs<CheckOneToOneConversationIsReadyUseCase.Result.Failure>(result)
+        assertEquals(MLSFailure.Disabled, result.coreFailure)
+    }
+
+    @Test
+    fun givenActiveMixedConversation_whenCheckingReadiness_thenReturnNotReadyWithoutCheckingCoreCrypto() = runTest {
+        val (arrangement, useCase) = arrange {
+            withActiveConversation(Either.Right(MIXED_CONVERSATION))
+        }
+
+        assertEquals(CheckOneToOneConversationIsReadyUseCase.Result.NotReady, useCase(OTHER_USER_ID))
+        verifySuspend(VerifyMode.not) {
+            arrangement.mlsConversationRepository.hasEstablishedMLSGroup(any(), any())
+        }
+    }
+
+    private suspend fun arrange(block: suspend Arrangement.() -> Unit) = Arrangement().apply {
+        withMLSTransactionReturning(Either.Right(Unit))
+        block()
+    }.let { arrangement ->
+        arrangement to CheckOneToOneConversationIsReadyUseCaseImpl(
+            conversationRepository = arrangement.conversationRepository,
+            mlsConversationRepository = arrangement.mlsConversationRepository,
+            transactionProvider = arrangement.cryptoTransactionProvider,
+        )
+    }
+
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
+        val conversationRepository = mock<ConversationRepository>(mode = MockMode.autoUnit)
+        val mlsConversationRepository = mock<MLSConversationRepository>(mode = MockMode.autoUnit)
+
+        suspend fun withActiveConversation(result: Either<StorageFailure, Conversation>) = apply {
+            everySuspend {
+                conversationRepository.observeOneToOneConversationWithOtherUser(any())
+            } returns flowOf(result)
+        }
+
+        suspend fun withEstablishedMLSGroup(result: Either<MLSFailure, Boolean>) = apply {
+            everySuspend {
+                mlsConversationRepository.hasEstablishedMLSGroup(any(), any())
+            } returns result
+        }
+    }
+
+    private companion object {
+        val OTHER_USER_ID = TestUser.OTHER_USER_ID
+        val PROTEUS_CONVERSATION = TestConversation.ONE_ON_ONE()
+        val MLS_CONVERSATION = TestConversation.ONE_ON_ONE(TestConversation.MLS_PROTOCOL_INFO)
+        val MIXED_CONVERSATION = TestConversation.ONE_ON_ONE(TestConversation.MIXED_PROTOCOL_INFO)
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GetOrCreateOneToOneConversationUseCaseTest.kt
@@ -37,18 +37,18 @@ import dev.mokkery.matcher.eq
 import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
 @Suppress("MaxLineLength")
 class GetOrCreateOneToOneConversationUseCaseTest {
 
     @Test
-    fun givenConversationExist_whenCallingTheUseCase_ThenReturnExistingConversation() = runTest {
+    fun givenConversationIsReady_whenCallingTheUseCase_thenReturnExistingConversation() = runTest {
         val (arrangement, useCase) = arrange {
-            withObserveOneToOneConversationWithOtherUserReturning(Either.Right(CONVERSATION))
+            withReadinessResult(CheckOneToOneConversationIsReadyUseCase.Result.Ready(CONVERSATION))
         }
 
         val result = useCase.invoke(OTHER_USER_ID)
@@ -56,18 +56,30 @@ class GetOrCreateOneToOneConversationUseCaseTest {
         assertIs<CreateConversationResult.Success>(result)
 
         verifySuspend(VerifyMode.not) {
-            arrangement.oneOnOneResolver.resolveOneOnOneConversationWithUser(any(), any(), any())
-        }
-
-        verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.conversationRepository.observeOneToOneConversationWithOtherUser(any())
+            arrangement.oneOnOneResolver.resolveOneOnOneConversationWithUser(any(), any(), any(), any())
         }
     }
 
     @Test
-    fun givenFailure_whenCallingTheUseCase_ThenErrorIsPropagated() = runTest {
+    fun givenReadinessFailure_whenCallingTheUseCase_thenErrorIsPropagatedWithoutResolving() = runTest {
+        val failure = CoreFailure.Unknown(null)
+        val (arrangement, useCase) = arrange {
+            withReadinessResult(CheckOneToOneConversationIsReadyUseCase.Result.Failure(failure))
+        }
+
+        val result = useCase.invoke(OTHER_USER_ID)
+
+        assertIs<CreateConversationResult.Failure>(result)
+        assertEquals(failure, result.coreFailure)
+        verifySuspend(VerifyMode.not) {
+            arrangement.oneOnOneResolver.resolveOneOnOneConversationWithUser(any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun givenConversationIsNotReadyAndResolvingFails_whenCallingTheUseCase_thenErrorIsPropagated() = runTest {
         val (_, useCase) = arrange {
-            withObserveOneToOneConversationWithOtherUserReturning(Either.Left(StorageFailure.DataNotFound))
+            withReadinessResult(CheckOneToOneConversationIsReadyUseCase.Result.NotReady)
             withUserByIdReturning(OTHER_USER.right())
             withResolveOneOnOneConversationWithUserReturning(Either.Left(CoreFailure.NoCommonProtocolFound.SelfNeedToUpdate))
         }
@@ -80,7 +92,7 @@ class GetOrCreateOneToOneConversationUseCaseTest {
     @Test
     fun givenFailureWhileGettingUser_whenCallingTheUseCase_ThenErrorIsPropagated() = runTest {
         val (_, useCase) = arrange {
-            withObserveOneToOneConversationWithOtherUserReturning(Either.Left(StorageFailure.DataNotFound))
+            withReadinessResult(CheckOneToOneConversationIsReadyUseCase.Result.NotReady)
             withUserByIdReturning(Either.Left(StorageFailure.DataNotFound))
         }
 
@@ -90,9 +102,9 @@ class GetOrCreateOneToOneConversationUseCaseTest {
     }
 
     @Test
-    fun givenConversationDoesNotExist_whenCallingTheUseCase_ThenResolveOneOnOneConversation() = runTest {
+    fun givenConversationIsNotReady_whenCallingTheUseCase_thenResolveOneOnOneConversation() = runTest {
         val (arrangement, useCase) = arrange {
-            withObserveOneToOneConversationWithOtherUserReturning(Either.Left(StorageFailure.DataNotFound))
+            withReadinessResult(CheckOneToOneConversationIsReadyUseCase.Result.NotReady)
             withUserByIdReturning(OTHER_USER.right())
             withResolveOneOnOneConversationWithUserReturning(Either.Right(CONVERSATION.id))
             withConversationDetailsByIdReturning(CONVERSATION.right())
@@ -103,8 +115,23 @@ class GetOrCreateOneToOneConversationUseCaseTest {
         assertIs<CreateConversationResult.Success>(result)
 
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.oneOnOneResolver.resolveOneOnOneConversationWithUser(any(), eq(OTHER_USER), any())
+            arrangement.oneOnOneResolver.resolveOneOnOneConversationWithUser(any(), eq(OTHER_USER), any(), eq(true))
         }
+    }
+
+    @Test
+    fun givenConversationIsNotReadyAndKeyPackagesAreMissing_whenCallingTheUseCase_thenPropagateMissingKeyPackages() = runTest {
+        val failure = CoreFailure.MissingKeyPackages(setOf(OTHER_USER_ID))
+        val (_, useCase) = arrange {
+            withReadinessResult(CheckOneToOneConversationIsReadyUseCase.Result.NotReady)
+            withUserByIdReturning(OTHER_USER.right())
+            withResolveOneOnOneConversationWithUserReturning(Either.Left(failure))
+        }
+
+        val result = useCase.invoke(OTHER_USER_ID)
+
+        assertIs<CreateConversationResult.Failure>(result)
+        assertEquals(failure, result.coreFailure)
     }
 
     private suspend fun arrange(block: suspend Arrangement.() -> Unit) = Arrangement(block).arrange()
@@ -115,6 +142,7 @@ class GetOrCreateOneToOneConversationUseCaseTest {
         val conversationRepository = mock<ConversationRepository>(mode = MockMode.autoUnit)
         val userRepository = mock<UserRepository>(mode = MockMode.autoUnit)
         val oneOnOneResolver = mock<OneOnOneResolver>(mode = MockMode.autoUnit)
+        val checkOneToOneConversationIsReady = mock<CheckOneToOneConversationIsReadyUseCase>(mode = MockMode.autoUnit)
 
         suspend fun arrange() = run {
             withTransactionReturning(Either.Right(Unit))
@@ -123,14 +151,13 @@ class GetOrCreateOneToOneConversationUseCaseTest {
                 conversationRepository = conversationRepository,
                 userRepository = userRepository,
                 oneOnOneResolver = oneOnOneResolver,
-                transactionProvider = cryptoTransactionProvider
+                transactionProvider = cryptoTransactionProvider,
+                checkOneToOneConversationIsReady = checkOneToOneConversationIsReady,
             )
         }
 
-        suspend fun withObserveOneToOneConversationWithOtherUserReturning(result: Either<CoreFailure, com.wire.kalium.logic.data.conversation.Conversation>) {
-            everySuspend {
-                conversationRepository.observeOneToOneConversationWithOtherUser(any())
-            } returns flowOf(result)
+        suspend fun withReadinessResult(result: CheckOneToOneConversationIsReadyUseCase.Result) {
+            everySuspend { checkOneToOneConversationIsReady(any()) } returns result
         }
 
         suspend fun withUserByIdReturning(result: Either<CoreFailure, com.wire.kalium.logic.data.user.OtherUser>) {
@@ -141,7 +168,7 @@ class GetOrCreateOneToOneConversationUseCaseTest {
 
         suspend fun withResolveOneOnOneConversationWithUserReturning(result: Either<CoreFailure, com.wire.kalium.logic.data.id.ConversationId>) {
             everySuspend {
-                oneOnOneResolver.resolveOneOnOneConversationWithUser(any(), any(), any())
+                oneOnOneResolver.resolveOneOnOneConversationWithUser(any(), any(), any(), eq(true))
             } returns result
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/MLSOneOnOneConversationResolverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/MLSOneOnOneConversationResolverTest.kt
@@ -18,11 +18,13 @@
 package com.wire.kalium.logic.feature.conversation.mls
 
 import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.MLSFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.FetchMLSOneToOneConversationUseCase
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCase
+import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
@@ -91,6 +93,47 @@ class MLSOneOnOneConversationResolverTest {
 
         result.shouldSucceed {
             assertEquals(CONVERSATION_ONE_ON_ONE_MLS_ESTABLISHED.id, it)
+        }
+
+        verifySuspend(VerifyMode.not) {
+            arrangement.fetchMLSOneToOneConversation(mokkeryAny(), mokkeryAny())
+        }
+    }
+
+    @Test
+    fun givenDatabaseEstablishedMLSConversationIsMissingFromCoreCrypto_thenShouldFetchAndEstablishIt() = runTest {
+        val (arrangement, getOrEstablishMlsOneToOneUseCase) = arrange {
+            withConversationsForUserIdReturning(Either.Right(ALL_CONVERSATIONS))
+            withHasEstablishedMLSGroup(Either.Right(false))
+            withFetchMLSOneToOneConversation(Either.Right(CONVERSATION_ONE_ON_ONE_MLS_ESTABLISHED))
+            withJoinExistingMLSConversationUseCaseReturning(Either.Right(Unit))
+        }
+
+        val result = getOrEstablishMlsOneToOneUseCase(arrangement.transactionContext, userId)
+
+        result.shouldSucceed {
+            assertEquals(CONVERSATION_ONE_ON_ONE_MLS_ESTABLISHED.id, it)
+        }
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.joinExistingMLSConversationUseCase.invoke(mokkeryAny(), mokkeryAny(), mokkeryAny(), mokkeryEq(true))
+        }
+    }
+
+    @Test
+    fun givenCoreCryptoCheckFailsForDatabaseEstablishedConversation_thenShouldPropagateFailure() = runTest {
+        val failure = MLSFailure.Disabled
+        val (arrangement, getOrEstablishMlsOneToOneUseCase) = arrange {
+            withConversationsForUserIdReturning(Either.Right(ALL_CONVERSATIONS))
+            withHasEstablishedMLSGroup(Either.Left(failure))
+        }
+
+        val result = getOrEstablishMlsOneToOneUseCase(arrangement.transactionContext, userId)
+
+        result.shouldFail {
+            assertEquals(failure, it)
+        }
+        verifySuspend(VerifyMode.not) {
+            arrangement.fetchMLSOneToOneConversation(mokkeryAny(), mokkeryAny())
         }
     }
 
@@ -167,6 +210,7 @@ class MLSOneOnOneConversationResolverTest {
         val conversationRepository = mock<ConversationRepository>(mode = MockMode.autoUnit)
         val joinExistingMLSConversationUseCase = mock<JoinExistingMLSConversationUseCase>(mode = MockMode.autoUnit)
         val fetchMLSOneToOneConversation = mock<FetchMLSOneToOneConversationUseCase>(mode = MockMode.autoUnit)
+        val mlsConversationRepository = mock<MLSConversationRepository>(mode = MockMode.autoUnit)
 
         suspend fun withFetchMLSOneToOneConversation(result: Either<CoreFailure, Conversation>) = apply {
             everySuspend {
@@ -186,12 +230,22 @@ class MLSOneOnOneConversationResolverTest {
             } returns result
         }
 
+        suspend fun withHasEstablishedMLSGroup(result: Either<MLSFailure, Boolean>) = apply {
+            everySuspend {
+                mlsConversationRepository.hasEstablishedMLSGroup(mokkeryAny(), mokkeryAny())
+            } returns result
+        }
+
         fun arrange() = run {
-            runBlocking { block() }
+            runBlocking {
+                withHasEstablishedMLSGroup(Either.Right(true))
+                block()
+            }
             this to MLSOneOnOneConversationResolverImpl(
                 conversationRepository = conversationRepository,
                 joinExistingMLSConversationUseCase = joinExistingMLSConversationUseCase,
-                fetchMLSOneToOneConversation = fetchMLSOneToOneConversation
+                fetchMLSOneToOneConversation = fetchMLSOneToOneConversation,
+                mlsConversationRepository = mlsConversationRepository,
             )
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/OneOnOneResolverTest.kt
@@ -58,6 +58,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
 class OneOnOneResolverTest {
@@ -264,6 +265,31 @@ class OneOnOneResolverTest {
 
         verifySuspend(VerifyMode.exactly(1)) {
             arrangement.oneOnOneMigrator.migrateExistingProteus(mokkeryEq(OTHER_USER))
+        }
+    }
+
+    @Test
+    fun givenOtherNeedsToUpdateAndMLSFallbackIsEnabled_whenResolving_thenPropagateMissingKeyPackagesFromMLS() = runTest {
+        val failure = CoreFailure.MissingKeyPackages(setOf(OTHER_USER.id))
+        val (arrangement, resolver) = arrange {
+            withGetProtocolForUser(CoreFailure.NoCommonProtocolFound.OtherNeedToUpdate.left())
+            withMigrateToMLSReturns(failure.left())
+        }
+
+        resolver.resolveOneOnOneConversationWithUser(
+            transactionContext = arrangement.transactionContext,
+            user = OTHER_USER,
+            invalidateCurrentKnownProtocols = false,
+            fallbackToMLS = true,
+        ).shouldFail {
+            assertEquals(failure, it)
+        }
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.oneOnOneMigrator.migrateToMLS(mokkeryAny(), mokkeryEq(OTHER_USER), mokkeryEq(true))
+        }
+        verifySuspend(VerifyMode.not) {
+            arrangement.oneOnOneMigrator.migrateExistingProteus(mokkeryAny())
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-18997
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-18997
----

# What's new in this PR?

### Issues
Android client allows creating 1:1 conversation with the user without clients (e.g. never logged in wire app).

### Causes (Optional)
Android client created default Proteus conversation without checking if other user is ready for MLS conversation.

### Solutions
- Add `CheckOneToOneConversationIsReadyUseCase` with:
  - `Ready(conversation)` for active Proteus conversations.
  - `Ready(conversation)` for active MLS conversations present in Core Crypto.
  - `NotReady` for missing active conversations, missing MLS groups, and Mixed 1:1 conversations.
  - `Failure(coreFailure)` for storage and crypto failures.
- Expose the readiness use case through `ConversationScope`.
- Update `GetOrCreateOneToOneConversationUseCase` to:
  - Return immediately only for ready conversations.
  - Resolve not-ready conversations.
  - Propagate readiness and resolver failures unchanged.
  - Request an MLS fallback for explicit start-conversation attempts.
- Update `OneOnOneResolver` so the explicit-start path attempts the canonical MLS conversation when protocol selection returns `OtherNeedToUpdate`.
  - This allows missing recipient key packages to surface as `CoreFailure.MissingKeyPackages`.
  - Existing background/event resolution continues using the Proteus fallback.
- Harden `MLSOneOnOneConversationResolver`:
  - A database `ESTABLISHED` state is reused only if the group exists in Core Crypto.
  - Stale database-established conversations are fetched and established/joined again.
  - Core Crypto lookup failures are propagated.