### PR TITLE
fix: getting version for stacked PRs [WPB-8645]

### DIFF
--- a/.github/workflows/jira-lint-and-link.yml
+++ b/.github/workflows/jira-lint-and-link.yml
@@ -7,30 +7,91 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read # required to read version metadata from the repository
-
 jobs:
   get-version:
     name: Get Version
     runs-on: ubuntu-latest
     # Skip for fork PRs — head.repo.full_name differs from the base repo for forks
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    permissions:
+      contents: read # required to read version metadata from the repository
+      pull-requests: read # required to resolve stacked PR base branches
     outputs:
       version_name: ${{ steps.version.outputs.version_name }}
     steps:
       - name: Get version name from Wire-Android
         id: version
         env:
-          WIRE_ANDROID_REF: ${{ github.event.pull_request.base.ref }}
+          GITHUB_TOKEN: ${{ github.token }}
+          ORIGINAL_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set -euo pipefail
-          URL="https://raw.githubusercontent.com/wireapp/wire-android/${WIRE_ANDROID_REF}/build-logic/plugins/src/main/kotlin/AndroidCoordinates.kt"
-          VERSION=$(curl -fsSL "$URL" | grep 'const val versionName' | sed -E 's/.*"([^"]+)".*/\1/')
+
+          wire_android_coordinates_url() {
+            local ref="$1"
+
+            echo "https://raw.githubusercontent.com/wireapp/wire-android/${ref}/build-logic/plugins/src/main/kotlin/AndroidCoordinates.kt"
+          }
+
+          version_from_wire_android() {
+            local url
+            url="$(wire_android_coordinates_url "$1")"
+
+            curl -fsSL "$url" 2>/dev/null | grep 'const val versionName' | sed -E 's/.*"([^"]+)".*/\1/'
+          }
+
+          base_ref_for_open_pr() {
+            local head_ref="$1"
+
+            curl -fsSL \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              --get \
+              --data-urlencode "state=open" \
+              --data-urlencode "head=${GITHUB_REPOSITORY_OWNER}:${head_ref}" \
+              "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pulls" \
+              | jq -r '.[0].base.ref // empty'
+          }
+
+          KALIUM_REF="$ORIGINAL_REF"
+          STACK_REFS=("$KALIUM_REF")
+
+          while true; do
+            NEXT_REF="$(base_ref_for_open_pr "$KALIUM_REF" || true)"
+            if [ -z "$NEXT_REF" ]; then
+              break
+            fi
+
+            if [ "$NEXT_REF" = "$KALIUM_REF" ]; then
+              echo "Detected self-referential stacked PR base '${KALIUM_REF}'." >&2
+              exit 1
+            fi
+
+            for ref in "${STACK_REFS[@]}"; do
+              if [ "$ref" = "$NEXT_REF" ]; then
+                echo "Detected cycle while resolving stacked PR bases:" >&2
+                printf '  - %s\n' "${STACK_REFS[@]}" >&2
+                echo "  - ${NEXT_REF}" >&2
+                exit 1
+              fi
+            done
+
+            echo "Resolved stacked Kalium PR base '${KALIUM_REF}' -> '${NEXT_REF}'."
+            KALIUM_REF="$NEXT_REF"
+            STACK_REFS+=("$KALIUM_REF")
+          done
+
+          WIRE_ANDROID_REF="$KALIUM_REF"
+          VERSION="$(version_from_wire_android "$WIRE_ANDROID_REF" || true)"
           if [ -z "$VERSION" ]; then
-            echo "Failed to read versionName from $URL" >&2
+            echo "Failed to read versionName from $(wire_android_coordinates_url "$WIRE_ANDROID_REF")" >&2
+            echo "Resolved Kalium base path:" >&2
+            printf '  - %s\n' "${STACK_REFS[@]}" >&2
             exit 1
           fi
+
+          echo "Resolved Wire-Android versionName '${VERSION}' from ref '${WIRE_ANDROID_REF}'."
           echo "version_name=$VERSION" >> "$GITHUB_OUTPUT"
 
   add-jira-description:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8645
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When using stacked PRs, PRs above the first one fail while resolving the version.

### Causes (Optional)

The workflow uses the PR base branch to fetch `versionName` from `wire-android`. For stacked PRs, the base of an upper PR is another Kalium feature branch, not `develop` or any other base of the whole stack, so the matching `wire-android` branch may not exist.

### Solutions

Resolve the bottom/base branch of the Kalium PR stack first, then fetch `versionName` from the corresponding `wire-android` ref.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
