### PR TITLE
test(sync): add on-demand mutation coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,14 @@ Common commands:
 ```bash
 ./gradlew build
 ./gradlew jvmTest -Djava.library.path=./native/libs
+./gradlew runMutationTests
 ./gradlew detekt
 ```
+
+`runMutationTests` runs PIT against shared KMP code compiled for the JVM, so it does not need an emulator or device.
+Reports are written per module under `build/reports/pitest`. Resource use and the required score can be configured
+with `-Pmutation.maxParallelMutants=2`, `-Pmutation.maxHeap=2g`, `-Pmutation.timeoutConstantMs=1000`, and
+`-Pmutation.threshold=60`. The setup does not mutate Kotlin/Native, Kotlin/JS, or Android-only binaries.
 
 JVM tests and the CLI need native libraries. Build them with:
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -184,6 +184,13 @@ tasks.register("runAllUnitTests") {
     }
 }
 
+tasks.register("runMutationTests") {
+    group = "verification"
+    description = "Runs mutation tests for KMP code on the JVM target."
+    dependsOn(":core:util:mutationTest")
+    dependsOn(":logic:mutationTest")
+}
+
 tasks.register("aggregateTestResults") {
     description = "Aggregates all Unit Test results into a single report."
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -47,5 +47,9 @@ gradlePlugin {
             id = libraryId
             implementationClass = "com.wire.kalium.plugins.LibraryPlugin"
         }
+        register("mutationTesting") {
+            id = libs.plugins.kalium.mutation.testing.get().pluginId
+            implementationClass = "com.wire.kalium.plugins.MutationTestingPlugin"
+        }
     }
 }

--- a/buildSrc/src/main/kotlin/com/wire/kalium/plugins/MutationTestingPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/wire/kalium/plugins/MutationTestingPlugin.kt
@@ -1,0 +1,166 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.plugins
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.file.FileCollection
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.testing.Test
+import org.gradle.kotlin.dsl.register
+import java.io.File
+
+private const val MAX_MUTATION_THRESHOLD = 100
+
+abstract class MutationTestingExtension {
+    abstract val targetClasses: ListProperty<String>
+    abstract val targetTests: ListProperty<String>
+}
+
+/**
+ * Runs mutation tests for KMP common code on the JVM target.
+ *
+ * PIT mutates JVM bytecode, so common KMP code is exercised through the JVM target.
+ */
+class MutationTestingPlugin : Plugin<Project> {
+    override fun apply(target: Project): Unit = with(target) {
+        val extension = extensions.create("mutationTesting", MutationTestingExtension::class.java).apply {
+            targetClasses.convention(listOf("com.wire.kalium.*"))
+            targetTests.convention(listOf("com.wire.kalium.*"))
+        }
+        val pitest = configurations.create("pitest") {
+            isCanBeConsumed = false
+            isCanBeResolved = true
+            description = "PIT command-line mutation testing engine."
+        }
+        dependencies.add(pitest.name, library("pitest-commandLine"))
+
+        val jvmTestClasspath = providers.provider {
+            tasks.named("jvmTest", Test::class.java).get().classpath
+        }
+        val mainClasses = layout.buildDirectory.dir("classes/kotlin/jvm/main")
+        val testClasses = layout.buildDirectory.dir("classes/kotlin/jvm/test")
+        val reports = layout.buildDirectory.dir("reports/pitest")
+        val parallelMutants = providers.gradleProperty("mutation.maxParallelMutants")
+            .map { value ->
+                value.toIntOrNull()?.takeIf { it > 0 }
+                    ?: error("mutation.maxParallelMutants must be a positive integer")
+            }
+            .orElse(2)
+        val mutationThreshold = providers.gradleProperty("mutation.threshold")
+            .map { value ->
+                value.toIntOrNull()?.takeIf { it in 0..MAX_MUTATION_THRESHOLD }
+                    ?: error("mutation.threshold must be an integer from 0 to 100")
+            }
+            .orElse(0)
+        val maxHeap = providers.gradleProperty("mutation.maxHeap").orElse("2g")
+        val timeoutConstantMs = providers.gradleProperty("mutation.timeoutConstantMs")
+            .map { value ->
+                value.toIntOrNull()?.takeIf { it > 0 }
+                    ?: error("mutation.timeoutConstantMs must be a positive integer")
+            }
+            .orElse(1_000)
+
+        tasks.register<JavaExec>("mutationTest") {
+            group = "verification"
+            description = "Runs PIT against KMP common code on the JVM target."
+            classpath(pitest)
+            mainClass.set("org.pitest.mutationtest.commandline.MutationCoverageReport")
+            workingDir(projectDir)
+            maxHeapSize = maxHeap.get()
+
+            dependsOn("compileKotlinJvm", "compileTestKotlinJvm")
+            inputs.dir(mainClasses)
+            inputs.dir(testClasses)
+            inputs.files(jvmTestClasspath).withPropertyName("jvmTestClasspath")
+            inputs.property("maxParallelMutants", parallelMutants)
+            inputs.property("mutationThreshold", mutationThreshold)
+            inputs.property("mutationMaxHeap", maxHeap)
+            inputs.property("mutationTimeoutConstantMs", timeoutConstantMs)
+            inputs.property("mutationTargetClasses", extension.targetClasses)
+            inputs.property("mutationTargetTests", extension.targetTests)
+            outputs.dir(reports)
+
+            doFirst {
+                configurePitestArguments(
+                    PitestArguments(
+                        testClasspath = jvmTestClasspath.get(),
+                        mainClassesDirectory = mainClasses.get().asFile,
+                        testClassesDirectory = testClasses.get().asFile,
+                        reportsDirectory = reports.get().asFile,
+                        sourceDirectories = mutationSourceDirectories(),
+                        parallelMutants = parallelMutants.get(),
+                        mutationThreshold = mutationThreshold.get(),
+                        maxHeap = maxHeap.get(),
+                        timeoutConstantMs = timeoutConstantMs.get(),
+                        targetClasses = extension.targetClasses.get(),
+                        targetTests = extension.targetTests.get(),
+                    ),
+                )
+            }
+        }
+    }
+}
+
+private fun Project.mutationSourceDirectories(): List<File> = listOf(
+    layout.projectDirectory.dir("src/commonMain/kotlin").asFile,
+    layout.projectDirectory.dir("src/jvmMain/kotlin").asFile,
+).filter(File::isDirectory)
+
+private class PitestArguments(
+    val testClasspath: FileCollection,
+    val mainClassesDirectory: File,
+    val testClassesDirectory: File,
+    val reportsDirectory: File,
+    val sourceDirectories: List<File>,
+    val parallelMutants: Int,
+    val mutationThreshold: Int,
+    val maxHeap: String,
+    val timeoutConstantMs: Int,
+    val targetClasses: List<String>,
+    val targetTests: List<String>,
+)
+
+private fun JavaExec.configurePitestArguments(arguments: PitestArguments) {
+    val runtimeClasspath = (
+        arguments.testClasspath.files +
+            arguments.mainClassesDirectory +
+            arguments.testClassesDirectory
+        )
+        .distinctBy(File::getAbsolutePath)
+        .joinToString(",", transform = File::getAbsolutePath)
+
+    setArgs(
+        listOf(
+            "--reportDir", arguments.reportsDirectory.absolutePath,
+            "--targetClasses", arguments.targetClasses.joinToString(","),
+            "--targetTests", arguments.targetTests.joinToString(","),
+            "--sourceDirs", arguments.sourceDirectories.joinToString(",", transform = File::getAbsolutePath),
+            "--classPath", runtimeClasspath,
+            "--mutableCodePaths", arguments.mainClassesDirectory.absolutePath,
+            "--outputFormats", "HTML,XML",
+            "--timestampedReports", "false",
+            "--threads", arguments.parallelMutants.toString(),
+            "--mutationThreshold", arguments.mutationThreshold.toString(),
+            "--jvmArgs", "-Xmx${arguments.maxHeap}",
+            "--timeoutConst", arguments.timeoutConstantMs.toString(),
+        ),
+    )
+}

--- a/core/util/build.gradle.kts
+++ b/core/util/build.gradle.kts
@@ -19,6 +19,7 @@
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     id(libs.plugins.kalium.library.get().pluginId)
+    id(libs.plugins.kalium.mutation.testing.get().pluginId)
     alias(libs.plugins.ksp)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ ktx-datetime = { strictly = "0.6.1" }
 ktx-serialization = "1.11.0"
 ktx-atomicfu = "0.32.1"
 kover = "0.9.8"
+pitest = "1.25.9"
 multiplatform-settings = "1.3.0"
 moduleGraph = "0.13.0"
 sqldelight = "0.0.8-2.3.2"
@@ -82,6 +83,7 @@ ksoup = "0.2.6"
 [plugins]
 # Home-made convention plugins
 kalium-library = { id = "kalium.library" }
+kalium-mutation-testing = { id = "kalium.mutation-testing" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 android-application = { id = "com.android.application", version.ref = "agp" }
 moduleGraph = { id = "dev.iurysouza.modulegraph", version.ref = "moduleGraph" }
@@ -113,6 +115,7 @@ kotlin-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin",
 kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin" }
 kotlinx-benchmark-runtime = { group = "org.jetbrains.kotlinx", name = "kotlinx-benchmark-runtime", version.ref = "benchmark" }
 androidx-benchmark-junit4 = { module = "androidx.benchmark:benchmark-junit4", version.ref = "androidx-benchmark" }
+pitest-commandLine = { module = "org.pitest:pitest-command-line", version.ref = "pitest" }
 
 kotlin-nativeUtils = { module = "org.jetbrains.kotlin:kotlin-native-utils", version.ref = "kotlin" }
 ktxSerialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "ktx-serialization" }

--- a/logic/build.gradle.kts
+++ b/logic/build.gradle.kts
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 plugins {
     alias(libs.plugins.kotlin.serialization)
     id(libs.plugins.kalium.library.get().pluginId)
+    id(libs.plugins.kalium.mutation.testing.get().pluginId)
     id("com.wire.kalium.apple-avs-runtime")
     alias(libs.plugins.ksp)
     alias(libs.plugins.mokkery)
@@ -31,6 +32,11 @@ kaliumLibrary {
     multiplatform {
         enableJs.set(false)
     }
+}
+
+mutationTesting {
+    targetClasses.set(listOf("com.wire.kalium.logic.sync.receiver.*"))
+    targetTests.set(listOf("com.wire.kalium.logic.sync.receiver.*"))
 }
 
 val useUnifiedCoreCrypto: Boolean = findProperty("USE_UNIFIED_CORE_CRYPTO")?.toString()?.toBoolean()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/ConversationEventReceiverTest.kt
@@ -21,6 +21,8 @@ import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.event.Event
+import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.sync.receiver.conversation.AccessUpdateEventHandler
@@ -443,6 +445,63 @@ class ConversationEventReceiverTest {
         }
     }
 
