### PR TITLE
fix: changelog generation error message improvement (WPB-28295)

### DIFF
--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -37,6 +37,5 @@ API-impacting label such as `api-impacting`, `public-api`, or the existing
 `🚨 Potential breaking changes` label.
 
 Use the `no-changelog-needed` label only when reviewers agree the change has no
-consumer-facing release note. Use `internal-only` only when the ABI gate confirms
-the published consumer surface did not change; it does not skip changelog
-requirements when ABI dumps changed.
+consumer-facing release note. The `internal-only` label documents scope but does
+not skip this changelog gate when public API/ABI release notes are required.

--- a/scripts/check-changelog-fragment.sh
+++ b/scripts/check-changelog-fragment.sh
@@ -12,7 +12,8 @@ Requires a changelog fragment when ABI dump files changed or the pull request ha
 an API-impacting label. The labels are read from GITHUB_EVENT_PATH when available.
 Skip labels:
   - no-changelog-needed
-  - internal-only
+Scope labels:
+  - internal-only (does not skip this gate)
 API labels:
   - api-impacting
   - api-impacting change
@@ -111,18 +112,8 @@ if event_has_label "no-changelog-needed"; then
   no_changelog_needed=true
 fi
 
-internal_only=false
-if event_has_label "internal-only"; then
-  internal_only=true
-fi
-
 if [[ "$has_changelog_fragment" == true || "$no_changelog_needed" == true ]]; then
   echo "Changelog gate passed."
-  exit 0
-fi
-
-if [[ "$internal_only" == true && "$abi_changed" == false ]]; then
-  echo "Changelog gate passed for internal-only change with no ABI dump changes."
   exit 0
 fi
 
@@ -130,10 +121,19 @@ if [[ "$abi_changed" == true || "$api_label" == true ]]; then
   cat >&2 <<'ERROR'
 This change appears to affect public API/ABI but does not include a changelog fragment.
 
-Add a consumer-facing Markdown fragment under changelog.d/, or apply one of these
-reviewer-accepted labels when appropriate:
+Choose one of these reviewer-visible resolutions:
+
+1. Add a consumer-facing Towncrier fragment under changelog.d/, for example:
+  changelog.d/<short-change-description>.added.md
+  changelog.d/<short-change-description>.changed.md
+  changelog.d/<short-change-description>.removed.md
+
+2. If reviewers agree this public API/ABI change does not need release notes, apply:
   - no-changelog-needed
-  - internal-only
+
+3. If the PR is internal-only, keep the internal-only label for scope clarity,
+   but still add a fragment or apply no-changelog-needed. The internal-only
+   label does not skip this gate.
 ERROR
   exit 1
 fi


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-28295
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Improve error message for changelog fragment generation

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
