### PR TITLE
feat: include ongoing meeting when getting next occurrence [WPB-27923]

### DIFF
--- a/changelog.d/get-next-meeting-occurrence-use-case.changed.md
+++ b/changelog.d/get-next-meeting-occurrence-use-case.changed.md
@@ -1,0 +1,6 @@
+Renamed `MeetingScope.getNextMeetingOccurrence` and `GetNextMeetingOccurrenceUseCase` to `MeetingScope.getNextUnfinishedMeetingOccurrence` and `GetNextUnfinishedMeetingOccurrenceUseCase`. The API now returns the current ongoing occurrence when it has not finished yet, otherwise the next future occurrence.
+
+  - ABI: breaking for consumers compiled against the previous next meeting occurrence API.
+  - Source: breaking for consumers calling `MeetingScope.getNextMeetingOccurrence` or referencing `GetNextMeetingOccurrenceUseCase`.
+  - Behavior: ongoing occurrences are now returned while their end time is after the supplied `from` instant.
+  - Migration: replace `getNextMeetingOccurrence` with `getNextUnfinishedMeetingOccurrence` and handle that the returned occurrence may already be ongoing.

--- a/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Meetings.sq
+++ b/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Meetings.sq
@@ -206,12 +206,12 @@ WHERE Member.conversation IN :conversationIds
     AND User.preview_asset_id IS NOT NULL
 ORDER BY Member.conversation ASC, Member.user ASC;
 
-selectNextMeetingOccurrenceDetailsId:
+selectNextUnfinishedMeetingOccurrenceDetailsId:
 SELECT MeetingOccurrence.occurrence_id
 FROM MeetingOccurrence
 JOIN Meeting ON Meeting.meeting_id = MeetingOccurrence.meeting_id
 WHERE MeetingOccurrence.meeting_id = :meetingId
-    AND MeetingOccurrence.occurrence_start > :fromDate
+    AND MeetingOccurrence.occurrence_end > :fromDate
 ORDER BY MeetingOccurrence.occurrence_start ASC,
     MeetingOccurrence.occurrence_end ASC,
     Meeting.title ASC

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/meeting/MeetingDao.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/meeting/MeetingDao.kt
@@ -46,7 +46,7 @@ interface MeetingDao {
         from: Instant,
     ): KaliumPager<MeetingOccurrenceDetailsEntity>
     suspend fun deleteMeeting(meetingId: QualifiedIDEntity)
-    suspend fun getNextMeetingOccurrenceDetailsId(meetingId: QualifiedIDEntity, from: Instant): String?
+    suspend fun getNextUnfinishedMeetingOccurrenceDetailsId(meetingId: QualifiedIDEntity, from: Instant): String?
     suspend fun getMeeting(meetingId: QualifiedIDEntity): MeetingEntity?
 }
 
@@ -138,9 +138,9 @@ internal class MeetingDaoImpl(
         }
     }
 
-    override suspend fun getNextMeetingOccurrenceDetailsId(meetingId: QualifiedIDEntity, from: Instant): String? =
+    override suspend fun getNextUnfinishedMeetingOccurrenceDetailsId(meetingId: QualifiedIDEntity, from: Instant): String? =
         withContext(readDispatcher.value) {
-            meetingsQueries.selectNextMeetingOccurrenceDetailsId(meetingId = meetingId, fromDate = from)
+            meetingsQueries.selectNextUnfinishedMeetingOccurrenceDetailsId(meetingId = meetingId, fromDate = from)
                 .awaitAsOneOrNull()
         }
 

--- a/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/meeting/MeetingDaoTest.kt
+++ b/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/meeting/MeetingDaoTest.kt
@@ -104,7 +104,7 @@ class MeetingDaoTest : BaseDatabaseTest() {
         }
 
     @Test