+    @Test
+    fun givenProtocolUpdateEvent_whenOnEventInvoked_thenProtocolHandlerResultIsPropagated() = runTest {
+        val event = TestEvent.newConversationProtocolEvent()
+        val (arrangement, handler) = Arrangement().arrange()
+
+        val result = handler.onEvent(arrangement.transactionContext, event, TestEvent.liveDeliveryInfo)
+
+        result.shouldSucceed()
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.protocolUpdateEventHandler.handle(any(), eq(event))
+        }
+    }
+
+    @Test
+    fun givenChannelAddPermissionEvent_whenOnEventInvoked_thenChannelHandlerResultIsPropagated() = runTest {
+        val event = TestEvent.newConversationChannelAddPermissionEvent()
+        val (arrangement, handler) = Arrangement().arrange()
+
+        val result = handler.onEvent(arrangement.transactionContext, event, TestEvent.liveDeliveryInfo)
+
+        result.shouldSucceed()
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.channelAddPermissionUpdateEventHandler.handle(eq(event))
+        }
+    }
+
+    @Test
+    fun givenMlsResetEvent_whenOnEventInvoked_thenMlsResetHandlerIsCalled() = runTest {
+        val event = Event.Conversation.MLSReset(
+            id = "event-id",
+            conversationId = TestEvent.newConversationProtocolEvent().conversationId,
+            from = TestUser.SELF.id,
+            groupID = GroupID("old-group"),
+            newGroupID = GroupID("new-group"),
+        )
+        val (arrangement, handler) = Arrangement().arrange()
+
+        val result = handler.onEvent(arrangement.transactionContext, event, TestEvent.liveDeliveryInfo)
+
+        result.shouldSucceed()
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.mlsResetConversationEventHandler.handle(any(), eq(event))
+        }
+    }
+
+    @Test
+    fun givenPendingMessageSideEffects_whenFlushing_thenNewMessageHandlerIsFlushed() = runTest {
+        val (arrangement, handler) = Arrangement().arrange()
+
+        val result = handler.flushPendingSideEffects()
+
+        result.shouldSucceed()
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.newMessageEventHandler.flushPendingSideEffects()
+        }
+    }
+
     private class Arrangement :
         CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMokkeryImpl() {
 
@@ -495,6 +554,7 @@ class ConversationEventReceiverTest {
         private suspend fun withDefaultSuccessfulHandlers() {
             everySuspend { newMessageEventHandler.handleNewProteusMessage(any(), any(), any()) } returns Unit
             everySuspend { newMessageEventHandler.handleNewMLSMessage(any(), any(), any()) } returns Unit
+            everySuspend { newMessageEventHandler.flushPendingSideEffects() } returns Unit
             everySuspend { newConversationEventHandler.handle(any(), any()) } returns Unit
             everySuspend { deletedConversationEventHandler.handle(any(), any()) } returns Unit
             everySuspend { memberJoinEventHandler.handle(any(), any()) } returns Either.Right(Unit)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserPropertiesEventReceiverTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/UserPropertiesEventReceiverTest.kt
@@ -18,12 +18,16 @@
 
 package com.wire.kalium.logic.sync.receiver
 
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.conversation.folders.ConversationFolderRepository
+import com.wire.kalium.logic.data.event.Event
 import com.wire.kalium.logic.framework.TestEvent
-import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMokkeryImpl
+import com.wire.kalium.logic.util.shouldFail
+import com.wire.kalium.logic.util.shouldSucceed
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
@@ -64,6 +68,36 @@ class UserPropertiesEventReceiverTest {
         }
     }
 
+    @Test
+    fun givenTypingIndicatorUpdateSucceeds_whenHandling_thenSuccessIsReturned() = runTest {
+        val event = Event.UserProperty.TypingIndicatorModeSet(id = "event-id", value = true)
+        val (arrangement, eventReceiver) = Arrangement()
+            .withUpdateTypingIndicator(Either.Right(Unit))
+            .arrange()
+
+        val result = eventReceiver.onEvent(arrangement.transactionContext, event, TestEvent.liveDeliveryInfo)
+
+        result.shouldSucceed()
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.userConfigRepository.setTypingIndicatorStatus(event.value)
+        }
+    }
+
+    @Test
+    fun givenTypingIndicatorUpdateFails_whenHandling_thenFailureIsReturned() = runTest {
+        val event = Event.UserProperty.TypingIndicatorModeSet(id = "event-id", value = false)
+        val (arrangement, eventReceiver) = Arrangement()
+            .withUpdateTypingIndicator(Either.Left(StorageFailure.DataNotFound))
+            .arrange()
+
+        val result = eventReceiver.onEvent(arrangement.transactionContext, event, TestEvent.liveDeliveryInfo)
+
+        result.shouldFail()
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.userConfigRepository.setTypingIndicatorStatus(event.value)
+        }
+    }
+
     private class Arrangement: CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMokkeryImpl() {
 
         val userConfigRepository = mock<UserConfigRepository>()
@@ -84,6 +118,12 @@ class UserPropertiesEventReceiverTest {
             everySuspend {
                 conversationFolderRepository.updateConversationFolders(any())
              } returns Either.Right(Unit)
+        }
+
+        suspend fun withUpdateTypingIndicator(result: Either<StorageFailure, Unit>) = apply {
+            everySuspend {
+                userConfigRepository.setTypingIndicatorStatus(any())
+            } returns result
         }
 
         fun arrange(block: suspend Arrangement.() -> Unit = {}) = let {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/asset/AssetMessageHandlerMutationTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/asset/AssetMessageHandlerMutationTest.kt
@@ -1,0 +1,347 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.receiver.asset
+
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.configuration.FileSharingStatus
+import com.wire.kalium.logic.data.message.AssetContent
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.framework.TestMessage
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.logic.util.arrangement.repository.MessageRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.repository.MessageRepositoryArrangementImpl
+import com.wire.kalium.logic.util.arrangement.repository.UserConfigRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.repository.UserConfigRepositoryArrangementImpl
+import com.wire.kalium.logic.util.arrangement.usecase.PersistMessageUseCaseArrangement
+import com.wire.kalium.logic.util.arrangement.usecase.PersistMessageUseCaseArrangementImpl
+import com.wire.kalium.logic.util.arrangement.usecase.ValidateAssetFileTypeUseCaseArrangement
+import com.wire.kalium.logic.util.arrangement.usecase.ValidateAssetFileTypeUseCaseArrangementImpl
+import dev.mokkery.matcher.any
+import dev.mokkery.matcher.eq
+import dev.mokkery.matcher.matches
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verify
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+@Suppress("TooManyFunctions")
+class AssetMessageHandlerMutationTest {
+
+    @Test
+    fun givenNonAssetMessage_whenHandling_thenMessageIsIgnored() = runTest {
+        val (arrangement, handler) = arrange {}
+
+        handler.handle(TestMessage.TEXT_MESSAGE)
+
+        verifySuspend(VerifyMode.not) { arrangement.userConfigRepository.isFileSharingEnabled() }
+        verifySuspend(VerifyMode.not) { arrangement.persistMessageUseCase.invoke(any()) }
+    }
+
+    @Test
+    fun givenFileSharingDisabled_whenHandling_thenRestrictedAssetIsPersisted() = runTest {
+        val message = assetMessage(completeAsset())
+        val (arrangement, handler) = arrange {
+            withFileSharing(FileSharingStatus.Value.Disabled)
+            withPersistingMessage(Either.Right(Unit))
+        }
+
+        handler.handle(message)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.persistMessageUseCase.invoke(
+                matches {
+                    it is Message.Regular && it.content == MessageContent.RestrictedAsset(
+                        mimeType = completeAsset().mimeType,
+                        sizeInBytes = completeAsset().sizeInBytes,
+                        name = completeAsset().name.orEmpty(),
+                    )
+                }
+            )
+        }
+        verifySuspend(VerifyMode.not) { arrangement.messageRepository.getMessageById(any(), any()) }
+    }
+
+    @Test
+    fun givenFileSharingEnabledAndNewCompleteAsset_whenHandling_thenVisibleAssetIsPersisted() = runTest {
+        val message = assetMessage(completeAsset())
+        val (arrangement, handler) = arrange {
+            withFileSharing(FileSharingStatus.Value.EnabledAll)
+            withMessageNotFound()
+            withPersistingMessage(Either.Right(Unit))
+        }
+
+        handler.handle(message)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.persistMessageUseCase.invoke(matches { it is Message.Regular && it.visibility == Message.Visibility.VISIBLE })
+        }
+    }
+
+    @Test
+    fun givenFileSharingEnabledAndIncompletePreview_whenHandling_thenHiddenAssetIsPersisted() = runTest {
+        val message = assetMessage(incompleteAsset())
+        val (arrangement, handler) = arrange {
+            withFileSharing(FileSharingStatus.Value.EnabledAll)
+            withMessageNotFound()
+            withPersistingMessage(Either.Right(Unit))
+        }
+
+        handler.handle(message)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.persistMessageUseCase.invoke(matches { it is Message.Regular && it.visibility == Message.Visibility.HIDDEN })
+        }
+    }
+
+    @Test
+    fun givenAllowedFileType_whenHandling_thenAssetProcessingContinues() = runTest {
+        val message = assetMessage(completeAsset())
+        val allowedTypes = listOf("pdf")
+        val (arrangement, handler) = arrange {
+            withFileSharing(FileSharingStatus.Value.EnabledSome(allowedTypes))
+            withValidateAssetFileTypeReturning(true)
+            withMessageNotFound()
+            withPersistingMessage(Either.Right(Unit))
+        }
+
+        handler.handle(message)
+
+        verify(VerifyMode.exactly(1)) {
+            arrangement.validateAssetFileTypeUseCase(
+                eq(completeAsset().name),
+                eq(completeAsset().mimeType),
+                eq(allowedTypes),
+            )
+        }
+        verifySuspend(VerifyMode.exactly(1)) { arrangement.persistMessageUseCase.invoke(message) }
+    }
+
+    @Test
+    fun givenDisallowedNamelessCompleteAssetWithoutPreview_whenHandling_thenRestrictedAssetIsPersisted() = runTest {
+        val content = completeAsset().copy(name = null)
+        val message = assetMessage(content)
+        val (arrangement, handler) = arrange {
+            withFileSharing(FileSharingStatus.Value.EnabledSome(listOf("pdf")))
+            withValidateAssetFileTypeReturning(false)
+            withMessageNotFound()
+            withPersistingMessage(Either.Right(Unit))
+        }
+
+        handler.handle(message)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.persistMessageUseCase.invoke(matches { it.content is MessageContent.RestrictedAsset })
+        }
+    }
+
+    @Test
+    fun givenDisallowedNamedAsset_whenHandling_thenRestrictedAssetIsPersistedImmediately() = runTest {
+        val content = incompleteAsset().copy(name = "blocked.exe")
+        val message = assetMessage(content)
+        val (arrangement, handler) = arrange {
+            withFileSharing(FileSharingStatus.Value.EnabledSome(listOf("pdf")))
+            withValidateAssetFileTypeReturning(false)
+            withPersistingMessage(Either.Right(Unit))
+        }
+
+        handler.handle(message)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.persistMessageUseCase.invoke(
+                matches {
+                    it.content == MessageContent.RestrictedAsset(
+                        mimeType = content.mimeType,
+                        sizeInBytes = content.sizeInBytes,
+                        name = content.name.orEmpty(),
+                    )
+                }
+            )
+        }
+        verifySuspend(VerifyMode.not) { arrangement.messageRepository.getMessageById(any(), any()) }
+    }
+
+    @Test
+    fun givenDisallowedNamelessIncompleteAsset_whenHandling_thenRestrictedAssetIsPersistedImmediately() = runTest {
+        val content = incompleteAsset().copy(name = null)
+        val message = assetMessage(content)
+        val (arrangement, handler) = arrange {
+            withFileSharing(FileSharingStatus.Value.EnabledSome(listOf("pdf")))
+            withValidateAssetFileTypeReturning(false)
+            withPersistingMessage(Either.Right(Unit))
+        }
+
+        handler.handle(message)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.persistMessageUseCase.invoke(matches { it.content is MessageContent.RestrictedAsset })
+        }
+        verifySuspend(VerifyMode.not) { arrangement.messageRepository.getMessageById(any(), any()) }
+    }
+
+    @Test
+    fun givenFollowUpAssetFromSameSender_whenHandling_thenDecryptionKeysAreUpdated() = runTest {
+        val previewContent = incompleteAsset()
+        val persistedPreview = assetMessage(previewContent)
+        val followUpContent = previewContent.copy(remoteData = validRemoteData("follow-up-asset"))
+        val followUpMessage = assetMessage(followUpContent)
+        val (arrangement, handler) = arrange {
+            withFileSharing(FileSharingStatus.Value.EnabledAll)
+            withPersistedMessage(persistedPreview)
+            withPersistingMessage(Either.Right(Unit))
+        }
+
+        handler.handle(followUpMessage)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.persistMessageUseCase.invoke(
+                matches {
+                    val asset = (it.content as? MessageContent.Asset)?.value
+                    it.visibility == Message.Visibility.VISIBLE && asset?.remoteData == followUpContent.remoteData
+                }
+            )
+        }
+    }
+
+    @Test
+    fun givenFollowUpAssetFromDifferentSender_whenHandling_thenExistingMessageIsNotChanged() = runTest {
+        val persistedPreview = assetMessage(incompleteAsset())
+        val followUpMessage = assetMessage(completeAsset()).copy(senderUserId = TestUser.OTHER_USER_ID)
+        val (arrangement, handler) = arrange {
+            withFileSharing(FileSharingStatus.Value.EnabledAll)
+            withPersistedMessage(persistedPreview)
+        }
+
+        handler.handle(followUpMessage)
+
+        verifySuspend(VerifyMode.not) { arrangement.persistMessageUseCase.invoke(any()) }
+    }
+
+    @Test
+    fun givenPersistedMessageIsNotAnAssetPreview_whenHandlingFollowUp_thenMessageIsNotChanged() = runTest {
+        val nonAssetContents = listOf(
+            MessageContent.RestrictedAsset("application/pdf", 100, "restricted.pdf"),
+            MessageContent.FailedDecryption(isDecryptionResolved = false, senderUserId = TestUser.USER_ID),
+            MessageContent.Knock(hotKnock = false),
+            MessageContent.Location(latitude = 1F, longitude = 2F),
+            MessageContent.Composite(textContent = null, buttonList = emptyList()),
+            MessageContent.Text("text"),
+            MessageContent.Multipart(value = "multipart"),
+            MessageContent.Unknown(),
+        )
+
+        nonAssetContents.forEach { persistedContent ->
+            val persistedMessage = assetMessage(incompleteAsset()).copy(content = persistedContent)
+            val (arrangement, handler) = arrange {
+                withFileSharing(FileSharingStatus.Value.EnabledAll)
+                withPersistedMessage(persistedMessage)
+            }
+
+            handler.handle(assetMessage(completeAsset()))
+
+            verifySuspend(VerifyMode.not) { arrangement.persistMessageUseCase.invoke(any()) }
+        }
+    }
+
+    @Test
+    fun givenFileSharingLookupFails_whenHandling_thenAssetIsNotPersisted() = runTest {
+        val (arrangement, handler) = arrange {
+            withFileSharingFailure()
+        }
+
+        handler.handle(assetMessage(completeAsset()))
+
+        verifySuspend(VerifyMode.not) { arrangement.persistMessageUseCase.invoke(any()) }
+        verifySuspend(VerifyMode.not) { arrangement.messageRepository.getMessageById(any(), any()) }
+    }
+
+    private suspend fun arrange(block: suspend Arrangement.() -> Unit) = Arrangement(block).arrange()
+
+    private class Arrangement(
+        private val block: suspend Arrangement.() -> Unit,
+    ) : MessageRepositoryArrangement by MessageRepositoryArrangementImpl(),
+        UserConfigRepositoryArrangement by UserConfigRepositoryArrangementImpl(),
+        PersistMessageUseCaseArrangement by PersistMessageUseCaseArrangementImpl(),
+        ValidateAssetFileTypeUseCaseArrangement by ValidateAssetFileTypeUseCaseArrangementImpl() {
+
+        suspend fun arrange() = run {
+            block()
+            this@Arrangement to AssetMessageHandlerImpl(
+                messageRepository = messageRepository,
+                persistMessage = persistMessageUseCase,
+                userConfigRepository = userConfigRepository,
+                validateAssetMimeTypeUseCase = validateAssetFileTypeUseCase,
+            )
+        }
+
+        suspend fun withFileSharing(state: FileSharingStatus.Value) {
+            withFileSharingEnabledReturning(Either.Right(FileSharingStatus(state, isStatusChanged = false)))
+        }
+
+        suspend fun withFileSharingFailure() {
+            withFileSharingEnabledReturning(Either.Left(StorageFailure.DataNotFound))
+        }
+
+        suspend fun withMessageNotFound() {
+            withGetMessageById(Either.Left(StorageFailure.DataNotFound))
+        }
+
+        suspend fun withPersistedMessage(message: Message) {
+            withGetMessageById(Either.Right(message))
+        }
+    }
+
+    private companion object {
+        fun assetMessage(assetContent: AssetContent) = TestMessage.TEXT_MESSAGE.copy(
+            content = MessageContent.Asset(assetContent),
+            senderUserId = TestUser.USER_ID,
+        )
+
+        fun completeAsset() = AssetContent(
+            sizeInBytes = 100,
+            name = "document.pdf",
+            mimeType = "application/pdf",
+            remoteData = validRemoteData("asset-id"),
+        )
+
+        fun incompleteAsset() = AssetContent(
+            sizeInBytes = 100,
+            name = "document.pdf",
+            mimeType = "application/pdf",
+            remoteData = AssetContent.RemoteData(
+                otrKey = byteArrayOf(),
+                sha256 = byteArrayOf(),
+                assetId = "",
+                assetToken = null,
+                assetDomain = null,
+                encryptionAlgorithm = null,
+            ),
+        )
+
+        fun validRemoteData(assetId: String) = AssetContent.RemoteData(
+            otrKey = byteArrayOf(1),
+            sha256 = byteArrayOf(2),
+            assetId = assetId,
+            assetToken = "token",
+            assetDomain = "wire.com",
+            encryptionAlgorithm = null,
+        )
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MLSWelcomeEventHandlerTest.kt
@@ -247,6 +247,40 @@ class MLSWelcomeEventHandlerTest {
     }
 
     @Test
+    fun givenRefillFailsWithUnknownFailure_whenHandlingEvent_thenWelcomeStillSucceeds() = runTest {
+        val (arrangement, mlsWelcomeEventHandler) = arrange {
+            withRefillKeyPackagesReturning(RefillKeyPackagesResult.Failure(CoreFailure.Unknown(IllegalStateException("refill"))))
+            withMLSClientProcessingOfWelcomeMessageReturnsSuccessfully()
+            withFetchConversationIfUnknownSucceeding()
+            withUpdateGroupStateReturning(Either.Right(Unit))
+            withObserveConversationDetailsByIdReturning(Either.Right(CONVERSATION_GROUP))
+        }
+
+        mlsWelcomeEventHandler.handle(arrangement.transactionContext, WELCOME_EVENT).shouldSucceed()
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.refillKeyPackagesUseCase.invoke(any())
+        }
+    }
+
+    @Test
+    fun givenRefillFailsWithNonUnknownFailure_whenHandlingEvent_thenWelcomeStillSucceeds() = runTest {
+        val (arrangement, mlsWelcomeEventHandler) = arrange {
+            withRefillKeyPackagesReturning(RefillKeyPackagesResult.Failure(StorageFailure.DataNotFound))
+            withMLSClientProcessingOfWelcomeMessageReturnsSuccessfully()
+            withFetchConversationIfUnknownSucceeding()
+            withUpdateGroupStateReturning(Either.Right(Unit))
+            withObserveConversationDetailsByIdReturning(Either.Right(CONVERSATION_GROUP))
+        }
+
+        mlsWelcomeEventHandler.handle(arrangement.transactionContext, WELCOME_EVENT).shouldSucceed()
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.refillKeyPackagesUseCase.invoke(any())
+        }
+    }
+
+    @Test
     fun givenWelcomeBundleWithNewDistributionsCRL_whenHandlingEvent_then_CheckRevocationList() = runTest {
         val failure = Either.Left(StorageFailure.DataNotFound)
         val (arrangement, mlsWelcomeEventHandler) = arrange {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/MemberJoinEventHandlerTest.kt
@@ -161,6 +161,42 @@ class MemberJoinEventHandlerTest {
     }
 
     @Test
+    fun givenMemberJoinEventInSelfConversation_whenHandling_thenNoSystemMessageIsPersisted() = runTest {
+        val conversation = TestConversation.SELF()
+        val event = TestEvent.memberJoin(members = listOf(Member(TEST_SELF_USER_ID, Member.Role.Member)))
+            .copy(conversationId = conversation.id)
+        val (arrangement, eventHandler) = arrange {
+            withFetchConversationSucceeding()
+            withConversationDetailsByIdReturning(conversation.right())
+        }
+
+        eventHandler.handle(arrangement.transactionContext, event)
+
+        verifySuspend(VerifyMode.not) { arrangement.persistMessageUseCase.invoke(any()) }
+        verifySuspend(VerifyMode.not) {
+            arrangement.newGroupConversationSystemMessagesCreator.conversationStartedUnverifiedWarning(any(), any())
+        }
+    }
+
+    @Test
+    fun givenMemberJoinEventInConnectionPendingConversation_whenHandling_thenNoSystemMessageIsPersisted() = runTest {
+        val conversation = TEST_GROUP_CONVERSATION.copy(type = Conversation.Type.ConnectionPending)
+        val event = TestEvent.memberJoin(members = listOf(Member(TestUser.OTHER_USER_ID, Member.Role.Member)))
+            .copy(conversationId = conversation.id)
+        val (arrangement, eventHandler) = arrange {
+            withFetchConversationSucceeding()
+            withConversationDetailsByIdReturning(conversation.right())
+        }
+
+        eventHandler.handle(arrangement.transactionContext, event)
+
+        verifySuspend(VerifyMode.not) { arrangement.persistMessageUseCase.invoke(any()) }
+        verifySuspend(VerifyMode.not) {
+            arrangement.newGroupConversationSystemMessagesCreator.conversationStartedUnverifiedWarning(any(), any())
+        }
+    }
+
+    @Test
     fun givenSelfMemberJoinEventInGroupConversation_whenHandlingIt_thenShouldPersistUnverifiedWarningSystemMessage() = runTest {
         val newMembers = listOf(Member(TEST_SELF_USER_ID, Member.Role.Admin))
         val conversation = TEST_GROUP_CONVERSATION
@@ -309,6 +345,69 @@ class MemberJoinEventHandlerTest {
     }
 
     @Test
+    fun givenDrivePermissionsEnabledAndSelfJoinsGroup_whenHandlingEvent_thenShouldPersistCellAccessStatus() = runTest {
+        val conversation = TEST_GROUP_CONVERSATION
+        val event = TestEvent.memberJoin(
+            members = listOf(Member(TEST_SELF_USER_ID, Member.Role.Member))
+        ).copy(conversationId = conversation.id)
+        val (arrangement, eventHandler) = arrange {
+            withDrivePermissionsEnabled(true)
+            withFetchConversationSucceeding()
+            withConversationDetailsByIdReturning(conversation.right())
+            withIsCellEnabledReturning(true.right())
+        }
+
+        eventHandler.handle(arrangement.transactionContext, event)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.newGroupConversationSystemMessagesCreator.conversationCellAccessStatus(
+                conversationId = eq(conversation.id),
+                conversationTeamId = eq(conversation.teamId?.value),
+                isCellEnabled = eq(true),
+                instant = eq(event.dateTime),
+            )
+        }
+    }
+
+    @Test
+    fun givenDrivePermissionsDisabledAndSelfJoinsGroup_whenHandlingEvent_thenShouldNotPersistCellAccessStatus() = runTest {
+        val conversation = TEST_GROUP_CONVERSATION
+        val event = TestEvent.memberJoin(
+            members = listOf(Member(TEST_SELF_USER_ID, Member.Role.Member))
+        ).copy(conversationId = conversation.id)
+        val (arrangement, eventHandler) = arrange {
+            withDrivePermissionsEnabled(false)
+            withFetchConversationSucceeding()
+            withConversationDetailsByIdReturning(conversation.right())
+        }
+
+        eventHandler.handle(arrangement.transactionContext, event)
+
+        verifySuspend(VerifyMode.not) {
+            arrangement.newGroupConversationSystemMessagesCreator.conversationCellAccessStatus(any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun givenDrivePermissionsEnabledAndOtherUserJoinsGroup_whenHandlingEvent_thenShouldNotPersistCellAccessStatus() = runTest {
+        val conversation = TEST_GROUP_CONVERSATION
+        val event = TestEvent.memberJoin(
+            members = listOf(Member(TestUser.OTHER_USER_ID, Member.Role.Member))
+        ).copy(conversationId = conversation.id)
+        val (arrangement, eventHandler) = arrange {
+            withDrivePermissionsEnabled(true)
+            withFetchConversationSucceeding()
+            withConversationDetailsByIdReturning(conversation.right())
+        }
+
+        eventHandler.handle(arrangement.transactionContext, event)
+
+        verifySuspend(VerifyMode.not) {
+            arrangement.newGroupConversationSystemMessagesCreator.conversationCellAccessStatus(any(), any(), any(), any())
+        }
+    }
+
+    @Test
     fun givenMemberJoinEvent_whenHandlingIt_thenShouldUpdateConversationLegalHoldIfNeeded() = runTest {
         // given
         val newMembers = listOf(Member(TestUser.USER_ID, Member.Role.Admin))
@@ -342,7 +441,10 @@ class MemberJoinEventHandlerTest {
         FetchConversationUseCaseArrangement by FetchConversationUseCaseArrangementImpl(),
         NewGroupConversationSystemMessageCreatorArrangement by NewGroupConversationSystemMessageCreatorArrangementImpl() {
 
+        private var kaliumConfigs = KaliumConfigs()
+
         suspend fun arrange() = run {
+            withIsCellEnabledReturning(false.right())
             block()
 
             withPersistingMessage(Unit.right())
@@ -352,7 +454,6 @@ class MemberJoinEventHandlerTest {
             withHandleConversationMembersChanged(Unit.right())
             withPersistUnverifiedWarningMessageSuccess()
             withPersistCellAccessMessageSuccess()
-            withIsCellEnabledReturning(false.right())
 
             this to MemberJoinEventHandlerImpl(
                 conversationRepository = conversationRepository,
@@ -362,8 +463,12 @@ class MemberJoinEventHandlerTest {
                 newGroupConversationSystemMessagesCreator = newGroupConversationSystemMessagesCreator,
                 selfUserId = TEST_SELF_USER_ID,
                 fetchConversation = fetchConversation,
-                kaliumConfigs = KaliumConfigs()
+                kaliumConfigs = kaliumConfigs
             )
+        }
+
+        fun withDrivePermissionsEnabled(enabled: Boolean) = apply {
+            kaliumConfigs = kaliumConfigs.copy(drivePermissionsEnabled = enabled)
         }
 
         suspend fun withFetchConversationIfUnknownFailingWith(coreFailure: com.wire.kalium.common.error.CoreFailure) = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ApplicationMessageHandlerTest.kt
@@ -31,14 +31,19 @@ import com.wire.kalium.logic.data.call.InCallReactionsRepository
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.history.HistoryClient
 import com.wire.kalium.logic.data.message.AssetContent
+import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.MessageRepository
 import com.wire.kalium.logic.data.message.PersistMessageUseCase
 import com.wire.kalium.logic.data.message.PersistReactionUseCase
 import com.wire.kalium.logic.data.message.ProtoContent
+import com.wire.kalium.logic.data.message.receipt.ReceiptType
+import com.wire.kalium.logic.data.user.UserAvailabilityStatus
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.logic.feature.message.linkpreview.LinkPreviewImagesResolver
 import com.wire.kalium.logic.framework.TestEvent
+import com.wire.kalium.logic.framework.TestMessage
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.logic.sync.receiver.asset.AssetMessageHandler
 import com.wire.kalium.logic.sync.receiver.handler.ButtonActionConfirmationHandler
@@ -72,7 +77,9 @@ import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.time.Duration.Companion.seconds
 
+@Suppress("TooManyFunctions")
 class ApplicationMessageHandlerTest {
 
     @Test
@@ -415,6 +422,335 @@ class ApplicationMessageHandlerTest {
     }
 
     @Test
+    fun givenAvailabilityMessage_whenHandling_thenUserAvailabilityIsUpdated() = runTest {
+        val content = MessageContent.Availability(UserAvailabilityStatus.AWAY)
+        val (arrangement, handler) = Arrangement()
+            .withUserAvailabilityUpdate()
+            .arrange()
+
+        val event = dispatch(arrangement, handler, content)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.userRepository.updateOtherUserAvailabilityStatus(event.senderUserId, content.status)
+        }
+    }
+
+    @Test
+    fun givenClientActionMessage_whenHandling_thenCryptoSessionResetMessageIsPersisted() = runTest {
+        val (arrangement, handler) = Arrangement()
+            .withPersistingMessageReturning(Either.Right(Unit))
+            .arrange()
+
+        val event = dispatch(arrangement, handler, MessageContent.ClientAction)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.persistMessage.invoke(
+                matches {
+                    it is Message.System &&
+                            it.content == MessageContent.CryptoSessionReset &&
+                            it.conversationId == event.conversationId &&
+                            it.senderUserId == event.senderUserId
+                }
+            )
+        }
+    }
+
+    @Test
+    fun givenReactionMessage_whenHandling_thenReactionUseCaseIsInvoked() = runTest {
+        val content = MessageContent.Reaction(messageId = "reacted-message", emojiSet = setOf("👍"))
+        val (arrangement, handler) = Arrangement()
+            .withPersistReaction()
+            .arrange()
+
+        val event = dispatch(arrangement, handler, content)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.persistReactionsUseCase.invoke(content, event.conversationId, event.senderUserId, event.messageInstant)
+        }
+    }
+
+    @Test
+    fun givenDeleteMessageSignal_whenHandling_thenDeleteMessageHandlerIsInvoked() = runTest {
+        val content = MessageContent.DeleteMessage("deleted-message")
+        val (arrangement, handler) = Arrangement().arrange()
+
+        val event = dispatch(arrangement, handler, content)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.deleteMessageHandler.invoke(content, event.conversationId, event.senderUserId)
+        }
+    }
+
+    @Test
+    fun givenDeleteForMeSignal_whenHandling_thenDeleteForMeHandlerIsInvoked() = runTest {
+        val content = MessageContent.DeleteForMe("deleted-message", TestEvent.newMessageEvent("content").conversationId)
+        val (arrangement, handler) = Arrangement().arrange()
+
+        dispatch(arrangement, handler, content)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.deleteForMeHandler.handle(any(), content)
+        }
+    }
+
+    @Test
+    fun givenTextEditSignal_whenHandling_thenTextEditHandlerIsInvoked() = runTest {
+        val content = MessageContent.TextEdited(editMessageId = "edited-message", newContent = "new content")
+        val (arrangement, handler) = Arrangement()
+            .withMessageTextEditHandler()
+            .arrange()
+
+        dispatch(arrangement, handler, content)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.messageTextEditHandler.handle(any(), content)
+        }
+    }
+
+    @Test
+    fun givenLastReadSignal_whenHandling_thenLastReadHandlerIsInvoked() = runTest {
+        val event = TestEvent.newMessageEvent("content")
+        val content = MessageContent.LastRead("last-read-message", event.conversationId, event.messageInstant)
+        val (arrangement, handler) = Arrangement().arrange()
+
+        dispatch(arrangement, handler, content)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.lastReadContentHandler.handle(any(), content)
+        }
+    }
+
+    @Test
+    fun givenClearedSignal_whenHandling_thenClearConversationHandlerIsInvoked() = runTest {
+        val event = TestEvent.newMessageEvent("content")
+        val content = MessageContent.Cleared(event.conversationId, event.messageInstant, needToRemoveLocally = true)
+        val (arrangement, handler) = Arrangement().arrange()
+
+        dispatch(arrangement, handler, content)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.clearConversationContentHandler.handle(any(), any(), content)
+        }
+    }
+
+    @Test
+    fun givenReceiptSignal_whenHandling_thenReceiptHandlerIsInvoked() = runTest {
+        val content = MessageContent.Receipt(ReceiptType.READ, listOf("read-message"))
+        val (arrangement, handler) = Arrangement().arrange()
+
+        dispatch(arrangement, handler, content)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.receiptMessageHandler.handle(any(), content)
+        }
+    }
+
+    @Test
+    fun givenHiddenUnknownMessage_whenHandling_thenHiddenMessageIsPersisted() = runTest {
+        val content = MessageContent.Unknown(typeName = "future-message", hidden = true)
+        val (arrangement, handler) = Arrangement()
+            .withPersistingMessageReturning(Either.Right(Unit))
+            .arrange()
+
+        dispatch(arrangement, handler, content)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.persistMessage.invoke(
+                matches { it is Message.Regular && it.content == content && it.visibility == Message.Visibility.HIDDEN }
+            )
+        }
+    }
+
+    @Test
+    fun givenSelfKnockWithExpiration_whenHandling_thenMessageMetadataIsPersisted() = runTest {
+        val content = MessageContent.Knock(hotKnock = true)
+        val (arrangement, handler) = Arrangement()
+            .withPersistingMessageReturning(Either.Right(Unit))
+            .arrange()
+
+        dispatch(
+            arrangement = arrangement,
+            handler = handler,
+            content = content,
+            senderUserId = TestUser.SELF.id,
+            expiresAfterMillis = 2.seconds.inWholeMilliseconds,
+        )
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.persistMessage.invoke(
+                matches {
+                    it is Message.Regular && it.isSelfMessage &&
+                            it.expirationData?.expireAfter == 2.seconds && it.content == content
+                }
+            )
+        }
+    }
+
+    @Test
+    fun givenRegularPersistableMessageTypes_whenHandling_thenEveryMessageIsPersisted() = runTest {
+        val contents = listOf(
+            MessageContent.Composite(textContent = null, buttonList = emptyList()),
+            MessageContent.Location(latitude = 1F, longitude = 2F),
+            MessageContent.FailedDecryption(
+                isDecryptionResolved = false,
+                senderUserId = TestUser.USER_ID,
+            ),
+            MessageContent.Multipart(value = "multipart"),
+        )
+        val (arrangement, handler) = Arrangement()
+            .withPersistingMessageReturning(Either.Right(Unit))
+            .arrange()
+
+        contents.forEach { dispatch(arrangement, handler, it) }
+
+        verifySuspend(VerifyMode.exactly(contents.size)) {
+            arrangement.persistMessage.invoke(any())
+        }
+    }
+
+    @Test
+    fun givenRestrictedAssetMessage_whenHandling_thenMessageIsIgnored() = runTest {
+        val content = MessageContent.RestrictedAsset(mimeType = "image/png", sizeInBytes = 10, name = "restricted.png")
+        val (arrangement, handler) = Arrangement().arrange()
+
+        dispatch(arrangement, handler, content)
+
+        verifySuspend(VerifyMode.not) { arrangement.persistMessage.invoke(any()) }
+        verifySuspend(VerifyMode.not) { arrangement.assetMessageHandler.handle(any()) }
+    }
+
+    @Test
+    fun givenPendingApplicationSideEffects_whenFlushing_thenLastReadsAreFlushed() = runTest {
+        val (arrangement, handler) = Arrangement().arrange()
+
+        handler.flushPendingSideEffects()
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.lastReadContentHandler.flushPendingLastReads()
+        }
+    }
+
+    @Test
+    fun givenQuoteWithoutHash_whenHandlingText_thenQuoteIsMarkedUnverifiedWithoutLookup() = runTest {
+        val quote = MessageContent.QuoteReference("quoted-message", quotedMessageSha256 = null, isVerified = true)
+        val content = MessageContent.Text(value = "quoted text", quotedMessageReference = quote)
+        val (arrangement, handler) = Arrangement()
+            .withPersistingMessageReturning(Either.Right(Unit))
+            .arrange()
+
+        dispatch(arrangement, handler, content)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.persistMessage.invoke(
+                matches {
+                    val text = (it.content as? MessageContent.Text)
+                    text?.quotedMessageReference?.isVerified == false
+                }
+            )
+        }
+        verifySuspend(VerifyMode.not) { arrangement.messageRepository.getMessageById(any(), any()) }
+    }
+
+    @Test
+    fun givenQuoteWithMatchingHash_whenHandlingMultipart_thenQuoteIsMarkedVerified() = runTest {
+        val original = TestMessage.TEXT_MESSAGE
+        val hash = MessageContentEncoder()
+            .encodeMessageContent(original.date, original.content)
+            ?.sha256Digest ?: error("Expected encodable test message")
+        val quote = MessageContent.QuoteReference(original.id, hash, isVerified = false)
+        val content = MessageContent.Multipart(value = "quoted multipart", quotedMessageReference = quote)
+        val (arrangement, handler) = Arrangement()
+            .withMessageById(Either.Right(original))
+            .withPersistingMessageReturning(Either.Right(Unit))
+            .arrange()
+
+        dispatch(arrangement, handler, content)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.persistMessage.invoke(
+                matches {
+                    val multipart = (it.content as? MessageContent.Multipart)
+                    multipart?.quotedMessageReference?.isVerified == true
+                }
+            )
+        }
+    }
+
+    @Test
+    fun givenQuotedMessageMissing_whenHandlingText_thenQuoteIsMarkedUnverified() = runTest {
+        val quote = MessageContent.QuoteReference("missing-message", byteArrayOf(1, 2, 3), isVerified = true)
+        val content = MessageContent.Text(value = "quoted text", quotedMessageReference = quote)
+        val (arrangement, handler) = Arrangement()
+            .withMessageById(Either.Left(StorageFailure.DataNotFound))
+            .withPersistingMessageReturning(Either.Right(Unit))
+            .arrange()
+
+        dispatch(arrangement, handler, content)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.persistMessage.invoke(
+                matches {
+                    val text = (it.content as? MessageContent.Text)
+                    text?.quotedMessageReference?.isVerified == false
+                }
+            )
+        }
+    }
+
+    @Test
+    fun givenQuotedMessageHashDoesNotMatch_whenHandlingText_thenQuoteIsMarkedUnverified() = runTest {
+        val original = TestMessage.TEXT_MESSAGE
+        val quote = MessageContent.QuoteReference(original.id, byteArrayOf(9, 8, 7), isVerified = true)
+        val content = MessageContent.Text(value = "quoted text", quotedMessageReference = quote)
+        val (arrangement, handler) = Arrangement()
+            .withMessageById(Either.Right(original))
+            .withPersistingMessageReturning(Either.Right(Unit))
+            .arrange()
+
+        dispatch(arrangement, handler, content)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.persistMessage.invoke(
+                matches {
+                    (it.content as? MessageContent.Text)?.quotedMessageReference?.isVerified == false
+                }
+            )
+        }
+    }
+
+    @Test
+    fun givenDecryptionErrorFromSelf_whenHandling_thenVisibleSelfMessageIsPersisted() = runTest {
+        val event = TestEvent.newMessageEvent(Base64.encode("Hello".encodeToByteArray()))
+        val content = MessageContent.FailedDecryption(
+            isDecryptionResolved = false,
+            senderUserId = TestUser.SELF.id,
+        )
+        val (arrangement, handler) = Arrangement()
+            .withPersistingMessageReturning(Either.Right(Unit))
+            .arrange()
+
+        handler.handleDecryptionError(
+            eventId = event.id,
+            conversationId = event.conversationId,
+            messageInstant = event.messageInstant,
+            senderUserId = TestUser.SELF.id,
+            senderClientId = event.senderClientId,
+            content = content,
+        )
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.persistMessage.invoke(
+                matches {
+                    it is Message.Regular &&
+                            it.content == content &&
+                            it.isSelfMessage &&
+                            it.visibility == Message.Visibility.VISIBLE
+                }
+            )
+        }
+    }
+
+    @Test
     fun givenHistoryClientsRequest_whenHandling_thenMessageIsSafelySkipped() = runTest {
         assertHistoryMessageIsSafelySkipped(
             content = MessageContent.History.ClientsRequest,
@@ -470,13 +806,36 @@ class ApplicationMessageHandlerTest {
         assertFalse(logEntry.message.contains(HISTORY_CLIENT_SECRET_MARKER))
     }
 
+    private suspend fun dispatch(
+        arrangement: Arrangement,
+        handler: ApplicationMessageHandler,
+        content: MessageContent.FromProto,
+        senderUserId: UserId = TestUser.USER_ID,
+        expiresAfterMillis: Long? = null,
+    ) = TestEvent.newMessageEvent(Base64.encode("Hello".encodeToByteArray())).also { event ->
+        handler.handleContent(
+            arrangement.transactionContext,
+            event.conversationId,
+            event.messageInstant,
+            senderUserId,
+            event.senderClientId,
+            ProtoContent.Readable(
+                messageUid = "messageId",
+                messageContent = content,
+                expectsReadConfirmation = false,
+                legalHoldStatus = Conversation.LegalHoldStatus.DISABLED,
+                expiresAfterMillis = expiresAfterMillis,
+            )
+        )
+    }
+
     private class Arrangement(
         kaliumLogger: KaliumLogger = KaliumLogger.disabled(),
     ) : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementImpl() {
 
         val persistMessage = mock<PersistMessageUseCase>(MockMode.autoUnit)
         val messageRepository = mock<MessageRepository>(MockMode.autoUnit)
-        private val userRepository = mock<UserRepository>(MockMode.autoUnit)
+        val userRepository = mock<UserRepository>(MockMode.autoUnit)
         val userConfigRepository = mock<UserConfigRepository>(MockMode.autoUnit)
         val persistReactionsUseCase = mock<PersistReactionUseCase>(MockMode.autoUnit)
         val messageTextEditHandler = mock<MessageTextEditHandler>(MockMode.autoUnit)
@@ -548,10 +907,34 @@ class ApplicationMessageHandlerTest {
             }.returns(Either.Left(storageFailure))
         }
 
+        fun withMessageById(result: Either<StorageFailure, Message>) = apply {
+            everySuspend {
+                messageRepository.getMessageById(any(), any())
+            }.returns(result)
+        }
+
         fun withButtonActionConfirmation(result: Either<StorageFailure, Unit>) = apply {
             everySuspend {
                 buttonActionConfirmationHandler.handle(any(), any(), any())
             }.returns(result)
+        }
+
+        fun withUserAvailabilityUpdate() = apply {
+            everySuspend {
+                userRepository.updateOtherUserAvailabilityStatus(any(), any())
+            }.returns(Unit)
+        }
+
+        fun withPersistReaction() = apply {
+            everySuspend {
+                persistReactionsUseCase.invoke(any(), any(), any(), any())
+            }.returns(Either.Right(Unit))
+        }
+
+        fun withMessageTextEditHandler() = apply {
+            everySuspend {
+                messageTextEditHandler.handle(any(), any())
+            }.returns(Either.Right(Unit))
         }
 
         fun withMessageCompositeEditHandler() = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageFailureHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageFailureHandlerTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package com.wire.kalium.logic.sync.receiver.conversation.message
+
+import com.wire.kalium.common.error.BackupFailure
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.E2EIFailure
+import com.wire.kalium.common.error.MLSFailure
+import com.wire.kalium.common.error.NetworkFailure
+import com.wire.kalium.common.error.ProteusFailure
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.cryptography.exceptions.ProteusException
+import com.wire.kalium.logic.framework.TestUser
+import com.wire.kalium.network.api.model.MLSErrorResponse
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MLSMessageFailureHandlerTest {
+
+    @Test
+    fun givenRejectedFailureThatRequiresReset_whenHandling_thenResetConversation() {
+        val failures = listOf(
+            NetworkFailure.MlsMessageRejectedFailure.GroupOutOfSync(listOf(TestUser.OTHER_USER_ID)),
+            NetworkFailure.MlsMessageRejectedFailure.InvalidLeafNodeIndex,
+            NetworkFailure.MlsMessageRejectedFailure.InvalidLeafNodeSignature,
+        )
+
+        failures.forEach {
+            assertEquals(MLSMessageFailureResolution.ResetConversation, MLSMessageFailureHandler.handleFailure(it))
+        }
+    }
+
+    @Test
+    fun givenRejectedFailureThatCanBeShown_whenHandling_thenInformUser() {
+        val failures = listOf(
+            NetworkFailure.MlsMessageRejectedFailure.ClientMismatch,
+            NetworkFailure.MlsMessageRejectedFailure.CommitMissingReferences,
+            NetworkFailure.MlsMessageRejectedFailure.MissingGroupInfo,
+            NetworkFailure.MlsMessageRejectedFailure.Other(MLSErrorResponse.ProtocolError("error")),
+            NetworkFailure.MlsMessageRejectedFailure.StaleMessage,
+        )
+
+        failures.forEach {
+            assertEquals(MLSMessageFailureResolution.InformUser, MLSMessageFailureHandler.handleFailure(it))
+        }
+    }
+
+    @Test
+    fun givenWrappedRejectedFailure_whenHandling_thenUseRejectedFailureResolution() {
+        val failure = MLSFailure.MessageRejected(NetworkFailure.MlsMessageRejectedFailure.InvalidLeafNodeSignature)
+
+        assertEquals(MLSMessageFailureResolution.ResetConversation, MLSMessageFailureHandler.handleFailure(failure))
+    }
+
+    @Test
+    fun givenEpochFailure_whenHandling_thenMarkConversationOutOfSync() {
+        assertFailureResolutions(
+            failures = listOf(MLSFailure.WrongEpoch, MLSFailure.InvalidGroupId),
+            expected = MLSMessageFailureResolution.OutOfSync,
+        )
+    }
+
+    @Test
+    fun givenIgnorableMlsOrBackupFailure_whenHandling_thenIgnore() {
+        assertFailureResolutions(
+            failures = listOf(
+                MLSFailure.DuplicateMessage,
+                MLSFailure.BufferedFutureMessage,
+                MLSFailure.SelfCommitIgnored,
+                MLSFailure.UnmergedPendingGroup,
+                MLSFailure.StaleProposal,
+                MLSFailure.StaleCommit,
+                MLSFailure.MessageEpochTooOld,
+                MLSFailure.InternalErrors,
+                MLSFailure.Disabled,
+                MLSFailure.CommitForMissingProposal,
+                MLSFailure.ConversationNotFound,
+                MLSFailure.BufferedCommit,
+                MLSFailure.OrphanWelcome,
+                CoreFailure.DevelopmentAPINotAllowedOnProduction,
+                BackupFailure.NoCryptoStateAvailable,
+            ),
+            expected = MLSMessageFailureResolution.Ignore,
+        )
+    }
+
+    @Test
+    fun givenNonRecoverableFailure_whenHandling_thenInformUser() {
+        assertFailureResolutions(
+            failures = listOf(
+                MLSFailure.ConversationAlreadyExists,
+                MLSFailure.ConversationDoesNotSupportMLS,
+                MLSFailure.Generic(IllegalStateException("generic MLS failure")),
+                MLSFailure.Other("other MLS failure"),
+                E2EIFailure.Disabled,
+                CoreFailure.NotSupportedByProteus,
+                CoreFailure.MissingClientRegistration,
+                CoreFailure.MissingKeyPackages(emptySet()),
+                NetworkFailure.FeatureNotSupported,
+                NetworkFailure.FederatedBackendFailure.ConflictingBackends(emptyList()),
+                NetworkFailure.FederatedBackendFailure.ConflictingBackendsWithMissingUsers(emptyList()),
+                NetworkFailure.FederatedBackendFailure.FailedDomains(),
+                NetworkFailure.FederatedBackendFailure.FederationDenied("denied"),
+                NetworkFailure.FederatedBackendFailure.FederationNotEnabled("disabled"),
+                NetworkFailure.FederatedBackendFailure.FederationNotImplemented("unsupported"),
+                NetworkFailure.FederatedBackendFailure.General("general"),
+                NetworkFailure.NoNetworkConnection(null),
+                NetworkFailure.ProxyError(null),
+                NetworkFailure.ServerMiscommunication(IllegalStateException("server")),
+                ProteusFailure(ProteusException("proteus", ProteusException.Code.INVALID_MESSAGE, 1)),
+                StorageFailure.DataNotFound,
+                StorageFailure.Generic(IllegalStateException("storage")),
+                CoreFailure.Unknown(null),
+            ),
+            expected = MLSMessageFailureResolution.InformUser,
+        )
+    }
+
+    private fun assertFailureResolutions(
+        failures: List<CoreFailure>,
+        expected: MLSMessageFailureResolution,
+    ) {
+        failures.forEach { failure ->
+            assertEquals(expected, MLSMessageFailureHandler.handleFailure(failure), "Unexpected resolution for $failure")
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageUnpackerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/MLSMessageUnpackerTest.kt
@@ -19,11 +19,20 @@
 package com.wire.kalium.logic.sync.receiver.conversation.message
 
 import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.MLSFailure
 import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ApplicationMessage
+import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.ConversationRepository
 import com.wire.kalium.logic.data.conversation.DecryptedMessageBundle
 import com.wire.kalium.logic.data.conversation.MLSConversationRepository
 import com.wire.kalium.logic.data.conversation.SubconversationRepository
+import com.wire.kalium.logic.data.id.GroupID
+import com.wire.kalium.logic.data.id.SubconversationId
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.message.PlainMessageBlob
+import com.wire.kalium.logic.data.message.ProtoContent
+import com.wire.kalium.logic.data.message.ProtoContentMapper
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.message.PendingProposalScheduler
 import com.wire.kalium.logic.framework.TestConversation
@@ -34,9 +43,11 @@ import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProvider
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMokkeryImpl
 import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
+import com.wire.kalium.logic.sync.KaliumSyncException
 import com.wire.kalium.util.DateTimeUtil
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
+import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.matcher.eq
@@ -49,6 +60,8 @@ import kotlinx.coroutines.test.runTest
 import kotlin.io.encoding.Base64
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
 import kotlin.time.Duration.Companion.seconds
 
 internal class MLSMessageUnpackerTest {
@@ -141,18 +154,145 @@ internal class MLSMessageUnpackerTest {
         }
     }
 
+    @Test
+    fun givenEmptyDecryptedBundleList_whenUnpacking_thenReturnHandshakeMessage() = runTest {
+        val (arrangement, mlsUnpacker) = Arrangement()
+            .withGetConversationProtocolInfoSuccessful(TestConversation.MLS_PROTOCOL_INFO)
+            .withDecryptMessageReturning(Either.Right(emptyList()))
+            .arrange()
+
+        val result = mlsUnpacker.unpackMlsMessage(
+            arrangement.mlsContext,
+            TestEvent.newMLSMessageEvent(DateTimeUtil.currentInstant()),
+        )
+
+        result.shouldSucceed {
+            assertEquals(listOf(MessageUnpackResult.HandshakeMessage), it)
+        }
+    }
+
+    @Test
+    fun givenSubconversationGroupExists_whenUnpacking_thenDecryptUsingSubconversationGroup() = runTest {
+        val subConversationId = SubconversationId("conference")
+        val subConversationGroupId = GroupID("subconversation-group")
+        val (arrangement, mlsUnpacker) = Arrangement()
+            .withSubconversationInfo(subConversationGroupId)
+            .withDecryptMessageReturning(Either.Right(emptyList()))
+            .arrange()
+        val event = TestEvent.newMLSMessageEvent(DateTimeUtil.currentInstant(), subConversationId)
+
+        mlsUnpacker.unpackMlsMessage(arrangement.mlsContext, event)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.mlsConversationRepository.decryptMessage(any(), any(), eq(subConversationGroupId))
+        }
+        verifySuspend(VerifyMode.not) { arrangement.conversationRepository.getConversationProtocolInfo(any()) }
+    }
+
+    @Test
+    fun givenSubconversationGroupIsMissing_whenUnpacking_thenFallBackToParentConversationGroup() = runTest {
+        val subConversationId = SubconversationId("conference")
+        val (arrangement, mlsUnpacker) = Arrangement()
+            .withSubconversationInfo(null)
+            .withGetConversationProtocolInfoSuccessful(TestConversation.MLS_PROTOCOL_INFO)
+            .withDecryptMessageReturning(Either.Right(emptyList()))
+            .arrange()
+        val event = TestEvent.newMLSMessageEvent(DateTimeUtil.currentInstant(), subConversationId)
+
+        mlsUnpacker.unpackMlsMessage(arrangement.mlsContext, event)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.mlsConversationRepository.decryptMessage(any(), any(), eq(TestConversation.GROUP_ID))
+        }
+    }
+
+    @Test
+    fun givenBufferedMlsFailure_whenUnpacking_thenReadEpochAndPropagateFailure() = runTest {
+        listOf(MLSFailure.BufferedFutureMessage, MLSFailure.BufferedCommit).forEach { failure ->
+            val (arrangement, mlsUnpacker) = Arrangement()
+                .withGetConversationProtocolInfoSuccessful(TestConversation.MLS_PROTOCOL_INFO)
+                .withDecryptMessageReturning(Either.Left(failure))
+                .withLocalGroupEpoch(Either.Right(42UL))
+                .arrange()
+
+            val result = mlsUnpacker.unpackMlsMessage(
+                arrangement.mlsContext,
+                TestEvent.newMLSMessageEvent(DateTimeUtil.currentInstant()),
+            )
+
+            result.shouldFail { assertEquals(failure, it) }
+            verifySuspend(VerifyMode.exactly(1)) {
+                arrangement.mlsConversationRepository.getLocalGroupEpoch(any(), eq(TestConversation.GROUP_ID))
+            }
+        }
+    }
+
+    @Test
+    fun givenReadableApplicationBundle_whenUnpacking_thenMapApplicationMessage() = runTest {
+        val readable = ProtoContent.Readable(
+            messageUid = "message-id",
+            messageContent = MessageContent.Text("hello"),
+            expectsReadConfirmation = false,
+            legalHoldStatus = Conversation.LegalHoldStatus.DISABLED,
+        )
+        val applicationMessage = ApplicationMessage(
+            message = byteArrayOf(1, 2, 3),
+            senderID = SELF_USER_ID,
+            senderClientID = ClientId("client-id"),
+        )
+        val (_, mlsUnpacker) = Arrangement()
+            .withDecodedProtoContent(readable)
+            .arrange()
+
+        val result = mlsUnpacker.unpackMlsBundle(
+            DECRYPTED_MESSAGE_BUNDLE.copy(applicationMessage = applicationMessage),
+            TestConversation.ID,
+            DateTimeUtil.currentInstant(),
+        )
+
+        assertIs<MessageUnpackResult.ApplicationMessage>(result)
+        assertEquals(readable, result.content)
+        assertEquals(SELF_USER_ID, result.senderUserId)
+        assertEquals(applicationMessage.senderClientID, result.senderClientId)
+    }
+
+    @Test
+    fun givenExternalApplicationBundle_whenUnpacking_thenRejectNestedExternalContent() = runTest {
+        val external = ProtoContent.ExternalMessageInstructions(
+            messageUid = "message-id",
+            otrKey = byteArrayOf(1),
+            sha256 = null,
+            encryptionAlgorithm = null,
+        )
+        val (_, mlsUnpacker) = Arrangement()
+            .withDecodedProtoContent(external)
+            .arrange()
+
+        assertFailsWith<KaliumSyncException> {
+            mlsUnpacker.unpackMlsBundle(
+                DECRYPTED_MESSAGE_BUNDLE.copy(
+                    applicationMessage = ApplicationMessage(byteArrayOf(1), SELF_USER_ID, ClientId("client-id"))
+                ),
+                TestConversation.ID,
+                DateTimeUtil.currentInstant(),
+            )
+        }
+    }
+
     private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMokkeryImpl() {
         val conversationRepository = mock<ConversationRepository>()
         val mlsConversationRepository = mock<MLSConversationRepository>()
         val pendingProposalScheduler = mock<PendingProposalScheduler>(mode = MockMode.autoUnit)
         val subconversationRepository = mock<SubconversationRepository>(mode = MockMode.autoUnit)
+        val protoContentMapper = mock<ProtoContentMapper>()
 
         private val mlsMessageUnpacker = MLSMessageUnpackerImpl(
             conversationRepository,
             subconversationRepository,
             mlsConversationRepository,
             pendingProposalScheduler,
-            SELF_USER_ID
+            SELF_USER_ID,
+            protoContentMapper,
         )
 
 
@@ -172,6 +312,24 @@ internal class MLSMessageUnpackerTest {
             everySuspend {
                 conversationRepository.getConversationProtocolInfo(any())
             }.returns(Either.Right(protocolInfo))
+        }
+
+        suspend fun withSubconversationInfo(groupId: GroupID?) = apply {
+            everySuspend {
+                subconversationRepository.getSubconversationInfo(any(), any())
+            }.returns(groupId)
+        }
+
+        suspend fun withLocalGroupEpoch(result: Either<CoreFailure, ULong>) = apply {
+            everySuspend {
+                mlsConversationRepository.getLocalGroupEpoch(any(), any())
+            }.returns(result)
+        }
+
+        fun withDecodedProtoContent(content: ProtoContent) = apply {
+            every {
+                protoContentMapper.decodeFromProtobuf(any<PlainMessageBlob>())
+            }.returns(content)
         }
 
         fun arrange(block: suspend Arrangement.() -> Unit = {}) = let {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/NewMessageEventHandlerTest.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.logic.sync.receiver.conversation.message
 import com.wire.kalium.cryptography.exceptions.ProteusException
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.MLSFailure
+import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.common.error.ProteusFailure
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Conversation
@@ -37,6 +38,7 @@ import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.logic.framework.TestUser
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.conversation.ResetMLSConversationUseCase
+import com.wire.kalium.logic.data.conversation.ResetMLSConversationResult
 import com.wire.kalium.logic.sync.receiver.handler.legalhold.LegalHoldHandler
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMokkeryImpl
@@ -47,6 +49,7 @@ import dev.mokkery.MockMode
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.matcher.eq
+import dev.mokkery.matcher.matches
 import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verify
@@ -57,6 +60,17 @@ import kotlinx.datetime.Instant
 import kotlin.test.Test
 
 class NewMessageEventHandlerTest {
+
+    @Test
+    fun givenPendingSideEffects_whenFlushing_thenDelegateToApplicationMessageHandler() = runTest {
+        val (arrangement, newMessageEventHandler) = Arrangement().arrange()
+
+        newMessageEventHandler.flushPendingSideEffects()
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.applicationMessageHandler.flushPendingSideEffects()
+        }
+    }
 
     @Test
     fun givenProteusEvent_whenHandling_shouldAskProteusUnpackerToDecrypt() = runTest {
@@ -514,6 +528,21 @@ class NewMessageEventHandlerTest {
         }
 
     @Test
+    fun givenMLSEventFailsWithInvalidLeafNodeIndex_whenHandling_thenResetConversation() = runTest {
+        val newMessageEvent = TestEvent.newMLSMessageEvent(DateTimeUtil.currentInstant())
+        val (arrangement, newMessageEventHandler) = Arrangement()
+            .withMLSUnpackerReturning(Either.Left(NetworkFailure.MlsMessageRejectedFailure.InvalidLeafNodeIndex))
+            .withResetConversationReturning(ResetMLSConversationResult.Success)
+            .arrange()
+
+        newMessageEventHandler.handleNewMLSMessage(arrangement.transactionContext, newMessageEvent, TestEvent.liveDeliveryInfo)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.resetMlsConversation(eq(newMessageEvent.conversationId), eq(arrangement.transactionContext))
+        }
+    }
+
+    @Test
     fun givenSubconversationId_whenHandlingInformUserFailure_thenShouldNotSendSystemMessage() = runTest {
         val event = TestEvent.newMLSMessageEvent(
             dateTime = DateTimeUtil.currentInstant(),
@@ -536,6 +565,27 @@ class NewMessageEventHandlerTest {
                 senderUserId = any(),
                 senderClientId = any(),
                 content = any()
+            )
+        }
+    }
+
+    @Test
+    fun givenParentConversation_whenHandlingInformUserFailure_thenShouldPersistDecryptionError() = runTest {
+        val event = TestEvent.newMLSMessageEvent(dateTime = DateTimeUtil.currentInstant())
+        val (arrangement, newMessageEventHandler) = Arrangement()
+            .withMLSUnpackerReturning(Either.Left(CoreFailure.Unknown(null)))
+            .arrange()
+
+        newMessageEventHandler.handleNewMLSMessage(arrangement.transactionContext, event, TestEvent.liveDeliveryInfo)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.applicationMessageHandler.handleDecryptionError(
+                eventId = eq(event.id),
+                conversationId = eq(event.conversationId),
+                messageInstant = eq(event.messageInstant),
+                senderUserId = eq(event.senderUserId),
+                senderClientId = any(),
+                content = matches { it.senderUserId == event.senderUserId && !it.isDecryptionResolved }
             )
         }
     }
@@ -598,6 +648,12 @@ class NewMessageEventHandlerTest {
         suspend fun withVerifyEpoch(result: Either<CoreFailure, Unit>) = apply {
             everySuspend {
                 staleEpochVerifier.verifyEpoch(any(), any(), any(), any())
+            }.returns(result)
+        }
+
+        suspend fun withResetConversationReturning(result: ResetMLSConversationResult) = apply {
+            everySuspend {
+                resetMlsConversation(any(), any())
             }.returns(result)
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ProteusMessageUnpackerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/conversation/message/ProteusMessageUnpackerTest.kt
@@ -18,10 +18,12 @@
 
 package com.wire.kalium.logic.sync.receiver.conversation.message
 
+import com.wire.kalium.common.error.ProteusFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.cryptography.CryptoClientId
 import com.wire.kalium.cryptography.CryptoSessionId
 import com.wire.kalium.cryptography.CryptoUserID
+import com.wire.kalium.cryptography.exceptions.ProteusException
 import com.wire.kalium.cryptography.utils.PlainData
 import com.wire.kalium.cryptography.utils.encryptDataWithAES256
 import com.wire.kalium.cryptography.utils.generateRandomAES256Key
@@ -35,6 +37,7 @@ import com.wire.kalium.logic.framework.TestEvent
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangement
 import com.wire.kalium.logic.util.arrangement.provider.CryptoTransactionProviderArrangementMokkeryImpl
 import com.wire.kalium.logic.util.shouldSucceed
+import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.protobuf.encodeToByteArray
 import com.wire.kalium.protobuf.messages.GenericMessage
 import com.wire.kalium.protobuf.messages.Text
@@ -137,6 +140,30 @@ class ProteusMessageUnpackerTest {
         }
     }
 
+    @Test
+    fun givenProteusFailure_whenUnpacking_thenEveryFailureResolutionIsPropagated() = runTest {
+        val codes = listOf(
+            ProteusException.Code.DUPLICATE_MESSAGE,
+            ProteusException.Code.SESSION_NOT_FOUND,
+            ProteusException.Code.INVALID_SIGNATURE,
+        )
+
+        codes.forEach { code ->
+            val exception = ProteusException("proteus failure", code, 1)
+            val (arrangement, proteusUnpacker) = Arrangement()
+                .withProteusClientThrowing(exception)
+                .arrange()
+            val event = TestEvent.newMessageEvent(Base64.encode("message".encodeToByteArray()))
+
+            val result = proteusUnpacker.unpackProteusMessage(arrangement.proteusContext, event) { it }
+
+            result.shouldFail {
+                assertIs<ProteusFailure>(it)
+                assertEquals(code, it.proteusException.code)
+            }
+        }
+    }
+
     private class Arrangement : CryptoTransactionProviderArrangement by CryptoTransactionProviderArrangementMokkeryImpl() {
         val protoContentMapper = mock<ProtoContentMapper>()
 
@@ -146,6 +173,14 @@ class ProteusMessageUnpackerTest {
             } calls {
                 val lambda = it.args[2] as suspend (ByteArray) -> Either<*, *>
                 lambda.invoke(decryptedData)
+            }
+        }
+
+        suspend fun withProteusClientThrowing(exception: ProteusException) = apply {
+            everySuspend {
+                proteusContext.decryptMessage<Either<*, *>>(any(), any(), any())
+            } calls {
+                throw exception
             }
         }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/CallingMessageHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/CallingMessageHandlerTest.kt
@@ -23,6 +23,7 @@ import com.wire.kalium.logic.data.call.CallModerationActionsRepository
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationRepository
+import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.CurrentClientIdProvider
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
@@ -101,6 +102,41 @@ class CallingMessageHandlerTest {
         }
         verifySuspend(VerifyMode.exactly(0)) {
             arrangement.callManager.onCallingMessageReceived(message, content)
+        }
+    }
+
+    @Test
+    fun givenSelfRemoteMuteWithTargetConversation_whenHandling_thenContentConversationIsUsed() = runTest {
+        val targetConversationId = ConversationId("target-conversation", "wire.com")
+        val content = REMOTE_MUTE_CONTENT.copy(conversationId = targetConversationId)
+        val message = CALLING_MESSAGE.copy(content = content, isSelfMessage = true)
+        val (arrangement, callingMessageHandler) = Arrangement()
+            .withShouldRemoteMuteCheckerReturning(true)
+            .arrange()
+
+        callingMessageHandler.handle(message, content)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.muteCallUseCase.invoke(targetConversationId, true)
+            arrangement.callModerationActionsRepository.addAction(
+                targetConversationId,
+                CallModerationAction(message.id, message.senderUserId, CallModerationAction.Type.MUTED)
+            )
+        }
+    }
+
+    @Test
+    fun givenSelfRemoteMuteWithoutTargetConversation_whenHandling_thenMessageConversationIsUsed() = runTest {
+        val content = REMOTE_MUTE_CONTENT.copy(conversationId = null)
+        val message = CALLING_MESSAGE.copy(content = content, isSelfMessage = true)
+        val (arrangement, callingMessageHandler) = Arrangement()
+            .withShouldRemoteMuteCheckerReturning(true)
+            .arrange()
+
+        callingMessageHandler.handle(message, content)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.muteCallUseCase.invoke(message.conversationId, true)
         }
     }
 

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/CellsConfigHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/CellsConfigHandlerTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.receiver.handler
+
+import com.wire.kalium.cells.domain.model.WireCellsConfig
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.isRight
+import com.wire.kalium.logic.data.featureConfig.CellsInternalConfigModel
+import com.wire.kalium.logic.data.featureConfig.CellsInternalModel
+import com.wire.kalium.logic.data.featureConfig.CellsModel
+import com.wire.kalium.logic.data.featureConfig.CollaboraEdition
+import com.wire.kalium.logic.data.featureConfig.Status
+import com.wire.kalium.logic.util.arrangement.repository.UserConfigRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.repository.UserConfigRepositoryArrangementImpl
+import dev.mokkery.matcher.eq
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class CellsConfigHandlerTest {
+
+    @Test
+    fun givenCellsEnabled_whenHandling_thenFeatureIsEnabled() = runTest {
+        val (arrangement, handler) = arrange {
+            withSetCellsEnabledReturning(Either.Right(Unit))
+        }
+
+        val result = handler.handle(CellsModel(Status.ENABLED))
+
+        assertTrue(result.isRight())
+        verifySuspend(VerifyMode.exactly(1)) { arrangement.userConfigRepository.setCellsEnabled(true) }
+    }
+
+    @Test
+    fun givenCellsConfigMissing_whenHandling_thenFeatureIsDisabled() = runTest {
+        val (arrangement, handler) = arrange {
+            withSetCellsEnabledReturning(Either.Right(Unit))
+        }
+
+        val result = handler.handle(null as CellsModel?)
+
+        assertTrue(result.isRight())
+        verifySuspend(VerifyMode.exactly(1)) { arrangement.userConfigRepository.setCellsEnabled(false) }
+    }
+
+    @Test
+    fun givenInternalCellsConfig_whenHandling_thenMappedConfigIsStored() = runTest {
+        val model = CellsInternalModel(
+            status = Status.ENABLED,
+            config = CellsInternalConfigModel(
+                backendUrl = "https://cells.example.com",
+                collaboraEdition = CollaboraEdition.CODE,
+                perUserQuotaBytes = 1024L,
+            )
+        )
+        val expected = WireCellsConfig(
+            backendUrl = model.config.backendUrl,
+            collabora = model.config.collaboraEdition,
+            teamQuotaBytes = model.config.perUserQuotaBytes,
+        )
+        val (arrangement, handler) = arrange {
+            withSetWireCellsConfigReturning(Either.Right(Unit))
+        }
+
+        val result = handler.handle(model)
+
+        assertTrue(result.isRight())
+        verifySuspend(VerifyMode.exactly(1)) { arrangement.userConfigRepository.setWireCellsConfig(eq(expected)) }
+    }
+
+    @Test
+    fun givenInternalCellsConfigMissing_whenHandling_thenStoredConfigIsCleared() = runTest {
+        val (arrangement, handler) = arrange {
+            withSetWireCellsConfigReturning(Either.Right(Unit))
+        }
+
+        val result = handler.handle(null as CellsInternalModel?)
+
+        assertTrue(result.isRight())
+        verifySuspend(VerifyMode.exactly(1)) { arrangement.userConfigRepository.setWireCellsConfig(eq(null)) }
+    }
+
+    private suspend fun arrange(block: suspend Arrangement.() -> Unit) = Arrangement(block).arrange()
+
+    private class Arrangement(
+        private val block: suspend Arrangement.() -> Unit,
+    ) : UserConfigRepositoryArrangement by UserConfigRepositoryArrangementImpl() {
+
+        suspend fun arrange() = run {
+            block()
+            this@Arrangement to CellsConfigHandler(userConfigRepository)
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/DeleteForMeHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/DeleteForMeHandlerTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.receiver.handler
+
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.conversation.ClientId
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.util.arrangement.PersistenceEventHookNotifierArrangement
+import com.wire.kalium.logic.util.arrangement.PersistenceEventHookNotifierArrangementImpl
+import com.wire.kalium.logic.util.arrangement.repository.MessageRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.repository.MessageRepositoryArrangementImpl
+import com.wire.kalium.logic.util.arrangement.usecase.IsMessageSentInSelfConversationUseCaseArrangement
+import com.wire.kalium.logic.util.arrangement.usecase.IsMessageSentInSelfConversationUseCaseArrangementImpl
+import com.wire.kalium.messaging.hooks.MessageDeleteEventData
+import dev.mokkery.matcher.any
+import dev.mokkery.matcher.eq
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+
+class DeleteForMeHandlerTest {
+
+    @Test
+    fun givenMessageFromSelfConversation_whenHandling_thenMessageIsDeletedAndHookIsNotified() = runTest {
+        val (arrangement, handler) = arrange {
+            withMessageSentInSelfConversationReturning(true)
+            withDeleteMessage(Either.Right(Unit))
+        }
+
+        handler.handle(MESSAGE, CONTENT)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.messageRepository.deleteMessage(eq(MESSAGE_ID), eq(CONVERSATION_ID))
+        }
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.persistenceEventHookNotifier.onMessageDeleted(
+                eq(MessageDeleteEventData(CONVERSATION_ID, MESSAGE_ID)),
+                eq(SELF_USER_ID)
+            )
+        }
+    }
+
+    @Test
+    fun givenMessageOutsideSelfConversation_whenHandling_thenMessageIsNotDeleted() = runTest {
+        val (arrangement, handler) = arrange {
+            withMessageSentInSelfConversationReturning(false)
+        }
+
+        handler.handle(MESSAGE, CONTENT)
+
+        verifySuspend(VerifyMode.not) { arrangement.messageRepository.deleteMessage(any(), any()) }
+        verifySuspend(VerifyMode.not) { arrangement.persistenceEventHookNotifier.onMessageDeleted(any(), any()) }
+    }
+
+    private suspend fun arrange(block: suspend Arrangement.() -> Unit) = Arrangement(block).arrange()
+
+    private class Arrangement(
+        private val block: suspend Arrangement.() -> Unit,
+    ) : MessageRepositoryArrangement by MessageRepositoryArrangementImpl(),
+        IsMessageSentInSelfConversationUseCaseArrangement by IsMessageSentInSelfConversationUseCaseArrangementImpl(),
+        PersistenceEventHookNotifierArrangement by PersistenceEventHookNotifierArrangementImpl() {
+
+        suspend fun arrange() = run {
+            block()
+            this@Arrangement to DeleteForMeHandlerImpl(
+                messageRepository = messageRepository,
+                isMessageSentInSelfConversation = isMessageSentInSelfConversationUseCase,
+                persistenceEventHookNotifier = persistenceEventHookNotifier,
+                selfUserId = SELF_USER_ID,
+            )
+        }
+    }
+
+    private companion object {
+        val SELF_USER_ID = UserId("self-user", "wire.com")
+        val CONVERSATION_ID = ConversationId("conversation", "wire.com")
+        const val MESSAGE_ID = "message-id"
+        val CONTENT = MessageContent.DeleteForMe(
+            messageId = MESSAGE_ID,
+            conversationId = CONVERSATION_ID,
+        )
+        val MESSAGE = Message.Signaling(
+            id = "signaling-message-id",
+            content = CONTENT,
+            conversationId = CONVERSATION_ID,
+            date = Instant.parse("2026-08-29T12:00:00Z"),
+            senderUserId = SELF_USER_ID,
+            senderClientId = ClientId("self-client"),
+            status = Message.Status.Sent,
+            isSelfMessage = true,
+            expirationData = null,
+        )
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/DeleteMessageHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/DeleteMessageHandlerTest.kt
@@ -295,6 +295,32 @@ class DeleteMessageHandlerTest {
         assertEquals(SELF_USER_ID, selfUserId)
     }
 
+    @Test
+    fun givenDeletedMessageHasRemoteAsset_whenHandled_thenLocalAssetIsDeleted() = runTest {
+        val conversationId = ConversationId("conversationId", "conversationDomain")
+        val originalMessage = TestMessage.TEXT_MESSAGE.copy(
+            content = TestMessage.ASSET_CONTENT,
+            conversationId = conversationId,
+            expirationData = null,
+        )
+        val assetId = TestMessage.ASSET_CONTENT.value.remoteData.assetId
+        val (arrangement, handler) = arrange {
+            withGetMessageById(Either.Right(originalMessage))
+            withMarkAsDeleted(Either.Right(Unit))
+            withDeleteAssetLocally(Either.Right(Unit))
+        }
+
+        handler(
+            content = MessageContent.DeleteMessage(originalMessage.id),
+            conversationId = conversationId,
+            senderUserId = originalMessage.senderUserId,
+        )
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.assetRepository.deleteAssetLocally(eq(assetId))
+        }
+    }
+
     private companion object {
         val SELF_USER_ID = UserId("selfID", "selfDomain")
     }
@@ -340,6 +366,12 @@ class DeleteMessageHandlerTest {
         suspend fun withMarkAsDeleted(result: Either<StorageFailure, Unit>) = apply {
             everySuspend {
                 messageRepository.markMessageAsDeleted(any(), any())
+            } returns result
+        }
+
+        suspend fun withDeleteAssetLocally(result: Either<com.wire.kalium.common.error.CoreFailure, Unit>) = apply {
+            everySuspend {
+                assetRepository.deleteAssetLocally(any())
             } returns result
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/FeatureConfigStatusHandlersTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/FeatureConfigStatusHandlersTest.kt
@@ -1,0 +1,156 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.sync.receiver.handler
+
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.isRight
+import com.wire.kalium.logic.data.featureConfig.AllowedGlobalOperationsModel
+import com.wire.kalium.logic.data.featureConfig.AssetAuditLogConfigModel
+import com.wire.kalium.logic.data.featureConfig.EnableUserProfileQRCodeConfigModel
+import com.wire.kalium.logic.data.featureConfig.PreventAdminlessGroupsConfigModel
+import com.wire.kalium.logic.data.featureConfig.Status
+import com.wire.kalium.logic.util.arrangement.repository.UserConfigRepositoryArrangement
+import com.wire.kalium.logic.util.arrangement.repository.UserConfigRepositoryArrangementImpl
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class FeatureConfigStatusHandlersTest {
+
+    @Test
+    fun givenAllowedGlobalOperationsEnabled_whenHandling_thenConfiguredMlsResetValueIsStored() = runTest {
+        val arrangement = arrange {
+            withSetMlsConversationsResetEnabledReturning(Either.Right(Unit))
+        }
+
+        val result = arrangement.allowedGlobalOperationsHandler.handle(
+            AllowedGlobalOperationsModel(mlsConversationsReset = true, status = Status.ENABLED)
+        )
+
+        assertTrue(result.isRight())
+        verifySuspend(VerifyMode.exactly(1)) { arrangement.userConfigRepository.setMlsConversationsResetEnabled(true) }
+    }
+
+    @Test
+    fun givenAllowedGlobalOperationsDisabled_whenHandling_thenMlsResetIsDisabled() = runTest {
+        val arrangement = arrange {
+            withSetMlsConversationsResetEnabledReturning(Either.Right(Unit))
+        }
+
+        val result = arrangement.allowedGlobalOperationsHandler.handle(
+            AllowedGlobalOperationsModel(mlsConversationsReset = true, status = Status.DISABLED)
+        )
+
+        assertTrue(result.isRight())
+        verifySuspend(VerifyMode.exactly(1)) { arrangement.userConfigRepository.setMlsConversationsResetEnabled(false) }
+    }
+
+    @Test
+    fun givenAssetAuditLogEnabled_whenHandling_thenFeatureIsEnabled() = runTest {
+        val arrangement = arrange {
+            withSetAssetAuditLogEnabledReturning(Either.Right(Unit))
+        }
+
+        val result = arrangement.assetAuditLogConfigHandler.handle(AssetAuditLogConfigModel(Status.ENABLED))
+
+        assertTrue(result.isRight())
+        verifySuspend(VerifyMode.exactly(1)) { arrangement.userConfigRepository.setAssetAuditLogEnabled(true) }
+    }
+
+    @Test
+    fun givenAssetAuditLogConfigMissing_whenHandling_thenFeatureIsDisabled() = runTest {
+        val arrangement = arrange {
+            withSetAssetAuditLogEnabledReturning(Either.Right(Unit))
+        }
+
+        val result = arrangement.assetAuditLogConfigHandler.handle(null)
+
+        assertTrue(result.isRight())
+        verifySuspend(VerifyMode.exactly(1)) { arrangement.userConfigRepository.setAssetAuditLogEnabled(false) }
+    }
+
+    @Test
+    fun givenProfileQrCodeDisabled_whenHandling_thenFeatureIsDisabled() = runTest {
+        val arrangement = arrange {
+            withSetProfileQRCodeEnabledReturning(Either.Right(Unit))
+        }
+
+        val result = arrangement.enableUserProfileQRCodeConfigHandler.handle(
+            EnableUserProfileQRCodeConfigModel(Status.DISABLED)
+        )
+
+        assertTrue(result.isRight())
+        verifySuspend(VerifyMode.exactly(1)) { arrangement.userConfigRepository.setProfileQRCodeEnabled(false) }
+    }
+
+    @Test
+    fun givenProfileQrCodeConfigMissing_whenHandling_thenFeatureDefaultsToEnabled() = runTest {
+        val arrangement = arrange {
+            withSetProfileQRCodeEnabledReturning(Either.Right(Unit))
+        }
+
+        val result = arrangement.enableUserProfileQRCodeConfigHandler.handle(null)
+
+        assertTrue(result.isRight())
+        verifySuspend(VerifyMode.exactly(1)) { arrangement.userConfigRepository.setProfileQRCodeEnabled(true) }
+    }
+
+    @Test
+    fun givenPreventAdminlessGroupsEnabled_whenHandling_thenFeatureIsEnabled() = runTest {
+        val arrangement = arrange {
+            withSetPreventAdminlessGroupsEnabledReturning(Either.Right(Unit))
+        }
+
+        val result = arrangement.preventAdminlessGroupsConfigHandler.handle(
+            PreventAdminlessGroupsConfigModel(Status.ENABLED)
+        )
+
+        assertTrue(result.isRight())
+        verifySuspend(VerifyMode.exactly(1)) { arrangement.userConfigRepository.setPreventAdminlessGroupsEnabled(true) }
+    }
+
+    @Test
+    fun givenPreventAdminlessGroupsConfigMissing_whenHandling_thenFeatureIsDisabled() = runTest {
+        val arrangement = arrange {
+            withSetPreventAdminlessGroupsEnabledReturning(Either.Right(Unit))
+        }
+
+        val result = arrangement.preventAdminlessGroupsConfigHandler.handle(null)
+
+        assertTrue(result.isRight())
+        verifySuspend(VerifyMode.exactly(1)) { arrangement.userConfigRepository.setPreventAdminlessGroupsEnabled(false) }
+    }
+
+    private suspend fun arrange(block: suspend Arrangement.() -> Unit) = Arrangement(block).arrange()
+
+    private class Arrangement(
+        private val block: suspend Arrangement.() -> Unit,
+    ) : UserConfigRepositoryArrangement by UserConfigRepositoryArrangementImpl() {
+        val allowedGlobalOperationsHandler = AllowedGlobalOperationsHandler(userConfigRepository)
+        val assetAuditLogConfigHandler = AssetAuditLogConfigHandler(userConfigRepository)
+        val enableUserProfileQRCodeConfigHandler = EnableUserProfileQRCodeConfigHandler(userConfigRepository)
+        val preventAdminlessGroupsConfigHandler = PreventAdminlessGroupsConfigHandler(userConfigRepository)
+
+        suspend fun arrange() = run {
+            block()
+            this@Arrangement
+        }
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/legalhold/LegalHoldHandlerTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/sync/receiver/handler/legalhold/LegalHoldHandlerTest.kt
@@ -522,6 +522,34 @@ class LegalHoldHandlerTest {
         }
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun givenSelfLegalHoldWasEnabledAndIsNowDisabled_whenHandlingLiveMessage_thenClearRequestAndNotify() = runTest {
+        val (arrangement, handler) = Arrangement()
+            .withObserveConversationLegalHoldStatus(Conversation.LegalHoldStatus.ENABLED)
+            .withUpdateLegalHoldStatusSuccess(isChanged = true)
+            .withGetConversationMembersSuccess(listOf(TestUser.SELF.id))
+            .withMembersHavingLegalHoldClientSuccess(listOf(TestUser.SELF.id))
+            .withObserveLegalHoldStateForUserSuccess(LegalHoldState.Disabled)
+            .withSetLegalHoldChangeNotifiedSuccess()
+            .withDeleteLegalHoldSuccess()
+            .withSyncStates(flowOf(SyncState.Live))
+            .arrange()
+        advanceUntilIdle()
+
+        handler.handleNewMessage(applicationMessage(Conversation.LegalHoldStatus.DISABLED), true)
+
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.userConfigRepository.setLegalHoldChangeNotified(eq(false))
+        }
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.userConfigRepository.deleteLegalHoldRequest()
+        }
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.legalHoldSystemMessagesHandler.handleDisabledForUser(eq(TestUser.SELF.id), any())
+        }
+    }
+
     @Test
     fun givenHandleMessageSendFailureFails_whenHandlingMessageSendFailure_thenPropagateThisFailure() = runTest {
         // given

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/PersistenceEventHookNotifierArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/PersistenceEventHookNotifierArrangement.kt
@@ -1,0 +1,30 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.util.arrangement
+
+import com.wire.kalium.messaging.hooks.PersistenceEventHookNotifier
+import dev.mokkery.MockMode
+import dev.mokkery.mock
+
+internal interface PersistenceEventHookNotifierArrangement {
+    val persistenceEventHookNotifier: PersistenceEventHookNotifier
+}
+
+internal class PersistenceEventHookNotifierArrangementImpl : PersistenceEventHookNotifierArrangement {
+    override val persistenceEventHookNotifier = mock<PersistenceEventHookNotifier>(mode = MockMode.autoUnit)
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/UserConfigRepositoryArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/repository/UserConfigRepositoryArrangement.kt
@@ -17,9 +17,11 @@
  */
 package com.wire.kalium.logic.util.arrangement.repository
 
+import com.wire.kalium.cells.domain.model.WireCellsConfig
 import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.right
+import com.wire.kalium.logic.configuration.FileSharingStatus
 import com.wire.kalium.logic.configuration.UserConfigRepository
 import com.wire.kalium.logic.data.featureConfig.MLSMigrationModel
 import com.wire.kalium.logic.data.mls.SupportedCipherSuite
@@ -55,6 +57,13 @@ internal interface UserConfigRepositoryArrangement {
     suspend fun withConferenceCallingEnabled(result: Boolean)
     suspend fun withDeleteLegalHoldRequestSuccess(): UserConfigRepositoryArrangement
     suspend fun withSetLegalHoldChangeNotifiedSuccess(): UserConfigRepositoryArrangement
+    suspend fun withFileSharingEnabledReturning(result: Either<StorageFailure, FileSharingStatus>)
+    suspend fun withSetMlsConversationsResetEnabledReturning(result: Either<StorageFailure, Unit>)
+    suspend fun withSetCellsEnabledReturning(result: Either<StorageFailure, Unit>)
+    suspend fun withSetWireCellsConfigReturning(result: Either<StorageFailure, Unit>)
+    suspend fun withSetAssetAuditLogEnabledReturning(result: Either<StorageFailure, Unit>)
+    suspend fun withSetProfileQRCodeEnabledReturning(result: Either<StorageFailure, Unit>)
+    suspend fun withSetPreventAdminlessGroupsEnabledReturning(result: Either<StorageFailure, Unit>)
 }
 
 internal class UserConfigRepositoryArrangementImpl : UserConfigRepositoryArrangement {
@@ -157,5 +166,33 @@ internal class UserConfigRepositoryArrangementImpl : UserConfigRepositoryArrange
 
     override suspend fun withSetLegalHoldChangeNotifiedSuccess() = apply {
         everySuspend { userConfigRepository.setLegalHoldChangeNotified(any()) }.returns(Either.Right(Unit))
+    }
+
+    override suspend fun withFileSharingEnabledReturning(result: Either<StorageFailure, FileSharingStatus>) {
+        everySuspend { userConfigRepository.isFileSharingEnabled() }.returns(result)
+    }
+
+    override suspend fun withSetMlsConversationsResetEnabledReturning(result: Either<StorageFailure, Unit>) {
+        everySuspend { userConfigRepository.setMlsConversationsResetEnabled(any()) }.returns(result)
+    }
+
+    override suspend fun withSetCellsEnabledReturning(result: Either<StorageFailure, Unit>) {
+        everySuspend { userConfigRepository.setCellsEnabled(any()) }.returns(result)
+    }
+
+    override suspend fun withSetWireCellsConfigReturning(result: Either<StorageFailure, Unit>) {
+        everySuspend { userConfigRepository.setWireCellsConfig(any<WireCellsConfig?>()) }.returns(result)
+    }
+
+    override suspend fun withSetAssetAuditLogEnabledReturning(result: Either<StorageFailure, Unit>) {
+        everySuspend { userConfigRepository.setAssetAuditLogEnabled(any()) }.returns(result)
+    }
+
+    override suspend fun withSetProfileQRCodeEnabledReturning(result: Either<StorageFailure, Unit>) {
+        everySuspend { userConfigRepository.setProfileQRCodeEnabled(any()) }.returns(result)
+    }
+
+    override suspend fun withSetPreventAdminlessGroupsEnabledReturning(result: Either<StorageFailure, Unit>) {
+        everySuspend { userConfigRepository.setPreventAdminlessGroupsEnabled(any()) }.returns(result)
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/usecase/IsMessageSentInSelfConversationUseCaseArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/usecase/IsMessageSentInSelfConversationUseCaseArrangement.kt
@@ -1,0 +1,40 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.util.arrangement.usecase
+
+import com.wire.kalium.logic.data.message.IsMessageSentInSelfConversationUseCase
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+
+internal interface IsMessageSentInSelfConversationUseCaseArrangement {
+    val isMessageSentInSelfConversationUseCase: IsMessageSentInSelfConversationUseCase
+
+    suspend fun withMessageSentInSelfConversationReturning(result: Boolean)
+}
+
+internal class IsMessageSentInSelfConversationUseCaseArrangementImpl : IsMessageSentInSelfConversationUseCaseArrangement {
+    override val isMessageSentInSelfConversationUseCase =
+        mock<IsMessageSentInSelfConversationUseCase>(mode = MockMode.autoUnit)
+
+    override suspend fun withMessageSentInSelfConversationReturning(result: Boolean) {
+        everySuspend { isMessageSentInSelfConversationUseCase(any()) }.returns(result)
+    }
+}

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/usecase/ValidateAssetFileTypeUseCaseArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/usecase/ValidateAssetFileTypeUseCaseArrangement.kt
@@ -1,0 +1,39 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.util.arrangement.usecase
+
+import com.wire.kalium.logic.feature.asset.ValidateAssetFileTypeUseCase
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+
+internal interface ValidateAssetFileTypeUseCaseArrangement {
+    val validateAssetFileTypeUseCase: ValidateAssetFileTypeUseCase
+
+    fun withValidateAssetFileTypeReturning(result: Boolean)
+}
+
+internal class ValidateAssetFileTypeUseCaseArrangementImpl : ValidateAssetFileTypeUseCaseArrangement {
+    override val validateAssetFileTypeUseCase = mock<ValidateAssetFileTypeUseCase>(mode = MockMode.autoUnit)
+
+    override fun withValidateAssetFileTypeReturning(result: Boolean) {
+        every { validateAssetFileTypeUseCase(any(), any(), any()) }.returns(result)
+    }
+}

--- a/scripts/testing.mk
+++ b/scripts/testing.mk
@@ -1,0 +1,4 @@
+.PHONY: mutation-tests
+
+mutation-tests:
+	./gradlew runMutationTests


### PR DESCRIPTION
## Goal

Introduce on-demand mutation testing for KMP JVM bytecode and use it to improve sync event-handler tests without changing production behavior.

## Changes

- add a reusable PIT Gradle convention with configurable resources and thresholds
- expose root and module-level mutation tasks for manual runs only
- target the complete sync receiver package in the logic module
- add focused behavior and edge-case coverage across conversation, user, message, asset, calling, feature-config, and legal-hold handlers
- reuse shared repository and use-case arrangements in the new dependency-based test classes
- keep mutation reports local under each module build directory

## Mutation results

| Metric | Before | After |
| --- | ---: | ---: |
| Detected mutations | 991 / 2426 (41%) | 1140 / 2426 (47%) |
| Line coverage | 2800 / 3192 (88%) | 3039 / 3192 (95%) |
| Test strength | 69% | 70% |
| No coverage | 985 | 806 |

The remaining uncovered entries are primarily compiler-generated null/void artifacts, plus a small set of logging and non-handler branches.