### PR TITLE
feat: fetch apps and collaborators (WPB-25747)

### DIFF
--- a/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/teams/TeamsDTO.kt
+++ b/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/teams/TeamsDTO.kt
@@ -61,6 +61,11 @@ data class TeamMemberIdList(
 )
 
 @Serializable
+data class TeamCollaboratorDTO(
+    @SerialName("user") val nonQualifiedUserId: NonQualifiedUserId
+)
+
+@Serializable
 data class PasswordRequest(
     @SerialName("password") val password: String?
 )

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/TeamsApi.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/TeamsApi.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.network.api.base.authenticated
 
+import com.wire.kalium.network.api.authenticated.teams.TeamCollaboratorDTO
 import com.wire.kalium.network.api.authenticated.teams.TeamMemberDTO
 import com.wire.kalium.network.api.authenticated.teams.TeamMemberIdList
 import com.wire.kalium.network.api.authenticated.teams.TeamMemberListNonPaginated
@@ -28,14 +29,17 @@ import com.wire.kalium.network.api.model.NonQualifiedUserId
 import com.wire.kalium.network.api.model.ServiceDetailResponse
 import com.wire.kalium.network.api.model.TeamDTO
 import com.wire.kalium.network.api.model.TeamId
+import com.wire.kalium.network.api.model.UserProfileDTO
 import com.wire.kalium.network.utils.NetworkResponse
 
