### PR TITLE
feat: delete meeting for me [WPB-27932]

### DIFF
--- a/changelog.d/delete-meeting-for-me-use-case.added.md
+++ b/changelog.d/delete-meeting-for-me-use-case.added.md
@@ -1,0 +1,6 @@
+Added `MeetingScope.deleteMeetingForMe` with `DeleteMeetingForMeUseCase`.
+
+  - ABI: additive
+  - Source: additive
+  - Behavior: resolves the meeting conversation by meeting ID, leaves it for the current user, and removes the meeting locally.
+  - Migration: use `MeetingScope.deleteMeetingForMe` when consumers need a self-user-only deletion flow.

--- a/changelog.d/delete-meeting-use-case.changed.md
+++ b/changelog.d/delete-meeting-use-case.changed.md
@@ -1,0 +1,6 @@
+Changed `MeetingScope.deleteMeeting` with `DeleteMeetingUseCase` to `MeetingScope.deleteMeetingForEveryone` with `DeleteMeetingForEveryoneUseCase`.
+
+  - ABI: changed
+  - Source: changed for consumers using the meeting deletion API.
+  - Behavior: unchanged; the use case still deletes the meeting for every participant.
+  - Migration: use `MeetingScope.deleteMeetingForEveryone` and `DeleteMeetingForEveryoneUseCase`.

--- a/logic/api/jvm/logic.api
+++ b/logic/api/jvm/logic.api
@@ -5366,26 +5366,51 @@ public final class com/wire/kalium/logic/feature/meeting/CreateNewMeetingUseCase
 	public fun toString ()Ljava/lang/String;
 }
 
