### PR TITLE
fix: handle expired session during token refresh [WPB-19677]

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/network/SessionManagerImpl.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/network/SessionManagerImpl.kt
@@ -47,6 +47,7 @@ import com.wire.kalium.network.session.SessionManager
 import com.wire.kalium.persistence.client.AuthTokenStorage
 import com.wire.kalium.util.KaliumDispatcherImpl
 import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
@@ -105,8 +106,10 @@ internal class SessionManagerImpl internal constructor(
                         cookieLabel = refreshResult.cookieLabel
                     )
                 }.fold({
-                    if (it is NetworkFailure.ServerMiscommunication) {
-                        onServerMissCommunication(it)
+                    val sessionInvalidated = it is NetworkFailure.ServerMiscommunication &&
+                            handleSessionInvalidatingFailure(it)
+                    if (sessionInvalidated) {
+                        throw CancellationException("Session was invalidated during auth token refresh")
                     }
                     val message = "Failure during auth token refresh. " +
                             "A network request is failing because of this. " +
@@ -119,14 +122,23 @@ internal class SessionManagerImpl internal constructor(
         }
     }
 
-    private suspend fun onServerMissCommunication(serverMiscommunication: NetworkFailure.ServerMiscommunication) {
-        with(serverMiscommunication.kaliumException) {
-            if (this is KaliumException.InvalidRequestError) {
-                if (this.errorResponse.code == HttpStatusCode.Forbidden.value)
-                    onSessionExpired()
-                if (this.isUnknownClient())
-                    onClientRemoved()
+    private suspend fun handleSessionInvalidatingFailure(
+        serverMiscommunication: NetworkFailure.ServerMiscommunication
+    ): Boolean {
+        val exception = serverMiscommunication.kaliumException as? KaliumException.InvalidRequestError
+            ?: return false
+        return when {
+            exception.isUnknownClient() -> {
+                onClientRemoved()
+                true
             }
+
+            exception.errorResponse.code == HttpStatusCode.Forbidden.value -> {
+                onSessionExpired()
+                true
+            }
+
+            else -> false
         }
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/network/SessionManagerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/network/SessionManagerTest.kt
@@ -32,6 +32,7 @@ import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.feature.session.token.AccessTokenRefresher
 import com.wire.kalium.logic.feature.session.token.AccessTokenRefresherFactory
 import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.test_util.TestNetworkException
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.network.api.base.authenticated.AccessTokenApi
@@ -51,6 +52,7 @@ import dev.mokkery.matcher.eq
 import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.Test
@@ -70,6 +72,19 @@ class SessionManagerTest {
         assertFailsWith<FailureToRefreshTokenException> {
             sessionManager.updateToken(arrangement.accessTokenApi, "egal")
         }
+    }
+
+    @Test
+    fun givenInvalidCredentialsOnRefresh_whenRefreshingToken_thenShouldExpireSessionWithoutRetryableFailure() = runTest {
+        val failure = NetworkFailure.ServerMiscommunication(TestNetworkException.invalidCredentials)
+        val (arrangement, sessionManager) = arrange {
+            withTokenRefresherResult(Either.Left(failure))
+        }
+
+        assertFailsWith<CancellationException> {
+            sessionManager.updateToken(arrangement.accessTokenApi, "refreshToken")
+        }
+        assertEquals(listOf(LogoutReason.SESSION_EXPIRED), arrangement.logoutReasons)
     }
 
     @Test
@@ -230,7 +245,8 @@ class SessionManagerTest {
         private val userId = TestUser.USER_ID
         private val tokenStorage = mock<AuthTokenStorage>()
 
-        private val logout = { _: LogoutReason -> }
+        val logoutReasons = mutableListOf<LogoutReason>()
+        private val logout = { reason: LogoutReason -> logoutReasons += reason }
         private val serverConfigMapper = mock<ServerConfigMapper>()
 
         private val sessionMapper = MapperProvider.sessionMapper()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-19677
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When the backend invalidates an expired session, refreshing the access token returns:

`403 invalid-credentials / Invalid zauth token`

Kalium correctly triggers logout with `SESSION_EXPIRED`, but then propagates the same error as `FailureToRefreshTokenException`.

This makes the terminal authentication failure look like a retryable `ServerMiscommunication`, which can leave the client showing “Waiting for network” even though connectivity is available.

### Solution

- Treat session-invalidating token refresh failures as terminal.
- Stop propagating them as retryable network failures after logout starts.
- Preserve `REMOVED_CLIENT` handling for `unknown-client`.
- Prevent the same response from triggering multiple logout paths.