### PR TITLE
fix: call does not end correctly after mls reset (WPB-26540)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/CallRepository.kt
@@ -355,15 +355,25 @@ internal class CallDataSource(
         }
     }
 
-    override suspend fun updateCallStatusById(conversationId: ConversationId, status: CallStatus) {
+    override suspend fun updateCallStatusById(
+        conversationId: ConversationId,
+        status: CallStatus
+    ) = mutexProvider.withLock(conversationId) {
+
+        val currentStatus = _callMetadataProfile.value[conversationId]?.callStatus
+
+        if (currentStatus == CallStatus.CLOSED && status != CallStatus.CLOSED) {
+            return@withLock
+        }
+
         updateCallStatusInDatabaseById(conversationId, status)
 
-        _callMetadataProfile.update(conversationId) { callMetadata ->
-            callMetadata.copy(
+        _callMetadataProfile.update(conversationId) { metadata ->
+            metadata.copy(
                 callStatus = status,
                 establishedTime = when (status) {
                     CallStatus.ESTABLISHED -> DateTimeUtil.currentInstant()
-                    else -> callMetadata.establishedTime
+                    else -> metadata.establishedTime
                 },
             )
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/EndCallOnMLSResetUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/call/EndCallOnMLSResetUseCase.kt
@@ -1,0 +1,25 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.data.call
+
+import com.wire.kalium.logic.data.id.ConversationId
+
+internal interface EndCallOnMLSResetUseCase {
+    suspend operator fun invoke(conversationId: ConversationId)
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt
@@ -34,12 +34,12 @@ import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.cryptography.CryptoTransactionContext
 import com.wire.kalium.cryptography.MlsCoreCryptoContext
 import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.data.call.EndCallOnMLSResetUseCase
 import com.wire.kalium.logic.data.client.CryptoTransactionProvider
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.toCrypto
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.feature.call.usecase.EndCallOnMLSResetUseCase
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.network.api.authenticated.conversation.ConvProtocol
 import com.wire.kalium.network.api.authenticated.conversation.ConversationResponse as NetworkConversationResponse

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCase.kt
@@ -39,6 +39,7 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.toCrypto
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.call.usecase.EndCallOnMLSResetUseCase
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.network.api.authenticated.conversation.ConvProtocol
 import com.wire.kalium.network.api.authenticated.conversation.ConversationResponse as NetworkConversationResponse
@@ -79,6 +80,7 @@ internal class ResetMLSConversationUseCaseImpl(
     private val conversationRepository: ConversationRepository,
     private val mlsConversationRepository: MLSConversationRepository,
     private val fetchConversationUseCase: FetchConversationUseCase,
+    private val endCallOnMLSReset: EndCallOnMLSResetUseCase,
     private val kaliumConfigs: KaliumConfigs,
 ) : ResetMLSConversationUseCase {
 
@@ -186,7 +188,7 @@ internal class ResetMLSConversationUseCaseImpl(
         localGroupId: GroupID,
         epoch: ULong,
     ): Either<CoreFailure, Unit> =
-        performReset(mlsContext, localGroupId, epoch)
+        performReset(conversationId, mlsContext, localGroupId, epoch)
             .flatMapLeft { failure ->
                 if (!failure.isMlsStaleMessageConflict()) return@flatMapLeft failure.left()
 
@@ -225,7 +227,7 @@ internal class ResetMLSConversationUseCaseImpl(
                     ).left()
                 }
 
-                performReset(mlsContext, localGroupId, remoteInfo.epoch)
+                performReset(conversationId, mlsContext, localGroupId, remoteInfo.epoch)
                     .flatMapLeft { retryFailure ->
                         if (!retryFailure.isMlsStaleMessageConflict()) return@flatMapLeft retryFailure.left()
                         retryResetWithRemoteInfo(
@@ -238,12 +240,14 @@ internal class ResetMLSConversationUseCaseImpl(
             }
 
     private suspend fun performReset(
+        conversationId: ConversationId,
         mlsContext: MlsCoreCryptoContext,
         localGroupId: GroupID,
         epoch: ULong
     ): Either<CoreFailure, Unit> =
         conversationRepository.resetMlsConversation(localGroupId, epoch)
             .onSuccess {
+                endCallOnMLSReset(conversationId)
                 // the result of the leave can be ignored
                 mlsConversationRepository.leaveGroup(mlsContext, localGroupId)
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -246,6 +246,8 @@ import com.wire.kalium.logic.feature.call.usecase.ConversationClientsInCallUpdat
 import com.wire.kalium.logic.feature.call.usecase.ConversationClientsInCallUpdaterImpl
 import com.wire.kalium.logic.feature.call.usecase.CreateAndPersistRecentlyEndedCallMetadataUseCase
 import com.wire.kalium.logic.feature.call.usecase.CreateAndPersistRecentlyEndedCallMetadataUseCaseImpl
+import com.wire.kalium.logic.feature.call.usecase.EndCallOnMLSResetUseCase
+import com.wire.kalium.logic.feature.call.usecase.EndCallOnMLSResetUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.EpochInfoUpdater
 import com.wire.kalium.logic.feature.call.usecase.EpochInfoUpdaterImpl
 import com.wire.kalium.logic.feature.call.usecase.GetCallConversationTypeProvider
@@ -1758,6 +1760,13 @@ public class UserSessionScope internal constructor(
         )
     }
 
+    private val endCallOnMLSReset: EndCallOnMLSResetUseCase by lazy {
+        EndCallOnMLSResetUseCaseImpl(
+            callManager = callManager,
+            callRepository = callRepository,
+        )
+    }
+
     internal val callBackgroundManager: CallBackgroundManager = CallBackgroundManagerImpl(
         callManager = callManager,
         syncStateObserver = syncStateObserver,
@@ -2077,6 +2086,7 @@ public class UserSessionScope internal constructor(
     private val mlsResetConversationEventHandler: MLSResetConversationEventHandler
         get() = MLSResetConversationEventHandlerImpl(
             mlsConversationRepository = mlsConversationRepository,
+            endCallOnMLSReset = endCallOnMLSReset,
         )
 
     private val conversationEventReceiver: ConversationEventReceiver by lazy {
@@ -2950,6 +2960,7 @@ public class UserSessionScope internal constructor(
             conversationRepository = conversationRepository,
             mlsConversationRepository = mlsConversationRepository,
             fetchConversationUseCase = fetchConversationUseCase,
+            endCallOnMLSReset = endCallOnMLSReset,
             kaliumConfigs = kaliumConfigs,
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -56,6 +56,7 @@ import com.wire.kalium.logic.data.call.CallDataSource
 import com.wire.kalium.logic.data.call.CallModerationActionsDataSource
 import com.wire.kalium.logic.data.call.CallModerationActionsRepository
 import com.wire.kalium.logic.data.call.CallRepository
+import com.wire.kalium.logic.data.call.EndCallOnMLSResetUseCase
 import com.wire.kalium.logic.data.call.InCallReactionsDataSource
 import com.wire.kalium.logic.data.call.InCallReactionsRepository
 import com.wire.kalium.logic.data.call.VideoStateChecker
@@ -246,7 +247,6 @@ import com.wire.kalium.logic.feature.call.usecase.ConversationClientsInCallUpdat
 import com.wire.kalium.logic.feature.call.usecase.ConversationClientsInCallUpdaterImpl
 import com.wire.kalium.logic.feature.call.usecase.CreateAndPersistRecentlyEndedCallMetadataUseCase
 import com.wire.kalium.logic.feature.call.usecase.CreateAndPersistRecentlyEndedCallMetadataUseCaseImpl
-import com.wire.kalium.logic.feature.call.usecase.EndCallOnMLSResetUseCase
 import com.wire.kalium.logic.feature.call.usecase.EndCallOnMLSResetUseCaseImpl
 import com.wire.kalium.logic.feature.call.usecase.EpochInfoUpdater
 import com.wire.kalium.logic.feature.call.usecase.EpochInfoUpdaterImpl

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnMLSResetUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnMLSResetUseCase.kt
@@ -1,0 +1,51 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.call.usecase
+
+import com.wire.kalium.logic.data.call.CallRepository
+import com.wire.kalium.logic.data.call.CallStatus
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.feature.call.CallManager
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+internal interface EndCallOnMLSResetUseCase {
+    suspend operator fun invoke(conversationId: ConversationId)
+}
+
+@Suppress("TooGenericExceptionCaught")
+internal class EndCallOnMLSResetUseCaseImpl(
+    private val callManager: Lazy<CallManager>,
+    private val callRepository: CallRepository,
+) : EndCallOnMLSResetUseCase {
+
+    private val mutex = Mutex()
+
+    override suspend fun invoke(conversationId: ConversationId) = mutex.withLock {
+
+        val hasActiveCall = callRepository.activeCallsFlow().first().any { it.conversationId == conversationId }
+
+        if (!hasActiveCall) return@withLock
+
+        callRepository.updateCallStatusById(conversationId, CallStatus.CLOSED)
+        callRepository.updateIsCameraOnById(conversationId, false)
+        callManager.value.endCall(conversationId)
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnMLSResetUseCaseImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnMLSResetUseCaseImpl.kt
@@ -20,15 +20,12 @@ package com.wire.kalium.logic.feature.call.usecase
 
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.CallStatus
+import com.wire.kalium.logic.data.call.EndCallOnMLSResetUseCase
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.call.CallManager
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-
-internal interface EndCallOnMLSResetUseCase {
-    suspend operator fun invoke(conversationId: ConversationId)
-}
 
 @Suppress("TooGenericExceptionCaught")
 internal class EndCallOnMLSResetUseCaseImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSenderImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/message/MessageSenderImpl.kt
@@ -187,7 +187,15 @@ internal class MessageSenderImpl internal constructor(
             .flatMap { protocolInfo ->
                 when (protocolInfo) {
                     is Conversation.ProtocolInfo.MLS -> {
-                        attemptToSendWithMLS(transactionContext, protocolInfo, message)
+                        if (
+                            message.content is MessageContent.Calling &&
+                            protocolInfo.groupState == Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_AFTER_RESET
+                        ) {
+                            logger.i("Skipping calling message while MLS reset is pending")
+                            Either.Right(message.date)
+                        } else {
+                            attemptToSendWithMLS(transactionContext, protocolInfo, message)
+                        }
                     }
 
                     is Conversation.ProtocolInfo.Proteus, is Conversation.ProtocolInfo.Mixed -> {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSResetConversationEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSResetConversationEventHandler.kt
@@ -19,9 +19,9 @@ package com.wire.kalium.logic.sync.receiver.conversation
 
 import com.wire.kalium.common.functional.getOrElse
 import com.wire.kalium.cryptography.CryptoTransactionContext
+import com.wire.kalium.logic.data.call.EndCallOnMLSResetUseCase
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.event.Event
-import com.wire.kalium.logic.feature.call.usecase.EndCallOnMLSResetUseCase
 import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 
 internal interface MLSResetConversationEventHandler {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSResetConversationEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSResetConversationEventHandler.kt
@@ -21,6 +21,7 @@ import com.wire.kalium.common.functional.getOrElse
 import com.wire.kalium.cryptography.CryptoTransactionContext
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.feature.call.usecase.EndCallOnMLSResetUseCase
 import com.wire.kalium.persistence.dao.conversation.ConversationEntity
 
 internal interface MLSResetConversationEventHandler {
@@ -29,8 +30,10 @@ internal interface MLSResetConversationEventHandler {
 
 internal class MLSResetConversationEventHandlerImpl(
     private val mlsConversationRepository: MLSConversationRepository,
+    private val endCallOnMLSReset: EndCallOnMLSResetUseCase,
 ) : MLSResetConversationEventHandler {
     override suspend fun handle(transaction: CryptoTransactionContext, event: Event.Conversation.MLSReset) {
+        endCallOnMLSReset(event.conversationId)
 
         transaction.mls?.let { mlsContext ->
             mlsConversationRepository.leaveGroup(mlsContext, event.groupID)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/call/CallRepositoryTest.kt
@@ -864,6 +864,26 @@ class CallRepositoryTest {
     }
 
     @Test
+    fun givenClosedCall_whenUpdatingToActiveStatus_thenKeepCallClosed() = runTest {
+        val (arrangement, callRepository) = Arrangement(testDispatcher.testKaliumDispatcher())
+            .withInitialCallMetadataProfile(
+                CallMetadataProfile(
+                    data = mapOf(
+                        Arrangement.conversationId to createCallMetadata().copy(callStatus = CallStatus.CLOSED)
+                    )
+                )
+            )
+            .arrange()
+
+        callRepository.updateCallStatusById(Arrangement.conversationId, CallStatus.STILL_ONGOING)
+
+        assertEquals(CallStatus.CLOSED, callRepository.getCallMetadata(Arrangement.conversationId)?.callStatus)
+        verifySuspend(VerifyMode.not) {
+            arrangement.callDAO.updateLastCallStatusByConversationId(any(), any())
+        }
+    }
+
+    @Test
     fun givenAConversationIdThatDoesNotExistsInTheFlow_whenUpdateCallStatusIsCalled_thenUpdateTheStatus() = runTest {
         val (arrangement, callRepository) = Arrangement(testDispatcher.testKaliumDispatcher()).arrange()
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCaseTest.kt
@@ -36,6 +36,7 @@ import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.conversation.mls.MLSAdditionResult
 import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.call.usecase.EndCallOnMLSResetUseCase
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
@@ -115,6 +116,10 @@ class ResetMLSConversationUseCaseTest {
         verifySuspend(VerifyMode.not) {
             arrangement.conversationRepository.resetMlsConversation(any(), any())
         }
+
+        verifySuspend(VerifyMode.not) {
+            arrangement.endCallOnMLSReset(any())
+        }
     }
 
     @Test
@@ -128,6 +133,49 @@ class ResetMLSConversationUseCaseTest {
 
         verifySuspend(VerifyMode.exactly(1)) {
             arrangement.conversationRepository.resetMlsConversation(any(), any())
+        }
+    }
+
+    @Test
+    fun givenResetIsAccepted_whenUseCaseCalled_thenCallIsEndedBeforeLeavingGroup() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withFeatureEnabled()
+            .arrange()
+
+        useCase(TEST_CONVERSATION_ID)
+
+        verifySuspend(VerifyMode.order) {
+            arrangement.conversationRepository.resetMlsConversation(any(), any())
+            arrangement.endCallOnMLSReset(eq(TEST_CONVERSATION_ID))
+            arrangement.mlsConversationRepository.leaveGroup(any(), any())
+        }
+    }
+
+    @Test
+    fun givenResetFails_whenUseCaseCalled_thenCallIsNotEnded() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withFeatureEnabled()
+            .withResetMlsConversationResponses(NetworkFailure.NoNetworkConnection(null).left())
+            .arrange()
+
+        useCase(TEST_CONVERSATION_ID)
+
+        verifySuspend(VerifyMode.not) {
+            arrangement.endCallOnMLSReset(any())
+        }
+    }
+
+    @Test
+    fun givenResetIsAcceptedAndConversationSyncFails_whenUseCaseCalled_thenCallIsStillEnded() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withFeatureEnabled()
+            .withFetchConversationResult(NetworkFailure.NoNetworkConnection(null).left())
+            .arrange()
+
+        useCase(TEST_CONVERSATION_ID)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.endCallOnMLSReset(eq(TEST_CONVERSATION_ID))
         }
     }
 
@@ -167,6 +215,10 @@ class ResetMLSConversationUseCaseTest {
 
         verifySuspend(VerifyMode.exactly(1)) {
             arrangement.conversationRepository.resetMlsConversation(eq(TestConversation.GROUP_ID), eq(remoteEpoch))
+        }
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.endCallOnMLSReset(eq(TEST_CONVERSATION_ID))
         }
     }
 
@@ -388,6 +440,7 @@ class ResetMLSConversationUseCaseTest {
         val conversationRepository: ConversationRepository = mock(mode = MockMode.autoUnit)
         val mlsConversationRepository: MLSConversationRepository = mock(mode = MockMode.autoUnit)
         val fetchConversationUseCase: FetchConversationUseCase = mock(mode = MockMode.autoUnit)
+        val endCallOnMLSReset: EndCallOnMLSResetUseCase = mock(mode = MockMode.autoUnit)
         var kaliumConfigs = KaliumConfigs(isMlsResetEnabled = true)
         private var remoteConversationResponses: List<ConversationResponse> = listOf(TestConversation.CONVERSATION_RESPONSE.copy(
             protocol = ConvProtocol.MLS,
@@ -396,6 +449,7 @@ class ResetMLSConversationUseCaseTest {
         ))
         private var resetConversationResults: List<Either<NetworkFailure, Unit>> = listOf(Unit.right())
         private var conversations: List<Conversation> = listOf(TestConversation.MLS_CONVERSATION)
+        private var fetchConversationResult: Either<CoreFailure, Unit> = Unit.right()
 
         fun withCompileTimeFlagDisabled() = apply {
             kaliumConfigs = kaliumConfigs.copy(isMlsResetEnabled = false)
@@ -444,6 +498,10 @@ class ResetMLSConversationUseCaseTest {
 
         fun withResetMlsConversationResponses(vararg results: Either<NetworkFailure, Unit>) = apply {
             resetConversationResults = results.toList()
+        }
+
+        fun withFetchConversationResult(result: Either<CoreFailure, Unit>) = apply {
+            fetchConversationResult = result
         }
 
         fun withLeaveGroupFailing() = apply {
@@ -513,7 +571,7 @@ class ResetMLSConversationUseCaseTest {
 
             everySuspend {
                 fetchConversationUseCase(any(), any(), reason = eq(ConversationSyncReason.ConversationReset))
-            } returns Unit.right()
+            } returns fetchConversationResult
 
             everySuspend {
                 conversationRepository.getConversationMembers(any())
@@ -526,6 +584,7 @@ class ResetMLSConversationUseCaseTest {
                 conversationRepository = conversationRepository,
                 mlsConversationRepository = mlsConversationRepository,
                 fetchConversationUseCase = fetchConversationUseCase,
+                endCallOnMLSReset = endCallOnMLSReset,
                 kaliumConfigs = kaliumConfigs,
             )
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/conversation/ResetMLSConversationUseCaseTest.kt
@@ -33,10 +33,10 @@ import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import dev.mokkery.answering.calls
 import com.wire.kalium.logic.configuration.UserConfigRepository
+import com.wire.kalium.logic.data.call.EndCallOnMLSResetUseCase
 import com.wire.kalium.logic.data.conversation.mls.MLSAdditionResult
 import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.feature.call.usecase.EndCallOnMLSResetUseCase
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnMLSResetUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnMLSResetUseCaseTest.kt
@@ -1,0 +1,154 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.logic.feature.call.usecase
+
+import com.wire.kalium.logic.data.call.Call
+import com.wire.kalium.logic.data.call.CallRepository
+import com.wire.kalium.logic.data.call.CallStatus
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.feature.call.CallManager
+import com.wire.kalium.logic.framework.TestCall
+import dev.mokkery.MockMode
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.matcher.eq
+import dev.mokkery.mock
+import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class EndCallOnMLSResetUseCaseTest {
+
+    @Test
+    fun givenActiveOneOnOneCall_whenInvoked_thenCallIsClosedAndEnded() = runTest {
+        val call = TestCall.oneOnOneEstablishedCall()
+        val (arrangement, useCase) = Arrangement().arrange(listOf(call))
+
+        useCase(call.conversationId)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.callRepository.updateCallStatusById(eq(call.conversationId), eq(CallStatus.CLOSED))
+        }
+        verify(VerifyMode.exactly(1)) {
+            arrangement.callRepository.updateIsCameraOnById(eq(call.conversationId), eq(false))
+        }
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.callManager.endCall(eq(call.conversationId))
+        }
+    }
+
+    @Test
+    fun givenAnsweredGroupCall_whenInvoked_thenCallIsClosedAndEnded() = runTest {
+        val call = TestCall.oneOnOneEstablishedCall().copy(
+            status = CallStatus.ANSWERED,
+            conversationType = Conversation.Type.Group.Regular,
+        )
+        val (arrangement, useCase) = Arrangement().arrange(listOf(call))
+
+        useCase(call.conversationId)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.callRepository.updateCallStatusById(eq(call.conversationId), eq(CallStatus.CLOSED))
+        }
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.callManager.endCall(eq(call.conversationId))
+        }
+    }
+
+    @Test
+    fun givenNoActiveCallForConversation_whenInvoked_thenNothingIsChanged() = runTest {
+        val call = TestCall.oneOnOneEstablishedCall()
+        val (arrangement, useCase) = Arrangement().arrange(emptyList())
+
+        useCase(call.conversationId)
+
+        verifySuspend(VerifyMode.not) {
+            arrangement.callRepository.updateCallStatusById(any(), any())
+        }
+        verify(VerifyMode.not) {
+            arrangement.callRepository.updateIsCameraOnById(any(), any())
+        }
+        verifySuspend(VerifyMode.not) {
+            arrangement.callManager.endCall(any())
+        }
+    }
+
+    @Test
+    fun givenConcurrentInvocationsForTheSameCall_whenInvoked_thenCallIsEndedOnce() = runTest {
+        val call = TestCall.oneOnOneEstablishedCall()
+        val (arrangement, useCase) = Arrangement().arrange(listOf(call))
+
+        awaitAll(
+            async { useCase(call.conversationId) },
+            async { useCase(call.conversationId) },
+        )
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.callManager.endCall(eq(call.conversationId))
+        }
+    }
+
+    private class Arrangement {
+        val callRepository = mock<CallRepository>(mode = MockMode.autoUnit)
+        val callManager = mock<CallManager>(mode = MockMode.autoUnit)
+        private val activeCalls = MutableStateFlow<List<Call>>(emptyList())
+
+        suspend fun arrange(
+            calls: List<Call>,
+            endCallFailure: Exception? = null,
+            updateStatusFailure: Exception? = null,
+        ): Pair<Arrangement, EndCallOnMLSResetUseCase> {
+            activeCalls.value = calls
+            every { callRepository.activeCallsFlow() } returns activeCalls
+            every { callRepository.updateIsCameraOnById(any(), any()) } returns Unit
+
+            if (updateStatusFailure == null) {
+                everySuspend {
+                    callRepository.updateCallStatusById(any(), any())
+                } calls {
+                    activeCalls.value = emptyList()
+                }
+            } else {
+                everySuspend {
+                    callRepository.updateCallStatusById(any(), any())
+                } throws updateStatusFailure
+            }
+
+            if (endCallFailure == null) {
+                everySuspend { callManager.endCall(any()) } returns Unit
+            } else {
+                everySuspend { callManager.endCall(any()) } throws endCallFailure
+            }
+
+            return this to EndCallOnMLSResetUseCaseImpl(
+                callManager = lazy { callManager },
+                callRepository = callRepository,
+            )
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnMLSResetUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/call/usecase/EndCallOnMLSResetUseCaseTest.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.logic.feature.call.usecase
 import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.call.CallRepository
 import com.wire.kalium.logic.data.call.CallStatus
+import com.wire.kalium.logic.data.call.EndCallOnMLSResetUseCase
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.feature.call.CallManager
 import com.wire.kalium.logic.framework.TestCall

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/message/MessageSenderTest.kt
@@ -378,6 +378,40 @@ class MessageSenderTest {
     }
 
     @Test
+    fun givenCallingMessageWhileMLSResetIsPending_whenSending_thenSkipMLSMessageCreationAndSending() {
+        val pendingResetProtocolInfo = Arrangement.MLS_PROTOCOL_INFO.copy(
+            groupState = Conversation.ProtocolInfo.MLSCapable.GroupState.PENDING_AFTER_RESET
+        )
+        val message = Message.Signaling(
+            id = Arrangement.TEST_MESSAGE_UUID,
+            content = MessageContent.Calling("calling-message"),
+            conversationId = Arrangement.TEST_CONVERSATION_ID,
+            date = TestMessage.TEST_DATE,
+            senderUserId = TestUser.SELF.id,
+            senderClientId = ClientId("clientId"),
+            status = Message.Status.Pending,
+            isSelfMessage = true,
+            expirationData = null
+        )
+        val (arrangement, messageSender) = arrange {
+            withGetProtocolInfo(pendingResetProtocolInfo)
+            withPromoteMessageToSentUpdatingServerTime()
+        }
+
+        arrangement.testScope.runTest {
+            val result = messageSender.sendMessage(message)
+
+            result.shouldSucceed()
+            verifySuspend(VerifyMode.not) {
+                arrangement.mlsMessageCreator.prepareMLSGroupAndCreateOutgoingMLSMessage(any(), any(), any())
+            }
+            verifySuspend(VerifyMode.not) {
+                arrangement.messageRepository.sendMLSMessage(any())
+            }
+        }
+    }
+
+    @Test
     fun givenReceivingStaleMessageError_whenSendingMlsMessage_thenRetryAfterSyncIsLive() {
         // given
         val (arrangement, messageSender) = arrange {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSResetConversationEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSResetConversationEventHandlerTest.kt
@@ -24,11 +24,13 @@ import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.id.GroupID
+import com.wire.kalium.logic.feature.call.usecase.EndCallOnMLSResetUseCase
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMokkeryImpl
 import com.wire.kalium.persistence.dao.conversation.ConversationEntity
+import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
@@ -44,12 +46,16 @@ import kotlin.test.Test
 class MLSResetConversationEventHandlerTest {
 
     @Test
-    fun givenMLSContextIsNull_whenHandlingEvent_thenShouldDoNothing() = runTest {
+    fun givenMLSContextIsNull_whenHandlingEvent_thenShouldOnlyEndCall() = runTest {
         val (arrangement, handler) = arrange {
             withMLSContextNull()
         }
 
         handler.handle(arrangement.transactionContext, MLS_RESET_EVENT)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.endCallOnMLSReset(eq(CONVERSATION_ID))
+        }
 
         verifySuspend(VerifyMode.not) {
             arrangement.mlsConversationRepository.leaveGroup(any(), any())
@@ -219,7 +225,8 @@ class MLSResetConversationEventHandlerTest {
 
         handler.handle(arrangement.transactionContext, MLS_RESET_EVENT)
 
-        verifySuspend(VerifyMode.exactly(1)) {
+        verifySuspend(VerifyMode.order) {
+            arrangement.endCallOnMLSReset(eq(CONVERSATION_ID))
             arrangement.mlsConversationRepository.leaveGroup(any(), eq(GROUP_ID))
         }
 
@@ -241,6 +248,7 @@ class MLSResetConversationEventHandlerTest {
         CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMokkeryImpl() {
 
         val mlsConversationRepository = mock<MLSConversationRepository>()
+        val endCallOnMLSReset = mock<EndCallOnMLSResetUseCase>(mode = MockMode.autoUnit)
 
         suspend fun withLeaveGroupSucceeding() = apply {
             everySuspend {
@@ -291,7 +299,8 @@ class MLSResetConversationEventHandlerTest {
         suspend fun arrange() = run {
             block()
             this@Arrangement to MLSResetConversationEventHandlerImpl(
-                mlsConversationRepository = mlsConversationRepository
+                mlsConversationRepository = mlsConversationRepository,
+                endCallOnMLSReset = endCallOnMLSReset,
             )
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSResetConversationEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSResetConversationEventHandlerTest.kt
@@ -21,10 +21,10 @@ import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.MLSFailure
 import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.call.EndCallOnMLSResetUseCase
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.data.id.GroupID
-import com.wire.kalium.logic.feature.call.usecase.EndCallOnMLSResetUseCase
 import com.wire.kalium.logic.framework.TestConversation
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26540
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-26540
----

# What's new in this PR?

### Issues

Resetting an MLS conversation during an active call could leave participants in a stale call state, show an incorrect Join button, or prevent new messages from being received after the reset.

### Causes (Optional)

The call remained active while the old MLS group was removed. Late AVS status callbacks could restore an active call status, and call-end signaling sent while the MLS group was pending reset could interfere with group re-establishment.

### Solutions

- End any active call when an MLS reset is accepted locally or received remotely. 
- Keep CLOSED as a terminal call status to ignore late callbacks.
- Skip calling messages while the MLS conversation is in PENDING_AFTER_RESET