-interface TeamsApi {
+interface TeamsApi : BaseApi {
 
     suspend fun deleteConversation(conversationId: NonQualifiedConversationId, teamId: TeamId): NetworkResponse<Unit>
     suspend fun getTeamMembers(teamId: TeamId, limitTo: Int?, pagingState: String? = null): NetworkResponse<TeamMemberListPaginated>
     suspend fun getTeamMembersByIds(teamId: TeamId, teamMemberIdList: TeamMemberIdList): NetworkResponse<TeamMemberListNonPaginated>
     suspend fun getTeamMember(teamId: TeamId, userId: NonQualifiedUserId): NetworkResponse<TeamMemberDTO>
+    suspend fun getTeamCollaborators(teamId: TeamId): NetworkResponse<List<TeamCollaboratorDTO>>
+    suspend fun getTeamApps(teamId: TeamId): NetworkResponse<List<UserProfileDTO>>
     suspend fun getTeamInfo(teamId: TeamId): NetworkResponse<TeamDTO>
     suspend fun whiteListedServices(teamId: TeamId, size: Int = DEFAULT_SERVICES_SIZE): NetworkResponse<ServiceDetailResponse>
     suspend fun approveLegalHoldRequest(teamId: TeamId, userId: NonQualifiedUserId, password: String?): NetworkResponse<Unit>
@@ -43,5 +47,7 @@ interface TeamsApi {
 
     companion object {
         const val DEFAULT_SERVICES_SIZE = 100 // this number is copied from the web client
+        const val MIN_API_VERSION_TEAM_COLLABORATORS = 10
+        const val MIN_API_VERSION_TEAM_APPS = 15
     }
 }

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/TeamsApiV0.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/TeamsApiV0.kt
@@ -19,18 +19,22 @@
 package com.wire.kalium.network.api.v0.authenticated
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
-import com.wire.kalium.network.api.base.authenticated.TeamsApi
+import com.wire.kalium.network.api.authenticated.teams.TeamCollaboratorDTO
 import com.wire.kalium.network.api.authenticated.teams.PasswordRequest
 import com.wire.kalium.network.api.authenticated.teams.TeamMemberDTO
 import com.wire.kalium.network.api.authenticated.teams.TeamMemberIdList
 import com.wire.kalium.network.api.authenticated.teams.TeamMemberListNonPaginated
 import com.wire.kalium.network.api.authenticated.teams.TeamMemberListPaginated
+import com.wire.kalium.network.api.base.authenticated.TeamsApi
+import com.wire.kalium.network.api.base.authenticated.TeamsApi.Companion.MIN_API_VERSION_TEAM_APPS
+import com.wire.kalium.network.api.base.authenticated.TeamsApi.Companion.MIN_API_VERSION_TEAM_COLLABORATORS
 import com.wire.kalium.network.api.model.LegalHoldStatusResponse
 import com.wire.kalium.network.api.model.NonQualifiedConversationId
 import com.wire.kalium.network.api.model.NonQualifiedUserId
 import com.wire.kalium.network.api.model.ServiceDetailResponse
 import com.wire.kalium.network.api.model.TeamDTO
 import com.wire.kalium.network.api.model.TeamId
+import com.wire.kalium.network.api.model.UserProfileDTO
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.wrapRequest
 import io.ktor.client.request.delete
@@ -87,6 +91,12 @@ internal open class TeamsApiV0 internal constructor(
         wrapRequest {
             httpClient.get("$PATH_TEAMS/$teamId/$PATH_MEMBERS/$userId")
         }
+
+    override suspend fun getTeamCollaborators(teamId: TeamId): NetworkResponse<List<TeamCollaboratorDTO>> =
+        getApiNotSupportedError(::getTeamCollaborators.name, MIN_API_VERSION_TEAM_COLLABORATORS)
+
+    override suspend fun getTeamApps(teamId: TeamId): NetworkResponse<List<UserProfileDTO>> =
+        getApiNotSupportedError(::getTeamApps.name, MIN_API_VERSION_TEAM_APPS)
 
     override suspend fun approveLegalHoldRequest(teamId: TeamId, userId: NonQualifiedUserId, password: String?): NetworkResponse<Unit> =
         wrapRequest {

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v10/authenticated/TeamsApiV10.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v10/authenticated/TeamsApiV10.kt
@@ -19,8 +19,18 @@
 package com.wire.kalium.network.api.v10.authenticated
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.authenticated.teams.TeamCollaboratorDTO
+import com.wire.kalium.network.api.model.TeamId
 import com.wire.kalium.network.api.v9.authenticated.TeamsApiV9
+import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.wrapRequest
+import io.ktor.client.request.get
 
 internal open class TeamsApiV10 internal constructor(
-    authenticatedNetworkClient: AuthenticatedNetworkClient
-) : TeamsApiV9(authenticatedNetworkClient)
+    private val authenticatedNetworkClient: AuthenticatedNetworkClient
+) : TeamsApiV9(authenticatedNetworkClient) {
+
+    override suspend fun getTeamCollaborators(teamId: TeamId): NetworkResponse<List<TeamCollaboratorDTO>> = wrapRequest {
+        authenticatedNetworkClient.httpClient.get("teams/$teamId/collaborators")
+    }
+}

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v15/authenticated/TeamsApiV15.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v15/authenticated/TeamsApiV15.kt
@@ -19,8 +19,18 @@
 package com.wire.kalium.network.api.v15.authenticated
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.model.TeamId
+import com.wire.kalium.network.api.model.UserProfileDTO
 import com.wire.kalium.network.api.v14.authenticated.TeamsApiV14
+import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.wrapRequest
+import io.ktor.client.request.get
 
 internal open class TeamsApiV15 internal constructor(
-    authenticatedNetworkClient: AuthenticatedNetworkClient
-) : TeamsApiV14(authenticatedNetworkClient)
+    private val authenticatedNetworkClient: AuthenticatedNetworkClient
+) : TeamsApiV14(authenticatedNetworkClient) {
+
+    override suspend fun getTeamApps(teamId: TeamId): NetworkResponse<List<UserProfileDTO>> = wrapRequest {
+        authenticatedNetworkClient.httpClient.get("teams/$teamId/apps")
+    }
+}

--- a/data/network/src/commonTest/kotlin/com/wire/kalium/api/v0/teams/TeamsApiV0Test.kt
+++ b/data/network/src/commonTest/kotlin/com/wire/kalium/api/v0/teams/TeamsApiV0Test.kt
@@ -22,13 +22,14 @@ import com.wire.kalium.api.ApiTest
 import com.wire.kalium.api.json.model.ErrorResponseJson
 import com.wire.kalium.mocks.responses.ServiceDetailsResponseJson
 import com.wire.kalium.mocks.responses.TeamsResponsesJson
-import com.wire.kalium.network.api.base.authenticated.TeamsApi
 import com.wire.kalium.network.api.authenticated.teams.PasswordRequest
+import com.wire.kalium.network.api.base.authenticated.TeamsApi
 import com.wire.kalium.network.api.model.GenericAPIErrorResponse
 import com.wire.kalium.network.api.model.NonQualifiedUserId
 import com.wire.kalium.network.api.model.ServiceDetailResponse
 import com.wire.kalium.network.api.model.TeamId
 import com.wire.kalium.network.api.v0.authenticated.TeamsApiV0
+import com.wire.kalium.network.exceptions.APINotSupported
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.tools.KtxSerializer
 import com.wire.kalium.network.utils.NetworkResponse
@@ -38,9 +39,23 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.fail
 
 @ExperimentalCoroutinesApi
 internal class TeamsApiV0Test : ApiTest() {
+
+    @Test
+    fun givenOlderApi_whenGettingCollaboratorsAndApps_thenReturnApiNotSupported() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(
+            "",
+            statusCode = HttpStatusCode.OK,
+            assertion = { fail("Unsupported endpoints must not make a network request") }
+        )
+        val teamsApi: TeamsApi = TeamsApiV0(networkClient)
+
+        assertIs<APINotSupported>((teamsApi.getTeamCollaborators(DUMMY_TEAM_ID) as NetworkResponse.Error).kException)
+        assertIs<APINotSupported>((teamsApi.getTeamApps(DUMMY_TEAM_ID) as NetworkResponse.Error).kException)
+    }
 
     @Test
     fun givenAValidGetTeamsFirstPageRequest_whenGettingTeamsMembers_theRequestShouldBeConfiguredCorrectly() =

--- a/data/network/src/commonTest/kotlin/com/wire/kalium/api/v10/teams/TeamsApiV10Test.kt
+++ b/data/network/src/commonTest/kotlin/com/wire/kalium/api/v10/teams/TeamsApiV10Test.kt
@@ -1,0 +1,78 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.api.v10.teams
+
+import com.wire.kalium.api.ApiTest
+import com.wire.kalium.network.api.authenticated.teams.TeamCollaboratorDTO
+import com.wire.kalium.network.api.v10.authenticated.TeamsApiV10
+import com.wire.kalium.network.exceptions.APINotSupported
+import com.wire.kalium.network.utils.NetworkResponse
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.fail
+
+internal class TeamsApiV10Test : ApiTest() {
+
+    @Test
+    fun givenTeam_whenGettingCollaborators_thenRequestAndResponseAreCorrect() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(
+            COLLABORATORS_RESPONSE,
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertGet()
+                assertNoQueryParams()
+                assertPathEqual("/teams/$TEAM_ID/collaborators")
+            }
+        )
+
+        val response = TeamsApiV10(networkClient).getTeamCollaborators(TEAM_ID)
+
+        val success = assertIs<NetworkResponse.Success<List<TeamCollaboratorDTO>>>(response)
+        assertEquals(listOf("collaborator-id"), success.value.map { it.nonQualifiedUserId })
+    }
+
+    @Test
+    fun givenApiBeforeV15_whenGettingTeamApps_thenReturnApiNotSupported() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(
+            "",
+            statusCode = HttpStatusCode.OK,
+            assertion = { fail("Unsupported endpoint must not make a network request") }
+        )
+
+        val response = TeamsApiV10(networkClient).getTeamApps(TEAM_ID)
+
+        assertIs<APINotSupported>(assertIs<NetworkResponse.Error>(response).kException)
+    }
+
+    private companion object {
+        const val TEAM_ID = "team-id"
+        const val COLLABORATORS_RESPONSE = """
+            [
+              {
+                "user": "collaborator-id",
+                "team": "team-id",
+                "permissions": { "copy": 0, "self": 0 },
+                "unused_future_field": true
+              }
+            ]
+        """
+    }
+}