-public abstract interface class com/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase {
+public abstract interface class com/wire/kalium/logic/feature/meeting/DeleteMeetingForEveryoneUseCase {
 	public abstract fun invoke (Lcom/wire/kalium/logic/data/id/QualifiedID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public abstract interface class com/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase$Result {
+public abstract interface class com/wire/kalium/logic/feature/meeting/DeleteMeetingForEveryoneUseCase$Result {
 }
 
-public final class com/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase$Result$Failure : com/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase$Result {
+public final class com/wire/kalium/logic/feature/meeting/DeleteMeetingForEveryoneUseCase$Result$Failure : com/wire/kalium/logic/feature/meeting/DeleteMeetingForEveryoneUseCase$Result {
 	public fun <init> (Lcom/wire/kalium/common/error/CoreFailure;)V
 	public final fun component1 ()Lcom/wire/kalium/common/error/CoreFailure;
-	public final fun copy (Lcom/wire/kalium/common/error/CoreFailure;)Lcom/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase$Result$Failure;
-	public static synthetic fun copy$default (Lcom/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase$Result$Failure;Lcom/wire/kalium/common/error/CoreFailure;ILjava/lang/Object;)Lcom/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase$Result$Failure;
+	public final fun copy (Lcom/wire/kalium/common/error/CoreFailure;)Lcom/wire/kalium/logic/feature/meeting/DeleteMeetingForEveryoneUseCase$Result$Failure;
+	public static synthetic fun copy$default (Lcom/wire/kalium/logic/feature/meeting/DeleteMeetingForEveryoneUseCase$Result$Failure;Lcom/wire/kalium/common/error/CoreFailure;ILjava/lang/Object;)Lcom/wire/kalium/logic/feature/meeting/DeleteMeetingForEveryoneUseCase$Result$Failure;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCoreFailure ()Lcom/wire/kalium/common/error/CoreFailure;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase$Result$Success : com/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase$Result {
-	public static final field INSTANCE Lcom/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase$Result$Success;
+public final class com/wire/kalium/logic/feature/meeting/DeleteMeetingForEveryoneUseCase$Result$Success : com/wire/kalium/logic/feature/meeting/DeleteMeetingForEveryoneUseCase$Result {
+	public static final field INSTANCE Lcom/wire/kalium/logic/feature/meeting/DeleteMeetingForEveryoneUseCase$Result$Success;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/wire/kalium/logic/feature/meeting/DeleteMeetingForMeUseCase {
+	public abstract fun invoke (Lcom/wire/kalium/logic/data/id/QualifiedID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/wire/kalium/logic/feature/meeting/DeleteMeetingForMeUseCase$Result {
+}
+
+public final class com/wire/kalium/logic/feature/meeting/DeleteMeetingForMeUseCase$Result$Failure : com/wire/kalium/logic/feature/meeting/DeleteMeetingForMeUseCase$Result {
+	public fun <init> (Lcom/wire/kalium/common/error/CoreFailure;)V
+	public final fun component1 ()Lcom/wire/kalium/common/error/CoreFailure;
+	public final fun copy (Lcom/wire/kalium/common/error/CoreFailure;)Lcom/wire/kalium/logic/feature/meeting/DeleteMeetingForMeUseCase$Result$Failure;
+	public static synthetic fun copy$default (Lcom/wire/kalium/logic/feature/meeting/DeleteMeetingForMeUseCase$Result$Failure;Lcom/wire/kalium/common/error/CoreFailure;ILjava/lang/Object;)Lcom/wire/kalium/logic/feature/meeting/DeleteMeetingForMeUseCase$Result$Failure;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCoreFailure ()Lcom/wire/kalium/common/error/CoreFailure;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/wire/kalium/logic/feature/meeting/DeleteMeetingForMeUseCase$Result$Success : com/wire/kalium/logic/feature/meeting/DeleteMeetingForMeUseCase$Result {
+	public static final field INSTANCE Lcom/wire/kalium/logic/feature/meeting/DeleteMeetingForMeUseCase$Result$Success;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -5415,7 +5440,8 @@ public final class com/wire/kalium/logic/feature/meeting/GetPaginatedMeetingOccu
 
 public final class com/wire/kalium/logic/feature/meeting/MeetingScope {
 	public final fun getCreateNewMeeting ()Lcom/wire/kalium/logic/feature/meeting/CreateNewMeetingUseCase;
-	public final fun getDeleteMeeting ()Lcom/wire/kalium/logic/feature/meeting/DeleteMeetingUseCase;
+	public final fun getDeleteMeetingForEveryone ()Lcom/wire/kalium/logic/feature/meeting/DeleteMeetingForEveryoneUseCase;
+	public final fun getDeleteMeetingForMe ()Lcom/wire/kalium/logic/feature/meeting/DeleteMeetingForMeUseCase;
 	public final fun getEnsureMeetingIsMLSEstablished ()Lcom/wire/kalium/logic/feature/meeting/EnsureMeetingIsMLSEstablishedUseCase;
 	public final fun getGetNextUnfinishedMeetingOccurrence ()Lcom/wire/kalium/logic/feature/meeting/GetNextUnfinishedMeetingOccurrenceUseCase;
 	public final fun getGetPaginatedMeetingOccurrenceDetails ()Lcom/wire/kalium/logic/feature/meeting/GetPaginatedMeetingOccurrencesUseCase;

--- a/logic/api/logic.klib.api
+++ b/logic/api/logic.klib.api
@@ -1401,27 +1401,52 @@ abstract interface com.wire.kalium.logic.feature.meeting/CreateNewMeetingUseCase
     }
 }
 
-abstract interface com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase { // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase|null[0]
-    abstract suspend fun invoke(com.wire.kalium.logic.data.id/QualifiedID): com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.invoke|invoke(com.wire.kalium.logic.data.id.QualifiedID){}[0]
+abstract interface com.wire.kalium.logic.feature.meeting/DeleteMeetingForEveryoneUseCase { // com.wire.kalium.logic.feature.meeting/DeleteMeetingForEveryoneUseCase|null[0]
+    abstract suspend fun invoke(com.wire.kalium.logic.data.id/QualifiedID): com.wire.kalium.logic.feature.meeting/DeleteMeetingForEveryoneUseCase.Result // com.wire.kalium.logic.feature.meeting/DeleteMeetingForEveryoneUseCase.invoke|invoke(com.wire.kalium.logic.data.id.QualifiedID){}[0]
 
-    sealed interface Result { // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result|null[0]
-        final class Failure : com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result { // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Failure|null[0]
-            constructor <init>(com.wire.kalium.common.error/CoreFailure) // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Failure.<init>|<init>(com.wire.kalium.common.error.CoreFailure){}[0]
+    sealed interface Result { // com.wire.kalium.logic.feature.meeting/DeleteMeetingForEveryoneUseCase.Result|null[0]
+        final class Failure : com.wire.kalium.logic.feature.meeting/DeleteMeetingForEveryoneUseCase.Result { // com.wire.kalium.logic.feature.meeting/DeleteMeetingForEveryoneUseCase.Result.Failure|null[0]
+            constructor <init>(com.wire.kalium.common.error/CoreFailure) // com.wire.kalium.logic.feature.meeting/DeleteMeetingForEveryoneUseCase.Result.Failure.<init>|<init>(com.wire.kalium.common.error.CoreFailure){}[0]
 
-            final val coreFailure // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Failure.coreFailure|{}coreFailure[0]
-                final fun <get-coreFailure>(): com.wire.kalium.common.error/CoreFailure // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Failure.coreFailure.<get-coreFailure>|<get-coreFailure>(){}[0]
+            final val coreFailure // com.wire.kalium.logic.feature.meeting/DeleteMeetingForEveryoneUseCase.Result.Failure.coreFailure|{}coreFailure[0]
+                final fun <get-coreFailure>(): com.wire.kalium.common.error/CoreFailure // com.wire.kalium.logic.feature.meeting/DeleteMeetingForEveryoneUseCase.Result.Failure.coreFailure.<get-coreFailure>|<get-coreFailure>(){}[0]
 
-            final fun component1(): com.wire.kalium.common.error/CoreFailure // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Failure.component1|component1(){}[0]
-            final fun copy(com.wire.kalium.common.error/CoreFailure = ...): com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Failure // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Failure.copy|copy(com.wire.kalium.common.error.CoreFailure){}[0]
-            final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Failure.equals|equals(kotlin.Any?){}[0]
-            final fun hashCode(): kotlin/Int // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Failure.hashCode|hashCode(){}[0]
-            final fun toString(): kotlin/String // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Failure.toString|toString(){}[0]
+            final fun component1(): com.wire.kalium.common.error/CoreFailure // com.wire.kalium.logic.feature.meeting/DeleteMeetingForEveryoneUseCase.Result.Failure.component1|component1(){}[0]
+            final fun copy(com.wire.kalium.common.error/CoreFailure = ...): com.wire.kalium.logic.feature.meeting/DeleteMeetingForEveryoneUseCase.Result.Failure // com.wire.kalium.logic.feature.meeting/DeleteMeetingForEveryoneUseCase.Result.Failure.copy|copy(com.wire.kalium.common.error.CoreFailure){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic.feature.meeting/DeleteMeetingForEveryoneUseCase.Result.Failure.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // com.wire.kalium.logic.feature.meeting/DeleteMeetingForEveryoneUseCase.Result.Failure.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // com.wire.kalium.logic.feature.meeting/DeleteMeetingForEveryoneUseCase.Result.Failure.toString|toString(){}[0]
         }
 
-        final object Success : com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result { // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Success|null[0]
-            final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Success.equals|equals(kotlin.Any?){}[0]
-            final fun hashCode(): kotlin/Int // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Success.hashCode|hashCode(){}[0]
-            final fun toString(): kotlin/String // com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase.Result.Success.toString|toString(){}[0]
+        final object Success : com.wire.kalium.logic.feature.meeting/DeleteMeetingForEveryoneUseCase.Result { // com.wire.kalium.logic.feature.meeting/DeleteMeetingForEveryoneUseCase.Result.Success|null[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic.feature.meeting/DeleteMeetingForEveryoneUseCase.Result.Success.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // com.wire.kalium.logic.feature.meeting/DeleteMeetingForEveryoneUseCase.Result.Success.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // com.wire.kalium.logic.feature.meeting/DeleteMeetingForEveryoneUseCase.Result.Success.toString|toString(){}[0]
+        }
+    }
+}
+
+abstract interface com.wire.kalium.logic.feature.meeting/DeleteMeetingForMeUseCase { // com.wire.kalium.logic.feature.meeting/DeleteMeetingForMeUseCase|null[0]
+    abstract suspend fun invoke(com.wire.kalium.logic.data.id/QualifiedID): com.wire.kalium.logic.feature.meeting/DeleteMeetingForMeUseCase.Result // com.wire.kalium.logic.feature.meeting/DeleteMeetingForMeUseCase.invoke|invoke(com.wire.kalium.logic.data.id.QualifiedID){}[0]
+
+    sealed interface Result { // com.wire.kalium.logic.feature.meeting/DeleteMeetingForMeUseCase.Result|null[0]
+        final class Failure : com.wire.kalium.logic.feature.meeting/DeleteMeetingForMeUseCase.Result { // com.wire.kalium.logic.feature.meeting/DeleteMeetingForMeUseCase.Result.Failure|null[0]
+            constructor <init>(com.wire.kalium.common.error/CoreFailure) // com.wire.kalium.logic.feature.meeting/DeleteMeetingForMeUseCase.Result.Failure.<init>|<init>(com.wire.kalium.common.error.CoreFailure){}[0]
+
+            final val coreFailure // com.wire.kalium.logic.feature.meeting/DeleteMeetingForMeUseCase.Result.Failure.coreFailure|{}coreFailure[0]
+                final fun <get-coreFailure>(): com.wire.kalium.common.error/CoreFailure // com.wire.kalium.logic.feature.meeting/DeleteMeetingForMeUseCase.Result.Failure.coreFailure.<get-coreFailure>|<get-coreFailure>(){}[0]
+
+            final fun component1(): com.wire.kalium.common.error/CoreFailure // com.wire.kalium.logic.feature.meeting/DeleteMeetingForMeUseCase.Result.Failure.component1|component1(){}[0]
+            final fun copy(com.wire.kalium.common.error/CoreFailure = ...): com.wire.kalium.logic.feature.meeting/DeleteMeetingForMeUseCase.Result.Failure // com.wire.kalium.logic.feature.meeting/DeleteMeetingForMeUseCase.Result.Failure.copy|copy(com.wire.kalium.common.error.CoreFailure){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic.feature.meeting/DeleteMeetingForMeUseCase.Result.Failure.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // com.wire.kalium.logic.feature.meeting/DeleteMeetingForMeUseCase.Result.Failure.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // com.wire.kalium.logic.feature.meeting/DeleteMeetingForMeUseCase.Result.Failure.toString|toString(){}[0]
+        }
+
+        final object Success : com.wire.kalium.logic.feature.meeting/DeleteMeetingForMeUseCase.Result { // com.wire.kalium.logic.feature.meeting/DeleteMeetingForMeUseCase.Result.Success|null[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // com.wire.kalium.logic.feature.meeting/DeleteMeetingForMeUseCase.Result.Success.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // com.wire.kalium.logic.feature.meeting/DeleteMeetingForMeUseCase.Result.Success.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // com.wire.kalium.logic.feature.meeting/DeleteMeetingForMeUseCase.Result.Success.toString|toString(){}[0]
         }
     }
 }
@@ -4424,8 +4449,10 @@ final class com.wire.kalium.logic.feature.incallreaction/SendInCallReactionUseCa
 final class com.wire.kalium.logic.feature.meeting/MeetingScope { // com.wire.kalium.logic.feature.meeting/MeetingScope|null[0]
     final val createNewMeeting // com.wire.kalium.logic.feature.meeting/MeetingScope.createNewMeeting|{}createNewMeeting[0]
         final fun <get-createNewMeeting>(): com.wire.kalium.logic.feature.meeting/CreateNewMeetingUseCase // com.wire.kalium.logic.feature.meeting/MeetingScope.createNewMeeting.<get-createNewMeeting>|<get-createNewMeeting>(){}[0]
-    final val deleteMeeting // com.wire.kalium.logic.feature.meeting/MeetingScope.deleteMeeting|{}deleteMeeting[0]
-        final fun <get-deleteMeeting>(): com.wire.kalium.logic.feature.meeting/DeleteMeetingUseCase // com.wire.kalium.logic.feature.meeting/MeetingScope.deleteMeeting.<get-deleteMeeting>|<get-deleteMeeting>(){}[0]
+    final val deleteMeetingForEveryone // com.wire.kalium.logic.feature.meeting/MeetingScope.deleteMeetingForEveryone|{}deleteMeetingForEveryone[0]
+        final fun <get-deleteMeetingForEveryone>(): com.wire.kalium.logic.feature.meeting/DeleteMeetingForEveryoneUseCase // com.wire.kalium.logic.feature.meeting/MeetingScope.deleteMeetingForEveryone.<get-deleteMeetingForEveryone>|<get-deleteMeetingForEveryone>(){}[0]
+    final val deleteMeetingForMe // com.wire.kalium.logic.feature.meeting/MeetingScope.deleteMeetingForMe|{}deleteMeetingForMe[0]
+        final fun <get-deleteMeetingForMe>(): com.wire.kalium.logic.feature.meeting/DeleteMeetingForMeUseCase // com.wire.kalium.logic.feature.meeting/MeetingScope.deleteMeetingForMe.<get-deleteMeetingForMe>|<get-deleteMeetingForMe>(){}[0]
     final val ensureMeetingIsMLSEstablished // com.wire.kalium.logic.feature.meeting/MeetingScope.ensureMeetingIsMLSEstablished|{}ensureMeetingIsMLSEstablished[0]
         final fun <get-ensureMeetingIsMLSEstablished>(): com.wire.kalium.logic.feature.meeting/EnsureMeetingIsMLSEstablishedUseCase // com.wire.kalium.logic.feature.meeting/MeetingScope.ensureMeetingIsMLSEstablished.<get-ensureMeetingIsMLSEstablished>|<get-ensureMeetingIsMLSEstablished>(){}[0]
     final val getNextUnfinishedMeetingOccurrence // com.wire.kalium.logic.feature.meeting/MeetingScope.getNextUnfinishedMeetingOccurrence|{}getNextUnfinishedMeetingOccurrence[0]

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepository.kt
@@ -95,6 +95,8 @@ internal interface MeetingRepository {
         from: Instant = currentInstant().asStartOfDay(),
     ): Flow<PagingData<MeetingOccurrence>>
 
+    suspend fun getMeeting(meetingId: MeetingId): Either<StorageFailure, Meeting>
+
     suspend fun deleteMeeting(meetingId: MeetingId): Either<CoreFailure, Unit>
 
     suspend fun deleteMeetingLocally(meetingId: MeetingId): Either<StorageFailure, Unit>
@@ -209,6 +211,10 @@ internal class MeetingDataSource(
         startingOffset = startingOffset,
         from = from,
     ).pagingDataFlow.map { pagingData -> pagingData.map(meetingMapper::fromDaoToModel) }
+
+    override suspend fun getMeeting(meetingId: MeetingId): Either<StorageFailure, Meeting> = wrapStorageRequest {
+        meetingDAO.getMeeting(meetingId.toDao())?.let(meetingMapper::fromDaoToModel)
+    }
 
     override suspend fun deleteMeeting(meetingId: MeetingId): Either<CoreFailure, Unit> = withContext(NonCancellable) {
         wrapApiRequest {

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -3030,6 +3030,7 @@ public class UserSessionScope internal constructor(
             resetMLSConversation = resetMlsConversation,
             refreshUsersWithoutMetadata = refreshUsersWithoutMetadata,
             joinExistingMLSConversation = joinExistingMLSConversationUseCase,
+            leaveConversation = conversations.leaveConversation,
             transactionProvider = cryptoTransactionProvider
         )
     }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/meeting/DeleteMeetingForEveryoneUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/meeting/DeleteMeetingForEveryoneUseCase.kt
@@ -1,0 +1,46 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.meeting
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.functional.fold
+import com.wire.kalium.logic.data.id.MeetingId
+import com.wire.kalium.logic.data.meeting.MeetingRepository
+
+/**
+ * Use case for deleting a meeting for every participant by its ID.
+ */
+public interface DeleteMeetingForEveryoneUseCase {
+    public suspend operator fun invoke(meetingId: MeetingId): Result
+
+    public sealed interface Result {
+        public data object Success : Result
+        public data class Failure(val coreFailure: CoreFailure) : Result
+    }
+}
+
+internal class DeleteMeetingForEveryoneUseCaseImpl(
+    private val meetingRepository: MeetingRepository,
+) : DeleteMeetingForEveryoneUseCase {
+    override suspend operator fun invoke(meetingId: MeetingId): DeleteMeetingForEveryoneUseCase.Result =
+        meetingRepository.deleteMeeting(meetingId).fold({
+            DeleteMeetingForEveryoneUseCase.Result.Failure(it)
+        }, {
+            DeleteMeetingForEveryoneUseCase.Result.Success
+        })
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/meeting/DeleteMeetingForMeUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/meeting/DeleteMeetingForMeUseCase.kt
@@ -23,6 +23,8 @@ import com.wire.kalium.logic.data.id.MeetingId
 import com.wire.kalium.logic.data.meeting.MeetingRepository
 import com.wire.kalium.logic.feature.conversation.LeaveConversationUseCase
 import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 
 /**
  * Use case for deleting a meeting only for the self user.
@@ -40,7 +42,7 @@ internal class DeleteMeetingForMeUseCaseImpl(
     private val meetingRepository: MeetingRepository,
     private val leaveConversation: LeaveConversationUseCase,
 ) : DeleteMeetingForMeUseCase {
-    override suspend operator fun invoke(meetingId: MeetingId): DeleteMeetingForMeUseCase.Result =
+    override suspend operator fun invoke(meetingId: MeetingId): DeleteMeetingForMeUseCase.Result = withContext(NonCancellable) {
         meetingRepository.getMeeting(meetingId).fold(
             {
                 DeleteMeetingForMeUseCase.Result.Failure(it)
@@ -53,4 +55,5 @@ internal class DeleteMeetingForMeUseCaseImpl(
                 }
             }
         )
+    }
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/meeting/DeleteMeetingForMeUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/meeting/DeleteMeetingForMeUseCase.kt
@@ -21,11 +21,13 @@ import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.functional.fold
 import com.wire.kalium.logic.data.id.MeetingId
 import com.wire.kalium.logic.data.meeting.MeetingRepository
+import com.wire.kalium.logic.feature.conversation.LeaveConversationUseCase
+import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
 
 /**
- * Use case for deleting a meeting by its ID.
+ * Use case for deleting a meeting only for the self user.
  */
-public interface DeleteMeetingUseCase {
+public interface DeleteMeetingForMeUseCase {
     public suspend operator fun invoke(meetingId: MeetingId): Result
 
     public sealed interface Result {
@@ -34,14 +36,21 @@ public interface DeleteMeetingUseCase {
     }
 }
 
-internal class DeleteMeetingUseCaseImpl(
+internal class DeleteMeetingForMeUseCaseImpl(
     private val meetingRepository: MeetingRepository,
-) : DeleteMeetingUseCase {
-    override suspend operator fun invoke(meetingId: MeetingId): DeleteMeetingUseCase.Result {
-        return meetingRepository.deleteMeeting(meetingId).fold({
-            DeleteMeetingUseCase.Result.Failure(it)
-        }, {
-            DeleteMeetingUseCase.Result.Success
-        })
-    }
+    private val leaveConversation: LeaveConversationUseCase,
+) : DeleteMeetingForMeUseCase {
+    override suspend operator fun invoke(meetingId: MeetingId): DeleteMeetingForMeUseCase.Result =
+        meetingRepository.getMeeting(meetingId).fold(
+            {
+                DeleteMeetingForMeUseCase.Result.Failure(it)
+            },
+            { meeting ->
+                when (val result = leaveConversation(meeting.conversationId)) {
+                    is RemoveMemberFromConversationUseCase.Result.Failure -> DeleteMeetingForMeUseCase.Result.Failure(result.cause)
+                    is RemoveMemberFromConversationUseCase.Result.Success -> meetingRepository.deleteMeetingLocally(meetingId)
+                        .fold({ DeleteMeetingForMeUseCase.Result.Failure(it) }, { DeleteMeetingForMeUseCase.Result.Success })
+                }
+            }
+        )
 }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/meeting/MeetingScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/meeting/MeetingScope.kt
@@ -24,6 +24,7 @@ import com.wire.kalium.logic.data.conversation.JoinExistingMLSConversationUseCas
 import com.wire.kalium.logic.data.conversation.ResetMLSConversationUseCase
 import com.wire.kalium.logic.data.meeting.MeetingRepository
 import com.wire.kalium.logic.data.user.UserRepository
+import com.wire.kalium.logic.feature.conversation.LeaveConversationUseCase
 import com.wire.kalium.logic.feature.publicuser.RefreshUsersWithoutMetadataUseCase
 import com.wire.kalium.util.KaliumDispatcher
 
@@ -36,6 +37,7 @@ public class MeetingScope internal constructor(
     private val refreshUsersWithoutMetadata: RefreshUsersWithoutMetadataUseCase,
     private val resetMLSConversation: ResetMLSConversationUseCase,
     private val joinExistingMLSConversation: JoinExistingMLSConversationUseCase,
+    private val leaveConversation: LeaveConversationUseCase,
     private val transactionProvider: CryptoTransactionProvider,
 ) {
     public val getPaginatedMeetingOccurrenceDetails: GetPaginatedMeetingOccurrencesUseCase
@@ -50,9 +52,15 @@ public class MeetingScope internal constructor(
             meetingRepository = meetingRepository,
         )
 
-    public val deleteMeeting: DeleteMeetingUseCase
-        get() = DeleteMeetingUseCaseImpl(
+    public val deleteMeetingForEveryone: DeleteMeetingForEveryoneUseCase
+        get() = DeleteMeetingForEveryoneUseCaseImpl(
             meetingRepository = meetingRepository,
+        )
+
+    public val deleteMeetingForMe: DeleteMeetingForMeUseCase
+        get() = DeleteMeetingForMeUseCaseImpl(
+            meetingRepository = meetingRepository,
+            leaveConversation = leaveConversation,
         )
 
     public val getNextUnfinishedMeetingOccurrence: GetNextUnfinishedMeetingOccurrenceUseCase

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/meeting/MeetingRepositoryTest.kt
@@ -287,6 +287,38 @@ class MeetingRepositoryTest {
     }
 
     @Test
+    fun givenDaoReturnsMeeting_whenGetMeeting_thenReturnsMappedMeeting() = runTest {
+        val meetingId = MEETING_ENTITY.meetingId.toModel()
+        val (arrangement, repository) = Arrangement()
+            .withStoredMeeting(MEETING_ENTITY)
+            .arrange()
+
+        val result = repository.getMeeting(meetingId)
+
+        assertIs<Either.Right<Meeting>>(result).also {
+            assertEquals(arrangement.meetingMapper.fromDaoToModel(MEETING_ENTITY), result.value)
+        }
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingDao.getMeeting(meetingId.toDao())
+        }
+    }
+
+    @Test
+    fun givenDaoReturnsNoMeeting_whenGetMeeting_thenReturnsDataNotFound() = runTest {
+        val meetingId = MeetingId("missing-meeting", "domain")
+        val (arrangement, repository) = Arrangement()
+            .withMissingStoredMeeting(meetingId)
+            .arrange()
+
+        val result = repository.getMeeting(meetingId)
+
+        assertIs<Either.Left<StorageFailure.DataNotFound>>(result)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingDao.getMeeting(meetingId.toDao())
+        }
+    }
+
+    @Test
     fun givenApiDeleteSucceeds_whenDeleteMeeting_thenMeetingIsDeletedLocally() = runTest {
         val meetingId = MeetingId("meeting1", "domain")
         val (arrangement, repository) = Arrangement()
@@ -1178,6 +1210,10 @@ class MeetingRepositoryTest {
 
         internal fun withStoredMeeting(storedMeeting: MeetingEntity) = apply {
             everySuspend { meetingDao.getMeeting(storedMeeting.meetingId) } returns storedMeeting
+        }
+
+        internal fun withMissingStoredMeeting(meetingId: MeetingId) = apply {
+            everySuspend { meetingDao.getMeeting(meetingId.toDao()) } returns null
         }
 
         internal fun withTransactionMlsContext() = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/meeting/DeleteMeetingForEveryoneUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/meeting/DeleteMeetingForEveryoneUseCaseTest.kt
@@ -32,7 +32,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
-class DeleteMeetingUseCaseTest {
+class DeleteMeetingForEveryoneUseCaseTest {
 
     @Test
     fun givenRepositoryDeleteSucceeds_whenInvoking_thenReturnsSuccess() = runTest {
@@ -43,7 +43,7 @@ class DeleteMeetingUseCaseTest {
 
         val result = useCase(meetingId)
 
-        assertEquals(DeleteMeetingUseCase.Result.Success, result)
+        assertEquals(DeleteMeetingForEveryoneUseCase.Result.Success, result)
         verifySuspend(VerifyMode.exactly(1)) {
             arrangement.meetingRepository.deleteMeeting(meetingId)
         }
@@ -59,7 +59,7 @@ class DeleteMeetingUseCaseTest {
 
         val result = useCase(meetingId)
 
-        assertEquals(failure, assertIs<DeleteMeetingUseCase.Result.Failure>(result).coreFailure)
+        assertEquals(failure, assertIs<DeleteMeetingForEveryoneUseCase.Result.Failure>(result).coreFailure)
     }
 
     inner class Arrangement {
@@ -69,6 +69,6 @@ class DeleteMeetingUseCaseTest {
             everySuspend { meetingRepository.deleteMeeting(meetingId) } returns result
         }
 
-        internal fun arrange() = this to DeleteMeetingUseCaseImpl(meetingRepository)
+        internal fun arrange() = this to DeleteMeetingForEveryoneUseCaseImpl(meetingRepository)
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/meeting/DeleteMeetingForMeUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/meeting/DeleteMeetingForMeUseCaseTest.kt
@@ -1,0 +1,157 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.logic.feature.meeting
+
+import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.MeetingId
+import com.wire.kalium.logic.data.meeting.Meeting
+import com.wire.kalium.logic.data.meeting.MeetingRepository
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.conversation.LeaveConversationUseCase
+import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class DeleteMeetingForMeUseCaseTest {
+
+    @Test
+    fun givenLeaveAndLocalDeleteSucceed_whenInvoking_thenReturnsSuccess() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withLeaveConversationReturning(RemoveMemberFromConversationUseCase.Result.Success)
+            .withDeleteMeetingLocallyReturning(Either.Right(Unit))
+            .arrange()
+
+        val result = useCase(MEETING_ID)
+
+        assertEquals(DeleteMeetingForMeUseCase.Result.Success, result)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingRepository.getMeeting(MEETING_ID)
+            arrangement.leaveConversation(CONVERSATION_ID)
+            arrangement.meetingRepository.deleteMeetingLocally(MEETING_ID)
+        }
+    }
+
+    @Test
+    fun givenLeaveFails_whenInvoking_thenReturnsFailureAndDoesNotDeleteMeetingLocally() = runTest {
+        val failure = CoreFailure.Unknown(RuntimeException("leave failed"))
+        val (arrangement, useCase) = Arrangement()
+            .withLeaveConversationReturning(RemoveMemberFromConversationUseCase.Result.Failure(failure))
+            .arrange()
+
+        val result = useCase(MEETING_ID)
+
+        assertEquals(failure, assertIs<DeleteMeetingForMeUseCase.Result.Failure>(result).coreFailure)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingRepository.getMeeting(MEETING_ID)
+            arrangement.leaveConversation(CONVERSATION_ID)
+        }
+        verifySuspend(VerifyMode.not) {
+            arrangement.meetingRepository.deleteMeetingLocally(any())
+        }
+    }
+
+    @Test
+    fun givenLocalDeleteFails_whenInvoking_thenReturnsFailure() = runTest {
+        val failure = StorageFailure.DataNotFound
+        val (arrangement, useCase) = Arrangement()
+            .withLeaveConversationReturning(RemoveMemberFromConversationUseCase.Result.Success)
+            .withDeleteMeetingLocallyReturning(Either.Left(failure))
+            .arrange()
+
+        val result = useCase(MEETING_ID)
+
+        assertEquals(failure, assertIs<DeleteMeetingForMeUseCase.Result.Failure>(result).coreFailure)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingRepository.getMeeting(MEETING_ID)
+            arrangement.leaveConversation(CONVERSATION_ID)
+            arrangement.meetingRepository.deleteMeetingLocally(MEETING_ID)
+        }
+    }
+
+    @Test
+    fun givenMeetingLookupFails_whenInvoking_thenReturnsFailureAndDoesNotLeaveConversation() = runTest {
+        val failure = StorageFailure.DataNotFound
+        val (arrangement, useCase) = Arrangement()
+            .withGetMeetingReturning(Either.Left(failure))
+            .arrange()
+
+        val result = useCase(MEETING_ID)
+
+        assertEquals(failure, assertIs<DeleteMeetingForMeUseCase.Result.Failure>(result).coreFailure)
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.meetingRepository.getMeeting(MEETING_ID)
+        }
+        verifySuspend(VerifyMode.not) {
+            arrangement.leaveConversation(any())
+            arrangement.meetingRepository.deleteMeetingLocally(any())
+        }
+    }
+
+    private class Arrangement {
+        val meetingRepository = mock<MeetingRepository>(mode = MockMode.autoUnit)
+        val leaveConversation = mock<LeaveConversationUseCase>()
+
+        init {
+            everySuspend { meetingRepository.getMeeting(any()) } returns Either.Right(MEETING)
+            everySuspend { leaveConversation(any()) } returns RemoveMemberFromConversationUseCase.Result.Success
+            everySuspend { meetingRepository.deleteMeetingLocally(any()) } returns Either.Right(Unit)
+        }
+
+        fun withGetMeetingReturning(result: Either<StorageFailure, Meeting>) = apply {
+            everySuspend { meetingRepository.getMeeting(MEETING_ID) } returns result
+        }
+
+        fun withLeaveConversationReturning(result: RemoveMemberFromConversationUseCase.Result) = apply {
+            everySuspend { leaveConversation(CONVERSATION_ID) } returns result
+        }
+
+        fun withDeleteMeetingLocallyReturning(result: Either<StorageFailure, Unit>) = apply {
+            everySuspend { meetingRepository.deleteMeetingLocally(MEETING_ID) } returns result
+        }
+
+        fun arrange() = this to DeleteMeetingForMeUseCaseImpl(meetingRepository, leaveConversation)
+    }
+
+    private companion object {
+        val MEETING_ID = MeetingId("meetingId", "domain")
+        val CONVERSATION_ID = ConversationId("conversationId", "domain")
+        val CREATOR_ID = UserId("creatorId", "domain")
+        val MEETING = Meeting(
+            meetingId = MEETING_ID,
+            conversationId = CONVERSATION_ID,
+            creatorId = CREATOR_ID,
+            title = "Meeting",
+            startTime = Instant.parse("2026-06-01T10:00:00Z"),
+            endTime = Instant.parse("2026-06-01T11:00:00Z"),
+            recurrence = null,
+        )
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-27932
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Meeting participant who is not a creator, needs to have an option to "delete meeting for me", which basically makes this user to leave the underlying conversation.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

User A creates a meeting and adds user B as a participant, then user B can "delete meeting for me" and it disappears from their meeting list.

### Attachments (Optional)

https://github.com/user-attachments/assets/1d501b6c-d274-4297-9abb-0760e56f6726

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