-    fun givenRecurringMeeting_whenGettingNextOccurrence_thenReturnsFirstOccurrenceThatHasNotStarted() =
+    fun givenRecurringMeeting_whenGettingNextUnfinishedOccurrence_thenReturnsFirstOccurrenceThatHasNotFinished() =
         runTest(dispatcher) {
             val meetingStart = Instant.parse("2026-01-02T10:00:00Z")
             val meeting = newMeeting(
@@ -122,19 +122,27 @@ class MeetingDaoTest : BaseDatabaseTest() {
             meetingDao.upsertMeetings(listOf(meeting, otherMeeting), GenerationLimit.Window(meetingStart - 1.days, meetingStart + 5.days))
             val occurrenceIdsByStartTime = occurrencesFor(meeting).associate { it.occurrence_start to it.occurrence_id }
 
-            val beforeTodaysOccurrenceStartId = meetingDao.getNextMeetingOccurrenceDetailsId(
+            val beforeTodaysOccurrenceStartId = meetingDao.getNextUnfinishedMeetingOccurrenceDetailsId(
                 meetingId = meeting.meetingId,
                 from = Instant.parse("2026-01-02T09:30:00Z")
             )
-            val atTodaysOccurrenceStartId = meetingDao.getNextMeetingOccurrenceDetailsId(meetingId = meeting.meetingId, from = meetingStart)
-            val afterTodaysOccurrenceStartId = meetingDao.getNextMeetingOccurrenceDetailsId(
+            val atTodaysOccurrenceStartId = meetingDao.getNextUnfinishedMeetingOccurrenceDetailsId(
+                meetingId = meeting.meetingId,
+                from = meetingStart
+            )
+            val whileTodaysOccurrenceIsOngoingId = meetingDao.getNextUnfinishedMeetingOccurrenceDetailsId(
                 meetingId = meeting.meetingId,
                 from = Instant.parse("2026-01-02T10:30:00Z")
             )
+            val atTodaysOccurrenceEndId = meetingDao.getNextUnfinishedMeetingOccurrenceDetailsId(
+                meetingId = meeting.meetingId,
+                from = meetingStart + 1.hours
+            )
 
             assertEquals(occurrenceIdsByStartTime.getValue(meetingStart), beforeTodaysOccurrenceStartId)
-            assertEquals(occurrenceIdsByStartTime.getValue(meetingStart + 1.days), atTodaysOccurrenceStartId)
-            assertEquals(occurrenceIdsByStartTime.getValue(meetingStart + 1.days), afterTodaysOccurrenceStartId)
+            assertEquals(occurrenceIdsByStartTime.getValue(meetingStart), atTodaysOccurrenceStartId)
+            assertEquals(occurrenceIdsByStartTime.getValue(meetingStart), whileTodaysOccurrenceIsOngoingId)
+            assertEquals(occurrenceIdsByStartTime.getValue(meetingStart + 1.days), atTodaysOccurrenceEndId)
         }
 
     @Test

--- a/logic/api/jvm/logic.api
+++ b/logic/api/jvm/logic.api
@@ -5358,13 +5358,13 @@ public abstract interface class com/wire/kalium/logic/feature/meeting/EnsureMeet
 	public abstract fun invoke (Lcom/wire/kalium/logic/data/id/QualifiedID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public abstract interface class com/wire/kalium/logic/feature/meeting/GetNextMeetingOccurrenceUseCase {
+public abstract interface class com/wire/kalium/logic/feature/meeting/GetNextUnfinishedMeetingOccurrenceUseCase {
 	public abstract fun invoke (Lcom/wire/kalium/logic/data/id/QualifiedID;Lkotlinx/datetime/Instant;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun invoke$default (Lcom/wire/kalium/logic/feature/meeting/GetNextMeetingOccurrenceUseCase;Lcom/wire/kalium/logic/data/id/QualifiedID;Lkotlinx/datetime/Instant;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun invoke$default (Lcom/wire/kalium/logic/feature/meeting/GetNextUnfinishedMeetingOccurrenceUseCase;Lcom/wire/kalium/logic/data/id/QualifiedID;Lkotlinx/datetime/Instant;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
-public final class com/wire/kalium/logic/feature/meeting/GetNextMeetingOccurrenceUseCase$DefaultImpls {
-	public static synthetic fun invoke$default (Lcom/wire/kalium/logic/feature/meeting/GetNextMeetingOccurrenceUseCase;Lcom/wire/kalium/logic/data/id/QualifiedID;Lkotlinx/datetime/Instant;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+public final class com/wire/kalium/logic/feature/meeting/GetNextUnfinishedMeetingOccurrenceUseCase$DefaultImpls {
+	public static synthetic fun invoke$default (Lcom/wire/kalium/logic/feature/meeting/GetNextUnfinishedMeetingOccurrenceUseCase;Lcom/wire/kalium/logic/data/id/QualifiedID;Lkotlinx/datetime/Instant;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class com/wire/kalium/logic/feature/meeting/GetPaginatedMeetingOccurrencesUseCase {
@@ -5380,7 +5380,7 @@ public final class com/wire/kalium/logic/feature/meeting/MeetingScope {
 	public final fun getCreateNewMeeting ()Lcom/wire/kalium/logic/feature/meeting/CreateNewMeetingUseCase;
 	public final fun getDeleteMeeting ()Lcom/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase;
 	public final fun getEnsureMeetingIsMLSEstablished ()Lcom/wire/kalium/logic/feature/meeting/EnsureMeetingIsMLSEstablishedUseCase;
-	public final fun getGetNextMeetingOccurrence ()Lcom/wire/kalium/logic/feature/meeting/GetNextMeetingOccurrenceUseCase;
+	public final fun getGetNextUnfinishedMeetingOccurrence ()Lcom/wire/kalium/logic/feature/meeting/GetNextUnfinishedMeetingOccurrenceUseCase;
 	public final fun getGetPaginatedMeetingOccurrenceDetails ()Lcom/wire/kalium/logic/feature/meeting/GetPaginatedMeetingOccurrencesUseCase;
 	public final fun getObserveMeetingOccurrence ()Lcom/wire/kalium/logic/feature/meeting/ObserveMeetingOccurrenceUseCase;
 	public final fun getUpdateMeeting ()Lcom/wire/kalium/logic/feature/meeting/UpdateMeetingUseCase;

--- a/logic/api/logic.klib.api
+++ b/logic/api/logic.klib.api
@@ -1392,8 +1392,8 @@ abstract interface com.wire.kalium.logic.feature.meeting/EnsureMeetingIsMLSEstab
     abstract suspend fun invoke(com.wire.kalium.logic.data.id/QualifiedID): kotlin/Boolean // com.wire.kalium.logic.feature.meeting/EnsureMeetingIsMLSEstablishedUseCase.invoke|invoke(com.wire.kalium.logic.data.id.QualifiedID){}[0]
 }
 
-abstract interface com.wire.kalium.logic.feature.meeting/GetNextMeetingOccurrenceUseCase { // com.wire.kalium.logic.feature.meeting/GetNextMeetingOccurrenceUseCase|null[0]
-    abstract suspend fun invoke(com.wire.kalium.logic.data.id/QualifiedID, kotlinx.datetime/Instant = ...): com.wire.kalium.logic.data.meeting/MeetingOccurrence? // com.wire.kalium.logic.feature.meeting/GetNextMeetingOccurrenceUseCase.invoke|invoke(com.wire.kalium.logic.data.id.QualifiedID;kotlinx.datetime.Instant){}[0]
+abstract interface com.wire.kalium.logic.feature.meeting/GetNextUnfinishedMeetingOccurrenceUseCase { // com.wire.kalium.logic.feature.meeting/GetNextUnfinishedMeetingOccurrenceUseCase|null[0]
+    abstract suspend fun invoke(com.wire.kalium.logic.data.id/QualifiedID, kotlinx.datetime/Instant = ...): com.wire.kalium.logic.data.meeting/MeetingOccurrence? // com.wire.kalium.logic.feature.meeting/GetNextUnfinishedMeetingOccurrenceUseCase.invoke|invoke(com.wire.kalium.logic.data.id.QualifiedID;kotlinx.datetime.Instant){}[0]
 }
 
 abstract interface com.wire.kalium.logic.feature.meeting/GetPaginatedMeetingOccurrencesUseCase { // com.wire.kalium.logic.feature.meeting/GetPaginatedMeetingOccurrencesUseCase|null[0]
@@ -4388,8 +4388,8 @@ final class com.wire.kalium.logic.feature.meeting/MeetingScope { // com.wire.kal
         final fun <get-deleteMeeting>(): com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase // com.wire.kalium.logic.feature.meeting/MeetingScope.deleteMeeting.<get-deleteMeeting>|<get-deleteMeeting>(){}[0]
     final val ensureMeetingIsMLSEstablished // com.wire.kalium.logic.feature.meeting/MeetingScope.ensureMeetingIsMLSEstablished|{}ensureMeetingIsMLSEstablished[0]
         final fun <get-ensureMeetingIsMLSEstablished>(): com.wire.kalium.logic.feature.meeting/EnsureMeetingIsMLSEstablishedUseCase // com.wire.kalium.logic.feature.meeting/MeetingScope.ensureMeetingIsMLSEstablished.<get-ensureMeetingIsMLSEstablished>|<get-ensureMeetingIsMLSEstablished>(){}[0]
-    final val getNextMeetingOccurrence // com.wire.kalium.logic.feature.meeting/MeetingScope.getNextMeetingOccurrence|{}getNextMeetingOccurrence[0]
-        final fun <get-getNextMeetingOccurrence>(): com.wire.kalium.logic.feature.meeting/GetNextMeetingOccurrenceUseCase // com.wire.kalium.logic.feature.meeting/MeetingScope.getNextMeetingOccurrence.<get-getNextMeetingOccurrence>|<get-getNextMeetingOccurrence>(){}[0]
+    final val getNextUnfinishedMeetingOccurrence // com.wire.kalium.logic.feature.meeting/MeetingScope.getNextUnfinishedMeetingOccurrence|{}getNextUnfinishedMeetingOccurrence[0]
+        final fun <get-getNextUnfinishedMeetingOccurrence>(): com.wire.kalium.logic.feature.meeting/GetNextUnfinishedMeetingOccurrenceUseCase // com.wire.kalium.logic.feature.meeting/MeetingScope.getNextUnfinishedMeetingOccurrence.<get-getNextUnfinishedMeetingOccurrence>|<get-getNextUnfinishedMeetingOccurrence>(){}[0]
     final val getPaginatedMeetingOccurrenceDetails // com.wire.kalium.logic.feature.meeting/MeetingScope.getPaginatedMeetingOccurrenceDetails|{}getPaginatedMeetingOccurrenceDetails[0]
         final fun <get-getPaginatedMeetingOccurrenceDetails>(): com.wire.kalium.logic.feature.meeting/GetPaginatedMeetingOccurrencesUseCase // com.wire.kalium.logic.feature.meeting/MeetingScope.getPaginatedMeetingOccurrenceDetails.<get-getPaginatedMeetingOccurrenceDetails>|<get-getPaginatedMeetingOccurrenceDetails>(){}[0]
     final val observeMeetingOccurrence // com.wire.kalium.logic.feature.meeting/MeetingScope.observeMeetingOccurrence|{}observeMeetingOccurrence[0]

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepository.kt
@@ -113,7 +113,7 @@ internal interface MeetingRepository {
         transactionContext: CryptoTransactionContext,
     ): Either<CoreFailure, MLSAdditionResult>
 
-    suspend fun getNextMeetingOccurrence(
+    suspend fun getNextUnfinishedMeetingOccurrence(
         meetingId: MeetingId,
         from: Instant = currentInstant()
     ): Either<StorageFailure, MeetingOccurrence>
@@ -216,11 +216,11 @@ internal class MeetingDataSource(
         }
     }
 
-    override suspend fun getNextMeetingOccurrence(
+    override suspend fun getNextUnfinishedMeetingOccurrence(
         meetingId: MeetingId,
         from: Instant
     ): Either<StorageFailure, MeetingOccurrence> = wrapStorageRequest {
-        meetingDAO.getNextMeetingOccurrenceDetailsId(meetingId.toDao(), from)?.let { occurrenceId ->
+        meetingDAO.getNextUnfinishedMeetingOccurrenceDetailsId(meetingId.toDao(), from)?.let { occurrenceId ->
             meetingDAO.getMeetingOccurrenceDetailsFlow(occurrenceId).firstOrNull()?.let(meetingMapper::fromDaoToModel)
         }
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/meeting/GetNextUnfinishedMeetingOccurrenceUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/meeting/GetNextUnfinishedMeetingOccurrenceUseCase.kt
@@ -27,17 +27,20 @@ import kotlinx.coroutines.withContext
 import kotlinx.datetime.Instant
 
 /**
- * Use case for getting the next soonest occurrence of a meeting after a given point in time.
+ * Use case for finding the next soonest unfinished occurrence of a meeting at the given point in time.
+ * Unfinished occurrences are those that have not yet ended at the given point in time.
+ * If there is a currently ongoing occurrence, it will be returned, otherwise the next upcoming occurrence will be returned.
+ * If there are no unfinished occurrences, null will be returned.
  */
-public interface GetNextMeetingOccurrenceUseCase {
+public interface GetNextUnfinishedMeetingOccurrenceUseCase {
     public suspend operator fun invoke(meetingId: MeetingId, from: Instant = currentInstant()): MeetingOccurrence?
 }
 
-internal class GetNextMeetingOccurrenceUseCaseImpl(
+internal class GetNextUnfinishedMeetingOccurrenceUseCaseImpl(
     private val dispatcher: KaliumDispatcher,
     private val meetingRepository: MeetingRepository,
-) : GetNextMeetingOccurrenceUseCase {
+) : GetNextUnfinishedMeetingOccurrenceUseCase {
     override suspend operator fun invoke(meetingId: MeetingId, from: Instant): MeetingOccurrence? = withContext(dispatcher.io) {
-        meetingRepository.getNextMeetingOccurrence(meetingId, from).getOrNull()
+        meetingRepository.getNextUnfinishedMeetingOccurrence(meetingId, from).getOrNull()
     }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/meeting/MeetingScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/meeting/MeetingScope.kt
@@ -55,8 +55,8 @@ public class MeetingScope internal constructor(
             meetingRepository = meetingRepository,
         )
 
-    public val getNextMeetingOccurrence: GetNextMeetingOccurrenceUseCase
-        get() = GetNextMeetingOccurrenceUseCaseImpl(
+    public val getNextUnfinishedMeetingOccurrence: GetNextUnfinishedMeetingOccurrenceUseCase
+        get() = GetNextUnfinishedMeetingOccurrenceUseCaseImpl(
             dispatcher = dispatcher,
             meetingRepository = meetingRepository,
         )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepositoryTest.kt
@@ -317,38 +317,38 @@ class MeetingRepositoryTest {
 
     @Suppress("UnusedFlow")
     @Test
-    fun givenDaoReturnsOccurrence_whenGetNextMeetingOccurrence_thenReturnsMappedOccurrence() = runTest {
+    fun givenDaoReturnsOccurrence_whenGetNextUnfinishedMeetingOccurrence_thenReturnsMappedOccurrence() = runTest {
         val meetingId = MEETING_OCCURRENCE_DETAILS.meeting.meetingId.toModel()
         val from = Instant.parse("2026-06-01T10:00:00Z")
         val occurrenceId = MEETING_OCCURRENCE_DETAILS.occurrence.occurrenceId
         val (arrangement, repository) = Arrangement()
-            .withNextMeetingOccurrenceId(meetingId, from, occurrenceId)
+            .withNextUnfinishedMeetingOccurrenceId(meetingId, from, occurrenceId)
             .withMeetingOccurrenceDetailsFlow(occurrenceId, flowOf(MEETING_OCCURRENCE_DETAILS))
             .arrange()
 
-        val result = repository.getNextMeetingOccurrence(meetingId, from)
+        val result = repository.getNextUnfinishedMeetingOccurrence(meetingId, from)
 
         assertIs<Either.Right<MeetingOccurrence>>(result).also {
             assertEquals(arrangement.meetingMapper.fromDaoToModel(MEETING_OCCURRENCE_DETAILS), result.value)
         }
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.meetingDao.getNextMeetingOccurrenceDetailsId(meetingId.toDao(), from)
+            arrangement.meetingDao.getNextUnfinishedMeetingOccurrenceDetailsId(meetingId.toDao(), from)
             arrangement.meetingDao.getMeetingOccurrenceDetailsFlow(occurrenceId)
         }
     }
 
     @Test
-    fun givenDaoReturnsNoOccurrenceId_whenGetNextMeetingOccurrence_thenReturnDataNotFound() = runTest {
+    fun givenDaoReturnsNoOccurrenceId_whenGetNextUnfinishedMeetingOccurrence_thenReturnDataNotFound() = runTest {
         val meetingId = MeetingId("meeting1", "domain")
         val from = Instant.parse("2026-06-01T10:00:00Z")
         val (arrangement, repository) = Arrangement()
-            .withNextMeetingOccurrenceId(meetingId, from, null)
+            .withNextUnfinishedMeetingOccurrenceId(meetingId, from, null)
             .arrange()
 
-        val result = repository.getNextMeetingOccurrence(meetingId, from)
+        val result = repository.getNextUnfinishedMeetingOccurrence(meetingId, from)
 
         assertIs<Either.Left<StorageFailure.DataNotFound>>(result)
-        verifySuspend(VerifyMode.exactly(1)) { arrangement.meetingDao.getNextMeetingOccurrenceDetailsId(meetingId.toDao(), from) }
+        verifySuspend(VerifyMode.exactly(1)) { arrangement.meetingDao.getNextUnfinishedMeetingOccurrenceDetailsId(meetingId.toDao(), from) }
     }
 
     @Test
@@ -1096,8 +1096,8 @@ class MeetingRepositoryTest {
             everySuspend { meetingApi.deleteMeeting(meetingId.toApi()) } returns NetworkResponse.Error(TestNetworkException.generic)
         }
 
-        internal fun withNextMeetingOccurrenceId(meetingId: MeetingId, from: Instant, result: String?) = apply {
-            everySuspend { meetingDao.getNextMeetingOccurrenceDetailsId(meetingId.toDao(), from) } returns result
+        internal fun withNextUnfinishedMeetingOccurrenceId(meetingId: MeetingId, from: Instant, result: String?) = apply {
+            everySuspend { meetingDao.getNextUnfinishedMeetingOccurrenceDetailsId(meetingId.toDao(), from) } returns result
         }
 
         internal fun withMeetingOccurrenceDetailsFlow(occurrenceId: String, result: Flow<MeetingOccurrenceDetailsEntity?>) = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/meeting/GetNextUnfinishedMeetingOccurrenceUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/meeting/GetNextUnfinishedMeetingOccurrenceUseCaseTest.kt
@@ -41,42 +41,46 @@ import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class GetNextMeetingOccurrenceUseCaseTest {
+class GetNextUnfinishedMeetingOccurrenceUseCaseTest {
 
     @Test
     fun givenRepositoryReturnsOccurrence_whenInvoking_thenReturnsOccurrence() = runTest {
         val (arrangement, useCase) = Arrangement(StandardTestDispatcher(testScheduler).testKaliumDispatcher())
-            .withNextMeetingOccurrenceReturning(MEETING.meetingId, FROM, MEETING_OCCURRENCE.right())
+            .withNextUnfinishedMeetingOccurrenceReturning(MEETING.meetingId, FROM, MEETING_OCCURRENCE.right())
             .arrange()
 
         val result = useCase(MEETING.meetingId, FROM)
 
         assertEquals(MEETING_OCCURRENCE, result)
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.meetingRepository.getNextMeetingOccurrence(MEETING.meetingId, FROM)
+            arrangement.meetingRepository.getNextUnfinishedMeetingOccurrence(MEETING.meetingId, FROM)
         }
     }
 
     @Test
     fun givenRepositoryReturnsNull_whenInvoking_thenReturnsNull() = runTest {
         val (arrangement, useCase) = Arrangement(StandardTestDispatcher(testScheduler).testKaliumDispatcher())
-            .withNextMeetingOccurrenceReturning(MEETING.meetingId, FROM, StorageFailure.DataNotFound.left())
+            .withNextUnfinishedMeetingOccurrenceReturning(MEETING.meetingId, FROM, StorageFailure.DataNotFound.left())
             .arrange()
 
         val result = useCase(MEETING.meetingId, FROM)
 
         assertEquals(null, result)
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.meetingRepository.getNextMeetingOccurrence(MEETING.meetingId, FROM)
+            arrangement.meetingRepository.getNextUnfinishedMeetingOccurrence(MEETING.meetingId, FROM)
         }
     }
 
     private class Arrangement(private val dispatcher: KaliumDispatcher) {
         val meetingRepository = mock<MeetingRepository>(mode = MockMode.autoUnit)
-        fun withNextMeetingOccurrenceReturning(id: MeetingId, from: Instant, result: Either<StorageFailure, MeetingOccurrence>) = apply {
-            everySuspend { meetingRepository.getNextMeetingOccurrence(id, from) } returns result
+        fun withNextUnfinishedMeetingOccurrenceReturning(
+            id: MeetingId,
+            from: Instant,
+            result: Either<StorageFailure, MeetingOccurrence>
+        ) = apply {
+            everySuspend { meetingRepository.getNextUnfinishedMeetingOccurrence(id, from) } returns result
         }
-        fun arrange() = this to GetNextMeetingOccurrenceUseCaseImpl(
+        fun arrange() = this to GetNextUnfinishedMeetingOccurrenceUseCaseImpl(
             dispatcher = dispatcher,
             meetingRepository = meetingRepository,
         )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-27923
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

To allow editing ongoing meetings, the use case for getting next occurrence needs to also return ongoing occurrence if there is one at a given time. Names of use case and all methods updated to be more clear about the purpose.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Have a recurring meeting where one of occurrences is actually ongoing and try to edit this meeting - the dates of currently ongoing occurrence should be prefilled on "edit meeting" screen.

### Attachments (Optional)

https://github.com/user-attachments/assets/6b1f187e-0dca-4a42-8e93-b7cf30366bc0

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