--- a/data/network/src/commonTest/kotlin/com/wire/kalium/api/v15/teams/TeamsApiV15Test.kt
+++ b/data/network/src/commonTest/kotlin/com/wire/kalium/api/v15/teams/TeamsApiV15Test.kt
@@ -1,0 +1,82 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.api.v15.teams
+
+import com.wire.kalium.api.ApiTest
+import com.wire.kalium.network.api.model.UserProfileDTO
+import com.wire.kalium.network.api.model.UserTypeDTO
+import com.wire.kalium.network.api.v15.authenticated.TeamsApiV15
+import com.wire.kalium.network.utils.NetworkResponse
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+internal class TeamsApiV15Test : ApiTest() {
+
+    @Test
+    fun givenTeam_whenGettingApps_thenRequestAndFullProfilesAreCorrect() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(
+            APPS_RESPONSE,
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertGet()
+                assertNoQueryParams()
+                assertPathEqual("/teams/$TEAM_ID/apps")
+            }
+        )
+
+        val response = TeamsApiV15(networkClient).getTeamApps(TEAM_ID)
+
+        val success = assertIs<NetworkResponse.Success<List<UserProfileDTO>>>(response)
+        assertEquals(1, success.value.size)
+        assertEquals("app-id", success.value.single().id.value)
+        assertEquals("wire.example", success.value.single().id.domain)
+        assertEquals(UserTypeDTO.APP, success.value.single().type)
+        assertEquals("Productivity", success.value.single().app?.category)
+    }
+
+    private companion object {
+        const val TEAM_ID = "team-id"
+        const val APPS_RESPONSE = """
+            [
+              {
+                "qualified_id": { "id": "app-id", "domain": "wire.example" },
+                "id": "app-id",
+                "name": "Calendar App",
+                "handle": "calendar-app",
+                "team": "team-id",
+                "accent_id": 1,
+                "assets": [],
+                "deleted": false,
+                "email": null,
+                "expires_at": null,
+                "service": null,
+                "supported_protocols": ["mls"],
+                "legalhold_status": "disabled",
+                "type": "app",
+                "app": {
+                  "description": "Schedules meetings",
+                  "category": "Productivity"
+                }
+              }
+            ]
+        """
+    }
+}

