### PR TITLE
fix: crash when sending pending messages (WPB-28301)

### DIFF
--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SendPendingMessagesUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/SendPendingMessagesUseCase.kt
@@ -55,18 +55,26 @@ internal class SendPendingMessagesUseCaseImpl(
 
         messageRepository.getAllPendingMessagesFromUser(userId)
             .onSuccess { pendingMessages ->
-                pendingMessages.forEach { message ->
-                    when (message) {
-                        is Message.Regular if message.content is MessageContent.Asset ->
-                            sendPendingAssetMessage(message)
+                pendingMessages
+                    .filterIsInstance<Message.Regular>()
+                    .forEach { message ->
 
-                        is Message.Regular if message.content is MessageContent.Text &&
-                                message.editStatus is Message.EditStatus.Edited ->
-                            resendPendingTextEdit(message, message.content as MessageContent.Text)
+                        when (message.content) {
+                            is MessageContent.Asset -> sendPendingAssetMessage(message)
+                            is MessageContent.Text if message.editStatus is Message.EditStatus.Edited ->
+                                resendPendingTextEdit(message, message.content as MessageContent.Text)
 
-                        else -> messageSender.sendPendingMessage(message.conversationId, message.id)
+                            is MessageContent.Location,
+                            is MessageContent.Multipart,
+                            is MessageContent.Text -> messageSender.sendPendingMessage(message.conversationId, message.id)
+
+                            else -> {
+                                val contentType = message.content::class.simpleName
+                                kaliumLogger.withFeatureId(SYNC)
+                                    .w("Skipping pending message ${message.id} with non-retryable content $contentType")
+                            }
+                        }
                     }
-                }
             }.onFailure {
                 kaliumLogger.withFeatureId(SYNC).w("Failed to fetch and attempt retry of pending messages: $it")
                 result = SendPendingMessagesUseCase.Result.Failure

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/SendPendingMessagesUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/SendPendingMessagesUseCaseTest.kt
@@ -30,6 +30,7 @@ import com.wire.kalium.logic.framework.TestMessage.TEST_DATE
 import com.wire.kalium.logic.framework.TestMessage.TEXT_CONTENT
 import com.wire.kalium.logic.framework.TestMessage.TEXT_MESSAGE
 import com.wire.kalium.logic.framework.TestMessage.assetMessage
+import com.wire.kalium.logic.framework.TestMessage.multipartMessage
 import com.wire.kalium.logic.framework.TestUser.USER_ID
 import com.wire.kalium.messaging.sending.MessageSender
 import dev.mokkery.MockMode
@@ -114,6 +115,38 @@ class SendPendingMessagesUseCaseTest {
         }
         verifySuspend(VerifyMode.not) {
             arrangement.messageSender.sendMessage(any(), any())
+        }
+    }
+
+    @Test
+    fun givenPendingLocationMessage_whenInvoked_thenSendsItAsPendingMessage() = runTest {
+        val message = TEXT_MESSAGE.copy(content = MessageContent.Location(1F, 2F))
+        val (arrangement, useCase) = Arrangement()
+            .withPendingMessages(Either.Right(listOf(message)))
+            .withPendingMessageResult(Either.Right(Unit))
+            .arrange()
+
+        val result = useCase()
+
+        assertIs<SendPendingMessagesUseCase.Result.Success>(result)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.messageSender.sendPendingMessage(message.conversationId, message.id)
+        }
+    }
+
+    @Test
+    fun givenPendingMultipartMessage_whenInvoked_thenSendsItAsPendingMessage() = runTest {
+        val message = multipartMessage()
+        val (arrangement, useCase) = Arrangement()
+            .withPendingMessages(Either.Right(listOf(message)))
+            .withPendingMessageResult(Either.Right(Unit))
+            .arrange()
+
+        val result = useCase()
+
+        assertIs<SendPendingMessagesUseCase.Result.Success>(result)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.messageSender.sendPendingMessage(message.conversationId, message.id)
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-28301
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-28301
----

# What's new in this PR?

### Issues

Application crash when sending pending messages.

### Causes (Optional)

Database may contain un-sendable messages with the PENDING status (e.g. Failed Decryption, Restricted Asset, Unknown). App throws exception when trying to serialize these messages into protobuf.

### Solutions

Allow retrying only specific message types which can be sent directly by user. Skip all other messages with PENDING status.