### PR TITLE
feat: handle meeting creation events [WPB-26734]

### DIFF
--- a/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/notification/EventContentDTO.kt
+++ b/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/notification/EventContentDTO.kt
@@ -43,6 +43,7 @@ import com.wire.kalium.network.api.authenticated.notification.user.RemoveClientE
 import com.wire.kalium.network.api.authenticated.notification.user.UserUpdateEventData
 import com.wire.kalium.network.api.authenticated.properties.LabelListResponseDTO
 import com.wire.kalium.network.api.model.ConversationId
+import com.wire.kalium.network.api.model.MeetingId
 import com.wire.kalium.network.api.model.TeamId
 import com.wire.kalium.network.api.model.UserId
 import com.wire.kalium.network.tools.KtxSerializer
@@ -189,6 +190,15 @@ sealed class EventContentDTO {
         @Serializable
         @SerialName("conversation.create")
         data class NewConversationDTO(
+            @SerialName("qualified_conversation") val qualifiedConversation: ConversationId,
+            @SerialName("qualified_from") val qualifiedFrom: UserId,
+            @SerialName("time") val time: Instant,
+            @SerialName("data") val data: ConversationResponse,
+        ) : Conversation()
+
+        @Serializable
+        @SerialName("conversation.create-meeting")
+        data class NewMeetingConversationDTO(
             @SerialName("qualified_conversation") val qualifiedConversation: ConversationId,
             @SerialName("qualified_from") val qualifiedFrom: UserId,
             @SerialName("time") val time: Instant,
@@ -484,6 +494,16 @@ sealed class EventContentDTO {
 
     @Serializable
     data class Unknown(val type: String? = null) : EventContentDTO()
+
+    @Serializable
+    sealed class Meeting : EventContentDTO() {
+        @Serializable
+        @SerialName("meeting.create")
+        data class MeetingCreateDTO(
+            @SerialName("qualified_id") val qualifiedMeetingId: MeetingId,
+            @SerialName("time") val time: Instant,
+        ) : Meeting()
+    }
 }
 
 @OptIn(ExperimentalSerializationApi::class, InternalSerializationApi::class)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/meeting/MeetingApi.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/meeting/MeetingApi.kt
@@ -28,6 +28,7 @@ import com.wire.kalium.network.utils.NetworkResponse
 @Suppress("TooManyFunctions")
 interface MeetingApi : BaseApi {
     suspend fun fetchMeetings(): NetworkResponse<List<MeetingDTO>>
+    suspend fun fetchMeeting(meetingId: MeetingId): NetworkResponse<MeetingDTO>
     suspend fun deleteMeeting(meetingId: MeetingId): NetworkResponse<Unit>
     suspend fun createNewMeeting(request: UpsertMeetingRequest): NetworkResponse<UpsertMeetingResponse>
     suspend fun updateMeeting(meetingId: MeetingId, request: UpsertMeetingRequest): NetworkResponse<UpsertMeetingResponse>

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/MeetingApiV0.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/MeetingApiV0.kt
@@ -31,6 +31,9 @@ internal open class MeetingApiV0 internal constructor() : MeetingApi {
     override suspend fun fetchMeetings(): NetworkResponse<List<MeetingDTO>> =
         getApiNotSupportedError("fetchMeetings", MIN_API_VERSION_MEETINGS)
 
+    override suspend fun fetchMeeting(meetingId: MeetingId): NetworkResponse<MeetingDTO> =
+        getApiNotSupportedError("fetchMeeting", MIN_API_VERSION_MEETINGS)
+
     override suspend fun deleteMeeting(meetingId: MeetingId): NetworkResponse<Unit> =
         getApiNotSupportedError("deleteMeeting", MIN_API_VERSION_MEETINGS)
 

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v16/authenticated/MeetingApiV16.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v16/authenticated/MeetingApiV16.kt
@@ -45,6 +45,10 @@ internal open class MeetingApiV16 internal constructor(
         httpClient.delete("$PATH_MEETINGS/${meetingId.domain}/${meetingId.value}")
     }
 
+    override suspend fun fetchMeeting(meetingId: MeetingId): NetworkResponse<MeetingDTO> = wrapRequest {
+        httpClient.get("$PATH_MEETINGS/${meetingId.domain}/${meetingId.value}")
+    }
+
     override suspend fun createNewMeeting(request: UpsertMeetingRequest): NetworkResponse<UpsertMeetingResponse> = wrapRequest {
         httpClient.post(PATH_MEETINGS) {
             setBody(request)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/KaliumException.kt
@@ -42,6 +42,7 @@ import com.wire.kalium.network.exceptions.NetworkErrorLabel.INVALID_CREDENTIALS
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.INVALID_EMAIL
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.INVALID_HANDLE
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.KEY_EXISTS
+import com.wire.kalium.network.exceptions.NetworkErrorLabel.MEETING_NOT_FOUND
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.MLS_STALE_MESSAGE
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.MISSING_AUTH
 import com.wire.kalium.network.exceptions.NetworkErrorLabel.MISSING_LEGALHOLD_CONSENT
@@ -228,5 +229,8 @@ fun KaliumException.InvalidRequestError.isAccountPendingActivation(): Boolean = 
 
 fun KaliumException.ServerError.isEnterpriseServiceNotEnabled(): Boolean =
     errorResponse.code == HttpStatusCode.ServiceUnavailable.value && errorResponse.label == ENTERPRISE_SERVICE_NOT_ENABLED
+
+fun KaliumException.InvalidRequestError.isMeetingNotFound(): Boolean =
+    errorResponse.code == HttpStatusCode.NotFound.value && errorResponse.label == MEETING_NOT_FOUND
 
 private const val HTTP_STATUS_NGINZ_TOO_MANY_REQUESTS = 420

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/NetworkErrorLabel.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/exceptions/NetworkErrorLabel.kt
@@ -49,6 +49,7 @@ internal object NetworkErrorLabel {
     const val USER_NOT_FOUND = "user_not_found"
     const val NO_CRYPTO_STATE = "no_crypto_state"
     const val MLS_STALE_MESSAGE = "mls-stale-message"
+    const val MEETING_NOT_FOUND = "meeting-not-found"
 
     // connection
     const val BAD_CONNECTION_UPDATE = "bad-conn-update"

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/Event.kt
@@ -49,6 +49,7 @@ import com.wire.kalium.logic.data.featureConfig.MeetingsConfigModel
 import com.wire.kalium.logic.data.featureConfig.PreventAdminlessGroupsConfigModel
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.GroupID
+import com.wire.kalium.logic.data.id.MeetingId
 import com.wire.kalium.logic.data.id.SubconversationId
 import com.wire.kalium.logic.data.legalhold.LastPreKey
 import com.wire.kalium.logic.data.user.Connection
@@ -114,6 +115,7 @@ internal sealed class Event(open val id: String) {
         const val memberIdKey = "memberId"
         const val timestampIsoKey = "timestampIso"
         const val selfDeletionDurationKey = "selfDeletionDuration"
+        const val meetingIdKey = "meetingId"
     }
 
     internal open fun toLogString(): String {
@@ -872,6 +874,24 @@ internal sealed class Event(open val id: String) {
                 typeKey to "Federation.ConnectionRemoved",
                 idKey to id,
                 "domains" to domains
+            )
+        }
+    }
+
+    internal sealed class Meeting(
+        id: String
+    ) : Event(id) {
+
+        internal data class Create(
+            override val id: String,
+            val meetingId: MeetingId,
+            val dateTime: Instant,
+        ) : Meeting(id) {
+            override fun toLogMap(): Map<String, Any?> = mapOf(
+                typeKey to "Meeting.Create",
+                idKey to id,
+                meetingIdKey to meetingId.toLogString(),
+                timestampIsoKey to dateTime
             )
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/event/EventMapper.kt
@@ -141,6 +141,8 @@ internal class EventMapper(
             is EventContentDTO.Conversation.ProtocolUpdate -> conversationProtocolUpdate(id, eventContentDTO)
             is EventContentDTO.Conversation.ChannelAddPermissionUpdate -> conversationChannelPermissionUpdate(id, eventContentDTO)
             is EventContentDTO.Conversation.MlsResetConversationDTO -> mlsConversationReset(id, eventContentDTO)
+            is EventContentDTO.Conversation.NewMeetingConversationDTO -> newMeetingConversation(id, eventContentDTO)
+            is EventContentDTO.Meeting.MeetingCreateDTO -> meetingCreate(id, eventContentDTO)
         }
 
     private fun conversationTyping(
@@ -661,6 +663,25 @@ internal class EventMapper(
         supportedProtocols = event.userData.supportedProtocols?.toModel()
     )
 
+    private fun newMeetingConversation(
+        id: String,
+        eventContentDTO: EventContentDTO.Conversation.NewMeetingConversationDTO,
+    ) = Event.Conversation.NewConversation(
+        id = id,
+        conversationId = eventContentDTO.qualifiedConversation.toModel(),
+        senderUserId = eventContentDTO.qualifiedFrom.toModel(),
+        dateTime = eventContentDTO.time,
+        conversation = eventContentDTO.data
+    )
+
+    private fun meetingCreate(
+        id: String,
+        event: EventContentDTO.Meeting.MeetingCreateDTO,
+    ) = Event.Meeting.Create(
+        id = id,
+        meetingId = event.qualifiedMeetingId.toModel(),
+        dateTime = event.time
+    )
 }
 
 private fun MemberLeaveReasonDTO.toModel(): MemberLeaveReason = when (this) {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepository.kt
@@ -162,20 +162,19 @@ internal class MeetingDataSource(
         wrapApiRequest {
             meetingApi.fetchMeeting(meetingId.toApi())
         }.flatMap { meetingDTO ->
-            wrapStorageRequest {
-                meetingMapper.fromApiToDao(meetingDTO)?.let { meetingEntity ->
-                    // in case the creator is not yet known, probably deleted, we insert an incomplete user to avoid
-                    // foreign key constraint violation and try to fetch the user details from the server if possible
-                    userRepository.insertOrIgnoreIncompleteUsers(listOf(meetingEntity.creatorId.toModel()))
-                    userRepository.fetchUsersIfUnknownByIds(setOf(meetingEntity.creatorId.toModel()))
-
+            meetingMapper.fromApiToDao(meetingDTO)?.let { meetingEntity ->
+                // in case the creator is not yet known, probably deleted, we insert an incomplete user to avoid
+                // foreign key constraint violation and try to fetch the user details from the server if possible
+                userRepository.insertOrIgnoreIncompleteUsers(listOf(meetingEntity.creatorId.toModel()))
+                userRepository.fetchUsersIfUnknownByIds(setOf(meetingEntity.creatorId.toModel()))
+                wrapStorageRequest {
                     meetingDAO.upsertMeetings(
                         meetings = listOf(meetingEntity),
                         generateOccurrencesWindow = GenerationLimit.Window(generateOccurrencesFrom, generateOccurrencesUntil)
                     )
                     meetingMapper.fromDaoToModel(meetingEntity)
                 }
-            }
+            } ?: Either.Left(MeetingNotSupportedFailure)
         }
 
     override suspend fun syncMeetingOccurrences(
@@ -410,6 +409,7 @@ internal class MeetingDataSource(
 
     data class EstablishMLSFailure(val conversationId: ConversationId, val reason: CoreFailure) : CoreFailure.FeatureFailure()
     data class UpdateConversationNameFailure(val conversationId: ConversationId, val reason: CoreFailure) : CoreFailure.FeatureFailure()
+    data object MeetingNotSupportedFailure : CoreFailure.FeatureFailure()
 }
 
 private const val OCCURRENCE_GENERATION_WINDOW_DAYS = 90

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepository.kt
@@ -73,6 +73,12 @@ internal interface MeetingRepository {
         generateOccurrencesUntil: Instant = occurrenceGenerationUntil()
     ): Either<CoreFailure, List<Meeting>>
 
+    suspend fun fetchAndPersistMeeting(
+        meetingId: MeetingId,
+        generateOccurrencesFrom: Instant = occurrenceOutdatedThreshold(),
+        generateOccurrencesUntil: Instant = occurrenceGenerationUntil()
+    ): Either<CoreFailure, Meeting>
+
     suspend fun syncMeetingOccurrences(
         removeOlderThan: Instant = occurrenceOutdatedThreshold(),
         generateOccurrencesUntil: Instant = occurrenceGenerationUntil()
@@ -140,6 +146,25 @@ internal class MeetingDataSource(
                         }
                     }
                     .map { meetingMapper.fromDaoToModel(it) }
+            }
+        }
+
+    override suspend fun fetchAndPersistMeeting(
+        meetingId: MeetingId,
+        generateOccurrencesFrom: Instant,
+        generateOccurrencesUntil: Instant
+    ): Either<CoreFailure, Meeting> =
+        wrapApiRequest {
+            meetingApi.fetchMeeting(meetingId.toApi())
+        }.flatMap { meetingDTO ->
+            wrapStorageRequest {
+                meetingMapper.fromApiToDao(meetingDTO)?.let { meetingEntity ->
+                    meetingDAO.upsertMeetings(
+                        meetings = listOf(meetingEntity),
+                        generateOccurrencesWindow = GenerationLimit.Window(generateOccurrencesFrom, generateOccurrencesUntil)
+                    )
+                    meetingMapper.fromDaoToModel(meetingEntity)
+                }
             }
         }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepository.kt
@@ -49,6 +49,7 @@ import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.id.toModel
 import com.wire.kalium.logic.data.mls.CipherSuite
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.network.api.authenticated.conversation.ConvProtocol
 import com.wire.kalium.network.api.authenticated.meeting.UpsertMeetingResponse
@@ -65,6 +66,7 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Instant
+import kotlin.collections.map
 import kotlin.time.Duration.Companion.days
 
 internal interface MeetingRepository {
@@ -124,6 +126,7 @@ internal class MeetingDataSource(
     private val mlsConversationRepository: MLSConversationRepository,
     private val conversationRepository: ConversationRepository,
     private val pendingActionsRepository: PendingActionsRepository,
+    private val userRepository: UserRepository,
     private val meetingMapper: MeetingMapper = MapperProvider.meetingMapper(),
     private val conversationMapper: ConversationMapper = MapperProvider.conversationMapper(selfUserId),
     private val idMapper: IdMapper = MapperProvider.idMapper(),
@@ -159,6 +162,11 @@ internal class MeetingDataSource(
         }.flatMap { meetingDTO ->
             wrapStorageRequest {
                 meetingMapper.fromApiToDao(meetingDTO)?.let { meetingEntity ->
+                    // in case the creator is not yet known, probably deleted, we insert an incomplete user to avoid
+                    // foreign key constraint violation and try to fetch the user details from the server if possible
+                    userRepository.insertOrIgnoreIncompleteUsers(listOf(meetingEntity.creatorId.toModel()))
+                    userRepository.fetchUsersIfUnknownByIds(setOf(meetingEntity.creatorId.toModel()))
+
                     meetingDAO.upsertMeetings(
                         meetings = listOf(meetingEntity),
                         generateOccurrencesWindow = GenerationLimit.Window(generateOccurrencesFrom, generateOccurrencesUntil)
@@ -266,33 +274,33 @@ internal class MeetingDataSource(
         transactionContext: CryptoTransactionContext,
     ): Either<CoreFailure, MLSAdditionResult> =
         if ((membersToAdd + membersToRemove).isNotEmpty() && conversation.groupId != null && conversation.mlsCipherSuiteTag != null) {
-        transactionContext.wrapInMLSContext { mlsContext ->
-            when {
-                membersToRemove.isNotEmpty() -> mlsConversationRepository.removeMembersFromMLSGroup(
-                    mlsContext = mlsContext,
-                    groupID = idMapper.fromGroupIDEntity(conversation.groupId!!),
-                    userIdList = membersToRemove,
-                )
-
-                else -> Either.Right(Unit)
-            }.flatMap {
+            transactionContext.wrapInMLSContext { mlsContext ->
                 when {
-                    membersToAdd.isNotEmpty() -> mlsConversationRepository.addMemberToMLSGroup(
+                    membersToRemove.isNotEmpty() -> mlsConversationRepository.removeMembersFromMLSGroup(
                         mlsContext = mlsContext,
                         groupID = idMapper.fromGroupIDEntity(conversation.groupId!!),
-                        userIdList = membersToAdd,
-                        cipherSuite = CipherSuite.fromTag(conversation.mlsCipherSuiteTag!!),
-                        allowPartialMemberList = true
+                        userIdList = membersToRemove,
                     )
 
-                    else -> Either.Right(MLSAdditionResult.Empty)
+                    else -> Either.Right(Unit)
+                }.flatMap {
+                    when {
+                        membersToAdd.isNotEmpty() -> mlsConversationRepository.addMemberToMLSGroup(
+                            mlsContext = mlsContext,
+                            groupID = idMapper.fromGroupIDEntity(conversation.groupId!!),
+                            userIdList = membersToAdd,
+                            cipherSuite = CipherSuite.fromTag(conversation.mlsCipherSuiteTag!!),
+                            allowPartialMemberList = true
+                        )
+
+                        else -> Either.Right(MLSAdditionResult.Empty)
+                    }
                 }
-            }
-        }.mapLeft { EstablishMLSFailure(conversationId = conversation.id.toModel(), reason = it) }
-    } else {
-        // no members to add and remove, or no group ID or cipher suite tag, so nothing to do
-        Either.Right(MLSAdditionResult.Empty)
-    }
+            }.mapLeft { EstablishMLSFailure(conversationId = conversation.id.toModel(), reason = it) }
+        } else {
+            // no members to add and remove, or no group ID or cipher suite tag, so nothing to do
+            Either.Right(MLSAdditionResult.Empty)
+        }
 
     private suspend fun UpsertMeetingResponse.persist(
         transactionContext: CryptoTransactionContext,

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -3001,6 +3001,7 @@ public class UserSessionScope internal constructor(
             mlsConversationRepository = mlsConversationRepository,
             conversationRepository = conversationRepository,
             pendingActionsRepository = pendingActionsRepository,
+            userRepository = userRepository,
             persistConversations = persistConversationsUseCase,
         )
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -479,6 +479,8 @@ import com.wire.kalium.logic.sync.receiver.FeatureConfigEventReceiver
 import com.wire.kalium.logic.sync.receiver.FeatureConfigEventReceiverImpl
 import com.wire.kalium.logic.sync.receiver.FederationEventReceiver
 import com.wire.kalium.logic.sync.receiver.FederationEventReceiverImpl
+import com.wire.kalium.logic.sync.receiver.MeetingEventReceiver
+import com.wire.kalium.logic.sync.receiver.MeetingEventReceiverImpl
 import com.wire.kalium.logic.sync.receiver.TeamEventReceiver
 import com.wire.kalium.logic.sync.receiver.TeamEventReceiverImpl
 import com.wire.kalium.logic.sync.receiver.UserEventReceiver
@@ -556,6 +558,8 @@ import com.wire.kalium.logic.sync.receiver.handler.TypingIndicatorHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldRequestHandlerImpl
 import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldSystemMessagesHandlerImpl
+import com.wire.kalium.logic.sync.receiver.meeting.MeetingCreateEventHandler
+import com.wire.kalium.logic.sync.receiver.meeting.MeetingCreateEventHandlerImpl
 import com.wire.kalium.logic.sync.slow.RestartSlowSyncProcessForRecoveryUseCase
 import com.wire.kalium.logic.sync.slow.RestartSlowSyncProcessForRecoveryUseCaseImpl
 import com.wire.kalium.logic.sync.slow.SlowSlowSyncCriteriaProviderImpl
@@ -1290,6 +1294,7 @@ public class UserSessionScope internal constructor(
             featureConfigEventReceiver = featureConfigEventReceiver,
             userPropertiesEventReceiver = userPropertiesEventReceiver,
             federationEventReceiver = federationEventReceiver,
+            meetingEventReceiver = meetingEventReceiver,
             processingScope = this@UserSessionScope,
             logger = userScopedLogger,
         )
@@ -2273,6 +2278,16 @@ public class UserSessionScope internal constructor(
             assetAuditLogConfigHandler,
             preventAdminlessGroupsConfigHandler,
             meetingsConfigHandler,
+        )
+
+    private val meetingCreateEventHandler: MeetingCreateEventHandler
+        get() = MeetingCreateEventHandlerImpl(
+            meetingRepository = meetingRepository,
+        )
+
+    private val meetingEventReceiver: MeetingEventReceiver
+        get() = MeetingEventReceiverImpl(
+            meetingCreateEventHandler = meetingCreateEventHandler
         )
 
     private val preKeyRepository: PreKeyRepository

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessor.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessor.kt
@@ -32,6 +32,7 @@ import com.wire.kalium.logic.data.event.EventRepository
 import com.wire.kalium.logic.sync.receiver.ConversationEventReceiver
 import com.wire.kalium.logic.sync.receiver.FeatureConfigEventReceiver
 import com.wire.kalium.logic.sync.receiver.FederationEventReceiver
+import com.wire.kalium.logic.sync.receiver.MeetingEventReceiver
 import com.wire.kalium.logic.sync.receiver.TeamEventReceiver
 import com.wire.kalium.logic.sync.receiver.UserEventReceiver
 import com.wire.kalium.logic.sync.receiver.UserPropertiesEventReceiver
@@ -97,6 +98,7 @@ internal class EventProcessorImpl(
     private val featureConfigEventReceiver: FeatureConfigEventReceiver,
     private val userPropertiesEventReceiver: UserPropertiesEventReceiver,
     private val federationEventReceiver: FederationEventReceiver,
+    private val meetingEventReceiver: MeetingEventReceiver,
     private val processingScope: CoroutineScope,
     logger: KaliumLogger = kaliumLogger,
 ) : EventProcessor {
@@ -142,6 +144,7 @@ internal class EventProcessorImpl(
             is Event.UserProperty -> userPropertiesEventReceiver.onEvent(transactionContext, event, deliveryInfo)
             is Event.Federation -> federationEventReceiver.onEvent(transactionContext, event, deliveryInfo)
             is Event.Team.MemberLeave -> teamEventReceiver.onEvent(transactionContext, event, deliveryInfo)
+            is Event.Meeting -> meetingEventReceiver.onEvent(transactionContext, event, deliveryInfo)
         }.map { event.id }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/MeetingEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/MeetingEventReceiver.kt
@@ -34,7 +34,7 @@ internal class MeetingEventReceiverImpl(
         transactionContext: CryptoTransactionContext,
         event: Event.Meeting,
         deliveryInfo: EventDeliveryInfo
-    ): Either<CoreFailure, Unit> = when(event) {
+    ): Either<CoreFailure, Unit> = when (event) {
         is Event.Meeting.Create -> meetingCreateEventHandler.handle(event)
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/MeetingEventReceiver.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/MeetingEventReceiver.kt
@@ -1,0 +1,41 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.receiver
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.cryptography.CryptoTransactionContext
+import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.event.EventDeliveryInfo
+import com.wire.kalium.logic.sync.receiver.meeting.MeetingCreateEventHandler
+
+internal interface MeetingEventReceiver : EventReceiver<Event.Meeting>
+
+internal class MeetingEventReceiverImpl(
+    private val meetingCreateEventHandler: MeetingCreateEventHandler,
+) : MeetingEventReceiver {
+
+    override suspend fun onEvent(
+        transactionContext: CryptoTransactionContext,
+        event: Event.Meeting,
+        deliveryInfo: EventDeliveryInfo
+    ): Either<CoreFailure, Unit> = when(event) {
+        is Event.Meeting.Create -> meetingCreateEventHandler.handle(event)
+    }
+
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/meeting/MeetingCreateEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/meeting/MeetingCreateEventHandler.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.common.functional.map
 import com.wire.kalium.common.functional.onSuccess
 import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.meeting.MeetingDataSource
 import com.wire.kalium.logic.data.meeting.MeetingRepository
 import com.wire.kalium.logic.util.EventLoggingStatus
 import com.wire.kalium.logic.util.createEventProcessingLogger
@@ -41,12 +42,21 @@ internal class MeetingCreateEventHandlerImpl(
     override suspend fun handle(event: Event.Meeting.Create): Either<CoreFailure, Unit> {
         val eventLogger = kaliumLogger.createEventProcessingLogger(event)
         return meetingRepository.fetchAndPersistMeeting(event.meetingId)
+            .onSuccess { eventLogger.logSuccess() }
             .flatMapLeft { failure ->
                 when {
                     failure is NetworkFailure.FeatureNotSupported -> {
                         eventLogger.logComplete(
                             status = EventLoggingStatus.SKIPPED,
                             extraInfo = arrayOf("info" to "Meetings feature not supported by current API version")
+                        )
+                        Either.Right(Unit)
+                    }
+
+                    failure is MeetingDataSource.MeetingNotSupportedFailure -> {
+                        eventLogger.logComplete(
+                            status = EventLoggingStatus.SKIPPED,
+                            extraInfo = arrayOf("info" to "Meeting not supported by current API version")
                         )
                         Either.Right(Unit)
                     }
@@ -65,7 +75,6 @@ internal class MeetingCreateEventHandlerImpl(
                     }
                 }
             }
-            .onSuccess { eventLogger.logSuccess() }
             .map {}
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/meeting/MeetingCreateEventHandler.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/receiver/meeting/MeetingCreateEventHandler.kt
@@ -1,0 +1,74 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.receiver.meeting
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.NetworkFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.flatMapLeft
+import com.wire.kalium.common.functional.map
+import com.wire.kalium.common.functional.onSuccess
+import com.wire.kalium.common.logger.kaliumLogger
+import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.meeting.MeetingRepository
+import com.wire.kalium.logic.util.EventLoggingStatus
+import com.wire.kalium.logic.util.createEventProcessingLogger
+import com.wire.kalium.network.exceptions.KaliumException.InvalidRequestError
+import com.wire.kalium.network.exceptions.isMeetingNotFound
+
+internal interface MeetingCreateEventHandler {
+    suspend fun handle(event: Event.Meeting.Create): Either<CoreFailure, Unit>
+}
+
+internal class MeetingCreateEventHandlerImpl(
+    private val meetingRepository: MeetingRepository,
+) : MeetingCreateEventHandler {
+    override suspend fun handle(event: Event.Meeting.Create): Either<CoreFailure, Unit> {
+        val eventLogger = kaliumLogger.createEventProcessingLogger(event)
+        return meetingRepository.fetchAndPersistMeeting(event.meetingId)
+            .flatMapLeft { failure ->
+                when {
+                    failure is NetworkFailure.FeatureNotSupported -> {
+                        eventLogger.logComplete(
+                            status = EventLoggingStatus.SKIPPED,
+                            extraInfo = arrayOf("info" to "Meetings feature not supported by current API version")
+                        )
+                        Either.Right(Unit)
+                    }
+
+                    failure.isMeetingNotFound() -> {
+                        eventLogger.logComplete(
+                            status = EventLoggingStatus.SKIPPED,
+                            extraInfo = arrayOf("info" to "Meeting not found on server")
+                        )
+                        Either.Right(Unit)
+                    }
+
+                    else -> {
+                        eventLogger.logFailure(failure = failure)
+                        Either.Left(failure)
+                    }
+                }
+            }
+            .onSuccess { eventLogger.logSuccess() }
+            .map {}
+    }
+}
+
+private fun CoreFailure.isMeetingNotFound(): Boolean =
+    ((this as? NetworkFailure.ServerMiscommunication)?.kaliumException as? InvalidRequestError)?.isMeetingNotFound() == true

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepositoryTest.kt
@@ -121,6 +121,92 @@ class MeetingRepositoryTest {
     }
 
     @Test
+    fun whenFetchAndPersistMeeting_thenMeetingIsFetchedAndPersistedWithNowDateTime() = runTest {
+        val meetingId = MeetingId("meeting1", "domain")
+        val meetingDTO = MeetingDTO(
+            meetingId = NetworkMeetingId("meeting1", "domain"),
+            conversationId = ApiConversationId("conversation1", "domain"),
+            creatorId = ApiUserId("user1", "domain"),
+            createdAt = Instant.parse("2026-06-01T00:00:00Z"),
+            updatedAt = null,
+            title = "Meeting 1",
+            startTime = Instant.parse("2026-06-01T10:00:00Z"),
+            endTime = Instant.parse("2026-06-01T11:00:00Z"),
+            trial = false,
+            recurrence = null,
+        )
+        val (arrangement, repository) = Arrangement()
+            .withFetchMeetingSuccess(meetingId, meetingDTO)
+            .arrange()
+        val generateOccurrencesFrom = Instant.parse("2026-05-01T00:00:00Z")
+        val generateOccurrencesUntil = Instant.parse("2026-07-01T00:00:00Z")
+        val expectedMeetingEntity = requireNotNull(arrangement.meetingMapper.fromApiToDao(meetingDTO))
+        val expectedMeeting = arrangement.meetingMapper.fromDaoToModel(expectedMeetingEntity)
+
+        val result = repository.fetchAndPersistMeeting(meetingId, generateOccurrencesFrom, generateOccurrencesUntil)
+
+        assertTrue(result.isRight())
+        assertEquals(expectedMeeting, result.getOrNull())
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingApi.fetchMeeting(meetingId = meetingId.toApi())
+            arrangement.meetingDao.upsertMeetings(
+                meetings = listOf(expectedMeetingEntity),
+                generateOccurrencesWindow = GenerationLimit.Window(generateOccurrencesFrom, generateOccurrencesUntil)
+            )
+        }
+    }
+
+    @Test
+    fun givenApiFetchMeetingFails_whenFetchAndPersistMeeting_thenReturnsNetworkFailureAndMeetingIsNotPersistedLocally() = runTest {
+        val meetingId = MeetingId("meeting1", "domain")
+        val (arrangement, repository) = Arrangement()
+            .withFetchMeetingFailure(meetingId)
+            .arrange()
+
+        val result = repository.fetchAndPersistMeeting(meetingId)
+
+        assertIs<Either.Left<NetworkFailure.ServerMiscommunication>>(result)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingApi.fetchMeeting(meetingId.toApi())
+        }
+        verifySuspend(VerifyMode.not) {
+            arrangement.meetingDao.upsertMeetings(any(), any())
+        }
+    }
+
+    @Test
+    fun givenPersistingMeetingFails_whenFetchAndPersistMeeting_thenReturnsStorageFailure() = runTest {
+        val meetingId = MeetingId("meeting1", "domain")
+        val meetingDTO = MeetingDTO(
+            meetingId = NetworkMeetingId("meeting1", "domain"),
+            conversationId = ApiConversationId("conversation1", "domain"),
+            creatorId = ApiUserId("user1", "domain"),
+            createdAt = Instant.parse("2026-06-01T00:00:00Z"),
+            updatedAt = null,
+            title = "Meeting 1",
+            startTime = Instant.parse("2026-06-01T10:00:00Z"),
+            endTime = Instant.parse("2026-06-01T11:00:00Z"),
+            trial = false,
+            recurrence = null,
+        )
+        val persistenceException = RuntimeException("An error occurred persisting the meeting")
+        val (arrangement, repository) = Arrangement()
+            .withFetchMeetingSuccess(meetingId, meetingDTO)
+            .withPersistMeetingFailure(persistenceException)
+            .arrange()
+
+        val result = repository.fetchAndPersistMeeting(meetingId)
+
+        assertIs<Either.Left<StorageFailure.Generic>>(result).also {
+            assertSame(persistenceException, it.value.rootCause)
+        }
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingApi.fetchMeeting(meetingId.toApi())
+            arrangement.meetingDao.upsertMeetings(any(), any())
+        }
+    }
+
+    @Test
     fun whenSyncMeetingOccurrences_thenDaoMethodsAreCalledWithProperDateTimes() = runTest {
         val (arrangement, repository) = Arrangement().arrange()
         val generateOccurrencesUntil = Instant.parse("2026-07-01T00:00:00Z")
@@ -616,6 +702,14 @@ class MeetingRepositoryTest {
 
         internal fun withFetchMeetingsSuccess(result: List<MeetingDTO>) = apply {
             everySuspend { meetingApi.fetchMeetings() } returns NetworkResponse.Success(result, mapOf(), HttpStatusCode.OK.value)
+        }
+
+        internal fun withFetchMeetingSuccess(id: MeetingId, result: MeetingDTO) = apply {
+            everySuspend { meetingApi.fetchMeeting(id.toApi()) } returns NetworkResponse.Success(result, mapOf(), HttpStatusCode.OK.value)
+        }
+
+        internal fun withFetchMeetingFailure(id: MeetingId) = apply {
+            everySuspend { meetingApi.fetchMeeting(id.toApi()) } returns NetworkResponse.Error(TestNetworkException.generic)
         }
 
         internal fun withDeleteMeetingSuccess(meetingId: MeetingId) = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepositoryTest.kt
@@ -40,6 +40,7 @@ import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.id.toModel
 import com.wire.kalium.logic.data.mls.CipherSuite
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.test_util.TestNetworkException
@@ -87,20 +88,12 @@ class MeetingRepositoryTest {
 
     @Test
     fun whenFetchAndPersistMeetings_thenMeetingsAreFetchedAndPersistedWithNowDateTime() = runTest {
-        val meetingDTO = MeetingDTO(
-            meetingId = NetworkMeetingId("meeting1", "domain"),
-            conversationId = ApiConversationId("conversation1", "domain"),
-            creatorId = ApiUserId("user1", "domain"),
-            createdAt = Instant.parse("2026-06-01T00:00:00Z"),
-            updatedAt = null,
-            title = "Meeting 1",
-            startTime = Instant.parse("2026-06-01T10:00:00Z"),
-            endTime = Instant.parse("2026-06-01T11:00:00Z"),
-            trial = false,
-            recurrence = null,
-        )
+        val creatorId = UserId("user1", "domain")
+        val meetingDTO = meetingDTO(creatorId = creatorId.toApi())
         val (arrangement, repository) = Arrangement()
             .withFetchMeetingsSuccess(listOf(meetingDTO))
+            .withInsertOrIgnoreIncompleteUsersSuccess(listOf(creatorId))
+            .withFetchUsersIfUnknownSuccess(setOf(creatorId))
             .arrange()
         val generateOccurrencesFrom = Instant.parse("2026-05-01T00:00:00Z")
         val generateOccurrencesUntil = Instant.parse("2026-07-01T00:00:00Z")
@@ -123,20 +116,12 @@ class MeetingRepositoryTest {
     @Test
     fun whenFetchAndPersistMeeting_thenMeetingIsFetchedAndPersistedWithNowDateTime() = runTest {
         val meetingId = MeetingId("meeting1", "domain")
-        val meetingDTO = MeetingDTO(
-            meetingId = NetworkMeetingId("meeting1", "domain"),
-            conversationId = ApiConversationId("conversation1", "domain"),
-            creatorId = ApiUserId("user1", "domain"),
-            createdAt = Instant.parse("2026-06-01T00:00:00Z"),
-            updatedAt = null,
-            title = "Meeting 1",
-            startTime = Instant.parse("2026-06-01T10:00:00Z"),
-            endTime = Instant.parse("2026-06-01T11:00:00Z"),
-            trial = false,
-            recurrence = null,
-        )
+        val creatorId = UserId("user1", "domain")
+        val meetingDTO = meetingDTO(meetingId = meetingId.toApi(), creatorId = creatorId.toApi())
         val (arrangement, repository) = Arrangement()
             .withFetchMeetingSuccess(meetingId, meetingDTO)
+            .withInsertOrIgnoreIncompleteUsersSuccess(listOf(creatorId))
+            .withFetchUsersIfUnknownSuccess(setOf(creatorId))
             .arrange()
         val generateOccurrencesFrom = Instant.parse("2026-05-01T00:00:00Z")
         val generateOccurrencesUntil = Instant.parse("2026-07-01T00:00:00Z")
@@ -153,6 +138,28 @@ class MeetingRepositoryTest {
                 meetings = listOf(expectedMeetingEntity),
                 generateOccurrencesWindow = GenerationLimit.Window(generateOccurrencesFrom, generateOccurrencesUntil)
             )
+        }
+    }
+
+    @Test
+    fun whenFetchAndPersistMeeting_thenCreatorIsPreparedOnceBeforePersistingMeeting() = runTest {
+        val meetingId = MeetingId("meeting1", "domain")
+        val creatorId = UserId("user1", "domain")
+        val meetingDTO = meetingDTO(meetingId = meetingId.toApi(), creatorId = creatorId.toApi())
+        val (arrangement, repository) = Arrangement()
+            .withFetchMeetingSuccess(meetingId, meetingDTO)
+            .withInsertOrIgnoreIncompleteUsersSuccess(listOf(creatorId))
+            .withFetchUsersIfUnknownSuccess(setOf(creatorId))
+            .arrange()
+        val expectedMeetingEntity = requireNotNull(arrangement.meetingMapper.fromApiToDao(meetingDTO))
+
+        val result = repository.fetchAndPersistMeeting(meetingId)
+
+        assertTrue(result.isRight())
+        verifySuspend(VerifyMode.exhaustiveOrder) {
+            arrangement.userRepository.insertOrIgnoreIncompleteUsers(userIds = listOf(creatorId))
+            arrangement.userRepository.fetchUsersIfUnknownByIds(ids = setOf(creatorId))
+            arrangement.meetingDao.upsertMeetings(meetings = listOf(expectedMeetingEntity), generateOccurrencesWindow = any())
         }
     }
 
@@ -177,21 +184,13 @@ class MeetingRepositoryTest {
     @Test
     fun givenPersistingMeetingFails_whenFetchAndPersistMeeting_thenReturnsStorageFailure() = runTest {
         val meetingId = MeetingId("meeting1", "domain")
-        val meetingDTO = MeetingDTO(
-            meetingId = NetworkMeetingId("meeting1", "domain"),
-            conversationId = ApiConversationId("conversation1", "domain"),
-            creatorId = ApiUserId("user1", "domain"),
-            createdAt = Instant.parse("2026-06-01T00:00:00Z"),
-            updatedAt = null,
-            title = "Meeting 1",
-            startTime = Instant.parse("2026-06-01T10:00:00Z"),
-            endTime = Instant.parse("2026-06-01T11:00:00Z"),
-            trial = false,
-            recurrence = null,
-        )
+        val creatorId = UserId("user1", "domain")
+        val meetingDTO = meetingDTO(meetingId = meetingId.toApi(), creatorId = creatorId.toApi())
         val persistenceException = RuntimeException("An error occurred persisting the meeting")
         val (arrangement, repository) = Arrangement()
             .withFetchMeetingSuccess(meetingId, meetingDTO)
+            .withInsertOrIgnoreIncompleteUsersSuccess(listOf(creatorId))
+            .withFetchUsersIfUnknownSuccess(setOf(creatorId))
             .withPersistMeetingFailure(persistenceException)
             .arrange()
 
@@ -694,6 +693,7 @@ class MeetingRepositoryTest {
         internal val mlsConversationRepository = mock<MLSConversationRepository>(mode = MockMode.autoUnit)
         internal val conversationRepository = mock<ConversationRepository>(mode = MockMode.autoUnit)
         internal val pendingActionsRepository = mock<PendingActionsRepository>(mode = MockMode.autoUnit)
+        internal val userRepository = mock<UserRepository>(mode = MockMode.autoUnit)
         internal val transactionContext = mock<CryptoTransactionContext>(mode = MockMode.autoUnit)
         internal val mlsContext = mock<MlsCoreCryptoContext>(mode = MockMode.autoUnit)
         internal val meetingMapper = MapperProvider.meetingMapper()
@@ -702,6 +702,14 @@ class MeetingRepositoryTest {
 
         internal fun withFetchMeetingsSuccess(result: List<MeetingDTO>) = apply {
             everySuspend { meetingApi.fetchMeetings() } returns NetworkResponse.Success(result, mapOf(), HttpStatusCode.OK.value)
+        }
+
+        internal fun withInsertOrIgnoreIncompleteUsersSuccess(userIds: List<UserId>) = apply {
+            everySuspend { userRepository.insertOrIgnoreIncompleteUsers(userIds) } returns Either.Right(Unit)
+        }
+
+        internal fun withFetchUsersIfUnknownSuccess(userIds: Set<UserId>) = apply {
+            everySuspend { userRepository.fetchUsersIfUnknownByIds(userIds) } returns Either.Right(Unit)
         }
 
         internal fun withFetchMeetingSuccess(id: MeetingId, result: MeetingDTO) = apply {
@@ -734,7 +742,8 @@ class MeetingRepositoryTest {
 
         internal fun withCreateNewMeetingSuccess(meeting: UpsertMeeting, response: UpsertMeetingResponse) = apply {
             everySuspend {
-                meetingApi.createNewMeeting(meetingMapper.fromModelToApi(meeting)) } returns NetworkResponse.Success(
+                meetingApi.createNewMeeting(meetingMapper.fromModelToApi(meeting))
+            } returns NetworkResponse.Success(
                 value = response,
                 headers = mapOf(),
                 httpCode = HttpStatusCode.Created.value
@@ -817,6 +826,7 @@ class MeetingRepositoryTest {
             mlsConversationRepository = mlsConversationRepository,
             conversationRepository = conversationRepository,
             pendingActionsRepository = pendingActionsRepository,
+            userRepository = userRepository,
             meetingMapper = meetingMapper,
             conversationMapper = conversationMapper,
             idMapper = idMapper,
@@ -863,6 +873,25 @@ class MeetingRepositoryTest {
     )
 
     private val expectedMLSAdditionResult = MLSAdditionResult(setOf(TestUser.OTHER.id), emptySet(), emptySet())
+
+    private fun meetingDTO(
+        meetingId: NetworkMeetingId = NetworkMeetingId("meeting1", "domain"),
+        conversationId: ApiConversationId = ApiConversationId("conversation1", "domain"),
+        creatorId: ApiUserId = ApiUserId("user1", "domain"),
+        title: String = "Meeting 1",
+        recurrence: MeetingRecurrenceDTO? = null,
+    ) = MeetingDTO(
+        meetingId = meetingId,
+        conversationId = conversationId,
+        creatorId = creatorId,
+        createdAt = Instant.parse("2026-06-01T00:00:00Z"),
+        updatedAt = null,
+        title = title,
+        startTime = Instant.parse("2026-06-01T10:00:00Z"),
+        endTime = Instant.parse("2026-06-01T11:00:00Z"),
+        trial = false,
+        recurrence = recurrence,
+    )
 
     private fun upsertMeetingResponse(
         protocol: ConvProtocol = ConvProtocol.MLS,

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepositoryTest.kt
@@ -167,6 +167,30 @@ class MeetingRepositoryTest {
     }
 
     @Test
+    fun givenUnsupportedMeeting_whenFetchAndPersistMeeting_thenReturnsMeetingNotSupportedFailureAndMeetingIsNotPersistedLocally() = runTest {
+        val meetingId = MeetingId("meeting1", "domain")
+        val meetingDTO = meetingDTO(
+            meetingId = meetingId.toApi(),
+            recurrence = MeetingRecurrenceDTO(frequency = MeetingFrequencyDTO.WEEKLY, interval = 7L, until = null)
+        )
+        val (arrangement, repository) = Arrangement()
+            .withFetchMeetingSuccess(meetingId, meetingDTO)
+            .arrange()
+
+        val result = repository.fetchAndPersistMeeting(meetingId)
+
+        assertEquals(MeetingDataSource.MeetingNotSupportedFailure, assertIs<Either.Left<CoreFailure>>(result).value)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingApi.fetchMeeting(meetingId.toApi())
+        }
+        verifySuspend(VerifyMode.not) {
+            arrangement.userRepository.insertOrIgnoreIncompleteUsers(any())
+            arrangement.userRepository.fetchUsersIfUnknownByIds(any())
+            arrangement.meetingDao.upsertMeetings(any(), any())
+        }
+    }
+
+    @Test
     fun givenApiFetchMeetingFails_whenFetchAndPersistMeeting_thenReturnsNetworkFailureAndMeetingIsNotPersistedLocally() = runTest {
         val meetingId = MeetingId("meeting1", "domain")
         val (arrangement, repository) = Arrangement()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/framework/TestEvent.kt
@@ -32,6 +32,7 @@ import com.wire.kalium.logic.data.event.EventEnvelope
 import com.wire.kalium.logic.data.event.MemberLeaveReason
 import com.wire.kalium.logic.data.featureConfig.AppLockModel
 import com.wire.kalium.logic.data.featureConfig.Status
+import com.wire.kalium.logic.data.id.MeetingId
 import com.wire.kalium.logic.data.id.SubconversationId
 import com.wire.kalium.logic.data.user.Connection
 import com.wire.kalium.logic.data.user.ConnectionState
@@ -269,6 +270,12 @@ internal object TestEvent {
 
     fun newUnknownFeatureUpdate() = Event.FeatureConfig.UnknownFeatureUpdated(
         id = "eventId",
+    )
+
+    fun meetingCreateEvent() = Event.Meeting.Create(
+        id = "eventId",
+        meetingId = MeetingId("meetingId", "domain"),
+        dateTime = Instant.UNIX_FIRST_DATE
     )
 
     fun Event.wrapInEnvelope(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessorTest.kt
@@ -20,11 +20,15 @@ package com.wire.kalium.logic.sync.incremental
 
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.id.MeetingId
 import com.wire.kalium.logic.framework.TestEvent
+import com.wire.kalium.logic.framework.TestEvent.meetingCreateEvent
 import com.wire.kalium.logic.framework.TestEvent.wrapInEnvelope
 import com.wire.kalium.logic.sync.receiver.ConversationEventReceiver
 import com.wire.kalium.logic.sync.receiver.FeatureConfigEventReceiver
 import com.wire.kalium.logic.sync.receiver.FederationEventReceiver
+import com.wire.kalium.logic.sync.receiver.MeetingEventReceiver
 import com.wire.kalium.logic.sync.receiver.TeamEventReceiver
 import com.wire.kalium.logic.sync.receiver.UserEventReceiver
 import com.wire.kalium.logic.sync.receiver.UserPropertiesEventReceiver
@@ -48,6 +52,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -137,6 +142,22 @@ class EventProcessorTest {
             .shouldFail { assertEquals(failure, it) }
     }
 
+    @Test
+    fun givenAMeetingEvent_whenSyncing_thenTheMeetingEventHandlerIsCalled() = runTest {
+        // Given
+        val event = meetingCreateEvent()
+        val (arrangement, eventProcessor) = Arrangement(this).arrange {
+            withMeetingEventReceiverReturning(Either.Right(Unit))
+        }
+
+        // When
+        eventProcessor.processEvent(arrangement.transactionContext, event.wrapInEnvelope())
+
+        // Then
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingEventReceiver.onEvent(any(), event, any())
+        }
+    }
 
     @Test
     fun givenUserPropertiesHandlerFails_whenSyncing_thenReturnsFailure() = runTest {
@@ -242,6 +263,7 @@ class EventProcessorTest {
         val featureConfigEventReceiver = mock<FeatureConfigEventReceiver>(mode = MockMode.autoUnit)
         val userPropertiesEventReceiver = mock<UserPropertiesEventReceiver>()
         val federationEventReceiver = mock<FederationEventReceiver>(mode = MockMode.autoUnit)
+        val meetingEventReceiver = mock<MeetingEventReceiver>(mode = MockMode.autoUnit)
 
         suspend fun withConversationEventReceiverReturning(result: Either<CoreFailure, Unit>) = apply {
             everySuspend {
@@ -275,6 +297,12 @@ class EventProcessorTest {
 
         suspend fun withTeamEventReceiverSucceeding() = withTeamEventReceiverReturning(Either.Right(Unit))
 
+        fun withMeetingEventReceiverReturning(result: Either<CoreFailure, Unit>) = apply {
+            everySuspend {
+                meetingEventReceiver.onEvent(any(), any(), any())
+            } returns result
+        }
+
         suspend fun withUserPropertiesEventReceiverReturning(result: Either<CoreFailure, Unit>) = apply {
             everySuspend {
                 userPropertiesEventReceiver.onEvent(any(), any(), any())
@@ -306,6 +334,7 @@ class EventProcessorTest {
                 featureConfigEventReceiver,
                 userPropertiesEventReceiver,
                 federationEventReceiver,
+                meetingEventReceiver,
                 processingScope
             )
         }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessorTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/incremental/EventProcessorTest.kt
@@ -20,8 +20,6 @@ package com.wire.kalium.logic.sync.incremental
 
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.functional.Either
-import com.wire.kalium.logic.data.event.Event
-import com.wire.kalium.logic.data.id.MeetingId
 import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.logic.framework.TestEvent.meetingCreateEvent
 import com.wire.kalium.logic.framework.TestEvent.wrapInEnvelope
@@ -52,7 +50,6 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.Instant
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/MeetingEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/MeetingEventReceiverTest.kt
@@ -22,13 +22,9 @@ import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.isRight
 import com.wire.kalium.logic.data.event.Event
-import com.wire.kalium.logic.data.meeting.MeetingDataSource
-import com.wire.kalium.logic.data.meeting.MeetingRepository
 import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.logic.framework.TestEvent.meetingCreateEvent
 import com.wire.kalium.logic.sync.receiver.meeting.MeetingCreateEventHandler
-import com.wire.kalium.logic.sync.receiver.meeting.MeetingCreateEventHandlerImpl
-import com.wire.kalium.logic.test_util.serverMiscommunicationFailure
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMokkeryImpl
 import dev.mokkery.MockMode
@@ -76,74 +72,15 @@ class MeetingEventReceiverTest {
         }
     }
 
-    @Test
-    fun givenFeatureNotSupportedFailure_whenProcessingCreateEvent_thenReturnSuccess() = runTest {
-        val event = meetingCreateEvent()
-        val (arrangement, eventReceiver) = Arrangement()
-            .withRepositoryBackedCreateHandler()
-            .withFetchAndPersistMeetingReturning(event, NetworkFailure.FeatureNotSupported)
-            .arrange()
-
-        val result = eventReceiver.onEvent(arrangement.transactionContext, event, TestEvent.liveDeliveryInfo)
-
-        assertTrue(result.isRight())
-        verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.meetingRepository.fetchAndPersistMeeting(event.meetingId)
-        }
-    }
-
-    @Test
-    fun givenMeetingNotSupportedFailure_whenProcessingCreateEvent_thenReturnSuccess() = runTest {
-        val event = meetingCreateEvent()
-        val (arrangement, eventReceiver) = Arrangement()
-            .withRepositoryBackedCreateHandler()
-            .withFetchAndPersistMeetingReturning(event, MeetingDataSource.MeetingNotSupportedFailure)
-            .arrange()
-
-        val result = eventReceiver.onEvent(arrangement.transactionContext, event, TestEvent.liveDeliveryInfo)
-
-        assertTrue(result.isRight())
-        verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.meetingRepository.fetchAndPersistMeeting(event.meetingId)
-        }
-    }
-
-    @Test
-    fun givenMeetingNotFoundFailure_whenProcessingCreateEvent_thenReturnSuccess() = runTest {
-        val event = meetingCreateEvent()
-        val failure = serverMiscommunicationFailure(code = 404, label = "meeting-not-found")
-        val (arrangement, eventReceiver) = Arrangement()
-            .withRepositoryBackedCreateHandler()
-            .withFetchAndPersistMeetingReturning(event, failure)
-            .arrange()
-
-        val result = eventReceiver.onEvent(arrangement.transactionContext, event, TestEvent.liveDeliveryInfo)
-
-        assertTrue(result.isRight())
-        verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.meetingRepository.fetchAndPersistMeeting(event.meetingId)
-        }
-    }
-
     private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMokkeryImpl() {
         val meetingCreateEventHandler = mock<MeetingCreateEventHandler>(mode = MockMode.autoUnit)
-        val meetingRepository = mock<MeetingRepository>(mode = MockMode.autoUnit)
-        private var handler: MeetingCreateEventHandler = meetingCreateEventHandler
-
-        fun withRepositoryBackedCreateHandler() = apply {
-            handler = MeetingCreateEventHandlerImpl(meetingRepository)
-        }
 
         fun withMeetingCreateHandlerReturning(event: Event.Meeting.Create, result: Either<CoreFailure, Unit>) = apply {
             everySuspend { meetingCreateEventHandler.handle(event) } returns result
         }
 
-        fun withFetchAndPersistMeetingReturning(event: Event.Meeting.Create, failure: CoreFailure) = apply {
-            everySuspend { meetingRepository.fetchAndPersistMeeting(event.meetingId) } returns Either.Left(failure)
-        }
-
         fun arrange() = this to MeetingEventReceiverImpl(
-            meetingCreateEventHandler = handler,
+            meetingCreateEventHandler = meetingCreateEventHandler,
         )
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/MeetingEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/MeetingEventReceiverTest.kt
@@ -22,6 +22,7 @@ import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.isRight
 import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.meeting.MeetingDataSource
 import com.wire.kalium.logic.data.meeting.MeetingRepository
 import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.logic.framework.TestEvent.meetingCreateEvent
@@ -81,6 +82,22 @@ class MeetingEventReceiverTest {
         val (arrangement, eventReceiver) = Arrangement()
             .withRepositoryBackedCreateHandler()
             .withFetchAndPersistMeetingReturning(event, NetworkFailure.FeatureNotSupported)
+            .arrange()
+
+        val result = eventReceiver.onEvent(arrangement.transactionContext, event, TestEvent.liveDeliveryInfo)
+
+        assertTrue(result.isRight())
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingRepository.fetchAndPersistMeeting(event.meetingId)
+        }
+    }
+
+    @Test
+    fun givenMeetingNotSupportedFailure_whenProcessingCreateEvent_thenReturnSuccess() = runTest {
+        val event = meetingCreateEvent()
+        val (arrangement, eventReceiver) = Arrangement()
+            .withRepositoryBackedCreateHandler()
+            .withFetchAndPersistMeetingReturning(event, MeetingDataSource.MeetingNotSupportedFailure)
             .arrange()
 
         val result = eventReceiver.onEvent(arrangement.transactionContext, event, TestEvent.liveDeliveryInfo)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/MeetingEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/MeetingEventReceiverTest.kt
@@ -1,0 +1,132 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.receiver
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.NetworkFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.isRight
+import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.meeting.MeetingRepository
+import com.wire.kalium.logic.framework.TestEvent
+import com.wire.kalium.logic.framework.TestEvent.meetingCreateEvent
+import com.wire.kalium.logic.sync.receiver.meeting.MeetingCreateEventHandler
+import com.wire.kalium.logic.sync.receiver.meeting.MeetingCreateEventHandlerImpl
+import com.wire.kalium.logic.test_util.serverMiscommunicationFailure
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
+import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMokkeryImpl
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertIs
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class MeetingEventReceiverTest {
+
+    @Test
+    fun givenCreateEvent_whenProcessingEvent_thenCreateHandlerIsInvoked() = runTest {
+        val event = meetingCreateEvent()
+        val (arrangement, eventReceiver) = Arrangement()
+            .withMeetingCreateHandlerReturning(event, Either.Right(Unit))
+            .arrange()
+
+        val result = eventReceiver.onEvent(arrangement.transactionContext, event, TestEvent.liveDeliveryInfo)
+
+        assertTrue(result.isRight())
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingCreateEventHandler.handle(event)
+        }
+    }
+
+    @Test
+    fun givenCreateHandlerFails_whenProcessingEvent_thenFailureIsReturned() = runTest {
+        val event = meetingCreateEvent()
+        val failure = NetworkFailure.NoNetworkConnection(null)
+        val (arrangement, eventReceiver) = Arrangement()
+            .withMeetingCreateHandlerReturning(event, Either.Left(failure))
+            .arrange()
+
+        val result = eventReceiver.onEvent(arrangement.transactionContext, event, TestEvent.liveDeliveryInfo)
+
+        assertSame(failure, assertIs<Either.Left<CoreFailure>>(result).value)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingCreateEventHandler.handle(event)
+        }
+    }
+
+    @Test
+    fun givenFeatureNotSupportedFailure_whenProcessingCreateEvent_thenReturnSuccess() = runTest {
+        val event = meetingCreateEvent()
+        val (arrangement, eventReceiver) = Arrangement()
+            .withRepositoryBackedCreateHandler()
+            .withFetchAndPersistMeetingReturning(event, NetworkFailure.FeatureNotSupported)
+            .arrange()
+
+        val result = eventReceiver.onEvent(arrangement.transactionContext, event, TestEvent.liveDeliveryInfo)
+
+        assertTrue(result.isRight())
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingRepository.fetchAndPersistMeeting(event.meetingId)
+        }
+    }
+
+    @Test
+    fun givenMeetingNotFoundFailure_whenProcessingCreateEvent_thenReturnSuccess() = runTest {
+        val event = meetingCreateEvent()
+        val failure = serverMiscommunicationFailure(code = 404, label = "meeting-not-found")
+        val (arrangement, eventReceiver) = Arrangement()
+            .withRepositoryBackedCreateHandler()
+            .withFetchAndPersistMeetingReturning(event, failure)
+            .arrange()
+
+        val result = eventReceiver.onEvent(arrangement.transactionContext, event, TestEvent.liveDeliveryInfo)
+
+        assertTrue(result.isRight())
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingRepository.fetchAndPersistMeeting(event.meetingId)
+        }
+    }
+
+    private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMokkeryImpl() {
+        val meetingCreateEventHandler = mock<MeetingCreateEventHandler>(mode = MockMode.autoUnit)
+        val meetingRepository = mock<MeetingRepository>(mode = MockMode.autoUnit)
+        private var handler: MeetingCreateEventHandler = meetingCreateEventHandler
+
+        fun withRepositoryBackedCreateHandler() = apply {
+            handler = MeetingCreateEventHandlerImpl(meetingRepository)
+        }
+
+        fun withMeetingCreateHandlerReturning(event: Event.Meeting.Create, result: Either<CoreFailure, Unit>) = apply {
+            everySuspend { meetingCreateEventHandler.handle(event) } returns result
+        }
+
+        fun withFetchAndPersistMeetingReturning(event: Event.Meeting.Create, failure: CoreFailure) = apply {
+            everySuspend { meetingRepository.fetchAndPersistMeeting(event.meetingId) } returns Either.Left(failure)
+        }
+
+        fun arrange() = this to MeetingEventReceiverImpl(
+            meetingCreateEventHandler = handler,
+        )
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/meeting/MeetingCreateEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/meeting/MeetingCreateEventHandlerTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.receiver.meeting
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.NetworkFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.isRight
+import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.meeting.MeetingDataSource
+import com.wire.kalium.logic.data.meeting.MeetingRepository
+import com.wire.kalium.logic.framework.TestEvent.meetingCreateEvent
+import com.wire.kalium.logic.test_util.serverMiscommunicationFailure
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertIs
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class MeetingCreateEventHandlerTest {
+
+    @Test
+    fun givenFeatureNotSupportedFailure_whenHandlingCreateEvent_thenReturnSuccess() = runTest {
+        val event = meetingCreateEvent()
+        val (arrangement, handler) = Arrangement()
+            .withFetchAndPersistMeetingReturning(event, NetworkFailure.FeatureNotSupported)
+            .arrange()
+
+        val result = handler.handle(event)
+
+        assertTrue(result.isRight())
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingRepository.fetchAndPersistMeeting(event.meetingId)
+        }
+    }
+
+    @Test
+    fun givenMeetingNotSupportedFailure_whenHandlingCreateEvent_thenReturnSuccess() = runTest {
+        val event = meetingCreateEvent()
+        val (arrangement, handler) = Arrangement()
+            .withFetchAndPersistMeetingReturning(event, MeetingDataSource.MeetingNotSupportedFailure)
+            .arrange()
+
+        val result = handler.handle(event)
+
+        assertTrue(result.isRight())
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingRepository.fetchAndPersistMeeting(event.meetingId)
+        }
+    }
+
+    @Test
+    fun givenMeetingNotFoundFailure_whenHandlingCreateEvent_thenReturnSuccess() = runTest {
+        val event = meetingCreateEvent()
+        val failure = serverMiscommunicationFailure(code = 404, label = "meeting-not-found")
+        val (arrangement, handler) = Arrangement()
+            .withFetchAndPersistMeetingReturning(event, failure)
+            .arrange()
+
+        val result = handler.handle(event)
+
+        assertTrue(result.isRight())
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingRepository.fetchAndPersistMeeting(event.meetingId)
+        }
+    }
+
+    @Test
+    fun givenOtherFailure_whenHandlingCreateEvent_thenReturnFailure() = runTest {
+        val event = meetingCreateEvent()
+        val failure = NetworkFailure.NoNetworkConnection(null)
+        val (_, handler) = Arrangement()
+            .withFetchAndPersistMeetingReturning(event, failure)
+            .arrange()
+
+        val result = handler.handle(event)
+
+        assertSame(failure, assertIs<Either.Left<CoreFailure>>(result).value)
+    }
+
+    private class Arrangement {
+        val meetingRepository = mock<MeetingRepository>(mode = MockMode.autoUnit)
+
+        fun withFetchAndPersistMeetingReturning(event: Event.Meeting.Create, failure: CoreFailure) = apply {
+            everySuspend { meetingRepository.fetchAndPersistMeeting(event.meetingId) } returns Either.Left(failure)
+        }
+
+        fun arrange() = this to MeetingCreateEventHandlerImpl(meetingRepository)
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26734
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Handling `meeting.create` and `conversation.create-meeting` events.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Create a meeting on your another client and you should receive these events and this meeting should appear also on your current client.

### Attachments (Optional)

https://github.com/user-attachments/assets/68606bfc-97e5-4d3f-8c57-553a1e1933ce

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
