### PR TITLE
fix: mls pending creation recovery [WPB-27337]

### DIFF
--- a/changelog.d/4405-pending-mls-group-creation-recovery.added.md
+++ b/changelog.d/4405-pending-mls-group-creation-recovery.added.md
@@ -1,0 +1,6 @@
+Added `ConversationCreationResult.PendingMLSGroupCreation` and `CreateRegularGroupUseCase.retryPendingMLSGroupCreation` so clients can recover a failed MLS group establishment using the existing conversation.
+
+  - ABI: additive
+  - Source: potentially breaking for consumers that exhaustively match `ConversationCreationResult`.
+  - Behavior: an MLS establishment failure after backend conversation creation now returns the pending conversation and schedules recovery instead of returning a generic creation failure.
+  - Migration: handle `PendingMLSGroupCreation` and optionally call `retryPendingMLSGroupCreation` to retry immediately.

--- a/logic/api/jvm/logic.api
+++ b/logic/api/jvm/logic.api
@@ -4354,6 +4354,12 @@ public final class com/wire/kalium/logic/feature/conversation/createconversation
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/wire/kalium/logic/feature/conversation/createconversation/ConversationCreationResult$PendingMLSGroupCreation : com/wire/kalium/logic/feature/conversation/createconversation/ConversationCreationResult {
+	public fun <init> (Lcom/wire/kalium/logic/data/id/QualifiedID;Lcom/wire/kalium/common/error/CoreFailure;)V
+	public final fun getCause ()Lcom/wire/kalium/common/error/CoreFailure;
+	public final fun getConversationId ()Lcom/wire/kalium/logic/data/id/QualifiedID;
+}
+
 public final class com/wire/kalium/logic/feature/conversation/createconversation/ConversationCreationResult$Success : com/wire/kalium/logic/feature/conversation/createconversation/ConversationCreationResult {
 	public fun <init> (Lcom/wire/kalium/logic/data/conversation/Conversation;)V
 	public final fun getConversation ()Lcom/wire/kalium/logic/data/conversation/Conversation;
@@ -4377,6 +4383,7 @@ public final class com/wire/kalium/logic/feature/conversation/createconversation
 
 public abstract interface class com/wire/kalium/logic/feature/conversation/createconversation/CreateRegularGroupUseCase {
 	public abstract fun invoke (Ljava/lang/String;Ljava/util/List;Lcom/wire/kalium/logic/data/conversation/CreateConversationParam;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun retryPendingMLSGroupCreation (Lcom/wire/kalium/logic/data/id/QualifiedID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class com/wire/kalium/logic/feature/conversation/delete/DeleteConversationLocallyUseCase {

--- a/logic/api/logic.klib.api
+++ b/logic/api/logic.klib.api
@@ -622,6 +622,7 @@ abstract interface com.wire.kalium.logic.feature.conversation.channel/UpdateChan
 
 abstract interface com.wire.kalium.logic.feature.conversation.createconversation/CreateRegularGroupUseCase { // com.wire.kalium.logic.feature.conversation.createconversation/CreateRegularGroupUseCase|null[0]
     abstract suspend fun invoke(kotlin/String, kotlin.collections/List<com.wire.kalium.logic.data.id/QualifiedID>, com.wire.kalium.logic.data.conversation/CreateConversationParam): com.wire.kalium.logic.feature.conversation.createconversation/ConversationCreationResult // com.wire.kalium.logic.feature.conversation.createconversation/CreateRegularGroupUseCase.invoke|invoke(kotlin.String;kotlin.collections.List<com.wire.kalium.logic.data.id.QualifiedID>;com.wire.kalium.logic.data.conversation.CreateConversationParam){}[0]
+    abstract suspend fun retryPendingMLSGroupCreation(com.wire.kalium.logic.data.id/QualifiedID): com.wire.kalium.logic.feature.conversation.createconversation/ConversationCreationResult // com.wire.kalium.logic.feature.conversation.createconversation/CreateRegularGroupUseCase.retryPendingMLSGroupCreation|retryPendingMLSGroupCreation(com.wire.kalium.logic.data.id.QualifiedID){}[0]
 }
 
 abstract interface com.wire.kalium.logic.feature.conversation.delete/DeleteConversationLocallyUseCase { // com.wire.kalium.logic.feature.conversation.delete/DeleteConversationLocallyUseCase|null[0]
@@ -2303,6 +2304,15 @@ sealed interface com.wire.kalium.logic.feature.conversation.createconversation/C
 
         final val domains // com.wire.kalium.logic.feature.conversation.createconversation/ConversationCreationResult.BackendConflictFailure.domains|{}domains[0]
             final fun <get-domains>(): kotlin.collections/List<kotlin/String> // com.wire.kalium.logic.feature.conversation.createconversation/ConversationCreationResult.BackendConflictFailure.domains.<get-domains>|<get-domains>(){}[0]
+    }
+
+    final class PendingMLSGroupCreation : com.wire.kalium.logic.feature.conversation.createconversation/ConversationCreationResult { // com.wire.kalium.logic.feature.conversation.createconversation/ConversationCreationResult.PendingMLSGroupCreation|null[0]
+        constructor <init>(com.wire.kalium.logic.data.id/QualifiedID, com.wire.kalium.common.error/CoreFailure) // com.wire.kalium.logic.feature.conversation.createconversation/ConversationCreationResult.PendingMLSGroupCreation.<init>|<init>(com.wire.kalium.logic.data.id.QualifiedID;com.wire.kalium.common.error.CoreFailure){}[0]
+
+        final val cause // com.wire.kalium.logic.feature.conversation.createconversation/ConversationCreationResult.PendingMLSGroupCreation.cause|{}cause[0]
+            final fun <get-cause>(): com.wire.kalium.common.error/CoreFailure // com.wire.kalium.logic.feature.conversation.createconversation/ConversationCreationResult.PendingMLSGroupCreation.cause.<get-cause>|<get-cause>(){}[0]
+        final val conversationId // com.wire.kalium.logic.feature.conversation.createconversation/ConversationCreationResult.PendingMLSGroupCreation.conversationId|{}conversationId[0]
+            final fun <get-conversationId>(): com.wire.kalium.logic.data.id/QualifiedID // com.wire.kalium.logic.feature.conversation.createconversation/ConversationCreationResult.PendingMLSGroupCreation.conversationId.<get-conversationId>|<get-conversationId>(){}[0]
     }
 
     final class Success : com.wire.kalium.logic.feature.conversation.createconversation/ConversationCreationResult { // com.wire.kalium.logic.feature.conversation.createconversation/ConversationCreationResult.Success|null[0]

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
@@ -74,6 +74,12 @@ internal interface ConversationGroupRepository {
         options: CreateConversationParam = CreateConversationParam(),
     ): Either<CoreFailure, Conversation>
 
+    suspend fun createGroupConversationWithPendingResult(
+        name: String? = null,
+        usersList: List<UserId>,
+        options: CreateConversationParam = CreateConversationParam(),
+    ): CreateGroupConversationResult
+
     suspend fun addMembers(userIdList: List<UserId>, conversationId: ConversationId): Either<CoreFailure, Unit>
     suspend fun addService(serviceId: ServiceId, conversationId: ConversationId): Either<CoreFailure, Unit>
     suspend fun deleteMember(userId: UserId, conversationId: ConversationId): Either<CoreFailure, Unit>
@@ -94,6 +100,21 @@ internal interface ConversationGroupRepository {
     fun observeGuestRoomLink(conversationId: ConversationId): Flow<Either<CoreFailure, ConversationGuestLink?>>
     suspend fun updateMessageTimer(conversationId: ConversationId, messageTimer: Long?): Either<CoreFailure, Unit>
     suspend fun updateGuestRoomLink(conversationId: ConversationId, accountUrl: String): Either<CoreFailure, Unit>
+}
+
+internal sealed interface CreateGroupConversationResult {
+    data class Success(val conversation: Conversation) : CreateGroupConversationResult
+    data class Failure(val cause: CoreFailure) : CreateGroupConversationResult
+    data class PendingMLSGroupCreation(
+        val conversationId: ConversationId,
+        val cause: CoreFailure,
+    ) : CreateGroupConversationResult
+
+    fun toEither(): Either<CoreFailure, Conversation> = when (this) {
+        is Success -> Either.Right(conversation)
+        is Failure -> Either.Left(cause)
+        is PendingMLSGroupCreation -> Either.Left(cause)
+    }
 }
 
 @Suppress("LongParameterList", "TooManyFunctions")
@@ -119,15 +140,24 @@ internal class ConversationGroupRepositoryImpl(
         name: String?,
         usersList: List<UserId>,
         options: CreateConversationParam,
-    ): Either<CoreFailure, Conversation> = createGroupConversation(name, usersList, options, LastUsersAttempt.None)
+    ): Either<CoreFailure, Conversation> =
+        createGroupConversation(name, usersList, options, LastUsersAttempt.None).toEither()
+
+    override suspend fun createGroupConversationWithPendingResult(
+        name: String?,
+        usersList: List<UserId>,
+        options: CreateConversationParam,
+    ): CreateGroupConversationResult = createGroupConversation(name, usersList, options, LastUsersAttempt.None)
 
     private suspend fun createGroupConversation(
         name: String?,
         usersList: List<UserId>,
         options: CreateConversationParam,
         lastUsersAttempt: LastUsersAttempt,
-    ): Either<CoreFailure, Conversation> =
-        teamIdProvider().flatMap { selfTeamId ->
+    ): CreateGroupConversationResult =
+        teamIdProvider().fold({ failure ->
+            CreateGroupConversationResult.Failure(failure)
+        }, { selfTeamId ->
             val apiResult = wrapApiRequest {
                 conversationApi.createNewConversation(
                     conversationMapper.toApiModel(name, usersList, selfTeamId?.value, options)
@@ -150,7 +180,7 @@ internal class ConversationGroupRepositoryImpl(
                     lastUsersAttempt = lastUsersAttempt
                 )
             }
-        }
+        })
 
     @Suppress("LongMethod")
     private suspend fun handleGroupConversationCreated(
@@ -158,7 +188,7 @@ internal class ConversationGroupRepositoryImpl(
         selfTeamId: TeamId?,
         usersList: List<UserId>,
         lastUsersAttempt: LastUsersAttempt,
-    ): Either<CoreFailure, Conversation> {
+    ): CreateGroupConversationResult {
         val conversationEntity = conversationMapper.fromApiModelToDaoModel(
             apiModel = conversationResponse,
             mlsGroupState = ConversationEntity.GroupState.PENDING_CREATION,
@@ -167,7 +197,7 @@ internal class ConversationGroupRepositoryImpl(
         val mlsPublicKeys = conversationMapper.fromApiModel(conversationResponse.publicKeys)
         val protocol = protocolInfoMapper.fromEntity(conversationEntity.protocolInfo)
 
-        return wrapStorageRequest {
+        val prepareResult = wrapStorageRequest {
             conversationDAO.insertConversation(conversationEntity)
         }.flatMap {
             newGroupConversationSystemMessagesCreator.value.conversationStartedUnverifiedWarning(conversationEntity.id.toModel())
@@ -183,7 +213,17 @@ internal class ConversationGroupRepositoryImpl(
                 type = conversationEntity.type
             )
         }.flatMap {
-            when (protocol) {
+            newConversationMembersRepository.persistMembersAdditionToTheConversation(
+                conversationId = conversationEntity.id,
+                conversationResponse = conversationResponse,
+                additionalMembers = if (protocol is Conversation.ProtocolInfo.MLSCapable) usersList else emptyList(),
+            )
+        }
+
+        return prepareResult.fold({ failure ->
+            CreateGroupConversationResult.Failure(failure)
+        }, {
+            val establishResult = when (protocol) {
                 is Conversation.ProtocolInfo.Proteus -> Either.Right(MLSAdditionResult.Empty)
                 is Conversation.ProtocolInfo.MLSCapable ->
                     transactionProvider.mlsTransaction("handleGroupConversationCreated") { mlsContext ->
@@ -196,40 +236,61 @@ internal class ConversationGroupRepositoryImpl(
                         )
                     }
             }
-        }.flatMap { additionResult ->
-            newConversationMembersRepository.persistMembersAdditionToTheConversation(
-                conversationEntity.id,
-                conversationResponse
-            ).flatMap {
-                if (additionResult.usersWithoutKeyPackages.isNotEmpty()) {
-                    newGroupConversationSystemMessagesCreator.value.conversationFailedToAddMembers(
-                        conversationId = conversationEntity.id.toModel(),
-                        userIdList = additionResult.usersWithoutKeyPackages.toList(),
-                        type = FailedToAdd.Type.MissingKeyPackages
-                    )
+
+            establishResult.fold({ failure ->
+                if (protocol is Conversation.ProtocolInfo.MLSCapable) {
+                    val conversationId = conversationEntity.id.toModel()
+                    CreateGroupConversationResult.PendingMLSGroupCreation(conversationId, failure)
                 } else {
-                    Either.Right(Unit)
+                    CreateGroupConversationResult.Failure(failure)
                 }
-            }.flatMap {
-                if (additionResult.usersWithUnreachableBackend.isNotEmpty()) {
+            }, { additionResult ->
+                finalizeGroupConversationCreation(
+                    conversationEntity = conversationEntity,
+                    additionResult = additionResult,
+                    lastUsersAttempt = lastUsersAttempt,
+                ).fold(
+                    { failure -> CreateGroupConversationResult.Failure(failure) },
+                    { conversation -> CreateGroupConversationResult.Success(conversation) }
+                )
+            })
+        })
+    }
+
+    private suspend fun finalizeGroupConversationCreation(
+        conversationEntity: ConversationEntity,
+        additionResult: MLSAdditionResult,
+        lastUsersAttempt: LastUsersAttempt,
+    ): Either<CoreFailure, Conversation> =
+        Either.Right(Unit).flatMap {
+            if (additionResult.usersWithoutKeyPackages.isNotEmpty()) {
+                newGroupConversationSystemMessagesCreator.value.conversationFailedToAddMembers(
+                    conversationId = conversationEntity.id.toModel(),
+                    userIdList = additionResult.usersWithoutKeyPackages.toList(),
+                    type = FailedToAdd.Type.MissingKeyPackages
+                )
+            } else {
+                Either.Right(Unit)
+            }
+        }.flatMap {
+            if (additionResult.usersWithUnreachableBackend.isNotEmpty()) {
+                newGroupConversationSystemMessagesCreator.value.conversationFailedToAddMembers(
+                    conversationId = conversationEntity.id.toModel(),
+                    userIdList = additionResult.usersWithUnreachableBackend.toList(),
+                    type = FailedToAdd.Type.Federation
+                )
+            } else {
+                Either.Right(Unit)
+            }
+        }.flatMap {
+            when (lastUsersAttempt) {
+                is LastUsersAttempt.None -> Either.Right(Unit)
+                is LastUsersAttempt.Failed ->
                     newGroupConversationSystemMessagesCreator.value.conversationFailedToAddMembers(
-                        conversationId = conversationEntity.id.toModel(),
-                        userIdList = additionResult.usersWithUnreachableBackend.toList(),
-                        type = FailedToAdd.Type.Federation
+                        conversationEntity.id.toModel(),
+                        lastUsersAttempt.failedUsers,
+                        lastUsersAttempt.failType
                     )
-                } else {
-                    Either.Right(Unit)
-                }
-            }.flatMap {
-                when (lastUsersAttempt) {
-                    is LastUsersAttempt.None -> Either.Right(Unit)
-                    is LastUsersAttempt.Failed ->
-                        newGroupConversationSystemMessagesCreator.value.conversationFailedToAddMembers(
-                            conversationEntity.id.toModel(),
-                            lastUsersAttempt.failedUsers,
-                            lastUsersAttempt.failType
-                        )
-                }
             }
         }.onSuccess {
             legalHoldHandler.handleConversationMembersChanged(conversationEntity.id.toModel())
@@ -240,7 +301,6 @@ internal class ConversationGroupRepositoryImpl(
                 }
             }
         }
-    }
 
     private suspend fun handleCreateConversationFailure(
         apiResult: Either.Left<NetworkFailure>,
@@ -248,7 +308,7 @@ internal class ConversationGroupRepositoryImpl(
         name: String?,
         options: CreateConversationParam,
         lastUsersAttempt: LastUsersAttempt
-    ): Either<CoreFailure, Conversation> {
+    ): CreateGroupConversationResult {
         val canRetryOnce = apiResult.value.isRetryable
                 && lastUsersAttempt is LastUsersAttempt.None
                 && apiResult.value !is NetworkFailure.FederatedBackendFailure.ConflictingBackends
@@ -257,14 +317,16 @@ internal class ConversationGroupRepositoryImpl(
 
         return if (canRetryOnce) {
             extractValidUsersForRetryableError(apiResult.value, usersList)
-                .flatMap { (validUsers, failedUsers, failType) ->
+                .fold({ failure ->
+                    CreateGroupConversationResult.Failure(failure)
+                }, { (validUsers, failedUsers, failType) ->
                     // edge case, in case backend goes 🍌 and returns non-matching domains
-                    if (failedUsers.isEmpty()) Either.Left(apiResult.value)
+                    if (failedUsers.isEmpty()) return CreateGroupConversationResult.Failure(apiResult.value)
 
                     createGroupConversation(name, validUsers, options, LastUsersAttempt.Failed(failedUsers, failType))
-                }
+                })
         } else {
-            Either.Left(apiResult.value)
+            CreateGroupConversationResult.Failure(apiResult.value)
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepository.kt
@@ -41,6 +41,7 @@ import com.wire.kalium.logic.data.id.toApi
 import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.id.toModel
 import com.wire.kalium.logic.data.conversation.mls.MLSAdditionResult
+import com.wire.kalium.logic.data.conversation.mls.PendingActionsRepository
 import com.wire.kalium.logic.data.message.MessageContent.MemberChange.FailedToAdd
 import com.wire.kalium.logic.data.mls.CipherSuite
 import com.wire.kalium.logic.data.service.ServiceId
@@ -117,7 +118,7 @@ internal sealed interface CreateGroupConversationResult {
     }
 }
 
-@Suppress("LongParameterList", "TooManyFunctions")
+@Suppress("LargeClass", "LongParameterList", "TooManyFunctions")
 internal class ConversationGroupRepositoryImpl(
     private val mlsConversationRepository: MLSConversationRepository,
     private val localEventRepository: LocalEventRepository,
@@ -131,6 +132,7 @@ internal class ConversationGroupRepositoryImpl(
     private val teamIdProvider: SelfTeamIdProvider,
     private val legalHoldHandler: LegalHoldHandler,
     private val transactionProvider: CryptoTransactionProvider,
+    private val pendingActionsRepository: PendingActionsRepository,
     private val conversationMapper: ConversationMapper = MapperProvider.conversationMapper(selfUserId),
     private val eventMapper: EventMapper = MapperProvider.eventMapper(selfUserId),
     private val protocolInfoMapper: ProtocolInfoMapper = MapperProvider.protocolInfoMapper(),
@@ -240,6 +242,7 @@ internal class ConversationGroupRepositoryImpl(
             establishResult.fold({ failure ->
                 if (protocol is Conversation.ProtocolInfo.MLSCapable) {
                     val conversationId = conversationEntity.id.toModel()
+                    pendingActionsRepository.enqueuePendingMLSGroupJoin(conversationId)
                     CreateGroupConversationResult.PendingMLSGroupCreation(conversationId, failure)
                 } else {
                     CreateGroupConversationResult.Failure(failure)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationUseCase.kt
@@ -298,7 +298,9 @@ internal class JoinExistingMLSConversationUseCaseImpl(
                             mlsContext,
                             protocol.groupId,
                             members,
-                            publicKeys
+                            publicKeys,
+                            allowSkippingUsersWithoutKeyPackages =
+                                protocol.groupState == Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_CREATION,
                         )
                     }
                 }.onSuccess {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/JoinExistingMLSConversationsUseCase.kt
@@ -96,7 +96,9 @@ internal class JoinExistingMLSConversationsUseCaseImpl(
     private suspend fun getPendingConversations(): Either<CoreFailure, List<Conversation>> =
         conversationRepository.getConversationsByGroupState(GroupState.PENDING_JOIN).flatMap { pendingJoin ->
             conversationRepository.getConversationsByGroupState(GroupState.PENDING_AFTER_RESET).flatMap { pendingAfterReset ->
-                Either.Right(pendingJoin + pendingAfterReset)
+                conversationRepository.getConversationsByGroupState(GroupState.PENDING_CREATION).flatMap { pendingCreation ->
+                    Either.Right((pendingJoin + pendingAfterReset + pendingCreation).distinctBy { it.id })
+                }
             }
         }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/NewConversationMembersRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/NewConversationMembersRepository.kt
@@ -20,6 +20,7 @@ package com.wire.kalium.logic.data.conversation
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.data.id.IdMapper
 import com.wire.kalium.logic.data.id.toModel
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
@@ -37,6 +38,7 @@ internal interface NewConversationMembersRepository {
     suspend fun persistMembersAdditionToTheConversation(
         conversationId: ConversationIDEntity,
         conversationResponse: ConversationResponse,
+        additionalMembers: List<UserId> = emptyList(),
     ): Either<CoreFailure, Unit>
 }
 
@@ -50,9 +52,14 @@ internal class NewConversationMembersRepositoryImpl(
     override suspend fun persistMembersAdditionToTheConversation(
         conversationId: ConversationIDEntity,
         conversationResponse: ConversationResponse,
+        additionalMembers: List<UserId>,
     ) = wrapStorageRequest {
+        val responseMembers = memberMapper.fromApiModelToDaoModel(conversationResponse.members)
+        val pendingMembers = additionalMembers.map {
+            memberMapper.toDaoModel(Conversation.Member(it, Conversation.Member.Role.Member))
+        }
         memberDAO.insertMembersWithQualifiedId(
-            memberMapper.fromApiModelToDaoModel(conversationResponse.members),
+            (responseMembers + pendingMembers).distinctBy { it.user },
             idMapper.fromApiToDao(conversationResponse.id)
         )
     }.flatMap {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -988,7 +988,7 @@ public class UserSessionScope internal constructor(
             userId,
             selfTeamId,
             legalHoldHandler,
-            cryptoTransactionProvider
+            cryptoTransactionProvider,
         )
 
     private val newConversationMembersRepository: NewConversationMembersRepository

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -989,6 +989,7 @@ public class UserSessionScope internal constructor(
             selfTeamId,
             legalHoldHandler,
             cryptoTransactionProvider,
+            pendingActionsRepository,
         )
 
     private val newConversationMembersRepository: NewConversationMembersRepository
@@ -1469,7 +1470,8 @@ public class UserSessionScope internal constructor(
             pendingActionsRepository = pendingActionsRepository,
             syncStateObserver = syncStateObserver.value,
             transactionProvider = cryptoTransactionProvider,
-            joinExistingMLSConversation = joinExistingMLSConversationUseCase
+            joinExistingMLSConversation = joinExistingMLSConversationUseCase,
+            conversationRepository = conversationRepository,
         )
 
     private val updateSupportedProtocols: UpdateSelfUserSupportedProtocolsUseCase
@@ -2454,6 +2456,7 @@ public class UserSessionScope internal constructor(
             currentPersistenceEventHookNotifier,
             memberJoinHandler,
             joinExistingMLSConversationUseCase,
+            pendingActionsRepository,
             KaliumDispatcherImpl,
         )
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -223,7 +223,9 @@ public class ConversationScope internal constructor(
             syncManager,
             currentClientIdProvider,
             newGroupConversationSystemMessagesCreator,
-            refreshUsersWithoutMetadata
+            refreshUsersWithoutMetadata,
+            transactionProvider,
+            joinExistingMLSConversation,
         )
 
     public val createRegularGroup: CreateRegularGroupUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/ConversationScope.kt
@@ -30,6 +30,7 @@ import com.wire.kalium.logic.data.connection.ConnectionRepository
 import com.wire.kalium.logic.data.conversation.ConversationGroupRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCase
+import com.wire.kalium.logic.data.conversation.mls.PendingActionsRepository
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.conversation.NewGroupConversationSystemMessagesCreator
 import com.wire.kalium.logic.data.conversation.PersistConversationsUseCase
@@ -151,6 +152,7 @@ public class ConversationScope internal constructor(
     private val persistenceEventHookNotifier: PersistenceEventHookNotifier,
     private val memberJoinEventHandler: MemberJoinEventHandler,
     private val joinExistingMLSConversation: JoinExistingMLSConversationUseCase,
+    private val pendingActionsRepository: PendingActionsRepository,
     internal val dispatcher: KaliumDispatcher,
 ) {
 
@@ -226,6 +228,7 @@ public class ConversationScope internal constructor(
             refreshUsersWithoutMetadata,
             transactionProvider,
             joinExistingMLSConversation,
+            pendingActionsRepository,
         )
 
     public val createRegularGroup: CreateRegularGroupUseCase

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/createconversation/ConversationCreationResult.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/createconversation/ConversationCreationResult.kt
@@ -19,6 +19,7 @@ package com.wire.kalium.logic.feature.conversation.createconversation
 
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.id.ConversationId
 
 public sealed interface ConversationCreationResult {
     /**
@@ -36,6 +37,14 @@ public sealed interface ConversationCreationResult {
      */
     public data object SyncFailure : ConversationCreationResult
     public data object Forbidden : ConversationCreationResult
+
+    /**
+     * The backend conversation exists, but its local MLS group still needs to be established.
+     */
+    public class PendingMLSGroupCreation(
+        public val conversationId: ConversationId,
+        public val cause: CoreFailure,
+    ) : ConversationCreationResult
 
     /**
      * Other, unknown failure.

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/createconversation/CreateRegularGroupUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/createconversation/CreateRegularGroupUseCase.kt
@@ -18,6 +18,7 @@
 package com.wire.kalium.logic.feature.conversation.createconversation
 
 import com.wire.kalium.logic.data.conversation.CreateConversationParam
+import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 
 /**
@@ -26,6 +27,7 @@ import com.wire.kalium.logic.data.user.UserId
  */
 public interface CreateRegularGroupUseCase {
     public suspend operator fun invoke(name: String, userIdList: List<UserId>, options: CreateConversationParam): ConversationCreationResult
+    public suspend fun retryPendingMLSGroupCreation(conversationId: ConversationId): ConversationCreationResult
 }
 
 /**
@@ -41,4 +43,7 @@ internal class CreateRegularGroupUseCaseImpl(
         options: CreateConversationParam
     ): ConversationCreationResult =
         createGroupConversation(name, userIdList, options.copy(groupType = CreateConversationParam.GroupType.REGULAR_GROUP))
+
+    override suspend fun retryPendingMLSGroupCreation(conversationId: ConversationId): ConversationCreationResult =
+        createGroupConversation.retryPendingMLSGroupCreation(conversationId)
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/createconversation/GroupConversationCreator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/createconversation/GroupConversationCreator.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.logic.feature.conversation.createconversation
 
 import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.MLSFailure
 import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
@@ -33,6 +34,7 @@ import com.wire.kalium.logic.data.conversation.CreateConversationParam
 import com.wire.kalium.logic.data.conversation.CreateGroupConversationResult
 import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCase
 import com.wire.kalium.logic.data.conversation.NewGroupConversationSystemMessagesCreator
+import com.wire.kalium.logic.data.conversation.mls.PendingActionsRepository
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
@@ -68,6 +70,7 @@ internal interface GroupConversationCreator {
 /**
  * Implementation of [GroupConversationCreator].
  */
+@Suppress("LongParameterList")
 internal class GroupConversationCreatorImpl(
     private val conversationRepository: ConversationRepository,
     private val conversationGroupRepository: ConversationGroupRepository,
@@ -77,6 +80,7 @@ internal class GroupConversationCreatorImpl(
     private val refreshUsersWithoutMetadata: RefreshUsersWithoutMetadataUseCase,
     private val transactionProvider: CryptoTransactionProvider,
     private val joinExistingMLSConversation: JoinExistingMLSConversationUseCase,
+    private val pendingActionsRepository: PendingActionsRepository,
 ) : GroupConversationCreator {
 
     override suspend fun invoke(
@@ -91,11 +95,13 @@ internal class GroupConversationCreatorImpl(
             { it }
         )
 
-        return when (val result = conversationGroupRepository.createGroupConversationWithPendingResult(
-            name,
-            userIdList,
-            options.copy(creatorClientId = clientId)
-        )) {
+        return when (
+            val result = conversationGroupRepository.createGroupConversationWithPendingResult(
+                name,
+                userIdList,
+                options.copy(creatorClientId = clientId)
+            )
+        ) {
             is CreateGroupConversationResult.Failure -> result.cause.toCreationFailure()
             is CreateGroupConversationResult.PendingMLSGroupCreation ->
                 ConversationCreationResult.PendingMLSGroupCreation(result.conversationId, result.cause)
@@ -115,12 +121,29 @@ internal class GroupConversationCreatorImpl(
                     joinExistingMLSConversation(transactionContext, conversationId)
                 }.flatMap {
                     conversationRepository.getConversationById(conversationId)
+                }.flatMap { recoveredConversation ->
+                    if (recoveredConversation.isMLSEstablished()) {
+                        Either.Right(recoveredConversation)
+                    } else {
+                        Either.Left(MLSFailure.Other("MLS group is still pending after creation retry"))
+                    }
                 }
             }
         }.fold(
             { failure -> failure.toCreationFailure() },
-            { conversation -> finishSuccessfulCreation(conversation) }
+            { conversation ->
+                val result = finishSuccessfulCreation(conversation)
+                if (result is ConversationCreationResult.Success) {
+                    pendingActionsRepository.acknowledgePendingMLSGroupJoins(listOf(conversationId))
+                }
+                result
+            }
         )
+
+    private fun Conversation.isMLSEstablished(): Boolean {
+        val mlsProtocol = protocol as? Conversation.ProtocolInfo.MLSCapable
+        return mlsProtocol?.groupState == Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED
+    }
 
     private suspend fun finishSuccessfulCreation(conversation: Conversation): ConversationCreationResult =
         Either.Right(conversation).onSuccess {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/createconversation/GroupConversationCreator.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/createconversation/GroupConversationCreator.kt
@@ -18,16 +18,23 @@
 
 package com.wire.kalium.logic.feature.conversation.createconversation
 
+import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.NetworkFailure
+import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
 import com.wire.kalium.common.functional.fold
 import com.wire.kalium.common.functional.map
 import com.wire.kalium.common.functional.onSuccess
+import com.wire.kalium.logic.data.client.CryptoTransactionProvider
+import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationGroupRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.CreateConversationParam
+import com.wire.kalium.logic.data.conversation.CreateGroupConversationResult
+import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCase
 import com.wire.kalium.logic.data.conversation.NewGroupConversationSystemMessagesCreator
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
+import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.publicuser.RefreshUsersWithoutMetadataUseCase
 import com.wire.kalium.logic.sync.SyncManager
@@ -54,6 +61,8 @@ internal interface GroupConversationCreator {
         userIdList: List<UserId>,
         options: CreateConversationParam
     ): ConversationCreationResult
+
+    suspend fun retryPendingMLSGroupCreation(conversationId: ConversationId): ConversationCreationResult
 }
 
 /**
@@ -66,49 +75,89 @@ internal class GroupConversationCreatorImpl(
     private val currentClientIdProvider: CurrentClientIdProvider,
     private val newGroupConversationSystemMessagesCreator: NewGroupConversationSystemMessagesCreator,
     private val refreshUsersWithoutMetadata: RefreshUsersWithoutMetadataUseCase,
+    private val transactionProvider: CryptoTransactionProvider,
+    private val joinExistingMLSConversation: JoinExistingMLSConversationUseCase,
 ) : GroupConversationCreator {
 
     override suspend fun invoke(
         name: String,
         userIdList: List<UserId>,
         options: CreateConversationParam
-    ): ConversationCreationResult =
-        syncManager.waitUntilLiveOrFailure().flatMap {
+    ): ConversationCreationResult {
+        val clientId = syncManager.waitUntilLiveOrFailure().flatMap {
             currentClientIdProvider()
-        }.flatMap { clientId ->
-            conversationGroupRepository.createGroupConversation(name, userIdList, options.copy(creatorClientId = clientId))
-        }.onSuccess {
+        }.fold(
+            { return it.toCreationFailure() },
+            { it }
+        )
+
+        return when (val result = conversationGroupRepository.createGroupConversationWithPendingResult(
+            name,
+            userIdList,
+            options.copy(creatorClientId = clientId)
+        )) {
+            is CreateGroupConversationResult.Failure -> result.cause.toCreationFailure()
+            is CreateGroupConversationResult.PendingMLSGroupCreation ->
+                ConversationCreationResult.PendingMLSGroupCreation(result.conversationId, result.cause)
+            is CreateGroupConversationResult.Success -> finishSuccessfulCreation(result.conversation)
+        }
+    }
+
+    override suspend fun retryPendingMLSGroupCreation(conversationId: ConversationId): ConversationCreationResult =
+        syncManager.waitUntilLiveOrFailure().flatMap {
+            conversationRepository.getConversationById(conversationId)
+        }.flatMap { conversation ->
+            val groupState = (conversation.protocol as? Conversation.ProtocolInfo.MLSCapable)?.groupState
+            if (groupState == Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED) {
+                Either.Right(conversation)
+            } else {
+                transactionProvider.transaction("retryPendingMLSGroupCreation") { transactionContext ->
+                    joinExistingMLSConversation(transactionContext, conversationId)
+                }.flatMap {
+                    conversationRepository.getConversationById(conversationId)
+                }
+            }
+        }.fold(
+            { failure -> failure.toCreationFailure() },
+            { conversation -> finishSuccessfulCreation(conversation) }
+        )
+
+    private suspend fun finishSuccessfulCreation(conversation: Conversation): ConversationCreationResult =
+        Either.Right(conversation).onSuccess {
             refreshUsersWithoutMetadata()
         }.flatMap { conversation ->
             // TODO(qol): this can be done in one query, e.g. pass current time when inserting
             conversationRepository.updateConversationModifiedDate(conversation.id, DateTimeUtil.currentInstant())
                 .map { conversation }
-        }.fold({
-            when (it) {
+        }.fold({ failure ->
+            failure.toCreationFailure()
+        }, { createdConversation ->
+            newGroupConversationSystemMessagesCreator.conversationReadReceiptStatus(createdConversation)
+            ConversationCreationResult.Success(createdConversation)
+        })
+
+    private fun CoreFailure.toCreationFailure(): ConversationCreationResult =
+        when (this) {
                 is NetworkFailure.NoNetworkConnection -> {
                     ConversationCreationResult.SyncFailure
                 }
 
                 is NetworkFailure.FederatedBackendFailure.ConflictingBackends -> {
-                    ConversationCreationResult.BackendConflictFailure(it.domains)
+                    ConversationCreationResult.BackendConflictFailure(domains)
                 }
 
                 is NetworkFailure.ServerMiscommunication -> {
-                    val exception = it.kaliumException
+                    val exception = kaliumException
                     if (exception is KaliumException.InvalidRequestError && exception.isOperationDenied()
                     ) {
                         ConversationCreationResult.Forbidden
                     } else {
-                        ConversationCreationResult.UnknownFailure(it)
+                        ConversationCreationResult.UnknownFailure(this)
                     }
                 }
 
                 else -> {
-                    ConversationCreationResult.UnknownFailure(it)
+                    ConversationCreationResult.UnknownFailure(this)
                 }
-            }
-        }, {
-            newGroupConversationSystemMessagesCreator.conversationReadReceiptStatus(it)
-            ConversationCreationResult.Success(it)
-        })
+        }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/RecoverPendingMLSGroupJoinsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/conversation/mls/RecoverPendingMLSGroupJoinsUseCase.kt
@@ -20,11 +20,14 @@ package com.wire.kalium.logic.feature.conversation.mls
 import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.flatMap
 import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.common.functional.onSuccess
 import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.cryptography.CryptoTransactionContext
 import com.wire.kalium.logic.data.client.CryptoTransactionProvider
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCase
 import com.wire.kalium.logic.data.conversation.mls.PendingActionsRepository
 import com.wire.kalium.logic.data.id.ConversationId
@@ -41,6 +44,7 @@ internal class RecoverPendingMLSGroupJoinsUseCaseImpl(
     private val syncStateObserver: SyncStateObserver,
     private val transactionProvider: CryptoTransactionProvider,
     private val joinExistingMLSConversation: JoinExistingMLSConversationUseCase,
+    private val conversationRepository: ConversationRepository,
 ) : RecoverPendingMLSGroupJoinsUseCase {
 
     override suspend fun invoke() {
@@ -76,6 +80,7 @@ internal class RecoverPendingMLSGroupJoinsUseCaseImpl(
                 conversationId = conversationId,
                 allowJoinByExternalCommit = true
             )
+                .flatMap { conversationRepository.getConversationById(conversationId) }
                 .onFailure {
                     kaliumLogger.w("Failed to recover pending MLS group join for ${conversationId.toLogString()}: $it")
                     if (it is NetworkFailure.ServerMiscommunication &&
@@ -87,10 +92,21 @@ internal class RecoverPendingMLSGroupJoinsUseCaseImpl(
                         successfulConversationIds.add(conversationId)
                     }
                 }
-                .onSuccess {
-                    successfulConversationIds.add(conversationId)
+                .onSuccess { conversation ->
+                    if (conversation.isMLSEstablished()) {
+                        successfulConversationIds.add(conversationId)
+                    } else {
+                        kaliumLogger.w(
+                            "Pending MLS group join for ${conversationId.toLogString()} completed without establishing the group"
+                        )
+                    }
                 }
         }
         return successfulConversationIds
+    }
+
+    private fun Conversation.isMLSEstablished(): Boolean {
+        val mlsProtocol = protocol as? Conversation.ProtocolInfo.MLSCapable
+        return mlsProtocol?.groupState == Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.logic.data.id.SelfTeamIdProvider
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.id.toApi
 import com.wire.kalium.logic.data.id.toDao
+import com.wire.kalium.logic.data.id.toModel
 import com.wire.kalium.logic.data.legalhold.ListUsersLegalHoldConsent
 import com.wire.kalium.logic.data.legalhold.ids
 import com.wire.kalium.logic.data.message.MessageContent
@@ -125,7 +126,7 @@ class ConversationGroupRepositoryTest {
             }
 
             verifySuspend(VerifyMode.exactly(1)) {
-                newConversationMembersRepository.persistMembersAdditionToTheConversation(any(), any())
+                newConversationMembersRepository.persistMembersAdditionToTheConversation(any(), any(), any())
             }
         }
     }
@@ -158,7 +159,7 @@ class ConversationGroupRepositoryTest {
             }
 
             verifySuspend(VerifyMode.exactly(1)) {
-                newConversationMembersRepository.persistMembersAdditionToTheConversation(any(), any())
+                newConversationMembersRepository.persistMembersAdditionToTheConversation(any(), any(), any())
             }
         }
     }
@@ -266,7 +267,7 @@ class ConversationGroupRepositoryTest {
             }
 
             verifySuspend(VerifyMode.exactly(1)) {
-                newConversationMembersRepository.persistMembersAdditionToTheConversation(any(), any())
+                newConversationMembersRepository.persistMembersAdditionToTheConversation(any(), any(), any())
             }
 
             verifySuspend(VerifyMode.exactly(1)) {
@@ -314,7 +315,7 @@ class ConversationGroupRepositoryTest {
             }
 
             verifySuspend(VerifyMode.exactly(0)) {
-                newConversationMembersRepository.persistMembersAdditionToTheConversation(any(), any())
+                newConversationMembersRepository.persistMembersAdditionToTheConversation(any(), any(), any())
             }
 
             verifySuspend(VerifyMode.exactly(0)) {
@@ -353,7 +354,7 @@ class ConversationGroupRepositoryTest {
             }
 
             verifySuspend(VerifyMode.exactly(0)) {
-                newConversationMembersRepository.persistMembersAdditionToTheConversation(any(), any())
+                newConversationMembersRepository.persistMembersAdditionToTheConversation(any(), any(), any())
             }
 
             verifySuspend(VerifyMode.exactly(0)) {
@@ -410,7 +411,7 @@ class ConversationGroupRepositoryTest {
             }
 
             verifySuspend(VerifyMode.exactly(1)) {
-                newConversationMembersRepository.persistMembersAdditionToTheConversation(any(), any())
+                newConversationMembersRepository.persistMembersAdditionToTheConversation(any(), any(), any())
             }
 
             verifySuspend(VerifyMode.exactly(1)) {
@@ -461,7 +462,7 @@ class ConversationGroupRepositoryTest {
             }
 
             verifySuspend(VerifyMode.exactly(0)) {
-                newConversationMembersRepository.persistMembersAdditionToTheConversation(any(), any())
+                newConversationMembersRepository.persistMembersAdditionToTheConversation(any(), any(), any())
             }
 
             verifySuspend(VerifyMode.exactly(0)) {
@@ -504,8 +505,45 @@ class ConversationGroupRepositoryTest {
             }
 
             verifySuspend(VerifyMode.exactly(1)) {
-                newConversationMembersRepository.persistMembersAdditionToTheConversation(any(), any())
+                newConversationMembersRepository.persistMembersAdditionToTheConversation(any(), any(), any())
             }
+        }
+    }
+
+    @Test
+    fun givenMLSGroupEstablishFails_whenCreatingConversation_thenPendingConversationIsReturned() = runTest {
+        val conversationResponse = CONVERSATION_RESPONSE.copy(protocol = MLS)
+        val establishFailure = CoreFailure.Unknown(UnsupportedOperationException("establish failed"))
+        val requestedMembers = listOf(TestUser.USER_ID, TestUser.OTHER_USER_ID)
+        val (arrangement, conversationGroupRepository) = Arrangement()
+            .withCreateNewConversationAPIResponses(arrayOf(NetworkResponse.Success(conversationResponse, emptyMap(), 201)))
+            .withSelfTeamId(Either.Right(TestUser.SELF.teamId))
+            .withInsertConversationSuccess()
+            .withMlsConversationEstablishFailure(establishFailure)
+            .withSuccessfulNewConversationGroupStartedHandled()
+            .withSuccessfulNewConversationMemberHandled()
+            .withSuccessfulNewConversationGroupStartedUnverifiedWarningHandled()
+            .withConversationAppsAccessIfEnabled()
+            .arrange()
+
+        val result = conversationGroupRepository.createGroupConversationWithPendingResult(
+            GROUP_NAME,
+            requestedMembers,
+            CreateConversationParam(protocol = CreateConversationParam.Protocol.MLS)
+        )
+
+        val pendingResult = assertIs<CreateGroupConversationResult.PendingMLSGroupCreation>(result)
+        assertEquals(conversationResponse.id.toModel(), pendingResult.conversationId)
+        assertEquals(establishFailure, pendingResult.cause)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.conversationApi.createNewConversation(any())
+        }
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.newConversationMembersRepository.persistMembersAdditionToTheConversation(
+                any(),
+                any(),
+                eq(requestedMembers),
+            )
         }
     }
 
@@ -1849,13 +1887,19 @@ class ConversationGroupRepositoryTest {
                 TestUser.SELF.id,
                 selfTeamIdProvider,
                 legalHoldHandler,
-                cryptoTransactionProvider
+                cryptoTransactionProvider,
             )
 
         suspend fun withMlsConversationEstablished(additionResult: MLSAdditionResult): Arrangement = apply {
             everySuspend {
                 mlsConversationRepository.establishMLSGroup(any(), any(), any(), any(), any())
             }.returns(Either.Right(additionResult))
+        }
+
+        suspend fun withMlsConversationEstablishFailure(failure: CoreFailure): Arrangement = apply {
+            everySuspend {
+                mlsConversationRepository.establishMLSGroup(any(), any(), any(), any(), any())
+            }.returns(Either.Left(failure))
         }
 
         /**
@@ -2125,7 +2169,7 @@ class ConversationGroupRepositoryTest {
 
         suspend fun withSuccessfulNewConversationMemberHandled() = apply {
             everySuspend {
-                newConversationMembersRepository.persistMembersAdditionToTheConversation(any(), any())
+                newConversationMembersRepository.persistMembersAdditionToTheConversation(any(), any(), any())
             }.returns(Either.Right(Unit))
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ConversationGroupRepositoryTest.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.right
 import com.wire.kalium.logic.data.conversation.mls.MLSAdditionResult
+import com.wire.kalium.logic.data.conversation.mls.PendingActionsRepository
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.SelfTeamIdProvider
@@ -511,7 +512,7 @@ class ConversationGroupRepositoryTest {
     }
 
     @Test
-    fun givenMLSGroupEstablishFails_whenCreatingConversation_thenPendingConversationIsReturned() = runTest {
+    fun givenMLSGroupEstablishFails_whenCreatingConversation_thenExistingConversationIsQueuedForRecovery() = runTest {
         val conversationResponse = CONVERSATION_RESPONSE.copy(protocol = MLS)
         val establishFailure = CoreFailure.Unknown(UnsupportedOperationException("establish failed"))
         val requestedMembers = listOf(TestUser.USER_ID, TestUser.OTHER_USER_ID)
@@ -544,6 +545,9 @@ class ConversationGroupRepositoryTest {
                 any(),
                 eq(requestedMembers),
             )
+        }
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.pendingActionsRepository.enqueuePendingMLSGroupJoin(conversationResponse.id.toModel())
         }
     }
 
@@ -1873,6 +1877,7 @@ class ConversationGroupRepositoryTest {
         val newGroupConversationSystemMessagesCreator: NewGroupConversationSystemMessagesCreator = mock(mode = MockMode.autoUnit)
         val legalHoldHandler: LegalHoldHandler = mock(mode = MockMode.autoUnit)
         val localEventRepository: LocalEventRepository = mock(mode = MockMode.autoUnit)
+        val pendingActionsRepository: PendingActionsRepository = mock(mode = MockMode.autoUnit)
 
         val conversationGroupRepository =
             ConversationGroupRepositoryImpl(
@@ -1888,6 +1893,7 @@ class ConversationGroupRepositoryTest {
                 selfTeamIdProvider,
                 legalHoldHandler,
                 cryptoTransactionProvider,
+                pendingActionsRepository,
             )
 
         suspend fun withMlsConversationEstablished(additionResult: MLSAdditionResult): Arrangement = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GroupConversationCreatorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GroupConversationCreatorTest.kt
@@ -30,6 +30,7 @@ import com.wire.kalium.logic.data.conversation.CreateConversationParam
 import com.wire.kalium.logic.data.conversation.CreateGroupConversationResult
 import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCase
 import com.wire.kalium.logic.data.conversation.NewGroupConversationSystemMessagesCreator
+import com.wire.kalium.logic.data.conversation.mls.PendingActionsRepository
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.conversation.createconversation.ConversationCreationResult
 import com.wire.kalium.logic.feature.conversation.createconversation.GroupConversationCreatorImpl
@@ -44,6 +45,7 @@ import com.wire.kalium.network.api.model.GenericAPIErrorResponse
 import com.wire.kalium.network.exceptions.KaliumException
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
+import dev.mokkery.answering.sequentiallyReturns
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.matcher.eq
@@ -247,9 +249,14 @@ class GroupConversationCreatorTest {
                 groupState = Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_CREATION
             )
         )
+        val establishedConversation = conversation.copy(
+            protocol = (conversation.protocol as Conversation.ProtocolInfo.MLS).copy(
+                groupState = Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED
+            )
+        )
         val (arrangement, createGroupConversation) = Arrangement()
             .withWaitingForSyncSucceeding()
-            .withConversationReturning(conversation)
+            .withConversationsReturning(conversation, establishedConversation)
             .withJoiningExistingMLSConversationSucceeding()
             .withUpdateConversationModifiedDateSucceeding()
             .withPersistingReadReceiptsSystemMessage()
@@ -262,6 +269,29 @@ class GroupConversationCreatorTest {
         assertEquals(conversation.id, result.conversation.id)
         verifySuspend(VerifyMode.exactly(1)) {
             arrangement.joinExistingMLSConversation.invoke(any(), conversation.id)
+            arrangement.pendingActionsRepository.acknowledgePendingMLSGroupJoins(listOf(conversation.id))
+        }
+    }
+
+    @Test
+    fun givenJoinReturnsSuccessButConversationIsStillPending_whenRetryingCreation_thenRecoveryRemainsQueued() = runTest {
+        val conversation = TestConversation.GROUP(
+            TestConversation.MLS_PROTOCOL_INFO.copy(
+                groupState = Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_CREATION
+            )
+        )
+        val (arrangement, createGroupConversation) = Arrangement()
+            .withWaitingForSyncSucceeding()
+            .withConversationReturning(conversation)
+            .withJoiningExistingMLSConversationSucceeding()
+            .withTransactionInvokingBlock()
+            .arrange()
+
+        val result = createGroupConversation.retryPendingMLSGroupCreation(conversation.id)
+
+        assertIs<ConversationCreationResult.UnknownFailure>(result)
+        verifySuspend(VerifyMode.not) {
+            arrangement.pendingActionsRepository.acknowledgePendingMLSGroupJoins(any())
         }
     }
 
@@ -296,6 +326,7 @@ class GroupConversationCreatorTest {
         val syncManager = mock<SyncManager>(mode = MockMode.autoUnit)
         val newGroupConversationSystemMessagesCreator = mock<NewGroupConversationSystemMessagesCreator>(mode = MockMode.autoUnit)
         val joinExistingMLSConversation = mock<JoinExistingMLSConversationUseCase>(mode = MockMode.autoUnit)
+        val pendingActionsRepository = mock<PendingActionsRepository>(mode = MockMode.autoUnit)
 
         private val createGroupConversation = GroupConversationCreatorImpl(
             conversationRepository,
@@ -306,6 +337,7 @@ class GroupConversationCreatorTest {
             refreshUsersWithoutMetadata,
             cryptoTransactionProvider,
             joinExistingMLSConversation,
+            pendingActionsRepository,
         )
 
         suspend fun withWaitingForSyncSucceeding() = withSyncReturning(Either.Right(Unit))
@@ -347,6 +379,12 @@ class GroupConversationCreatorTest {
             everySuspend {
                 conversationRepository.getConversationById(conversation.id)
             } returns Either.Right(conversation)
+        }
+
+        suspend fun withConversationsReturning(vararg conversations: Conversation) = apply {
+            everySuspend {
+                conversationRepository.getConversationById(conversations.first().id)
+            } sequentiallyReturns conversations.map { Either.Right(it) }
         }
 
         suspend fun withJoiningExistingMLSConversationSucceeding() = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GroupConversationCreatorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/GroupConversationCreatorTest.kt
@@ -27,6 +27,8 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationGroupRepository
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.CreateConversationParam
+import com.wire.kalium.logic.data.conversation.CreateGroupConversationResult
+import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCase
 import com.wire.kalium.logic.data.conversation.NewGroupConversationSystemMessagesCreator
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.feature.conversation.createconversation.ConversationCreationResult
@@ -36,6 +38,8 @@ import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.sync.SyncManager
 import com.wire.kalium.logic.test_util.wasInTheLastSecond
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementImpl
 import com.wire.kalium.network.api.model.GenericAPIErrorResponse
 import com.wire.kalium.network.exceptions.KaliumException
 import dev.mokkery.MockMode
@@ -136,7 +140,11 @@ class GroupConversationCreatorTest {
         }
 
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.conversationGroupRepository.createGroupConversation(eq(name), eq(members), eq(conversationOptions))
+            arrangement.conversationGroupRepository.createGroupConversationWithPendingResult(
+                eq(name),
+                eq(members),
+                eq(conversationOptions)
+            )
         }
     }
 
@@ -209,7 +217,77 @@ class GroupConversationCreatorTest {
         }
     }
 
-    private class Arrangement {
+    @Test
+    fun givenMLSGroupEstablishFails_whenCreatingGroupConversation_thenPendingConversationIsReturned() = runTest {
+        val conversation = TestConversation.GROUP(TestConversation.MLS_PROTOCOL_INFO)
+        val rootCause = StorageFailure.DataNotFound
+        val (_, createGroupConversation) = Arrangement()
+            .withWaitingForSyncSucceeding()
+            .withCurrentClientIdReturning(ClientId("client-id"))
+            .withCreateGroupConversationReturning(
+                CreateGroupConversationResult.PendingMLSGroupCreation(conversation.id, rootCause)
+            )
+            .arrange()
+
+        val result = createGroupConversation(
+            conversation.name.orEmpty(),
+            listOf(TestUser.USER_ID),
+            CreateConversationParam(protocol = CreateConversationParam.Protocol.MLS)
+        )
+
+        assertIs<ConversationCreationResult.PendingMLSGroupCreation>(result)
+        assertEquals(conversation.id, result.conversationId)
+        assertEquals(rootCause, result.cause)
+    }
+
+    @Test
+    fun givenPendingMLSGroup_whenRetryingCreation_thenExistingConversationIsEstablished() = runTest {
+        val conversation = TestConversation.GROUP(
+            TestConversation.MLS_PROTOCOL_INFO.copy(
+                groupState = Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_CREATION
+            )
+        )
+        val (arrangement, createGroupConversation) = Arrangement()
+            .withWaitingForSyncSucceeding()
+            .withConversationReturning(conversation)
+            .withJoiningExistingMLSConversationSucceeding()
+            .withUpdateConversationModifiedDateSucceeding()
+            .withPersistingReadReceiptsSystemMessage()
+            .withTransactionInvokingBlock()
+            .arrange()
+
+        val result = createGroupConversation.retryPendingMLSGroupCreation(conversation.id)
+
+        assertIs<ConversationCreationResult.Success>(result)
+        assertEquals(conversation.id, result.conversation.id)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.joinExistingMLSConversation.invoke(any(), conversation.id)
+        }
+    }
+
+    @Test
+    fun givenMLSGroupWasAlreadyRecovered_whenRetryingCreation_thenEstablishIsNotRepeated() = runTest {
+        val conversation = TestConversation.GROUP(
+            TestConversation.MLS_PROTOCOL_INFO.copy(
+                groupState = Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED
+            )
+        )
+        val (arrangement, createGroupConversation) = Arrangement()
+            .withWaitingForSyncSucceeding()
+            .withConversationReturning(conversation)
+            .withUpdateConversationModifiedDateSucceeding()
+            .withPersistingReadReceiptsSystemMessage()
+            .arrange()
+
+        val result = createGroupConversation.retryPendingMLSGroupCreation(conversation.id)
+
+        assertIs<ConversationCreationResult.Success>(result)
+        verifySuspend(VerifyMode.not) {
+            arrangement.joinExistingMLSConversation.invoke(any(), any())
+        }
+    }
+
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
 
         val conversationRepository = mock<ConversationRepository>(mode = MockMode.autoUnit)
         val conversationGroupRepository = mock<ConversationGroupRepository>(mode = MockMode.autoUnit)
@@ -217,6 +295,7 @@ class GroupConversationCreatorTest {
         val currentClientIdProvider = mock<CurrentClientIdProvider>(mode = MockMode.autoUnit)
         val syncManager = mock<SyncManager>(mode = MockMode.autoUnit)
         val newGroupConversationSystemMessagesCreator = mock<NewGroupConversationSystemMessagesCreator>(mode = MockMode.autoUnit)
+        val joinExistingMLSConversation = mock<JoinExistingMLSConversationUseCase>(mode = MockMode.autoUnit)
 
         private val createGroupConversation = GroupConversationCreatorImpl(
             conversationRepository,
@@ -224,7 +303,9 @@ class GroupConversationCreatorTest {
             syncManager,
             currentClientIdProvider,
             newGroupConversationSystemMessagesCreator,
-            refreshUsersWithoutMetadata
+            refreshUsersWithoutMetadata,
+            cryptoTransactionProvider,
+            joinExistingMLSConversation,
         )
 
         suspend fun withWaitingForSyncSucceeding() = withSyncReturning(Either.Right(Unit))
@@ -251,15 +332,31 @@ class GroupConversationCreatorTest {
         }
 
         suspend fun withCreateGroupConversationFailingWith(coreFailure: CoreFailure) =
-            withCreateGroupConversationReturning(Either.Left(coreFailure))
+            withCreateGroupConversationReturning(CreateGroupConversationResult.Failure(coreFailure))
 
         suspend fun withCreateGroupConversationReturning(conversation: Conversation) =
-            withCreateGroupConversationReturning(Either.Right(conversation))
+            withCreateGroupConversationReturning(CreateGroupConversationResult.Success(conversation))
 
-        private suspend fun withCreateGroupConversationReturning(result: Either<CoreFailure, Conversation>) = apply {
+        suspend fun withCreateGroupConversationReturning(result: CreateGroupConversationResult) = apply {
             everySuspend {
-                conversationGroupRepository.createGroupConversation(any(), any(), any())
+                conversationGroupRepository.createGroupConversationWithPendingResult(any(), any(), any())
             } returns result
+        }
+
+        suspend fun withConversationReturning(conversation: Conversation) = apply {
+            everySuspend {
+                conversationRepository.getConversationById(conversation.id)
+            } returns Either.Right(conversation)
+        }
+
+        suspend fun withJoiningExistingMLSConversationSucceeding() = apply {
+            everySuspend {
+                joinExistingMLSConversation.invoke(any(), any())
+            } returns Either.Right(Unit)
+        }
+
+        suspend fun withTransactionInvokingBlock() = apply {
+            withTransactionReturning(Either.Right(Unit))
         }
 
         suspend fun withCurrentClientIdReturning(clientId: ClientId) = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/JoinExistingMLSConversationsUseCaseTest.kt
@@ -124,6 +124,28 @@ class JoinExistingMLSConversationsUseCaseTest {
     }
 
     @Test
+    fun givenPendingCreationConversation_whenInvokingUseCase_thenRequestToJoinConversationIsCalled() = runTest {
+        val (arrangement, joinExistingMLSConversationsUseCase) = Arrangement()
+            .withIsMLSSupported(true)
+            .withHasRegisteredMLSClient(true)
+            .withGetConversationsByGroupStateSuccessful(emptyList())
+            .withPendingCreationConversations(listOf(Arrangement.MLS_PENDING_CREATION_CONVERSATION))
+            .withJoinExistingMLSConversationSuccessful()
+            .arrange()
+
+        joinExistingMLSConversationsUseCase().shouldSucceed()
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.joinExistingMLSConversationUseCase.invoke(
+                any(),
+                eq(Arrangement.MLS_PENDING_CREATION_CONVERSATION.id),
+                any(),
+                any(),
+            )
+        }
+    }
+
+    @Test
     fun givenPendingConversationWithoutSelfMembership_whenInvokingUseCase_thenConversationIsSkipped() = runTest {
         val (arrangement, joinExistingMLSConversationsUseCase) = Arrangement()
             .withIsMLSSupported(true)
@@ -334,12 +356,21 @@ class JoinExistingMLSConversationsUseCaseTest {
                 conversationRepository.getConversationsByGroupState(eq(Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_JOIN))
             } returns Either.Right(conversations)
             withPendingAfterResetConversations(emptyList())
+            withPendingCreationConversations(emptyList())
         }
 
         suspend fun withPendingAfterResetConversations(conversations: List<Conversation>) = apply {
             everySuspend {
                 conversationRepository.getConversationsByGroupState(
                     eq(Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_AFTER_RESET)
+                )
+            } returns Either.Right(conversations)
+        }
+
+        suspend fun withPendingCreationConversations(conversations: List<Conversation>) = apply {
+            everySuspend {
+                conversationRepository.getConversationsByGroupState(
+                    eq(Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_CREATION)
                 )
             } returns Either.Right(conversations)
         }
@@ -448,6 +479,16 @@ class JoinExistingMLSConversationsUseCaseTest {
                     cipherSuite = CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
                 )
             ).copy(id = ConversationId("id-after-reset", "domain"))
+
+            val MLS_PENDING_CREATION_CONVERSATION = TestConversation.GROUP(
+                Conversation.ProtocolInfo.MLS(
+                    GroupID("group-pending-creation"),
+                    Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_CREATION,
+                    epoch = 0UL,
+                    keyingMaterialLastUpdate = DateTimeUtil.currentInstant(),
+                    cipherSuite = CipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+                )
+            ).copy(id = ConversationId("id-pending-creation", "domain"))
         }
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/RecoverPendingMLSGroupJoinsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/conversation/mls/RecoverPendingMLSGroupJoinsUseCaseTest.kt
@@ -19,6 +19,8 @@ package com.wire.kalium.logic.feature.conversation.mls
 
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCase
 import com.wire.kalium.logic.data.conversation.mls.PendingActionsRepository
 import com.wire.kalium.logic.data.id.ConversationId
@@ -57,6 +59,7 @@ class RecoverPendingMLSGroupJoinsUseCaseTest {
             .withSyncWaitResult(Either.Right(Unit))
             .withPendingConversationIds(pendingConversationIds)
             .withJoinResult(Either.Right(Unit))
+            .withConversationEstablished()
             .arrange()
 
         useCase()
@@ -90,6 +93,7 @@ class RecoverPendingMLSGroupJoinsUseCaseTest {
             .withPendingConversationIds(pendingConversationIds)
             .withJoinResult(Either.Right(Unit))
             .withJoinResultForConversation(failedConversationId, Either.Left(CoreFailure.Unknown(RuntimeException("boom"))))
+            .withConversationEstablished()
             .arrange()
 
         useCase()
@@ -99,12 +103,28 @@ class RecoverPendingMLSGroupJoinsUseCaseTest {
         }
     }
 
+    @Test
+    fun givenJoinSucceedsButConversationIsStillPending_whenInvoked_thenDoesNotAcknowledgeRecovery() = runTest {
+        val pendingConversationIds = listOf(TestConversation.ID)
+        val (arrangement, useCase) = Arrangement()
+            .withSyncWaitResult(Either.Right(Unit))
+            .withPendingConversationIds(pendingConversationIds)
+            .withJoinResult(Either.Right(Unit))
+            .withConversationPendingCreation()
+            .arrange()
+
+        useCase()
+
+        verifySuspend(VerifyMode.not) { arrangement.pendingActionsRepository.acknowledgePendingMLSGroupJoins(any()) }
+    }
+
     private class Arrangement :
         CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
 
         val pendingActionsRepository = mock<PendingActionsRepository>(mode = MockMode.autoUnit)
         val syncStateObserver = mock<SyncStateObserver>(mode = MockMode.autoUnit)
         val joinExistingMLSConversation = mock<JoinExistingMLSConversationUseCase>(mode = MockMode.autoUnit)
+        val conversationRepository = mock<ConversationRepository>(mode = MockMode.autoUnit)
 
         suspend fun withSyncWaitResult(result: Either<CoreFailure, Unit>) = apply {
             everySuspend { syncStateObserver.waitUntilLiveOrFailure() } returns result
@@ -138,12 +158,26 @@ class RecoverPendingMLSGroupJoinsUseCaseTest {
             } returns result
         }
 
+        suspend fun withConversationEstablished() = withConversationGroupState(
+            Conversation.ProtocolInfo.MLSCapable.GroupState.ESTABLISHED
+        )
+
+        suspend fun withConversationPendingCreation() = withConversationGroupState(
+            Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_CREATION
+        )
+
+        private suspend fun withConversationGroupState(groupState: Conversation.ProtocolInfo.MLSCapable.GroupState) = apply {
+            val conversation = TestConversation.GROUP(TestConversation.MLS_PROTOCOL_INFO.copy(groupState = groupState))
+            everySuspend { conversationRepository.getConversationById(any()) } returns Either.Right(conversation)
+        }
+
         suspend fun arrange(): Pair<Arrangement, RecoverPendingMLSGroupJoinsUseCase> = this to
             RecoverPendingMLSGroupJoinsUseCaseImpl(
                 pendingActionsRepository = pendingActionsRepository,
                 syncStateObserver = syncStateObserver,
                 transactionProvider = cryptoTransactionProvider,
-                joinExistingMLSConversation = joinExistingMLSConversation
+                joinExistingMLSConversation = joinExistingMLSConversation,
+                conversationRepository = conversationRepository,
             )
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-27337
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When creating an MLS group, the backend conversation is persisted before the MLS group is established. If MLS establishment fails, the conversation remains in `PENDING_CREATION`.

Retrying the creation flow could create another backend conversation instead of recovering the existing one.

### Causes

The MLS establishment failure was returned as a generic creation failure. The existing conversation ID was not exposed to the caller and there was no durable recovery action for it.

### Solutions

- Return a dedicated pending-creation result containing the existing conversation ID.
- Add an API for retrying MLS establishment using that conversation.
- Store pending MLS group joins in the pending-actions queue.
- Recover queued conversations when the recovery mechanism runs.
- Consider recovery successful and remove the pending action only after the conversation reaches `ESTABLISHED`.
- Keep the pending action when MLS establishment fails or the conversation remains pending.
- Add automated tests for creation failure, manual retry and queued recovery.