--- a/logic/api/jvm/logic.api
+++ b/logic/api/jvm/logic.api
@@ -1028,6 +1028,7 @@ public final class com/wire/kalium/logic/feature/app/AppScope {
 	public final fun getObserveAllApps ()Lcom/wire/kalium/logic/feature/app/ObserveAllAppsUseCase;
 	public final fun getObserveIsAppMember ()Lcom/wire/kalium/logic/feature/app/ObserveIsAppMemberUseCase;
 	public final fun getSearchAppsByName ()Lcom/wire/kalium/logic/feature/app/SearchAppsByNameUseCase;
+	public final fun getSyncApps ()Lcom/wire/kalium/logic/feature/app/SyncAppsUseCase;
 }
 
 public abstract interface class com/wire/kalium/logic/feature/app/GetAppByIdUseCase {
@@ -1069,6 +1070,31 @@ public abstract interface class com/wire/kalium/logic/feature/app/ObserveIsAppMe
 
 public abstract interface class com/wire/kalium/logic/feature/app/SearchAppsByNameUseCase {
 	public abstract fun invoke (Ljava/lang/String;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class com/wire/kalium/logic/feature/app/SyncAppsUseCase {
+	public abstract fun invoke (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/wire/kalium/logic/feature/app/SyncAppsUseCase$Result {
+}
+
+public final class com/wire/kalium/logic/feature/app/SyncAppsUseCase$Result$Failure : com/wire/kalium/logic/feature/app/SyncAppsUseCase$Result {
+	public fun <init> (Lcom/wire/kalium/common/error/CoreFailure;)V
+	public final fun component1 ()Lcom/wire/kalium/common/error/CoreFailure;
+	public final fun copy (Lcom/wire/kalium/common/error/CoreFailure;)Lcom/wire/kalium/logic/feature/app/SyncAppsUseCase$Result$Failure;
+	public static synthetic fun copy$default (Lcom/wire/kalium/logic/feature/app/SyncAppsUseCase$Result$Failure;Lcom/wire/kalium/common/error/CoreFailure;ILjava/lang/Object;)Lcom/wire/kalium/logic/feature/app/SyncAppsUseCase$Result$Failure;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getError ()Lcom/wire/kalium/common/error/CoreFailure;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/wire/kalium/logic/feature/app/SyncAppsUseCase$Result$Success : com/wire/kalium/logic/feature/app/SyncAppsUseCase$Result {
+	public static final field INSTANCE Lcom/wire/kalium/logic/feature/app/SyncAppsUseCase$Result$Success;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class com/wire/kalium/logic/feature/appVersioning/ObserveIfAppUpdateRequiredUseCase {

--- a/logic/api/logic.klib.api
+++ b/logic/api/logic.klib.api
@@ -224,6 +224,31 @@ abstract interface com.wire.kalium.logic.feature.app/SearchAppsByNameUseCase { /
     abstract fun invoke(kotlin/String): kotlinx.coroutines.flow/Flow<kotlin.collections/List<com.wire.kalium.logic.data.service/ServiceDetails>> // com.wire.kalium.logic.feature.app/SearchAppsByNameUseCase.invoke|invoke(kotlin.String){}[0]
 }
 
+abstract interface com.wire.kalium.logic.feature.app/SyncAppsUseCase { // com.wire.kalium.logic.feature.app/SyncAppsUseCase|null[0]
+    abstract suspend fun invoke(): com.wire.kalium.logic.feature.app/SyncAppsUseCase.Result // com.wire.kalium.logic.feature.app/SyncAppsUseCase.invoke|invoke(){}[0]
+
+    sealed interface Result { // com.wire.kalium.logic.feature.app/SyncAppsUseCase.Result|null[0]
+        final class Failure : com.wire.kalium.logic.feature.app/SyncAppsUseCase.Result { // com.wire.kalium.logic.feature.app/SyncAppsUseCase.Result.Failure|null[0]
+            constructor <init>(com.wire.kalium.common.error/CoreFailure) // com.wire.kalium.logic.feature.app/SyncAppsUseCase.Result.Failure.<init>|<init>(com.wire.kalium.common.error.CoreFailure){}[0]
+
+            final val error // com.wire.kalium.logic.feature.app/SyncAppsUseCase.Result.Failure.error|{}error[0]
+                final fun <get-error>(): com.wire.kalium.common.error/CoreFailure // com.wire.kalium.logic.feature.app/SyncAppsUseCase.Result.Failure.error.<get-error>|<get-error>(){}[0]
+
+            final fun component1(): com.wire.kalium.common.error/CoreFailure // com.wire.kalium.logic.feature.app/SyncAppsUseCase.Result.Failure.component1|component1(){}[0]
+            final fun copy(com.wire.kalium.common.error/CoreFailure = ...): com.wire.kalium.logic.feature.app/SyncAppsUseCase.Result.Failure // com.wire.kalium.logic.feature.app/SyncAppsUseCase.Result.Failure.copy|copy(com.wire.kalium.common.error.CoreFailure){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic.feature.app/SyncAppsUseCase.Result.Failure.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // com.wire.kalium.logic.feature.app/SyncAppsUseCase.Result.Failure.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // com.wire.kalium.logic.feature.app/SyncAppsUseCase.Result.Failure.toString|toString(){}[0]
+        }
+
+        final object Success : com.wire.kalium.logic.feature.app/SyncAppsUseCase.Result { // com.wire.kalium.logic.feature.app/SyncAppsUseCase.Result.Success|null[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic.feature.app/SyncAppsUseCase.Result.Success.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // com.wire.kalium.logic.feature.app/SyncAppsUseCase.Result.Success.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // com.wire.kalium.logic.feature.app/SyncAppsUseCase.Result.Success.toString|toString(){}[0]
+        }
+    }
+}
+
 abstract interface com.wire.kalium.logic.feature.appVersioning/ObserveIfAppUpdateRequiredUseCase { // com.wire.kalium.logic.feature.appVersioning/ObserveIfAppUpdateRequiredUseCase|null[0]
     abstract suspend fun invoke(kotlin/Int): kotlinx.coroutines.flow/Flow<kotlin/Boolean> // com.wire.kalium.logic.feature.appVersioning/ObserveIfAppUpdateRequiredUseCase.invoke|invoke(kotlin.Int){}[0]
 }
@@ -3199,6 +3224,8 @@ final class com.wire.kalium.logic.feature.app/AppScope { // com.wire.kalium.logi
         final fun <get-observeIsAppMember>(): com.wire.kalium.logic.feature.app/ObserveIsAppMemberUseCase // com.wire.kalium.logic.feature.app/AppScope.observeIsAppMember.<get-observeIsAppMember>|<get-observeIsAppMember>(){}[0]
     final val searchAppsByName // com.wire.kalium.logic.feature.app/AppScope.searchAppsByName|{}searchAppsByName[0]
         final fun <get-searchAppsByName>(): com.wire.kalium.logic.feature.app/SearchAppsByNameUseCase // com.wire.kalium.logic.feature.app/AppScope.searchAppsByName.<get-searchAppsByName>|<get-searchAppsByName>(){}[0]
+    final val syncApps // com.wire.kalium.logic.feature.app/AppScope.syncApps|{}syncApps[0]
+        final fun <get-syncApps>(): com.wire.kalium.logic.feature.app/SyncAppsUseCase // com.wire.kalium.logic.feature.app/AppScope.syncApps.<get-syncApps>|<get-syncApps>(){}[0]
 }
 
 final class com.wire.kalium.logic.feature.asset.upload/AssetUploadParams { // com.wire.kalium.logic.feature.asset.upload/AssetUploadParams|null[0]

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/app/AppRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/app/AppRepository.kt
@@ -17,25 +17,44 @@
  */
 package com.wire.kalium.logic.data.app
 
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.error.wrapApiRequest
 import com.wire.kalium.common.error.wrapFlowStorageRequest
 import com.wire.kalium.common.error.wrapNullableFlowStorageRequest
 import com.wire.kalium.common.error.wrapStorageNullableRequest
+import com.wire.kalium.common.error.wrapStorageRequest
 import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.common.functional.flatMapLeft
+import com.wire.kalium.common.functional.foldToEitherWhileRight
+import com.wire.kalium.common.functional.map
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.id.TeamId
+import com.wire.kalium.logic.data.id.toApi
 import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.id.toModel
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.di.MapperProvider
+import com.wire.kalium.network.api.authenticated.userDetails.ListUserRequest
+import com.wire.kalium.network.api.authenticated.userDetails.qualifiedIds
+import com.wire.kalium.network.api.base.authenticated.TeamsApi
+import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
+import com.wire.kalium.network.api.model.UserProfileDTO
+import com.wire.kalium.network.api.model.UserTypeDTO
+import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.persistence.dao.AppDAO
 import com.wire.kalium.persistence.dao.TeamDAO
+import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlin.collections.map
 
 internal interface AppRepository {
+    suspend fun syncApps(teamId: TeamId, includeTeamApps: Boolean): Either<CoreFailure, Unit>
     fun observeAllApps(): Flow<Either<StorageFailure, List<AppDetails>>>
     fun searchAppsByName(name: String): Flow<Either<StorageFailure, List<AppDetails>>>
     suspend fun getAppById(appId: QualifiedID): Either<StorageFailure, AppDetails?>
@@ -46,10 +65,55 @@ internal interface AppRepository {
 }
 
 internal class AppDataSource internal constructor(
+    private val selfUserId: UserId,
     private val appDAO: AppDAO,
     private val teamDAO: TeamDAO,
+    private val teamsApi: TeamsApi,
+    private val userDetailsApi: UserDetailsApi,
     private val appMapper: AppMapper = MapperProvider.appMapper()
 ) : AppRepository {
+
+    override suspend fun syncApps(teamId: TeamId, includeTeamApps: Boolean): Either<CoreFailure, Unit> =
+        fetchTeamApps(teamId, includeTeamApps).flatMap { teamApps ->
+            fetchCollaborators(teamId).flatMap { collaboratorIds ->
+                val teamAppIds = teamApps.mapTo(mutableSetOf()) { it.id.value }
+                val qualifiedCollaboratorIds = collaboratorIds
+                    .asSequence()
+                    .filterNot(teamAppIds::contains)
+                    .distinct()
+                    .map { collaboratorId -> UserId(collaboratorId, selfUserId.domain) }
+                    .toList()
+
+                fetchCollaboratorProfiles(qualifiedCollaboratorIds).flatMap { collaboratorProfiles ->
+                    val apps = (teamApps + collaboratorProfiles.filter { it.type == UserTypeDTO.APP })
+                        .distinctBy { it.id }
+                        .map(appMapper::fromUserProfileToAppEntity)
+                    wrapStorageRequest { appDAO.upsertApps(apps) }
+                }
+            }
+        }
+
+    private suspend fun fetchTeamApps(teamId: TeamId, includeTeamApps: Boolean): Either<CoreFailure, List<UserProfileDTO>> =
+        if (includeTeamApps) {
+            wrapApiRequest { teamsApi.getTeamApps(teamId.value) }
+        } else {
+            Either.Right(emptyList())
+        }
+
+    private suspend fun fetchCollaborators(teamId: TeamId): Either<CoreFailure, List<String>> =
+        wrapApiRequest { teamsApi.getTeamCollaborators(teamId.value) }
+            .map { collaborators -> collaborators.map { it.nonQualifiedUserId } }
+            .flatMapLeft { failure ->
+                if (failure.isInsufficientPermissions()) Either.Right(emptyList()) else Either.Left(failure)
+            }
+
+    private suspend fun fetchCollaboratorProfiles(collaboratorIds: List<UserId>): Either<CoreFailure, List<UserProfileDTO>> =
+        collaboratorIds.chunked(USER_BATCH_SIZE).foldToEitherWhileRight(emptyList()) { ids, profiles ->
+            wrapApiRequest {
+                userDetailsApi.getMultipleUsers(ListUserRequest.qualifiedIds(ids.map { it.toApi() }))
+            }.map { response -> profiles + response.usersFound }
+        }
+
     override fun observeAllApps(): Flow<Either<StorageFailure, List<AppDetails>>> =
         wrapFlowStorageRequest {
             appDAO.observeAllApps().map { apps ->
@@ -86,4 +150,17 @@ internal class AppDataSource internal constructor(
             conversationId = conversationId.toDao()
         ).map { it?.toModel() }
     }
+
+    private companion object {
+        const val USER_BATCH_SIZE = 500
+    }
 }
+
+private fun CoreFailure.isInsufficientPermissions(): Boolean {
+    val error = (this as? NetworkFailure.ServerMiscommunication)
+        ?.kaliumException as? KaliumException.InvalidRequestError
+    return error?.errorResponse?.code == HttpStatusCode.Forbidden.value &&
+        error.errorResponse.label == INSUFFICIENT_PERMISSIONS_LABEL
+}
+
+private const val INSUFFICIENT_PERMISSIONS_LABEL = "insufficient-permissions"

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1111,8 +1111,11 @@ public class UserSessionScope internal constructor(
 
     private val appRepository: AppRepository
         get() = AppDataSource(
+            selfUserId = userId,
             appDAO = userStorage.database.appDAO,
-            teamDAO = userStorage.database.teamDAO
+            teamDAO = userStorage.database.teamDAO,
+            teamsApi = authenticatedNetworkContainer.teamsApi,
+            userDetailsApi = authenticatedNetworkContainer.userDetailsApi,
         )
 
     private val persistConversationsUseCase: PersistConversationsUseCase
@@ -2804,7 +2807,9 @@ public class UserSessionScope internal constructor(
 
     public val apps: AppScope
         get() = AppScope(
-            appRepository = appRepository
+            appRepository = appRepository,
+            selfTeamIdProvider = selfTeamId,
+            apiVersion = sessionManager.serverConfig().metaData.commonApiVersion.version
         )
 
     public val calls: CallsScope

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/app/AppScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/app/AppScope.kt
@@ -18,10 +18,20 @@
 package com.wire.kalium.logic.feature.app
 
 import com.wire.kalium.logic.data.app.AppRepository
+import com.wire.kalium.logic.data.id.SelfTeamIdProvider
 
 public class AppScope internal constructor(
-    private val appRepository: AppRepository
+    private val appRepository: AppRepository,
+    private val selfTeamIdProvider: SelfTeamIdProvider,
+    private val apiVersion: Int
 ) {
+
+    public val syncApps: SyncAppsUseCase
+        get() = SyncAppsUseCaseImpl(
+            appRepository = appRepository,
+            selfTeamIdProvider = selfTeamIdProvider,
+            apiVersion = apiVersion
+        )
 
     public val getAppById: GetAppByIdUseCase
         get() = GetAppByIdUseCaseImpl(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/app/SyncAppsUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/app/SyncAppsUseCase.kt
@@ -1,0 +1,67 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.app
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.common.functional.fold
+import com.wire.kalium.logic.data.app.AppRepository
+import com.wire.kalium.logic.data.id.SelfTeamIdProvider
+
+/** Synchronizes apps available to the current self-team. */
+public interface SyncAppsUseCase {
+
+    public suspend operator fun invoke(): Result
+
+    public sealed interface Result {
+        public data object Success : Result
+        public data class Failure(val error: CoreFailure) : Result
+    }
+}
+
+internal class SyncAppsUseCaseImpl internal constructor(
+    private val appRepository: AppRepository,
+    private val selfTeamIdProvider: SelfTeamIdProvider,
+    private val apiVersion: Int
+) : SyncAppsUseCase {
+
+    override suspend fun invoke(): SyncAppsUseCase.Result =
+        if (apiVersion < MIN_API_VERSION_TEAM_COLLABORATORS) {
+            SyncAppsUseCase.Result.Success
+        } else {
+            selfTeamIdProvider()
+                .flatMap { teamId ->
+                    teamId?.let {
+                        appRepository.syncApps(
+                            teamId = it,
+                            includeTeamApps = apiVersion >= MIN_API_VERSION_TEAM_APPS
+                        )
+                    } ?: Either.Right(Unit)
+                }
+                .fold(
+                    { SyncAppsUseCase.Result.Failure(it) },
+                    { SyncAppsUseCase.Result.Success }
+                )
+        }
+
+    private companion object {
+        const val MIN_API_VERSION_TEAM_COLLABORATORS = 10
+        const val MIN_API_VERSION_TEAM_APPS = 15
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/app/AppRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/app/AppRepositoryTest.kt
@@ -22,9 +22,24 @@ import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.id.PersistenceQualifiedId
 import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.id.toModel
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
+import com.wire.kalium.network.api.authenticated.teams.TeamCollaboratorDTO
+import com.wire.kalium.network.api.authenticated.userDetails.ListUsersDTO
+import com.wire.kalium.network.api.authenticated.userDetails.QualifiedUserIdListRequest
+import com.wire.kalium.network.api.base.authenticated.TeamsApi
+import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
+import com.wire.kalium.network.api.model.AppDTO
+import com.wire.kalium.network.api.model.GenericAPIErrorResponse
+import com.wire.kalium.network.api.model.QualifiedID as NetworkQualifiedID
+import com.wire.kalium.network.api.model.UserProfileDTO
+import com.wire.kalium.network.api.model.UserTypeDTO
+import com.wire.kalium.network.exceptions.KaliumException
+import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.persistence.dao.AppDAO
 import com.wire.kalium.persistence.dao.AppEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
@@ -34,7 +49,9 @@ import dev.mokkery.answering.returns
 import dev.mokkery.answering.throws
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
+import dev.mokkery.matcher.matches
 import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -236,11 +253,106 @@ class AppRepositoryTest {
         }
     }
 
+    @Test
+    fun givenTeamAndCollaboratorApps_whenSyncing_thenAppsAreMergedFilteredAndPersisted() = runTest {
+        val teamApp = Arrangement.appProfile("team-app", UserTypeDTO.APP)
+        val collaboratorApp = Arrangement.appProfile("collaborator-app", UserTypeDTO.APP)
+        val regularCollaborator = Arrangement.appProfile("regular-user", UserTypeDTO.REGULAR)
+        val failedId = NetworkQualifiedID("failed-user", Arrangement.DOMAIN)
+        val (arrangement, appRepository) = Arrangement()
+            .withTeamApps(listOf(teamApp))
+            .withCollaborators(listOf("team-app", "collaborator-app", "regular-user", "failed-user"))
+            .withUsers(ListUsersDTO(listOf(failedId), listOf(collaboratorApp, regularCollaborator)))
+            .withUpsertAppsSuccess()
+            .arrange()
+
+        appRepository.syncApps(TeamId(Arrangement.TEAM_ID), includeTeamApps = true).shouldSucceed()
+
+        verifySuspend {
+            arrangement.userDetailsApi.getMultipleUsers(matches { request ->
+                (request as QualifiedUserIdListRequest).qualifiedIds.map { it.value }.toSet() ==
+                        setOf("collaborator-app", "regular-user", "failed-user")
+            })
+            arrangement.appDAO.upsertApps(matches { apps ->
+                apps.map { it.id.value }.toSet() == setOf("team-app", "collaborator-app")
+            })
+        }
+    }
+
+    @Test
+    fun givenCollaboratorOnlySync_whenSyncing_thenTeamAppsEndpointIsNotCalled() = runTest {
+        val collaboratorApp = Arrangement.appProfile("collaborator-app", UserTypeDTO.APP)
+        val (arrangement, appRepository) = Arrangement()
+            .withCollaborators(listOf("collaborator-app"))
+            .withUsers(ListUsersDTO(emptyList(), listOf(collaboratorApp)))
+            .withUpsertAppsSuccess()
+            .arrange()
+
+        appRepository.syncApps(TeamId(Arrangement.TEAM_ID), includeTeamApps = false).shouldSucceed()
+
+        verifySuspend(VerifyMode.exactly(0)) { arrangement.teamsApi.getTeamApps(any()) }
+        verifySuspend { arrangement.appDAO.upsertApps(matches { it.single().id.value == "collaborator-app" }) }
+    }
+
+    @Test
+    fun givenMoreThanFiveHundredCollaborators_whenSyncing_thenUsersAreFetchedInBatches() = runTest {
+        val collaboratorIds = (1..501).map { "collaborator-$it" }
+        val (arrangement, appRepository) = Arrangement()
+            .withCollaborators(collaboratorIds)
+            .withUsers(ListUsersDTO(emptyList(), emptyList()))
+            .withUpsertAppsSuccess()
+            .arrange()
+
+        appRepository.syncApps(TeamId(Arrangement.TEAM_ID), includeTeamApps = false).shouldSucceed()
+
+        verifySuspend(VerifyMode.exactly(2)) { arrangement.userDetailsApi.getMultipleUsers(any()) }
+    }
+
+    @Test
+    fun givenInsufficientCollaboratorPermissions_whenSyncing_thenTeamAppsAreStillPersisted() = runTest {
+        val teamApp = Arrangement.appProfile("team-app", UserTypeDTO.APP)
+        val (arrangement, appRepository) = Arrangement()
+            .withTeamApps(listOf(teamApp))
+            .withCollaboratorFailure(
+                KaliumException.InvalidRequestError(
+                    GenericAPIErrorResponse(403, "Forbidden", "insufficient-permissions")
+                )
+            )
+            .withUpsertAppsSuccess()
+            .arrange()
+
+        appRepository.syncApps(TeamId(Arrangement.TEAM_ID), includeTeamApps = true).shouldSucceed()
+
+        verifySuspend { arrangement.appDAO.upsertApps(matches { it.single().id.value == "team-app" }) }
+        verifySuspend(VerifyMode.exactly(0)) { arrangement.userDetailsApi.getMultipleUsers(any()) }
+    }
+
+    @Test
+    fun givenOtherCollaboratorFailure_whenSyncing_thenExistingCacheIsNotChanged() = runTest {
+        val teamApp = Arrangement.appProfile("team-app", UserTypeDTO.APP)
+        val (arrangement, appRepository) = Arrangement()
+            .withTeamApps(listOf(teamApp))
+            .withCollaboratorFailure(KaliumException.GenericError(IllegalStateException("network failure")))
+            .arrange()
+
+        appRepository.syncApps(TeamId(Arrangement.TEAM_ID), includeTeamApps = true).shouldFail()
+
+        verifySuspend(VerifyMode.exactly(0)) { arrangement.appDAO.upsertApps(any()) }
+    }
+
     private class Arrangement {
         val appDAO = mock<AppDAO>()
         val teamDAO = mock<TeamDAO>()
+        val teamsApi = mock<TeamsApi>()
+        val userDetailsApi = mock<UserDetailsApi>()
 
-        private val appRepository = AppDataSource(appDAO, teamDAO)
+        private val appRepository = AppDataSource(
+            appDAO = appDAO,
+            teamDAO = teamDAO,
+            teamsApi = teamsApi,
+            userDetailsApi = userDetailsApi,
+            selfUserId = UserId("self-user", "wire.com")
+        )
 
         init {
             everySuspend { teamDAO.getTeamById(any()) } returns flowOf(null)
@@ -303,6 +415,30 @@ class AppRepositoryTest {
             } throws error
         }
 
+        fun withTeamApps(apps: List<UserProfileDTO>) = apply {
+            everySuspend { teamsApi.getTeamApps(TEAM_ID) } returns NetworkResponse.Success(apps, emptyMap(), 200)
+        }
+
+        fun withCollaborators(ids: List<String>) = apply {
+            everySuspend { teamsApi.getTeamCollaborators(TEAM_ID) } returns NetworkResponse.Success(
+                ids.map(::TeamCollaboratorDTO),
+                emptyMap(),
+                200
+            )
+        }
+
+        fun withCollaboratorFailure(error: KaliumException) = apply {
+            everySuspend { teamsApi.getTeamCollaborators(TEAM_ID) } returns NetworkResponse.Error(error)
+        }
+
+        fun withUsers(users: ListUsersDTO) = apply {
+            everySuspend { userDetailsApi.getMultipleUsers(any()) } returns NetworkResponse.Success(users, emptyMap(), 200)
+        }
+
+        fun withUpsertAppsSuccess() = apply {
+            everySuspend { appDAO.upsertApps(any()) } returns Unit
+        }
+
         fun arrange() = this to appRepository
 
         companion object {
@@ -320,6 +456,7 @@ class AppRepositoryTest {
             const val APP_NAME = "App Name"
             const val APP_DESCRIPTION = "App Description"
             const val APP_CATEGORY = "DEVELOPER"
+            const val DOMAIN = "wire.com"
 
             val CONVERSATION_ID = QualifiedID(
                 value = Uuid.random().toString(),
@@ -344,6 +481,14 @@ class AppRepositoryTest {
                 teamId = TEAM_ID,
                 previewAssetId = null,
                 completeAssetId = null
+            )
+
+            fun appProfile(id: String, type: UserTypeDTO): UserProfileDTO = TestUser.USER_PROFILE_DTO.copy(
+                id = NetworkQualifiedID(id, DOMAIN),
+                nonQualifiedId = id,
+                name = id,
+                type = type,
+                app = if (type == UserTypeDTO.APP) AppDTO(APP_DESCRIPTION, APP_CATEGORY) else null
             )
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/app/SyncAppsUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/app/SyncAppsUseCaseTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.app
+
+import com.wire.kalium.common.error.NetworkFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.app.AppRepository
+import com.wire.kalium.logic.data.id.SelfTeamIdProvider
+import com.wire.kalium.logic.data.id.TeamId
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class SyncAppsUseCaseTest {
+
+    @Test
+    fun givenApiBelowV10_whenSyncing_thenNoOp() = runTest {
+        val arrangement = Arrangement(apiVersion = 9)
+
+        assertIs<SyncAppsUseCase.Result.Success>(arrangement.useCase())
+        verifySuspend(VerifyMode.exactly(0)) { arrangement.selfTeamIdProvider() }
+        verifySuspend(VerifyMode.exactly(0)) { arrangement.appRepository.syncApps(any(), any()) }
+    }
+
+    @Test
+    fun givenTeamlessUser_whenSyncing_thenNoOp() = runTest {
+        val arrangement = Arrangement(apiVersion = 15).withTeam(null)
+
+        assertIs<SyncAppsUseCase.Result.Success>(arrangement.useCase())
+        verifySuspend(VerifyMode.exactly(0)) { arrangement.appRepository.syncApps(any(), any()) }
+    }
+
+    @Test
+    fun givenApiV10ToV14_whenSyncing_thenOnlyCollaboratorAppsAreRequested() = runTest {
+        val arrangement = Arrangement(apiVersion = 14).withTeam(TEAM_ID).withSyncSuccess(includeTeamApps = false)
+
+        assertIs<SyncAppsUseCase.Result.Success>(arrangement.useCase())
+        verifySuspend { arrangement.appRepository.syncApps(TEAM_ID, includeTeamApps = false) }
+    }
+
+    @Test
+    fun givenApiV15_whenSyncing_thenTeamAndCollaboratorAppsAreRequested() = runTest {
+        val arrangement = Arrangement(apiVersion = 15).withTeam(TEAM_ID).withSyncSuccess(includeTeamApps = true)
+
+        assertIs<SyncAppsUseCase.Result.Success>(arrangement.useCase())
+        verifySuspend { arrangement.appRepository.syncApps(TEAM_ID, includeTeamApps = true) }
+    }
+
+    @Test
+    fun givenRepositoryFailure_whenSyncing_thenFailureIsPropagated() = runTest {
+        val failure = NetworkFailure.NoNetworkConnection(null)
+        val arrangement = Arrangement(apiVersion = 15).withTeam(TEAM_ID).withSyncFailure(failure)
+
+        val result = assertIs<SyncAppsUseCase.Result.Failure>(arrangement.useCase())
+        assertEquals(failure, result.error)
+    }
+
+    private class Arrangement(apiVersion: Int) {
+        val appRepository = mock<AppRepository>()
+        val selfTeamIdProvider = mock<SelfTeamIdProvider>()
+        val useCase = SyncAppsUseCaseImpl(appRepository, selfTeamIdProvider, apiVersion)
+
+        fun withTeam(teamId: TeamId?) = apply {
+            everySuspend { selfTeamIdProvider() } returns Either.Right(teamId)
+        }
+
+        fun withSyncSuccess(includeTeamApps: Boolean) = apply {
+            everySuspend { appRepository.syncApps(TEAM_ID, includeTeamApps) } returns Either.Right(Unit)
+        }
+
+        fun withSyncFailure(failure: NetworkFailure) = apply {
+            everySuspend { appRepository.syncApps(TEAM_ID, true) } returns Either.Left(failure)
+        }
+    }
+
+    private companion object {
+        val TEAM_ID = TeamId("team-id")
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-25747
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-25747
----

# What's new in this PR?

### Issues

Apps are represented by users, but clients in teams with more than 2,000 members are not guaranteed to know about every team member. Consequently, the local apps database may be incomplete and app search can incorrectly return no results.

### Solutions

Add versioned support for:
- GET /teams/{tid}/collaborators from API v10.
- GET /teams/{tid}/apps from API v15.

Introduce SyncAppsUseCase, exposed through AppScope, which:
- Performs no synchronization below API v10 or when the self user has no team.
- Fetches collaborators on API v10–v14.
- Fetches both team apps and collaborators on API v15 and later.
- Hydrates collaborator profiles in batches of 500, keeps only app users, deduplicates the results, and upserts them into the local apps database.
- Tolerates the known 403 insufficient-permissions response from the collaborators endpoint so directly returned team apps remain available.
- Preserves the existing cache when other network or storage operations fail.
