### PR TITLE
feat: add apps and collaborators to team sync [WPB-28428]

### DIFF
--- a/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/teams/TeamsDTO.kt
+++ b/data/network-model/src/commonMain/kotlin/com/wire/kalium/network/api/authenticated/teams/TeamsDTO.kt
@@ -65,6 +65,22 @@ data class PasswordRequest(
     @SerialName("password") val password: String?
 )
 
+@Serializable
+data class TeamCollaboratorDTO(
+    @SerialName("user") val nonQualifiedUserId: NonQualifiedUserId,
+    @SerialName("team") val teamId: TeamId,
+    @SerialName("permissions") val permissions: List<CollaboratorPermissionDTO>
+)
+
+@Serializable
+enum class CollaboratorPermissionDTO {
+    @SerialName("create_team_conversation")
+    CREATE_TEAM_CONVERSATION,
+
+    @SerialName("implicit_connection")
+    IMPLICIT_CONNECTION
+}
+
 sealed interface GetTeamsOptionsInterface
 
 /**

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/TeamsApi.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/TeamsApi.kt
@@ -18,6 +18,7 @@
 
 package com.wire.kalium.network.api.base.authenticated
 
+import com.wire.kalium.network.api.authenticated.teams.TeamCollaboratorDTO
 import com.wire.kalium.network.api.authenticated.teams.TeamMemberDTO
 import com.wire.kalium.network.api.authenticated.teams.TeamMemberIdList
 import com.wire.kalium.network.api.authenticated.teams.TeamMemberListNonPaginated
@@ -28,6 +29,7 @@ import com.wire.kalium.network.api.model.NonQualifiedUserId
 import com.wire.kalium.network.api.model.ServiceDetailResponse
 import com.wire.kalium.network.api.model.TeamDTO
 import com.wire.kalium.network.api.model.TeamId
+import com.wire.kalium.network.api.model.UserProfileDTO
 import com.wire.kalium.network.utils.NetworkResponse
 
 interface TeamsApi {
@@ -38,6 +40,8 @@ interface TeamsApi {
     suspend fun getTeamMember(teamId: TeamId, userId: NonQualifiedUserId): NetworkResponse<TeamMemberDTO>
     suspend fun getTeamInfo(teamId: TeamId): NetworkResponse<TeamDTO>
     suspend fun whiteListedServices(teamId: TeamId, size: Int = DEFAULT_SERVICES_SIZE): NetworkResponse<ServiceDetailResponse>
+    suspend fun getTeamApps(teamId: TeamId): NetworkResponse<List<UserProfileDTO>>
+    suspend fun getTeamCollaborators(teamId: TeamId): NetworkResponse<List<TeamCollaboratorDTO>>
     suspend fun approveLegalHoldRequest(teamId: TeamId, userId: NonQualifiedUserId, password: String?): NetworkResponse<Unit>
     suspend fun fetchLegalHoldStatus(teamId: TeamId, userId: NonQualifiedUserId): NetworkResponse<LegalHoldStatusResponse>
 

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/TeamsApi.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/TeamsApi.kt
@@ -32,7 +32,7 @@ import com.wire.kalium.network.api.model.TeamId
 import com.wire.kalium.network.api.model.UserProfileDTO
 import com.wire.kalium.network.utils.NetworkResponse
 
-interface TeamsApi {
+interface TeamsApi : BaseApi {
 
     suspend fun deleteConversation(conversationId: NonQualifiedConversationId, teamId: TeamId): NetworkResponse<Unit>
     suspend fun getTeamMembers(teamId: TeamId, limitTo: Int?, pagingState: String? = null): NetworkResponse<TeamMemberListPaginated>

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/TeamsApiV0.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/TeamsApiV0.kt
@@ -21,6 +21,7 @@ package com.wire.kalium.network.api.v0.authenticated
 import com.wire.kalium.network.AuthenticatedNetworkClient
 import com.wire.kalium.network.api.base.authenticated.TeamsApi
 import com.wire.kalium.network.api.authenticated.teams.PasswordRequest
+import com.wire.kalium.network.api.authenticated.teams.TeamCollaboratorDTO
 import com.wire.kalium.network.api.authenticated.teams.TeamMemberDTO
 import com.wire.kalium.network.api.authenticated.teams.TeamMemberIdList
 import com.wire.kalium.network.api.authenticated.teams.TeamMemberListNonPaginated
@@ -31,6 +32,7 @@ import com.wire.kalium.network.api.model.NonQualifiedUserId
 import com.wire.kalium.network.api.model.ServiceDetailResponse
 import com.wire.kalium.network.api.model.TeamDTO
 import com.wire.kalium.network.api.model.TeamId
+import com.wire.kalium.network.api.model.UserProfileDTO
 import com.wire.kalium.network.utils.NetworkResponse
 import com.wire.kalium.network.utils.wrapRequest
 import io.ktor.client.request.delete
@@ -88,6 +90,16 @@ internal open class TeamsApiV0 internal constructor(
             httpClient.get("$PATH_TEAMS/$teamId/$PATH_MEMBERS/$userId")
         }
 
+    override suspend fun getTeamApps(teamId: TeamId): NetworkResponse<List<UserProfileDTO>> =
+        wrapRequest {
+            httpClient.get("$PATH_TEAMS/$teamId/$PATH_APPS")
+        }
+
+    override suspend fun getTeamCollaborators(teamId: TeamId): NetworkResponse<List<TeamCollaboratorDTO>> =
+        wrapRequest {
+            httpClient.get("$PATH_TEAMS/$teamId/$PATH_COLLABORATORS")
+        }
+
     override suspend fun approveLegalHoldRequest(teamId: TeamId, userId: NonQualifiedUserId, password: String?): NetworkResponse<Unit> =
         wrapRequest {
             httpClient.put("$PATH_TEAMS/$teamId/$PATH_LEGAL_HOLD/$userId/$PATH_APPROVE") {
@@ -109,5 +121,7 @@ internal open class TeamsApiV0 internal constructor(
         const val PATH_WHITELISTED = "whitelisted"
         const val PATH_LEGAL_HOLD = "legalhold"
         const val PATH_APPROVE = "approve"
+        const val PATH_APPS = "apps"
+        const val PATH_COLLABORATORS = "collaborators"
     }
 }

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/TeamsApiV0.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v0/authenticated/TeamsApiV0.kt
@@ -46,7 +46,7 @@ internal open class TeamsApiV0 internal constructor(
     private val authenticatedNetworkClient: AuthenticatedNetworkClient
 ) : TeamsApi {
 
-    private val httpClient get() = authenticatedNetworkClient.httpClient
+    protected val httpClient get() = authenticatedNetworkClient.httpClient
 
     override suspend fun deleteConversation(conversationId: NonQualifiedConversationId, teamId: TeamId): NetworkResponse<Unit> =
         wrapRequest {
@@ -91,14 +91,10 @@ internal open class TeamsApiV0 internal constructor(
         }
 
     override suspend fun getTeamApps(teamId: TeamId): NetworkResponse<List<UserProfileDTO>> =
-        wrapRequest {
-            httpClient.get("$PATH_TEAMS/$teamId/$PATH_APPS")
-        }
+        getApiNotSupportedError(::getTeamApps.name, MIN_API_VERSION_APPS)
 
     override suspend fun getTeamCollaborators(teamId: TeamId): NetworkResponse<List<TeamCollaboratorDTO>> =
-        wrapRequest {
-            httpClient.get("$PATH_TEAMS/$teamId/$PATH_COLLABORATORS")
-        }
+        getApiNotSupportedError(::getTeamCollaborators.name, MIN_API_VERSION_COLLABORATORS)
 
     override suspend fun approveLegalHoldRequest(teamId: TeamId, userId: NonQualifiedUserId, password: String?): NetworkResponse<Unit> =
         wrapRequest {
@@ -112,7 +108,7 @@ internal open class TeamsApiV0 internal constructor(
             httpClient.get("$PATH_TEAMS/$teamId/$PATH_LEGAL_HOLD/$userId")
         }
 
-    private companion object {
+    protected companion object {
         const val PATH_TEAMS = "teams"
         const val PATH_CONVERSATIONS = "conversations"
         const val PATH_MEMBERS = "members"
@@ -121,7 +117,7 @@ internal open class TeamsApiV0 internal constructor(
         const val PATH_WHITELISTED = "whitelisted"
         const val PATH_LEGAL_HOLD = "legalhold"
         const val PATH_APPROVE = "approve"
-        const val PATH_APPS = "apps"
-        const val PATH_COLLABORATORS = "collaborators"
+        const val MIN_API_VERSION_COLLABORATORS = 10
+        const val MIN_API_VERSION_APPS = 15
     }
 }

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v10/authenticated/TeamsApiV10.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v10/authenticated/TeamsApiV10.kt
@@ -19,8 +19,23 @@
 package com.wire.kalium.network.api.v10.authenticated
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.authenticated.teams.TeamCollaboratorDTO
+import com.wire.kalium.network.api.model.TeamId
 import com.wire.kalium.network.api.v9.authenticated.TeamsApiV9
+import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.wrapRequest
+import io.ktor.client.request.get
 
 internal open class TeamsApiV10 internal constructor(
     authenticatedNetworkClient: AuthenticatedNetworkClient
-) : TeamsApiV9(authenticatedNetworkClient)
+) : TeamsApiV9(authenticatedNetworkClient) {
+
+    override suspend fun getTeamCollaborators(teamId: TeamId): NetworkResponse<List<TeamCollaboratorDTO>> =
+        wrapRequest {
+            httpClient.get("$PATH_TEAMS/$teamId/$PATH_COLLABORATORS")
+        }
+
+    private companion object {
+        const val PATH_COLLABORATORS = "collaborators"
+    }
+}

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v15/authenticated/TeamsApiV15.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v15/authenticated/TeamsApiV15.kt
@@ -19,8 +19,23 @@
 package com.wire.kalium.network.api.v15.authenticated
 
 import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.model.TeamId
+import com.wire.kalium.network.api.model.UserProfileDTO
 import com.wire.kalium.network.api.v14.authenticated.TeamsApiV14
+import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.wrapRequest
+import io.ktor.client.request.get
 
 internal open class TeamsApiV15 internal constructor(
     authenticatedNetworkClient: AuthenticatedNetworkClient
-) : TeamsApiV14(authenticatedNetworkClient)
+) : TeamsApiV14(authenticatedNetworkClient) {
+
+    override suspend fun getTeamApps(teamId: TeamId): NetworkResponse<List<UserProfileDTO>> =
+        wrapRequest {
+            httpClient.get("$PATH_TEAMS/$teamId/$PATH_APPS")
+        }
+
+    private companion object {
+        const val PATH_APPS = "apps"
+    }
+}

--- a/data/network/src/commonTest/kotlin/com/wire/kalium/api/v0/teams/TeamsApiV0Test.kt
+++ b/data/network/src/commonTest/kotlin/com/wire/kalium/api/v0/teams/TeamsApiV0Test.kt
@@ -32,11 +32,13 @@ import com.wire.kalium.network.api.v0.authenticated.TeamsApiV0
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.tools.KtxSerializer
 import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.isSuccessful
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 
 @ExperimentalCoroutinesApi
@@ -183,6 +185,22 @@ internal class TeamsApiV0Test : ApiTest() {
         )
         val teamsApi: TeamsApi = TeamsApiV0(networkClient)
         teamsApi.fetchLegalHoldStatus(teamId, userId)
+    }
+
+    @Test
+    fun givenApiV0_whenGettingTeamApps_thenRequestShouldNotBeSupported() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient("", statusCode = HttpStatusCode.OK)
+        val teamsApi: TeamsApi = TeamsApiV0(networkClient)
+        val response = teamsApi.getTeamApps(DUMMY_TEAM_ID)
+        assertFalse(response.isSuccessful())
+    }
+
+    @Test
+    fun givenApiV0_whenGettingTeamCollaborators_thenRequestShouldNotBeSupported() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient("", statusCode = HttpStatusCode.OK)
+        val teamsApi: TeamsApi = TeamsApiV0(networkClient)
+        val response = teamsApi.getTeamCollaborators(DUMMY_TEAM_ID)
+        assertFalse(response.isSuccessful())
     }
 
     private companion object {

--- a/data/network/src/commonTest/kotlin/com/wire/kalium/api/v10/TeamsApiV10Test.kt
+++ b/data/network/src/commonTest/kotlin/com/wire/kalium/api/v10/TeamsApiV10Test.kt
@@ -1,0 +1,85 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.api.v10
+
+import com.wire.kalium.api.ApiTest
+import com.wire.kalium.network.api.authenticated.teams.CollaboratorPermissionDTO
+import com.wire.kalium.network.api.authenticated.teams.TeamCollaboratorDTO
+import com.wire.kalium.network.api.base.authenticated.TeamsApi
+import com.wire.kalium.network.api.v10.authenticated.TeamsApiV10
+import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.isSuccessful
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+
+internal class TeamsApiV10Test : ApiTest() {
+
+    @Test
+    fun givenApiV10_whenGettingTeamCollaborators_theRequestShouldBeConfiguredCorrectlyAndParsed() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(
+            COLLABORATORS_RESPONSE,
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertGet()
+                assertPathEqual("/$PATH_TEAMS/$DUMMY_TEAM_ID/$PATH_COLLABORATORS")
+            }
+        )
+        val teamsApi: TeamsApi = TeamsApiV10(networkClient)
+        val response = teamsApi.getTeamCollaborators(DUMMY_TEAM_ID)
+
+        assertIs<NetworkResponse.Success<List<TeamCollaboratorDTO>>>(response)
+        assertEquals(
+            listOf(
+                TeamCollaboratorDTO(
+                    nonQualifiedUserId = DUMMY_USER_ID,
+                    teamId = DUMMY_TEAM_ID,
+                    permissions = listOf(CollaboratorPermissionDTO.CREATE_TEAM_CONVERSATION)
+                )
+            ),
+            response.value
+        )
+    }
+
+    @Test
+    fun givenApiV10_whenGettingTeamApps_thenRequestShouldStillNotBeSupported() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient("", statusCode = HttpStatusCode.OK)
+        val teamsApi: TeamsApi = TeamsApiV10(networkClient)
+        val response = teamsApi.getTeamApps(DUMMY_TEAM_ID)
+        assertFalse(response.isSuccessful())
+    }
+
+    private companion object {
+        const val PATH_TEAMS = "teams"
+        const val PATH_COLLABORATORS = "collaborators"
+        const val DUMMY_TEAM_ID = "770b0623-ffd5-4e08-8092-7a6b9b9ca3b4"
+        const val DUMMY_USER_ID = "96a6e8e4-6420-49db-aa83-2711edf7580d"
+        val COLLABORATORS_RESPONSE = """
+            [
+                {
+                    "user": "$DUMMY_USER_ID",
+                    "team": "$DUMMY_TEAM_ID",
+                    "permissions": ["create_team_conversation"]
+                }
+            ]
+        """.trimIndent()
+    }
+}

--- a/data/network/src/commonTest/kotlin/com/wire/kalium/api/v15/TeamsApiV15Test.kt
+++ b/data/network/src/commonTest/kotlin/com/wire/kalium/api/v15/TeamsApiV15Test.kt
@@ -1,0 +1,78 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.api.v15
+
+import com.wire.kalium.api.ApiTest
+import com.wire.kalium.network.api.base.authenticated.TeamsApi
+import com.wire.kalium.network.api.model.UserProfileDTO
+import com.wire.kalium.network.api.v15.authenticated.TeamsApiV15
+import com.wire.kalium.network.utils.NetworkResponse
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+internal class TeamsApiV15Test : ApiTest() {
+
+    @Test
+    fun givenApiV15_whenGettingTeamApps_theRequestShouldBeConfiguredCorrectlyAndParsed() = runTest {
+        val networkClient = mockAuthenticatedNetworkClient(
+            APPS_RESPONSE,
+            statusCode = HttpStatusCode.OK,
+            assertion = {
+                assertGet()
+                assertPathEqual("/$PATH_TEAMS/$DUMMY_TEAM_ID/$PATH_APPS")
+            }
+        )
+        val teamsApi: TeamsApi = TeamsApiV15(networkClient)
+        val response = teamsApi.getTeamApps(DUMMY_TEAM_ID)
+
+        assertIs<NetworkResponse.Success<List<UserProfileDTO>>>(response)
+        assertEquals(1, response.value.size)
+        assertEquals(DUMMY_USER_ID, response.value.first().id.value)
+    }
+
+    private companion object {
+        const val PATH_TEAMS = "teams"
+        const val PATH_APPS = "apps"
+        const val DUMMY_TEAM_ID = "770b0623-ffd5-4e08-8092-7a6b9b9ca3b4"
+        const val DUMMY_USER_ID = "96a6e8e4-6420-49db-aa83-2711edf7580d"
+        val APPS_RESPONSE = """
+            [
+                {
+                    "qualified_id": {"id": "$DUMMY_USER_ID", "domain": "domain.com"},
+                    "name": "An App",
+                    "handle": null,
+                    "team": "$DUMMY_TEAM_ID",
+                    "accent_id": 0,
+                    "assets": [],
+                    "deleted": false,
+                    "email": null,
+                    "expires_at": null,
+                    "id": "$DUMMY_USER_ID",
+                    "service": null,
+                    "supported_protocols": null,
+                    "legalhold_status": "disabled",
+                    "type": "app",
+                    "app": {"description": "an app", "category": "productivity"}
+                }
+            ]
+        """.trimIndent()
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/team/TeamRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/team/TeamRepository.kt
@@ -19,6 +19,7 @@
 package com.wire.kalium.logic.data.team
 
 import com.wire.kalium.common.error.CoreFailure
+import com.wire.kalium.logic.data.app.AppMapper
 import com.wire.kalium.logic.data.conversation.LegalHoldStatusMapper
 import com.wire.kalium.logic.data.event.EventMapper
 import com.wire.kalium.logic.data.id.ConversationId
@@ -26,6 +27,7 @@ import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.service.ServiceMapper
 import com.wire.kalium.logic.data.user.LegalHoldStatus
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.data.user.UserMapper
 import com.wire.kalium.logic.data.user.type.UserEntityTypeMapper
 import com.wire.kalium.logic.di.MapperProvider
 import com.wire.kalium.common.functional.Either
@@ -40,10 +42,14 @@ import com.wire.kalium.common.error.wrapStorageRequest
 import com.wire.kalium.network.api.base.authenticated.TeamsApi
 import com.wire.kalium.network.api.authenticated.notification.EventContentDTO
 import com.wire.kalium.network.api.model.LegalHoldStatusDTO
+import com.wire.kalium.network.api.model.UserTypeDTO
+import com.wire.kalium.persistence.dao.AppDAO
+import com.wire.kalium.persistence.dao.ConnectionEntity
 import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.ServiceDAO
 import com.wire.kalium.persistence.dao.TeamDAO
 import com.wire.kalium.persistence.dao.UserDAO
+import com.wire.kalium.persistence.dao.UserTypeEntity
 import com.wire.kalium.persistence.dao.message.LocalId
 import com.wire.kalium.persistence.dao.UserConfigDAO
 import kotlinx.coroutines.flow.Flow
@@ -62,6 +68,8 @@ internal interface TeamRepository {
     suspend fun deleteConversation(conversationId: ConversationId, teamId: TeamId): Either<CoreFailure, Unit>
     suspend fun syncTeam(teamId: TeamId): Either<CoreFailure, Team>
     suspend fun syncServices(teamId: TeamId): Either<CoreFailure, Unit>
+    suspend fun fetchAppsByTeamId(teamId: TeamId): Either<CoreFailure, Unit>
+    suspend fun fetchCollaboratorsByTeamId(teamId: TeamId): Either<CoreFailure, Unit>
     suspend fun approveLegalHoldRequest(teamId: TeamId, password: String?): Either<CoreFailure, Unit>
     suspend fun fetchLegalHoldStatus(teamId: TeamId): Either<CoreFailure, LegalHoldStatus>
 
@@ -78,6 +86,7 @@ internal class TeamDataSource(
     private val teamsApi: TeamsApi,
     private val selfUserId: UserId,
     private val serviceDAO: ServiceDAO,
+    private val appDAO: AppDAO,
     private val legalHoldHandler: LegalHoldHandler,
     private val legalHoldRequestHandler: LegalHoldRequestHandler,
     private val teamMapper: TeamMapper = MapperProvider.teamMapper(),
@@ -85,6 +94,8 @@ internal class TeamDataSource(
     private val userTypeEntityTypeMapper: UserEntityTypeMapper = MapperProvider.userTypeEntityMapper(),
     private val legalHoldStatusMapper: LegalHoldStatusMapper = MapperProvider.legalHoldStatusMapper(),
     private val eventMapper: EventMapper = MapperProvider.eventMapper(selfUserId),
+    private val appMapper: AppMapper = MapperProvider.appMapper(),
+    private val userMapper: UserMapper = MapperProvider.userMapper(),
 ) : TeamRepository {
 
     override suspend fun fetchTeamById(teamId: TeamId): Either<CoreFailure, Team> = wrapApiRequest {
@@ -181,6 +192,36 @@ internal class TeamDataSource(
     }.flatMap {
         wrapStorageRequest {
             serviceDAO.insertMultiple(it)
+        }
+    }
+
+    override suspend fun fetchAppsByTeamId(teamId: TeamId): Either<CoreFailure, Unit> = wrapApiRequest {
+        teamsApi.getTeamApps(teamId = teamId.value)
+    }.flatMap { apps ->
+        val appProfiles = apps.filter { it.type == UserTypeDTO.APP }
+        val userEntities = appProfiles.map { app ->
+            userMapper.fromUserProfileDtoToUserEntity(
+                userProfile = app,
+                connectionState = ConnectionEntity.State.ACCEPTED,
+                userTypeEntity = UserTypeEntity.APP,
+                selfUserId = selfUserId,
+                selfTeamId = teamId
+            )
+        }
+        val appEntities = appProfiles.map(appMapper::fromUserProfileToAppEntity)
+        wrapStorageRequest {
+            userDAO.upsertUsers(userEntities)
+            appDAO.upsertApps(appEntities)
+        }
+    }
+
+    override suspend fun fetchCollaboratorsByTeamId(teamId: TeamId): Either<CoreFailure, Unit> = wrapApiRequest {
+        teamsApi.getTeamCollaborators(teamId = teamId.value)
+    }.flatMap { collaborators ->
+        val userIds = collaborators.map { QualifiedIDEntity(it.nonQualifiedUserId, selfUserId.domain) }
+        wrapStorageRequest {
+            userDAO.insertOrIgnoreIncompleteUsers(userIds)
+            userDAO.upsertConnectionStatuses(userIds.associateWith { ConnectionEntity.State.ACCEPTED })
         }
     }
 

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/user/UserRepository.kt
@@ -381,11 +381,9 @@ internal class UserDataSource internal constructor(
                     selfTeamId = selfTeamId
                 )
             }
-        val appTeamMembers = listUserProfileDTO
-            .filter { userProfileDTO ->
-                mapTeamMemberDTO.containsKey(userProfileDTO.id.value)
-                        && userProfileDTO.type == UserTypeDTO.APP
-            }
+
+        val apps = listUserProfileDTO
+            .filter { userProfileDTO -> userProfileDTO.type == UserTypeDTO.APP }
             .map(appMapper::fromUserProfileToAppEntity)
 
         return listUserProfileDTO
@@ -402,8 +400,8 @@ internal class UserDataSource internal constructor(
                     if (otherUsers.isNotEmpty()) {
                         userDAO.upsertUsers(otherUsers)
                     }
-                    if (appTeamMembers.isNotEmpty()) {
-                        appDAO.upsertApps(appTeamMembers)
+                    if (apps.isNotEmpty()) {
+                        appDAO.upsertApps(apps)
                     }
                 }
             }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/UserSessionScope.kt
@@ -1098,6 +1098,7 @@ public class UserSessionScope internal constructor(
             authenticatedNetworkContainer.teamsApi,
             userId,
             userStorage.database.serviceDAO,
+            userStorage.database.appDAO,
             legalHoldHandler,
             legalHoldRequestHandler,
         )

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/SyncSelfTeamUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/team/SyncSelfTeamUseCase.kt
@@ -24,8 +24,10 @@ import com.wire.kalium.logic.data.team.TeamRepository
 import com.wire.kalium.logic.data.user.UserRepository
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.flatMap
-import com.wire.kalium.common.functional.onSuccess
+import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.common.logger.kaliumLogger
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 
 internal interface SyncSelfTeamUseCase {
     suspend operator fun invoke(): Either<CoreFailure, Unit>
@@ -41,13 +43,28 @@ internal class SyncSelfTeamUseCaseImpl(
         userRepository.getSelfUser().flatMap { selfUser ->
             selfUser.teamId?.let { teamId ->
                 teamRepository.fetchTeamById(teamId = teamId).flatMap {
-                    teamRepository.fetchMembersByTeamId(
-                        teamId = teamId,
-                        userDomain = selfUser.id.domain,
-                        fetchedUsersLimit = fetchedUsersLimit
-                    )
-                }.onSuccess {
-                    teamRepository.syncServices(teamId = teamId)
+                    coroutineScope {
+                        launch {
+                            teamRepository.fetchMembersByTeamId(
+                                teamId = teamId,
+                                userDomain = selfUser.id.domain,
+                                fetchedUsersLimit = fetchedUsersLimit
+                            ).onFailure { kaliumLogger.withFeatureId(SYNC).w("Failed to fetch team members: $it") }
+                        }
+                        launch {
+                            teamRepository.fetchAppsByTeamId(teamId = teamId)
+                                .onFailure { kaliumLogger.withFeatureId(SYNC).w("Failed to fetch team apps: $it") }
+                        }
+                        launch {
+                            teamRepository.fetchCollaboratorsByTeamId(teamId = teamId)
+                                .onFailure { kaliumLogger.withFeatureId(SYNC).w("Failed to fetch team collaborators: $it") }
+                        }
+                        launch {
+                            teamRepository.syncServices(teamId = teamId)
+                                .onFailure { kaliumLogger.withFeatureId(SYNC).w("Failed to sync team services: $it") }
+                        }
+                    }
+                    Either.Right(Unit)
                 }
             } ?: run {
                 kaliumLogger.withFeatureId(SYNC).i("Skipping team sync because user doesn't belong to a team")

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/sync/slow/SlowSyncManager.kt
@@ -77,8 +77,7 @@ internal interface SlowSyncManager {
          * Useful when a new step is added to Slow Sync, or when we fix some bug in Slow Sync,
          * and we'd like to get all users to take advantage of the fix.
          */
-        const val CURRENT_VERSION = 11
-        // because we already had version 9, the next version should be 10
+        const val CURRENT_VERSION = 12
 
         val MIN_RETRY_DELAY = 1.seconds
         val MAX_RETRY_DELAY = 10.minutes

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/team/TeamRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/team/TeamRepositoryTest.kt
@@ -33,16 +33,24 @@ import com.wire.kalium.logic.util.shouldFail
 import com.wire.kalium.logic.util.shouldSucceed
 import com.wire.kalium.network.api.authenticated.client.ClientIdDTO
 import com.wire.kalium.network.api.authenticated.keypackage.LastPreKeyDTO
+import com.wire.kalium.network.api.authenticated.teams.CollaboratorPermissionDTO
+import com.wire.kalium.network.api.authenticated.teams.TeamCollaboratorDTO
 import com.wire.kalium.network.api.authenticated.teams.TeamMemberListPaginated
 import com.wire.kalium.network.api.base.authenticated.TeamsApi
+import com.wire.kalium.network.api.model.AppDTO
 import com.wire.kalium.network.api.model.GenericAPIErrorResponse
 import com.wire.kalium.network.api.model.LegalHoldStatusDTO
 import com.wire.kalium.network.api.model.LegalHoldStatusResponse
 import com.wire.kalium.network.api.model.ServiceDetailDTO
 import com.wire.kalium.network.api.model.ServiceDetailResponse
 import com.wire.kalium.network.api.model.TeamDTO
+import com.wire.kalium.network.api.model.UserProfileDTO
+import com.wire.kalium.network.api.model.UserTypeDTO
 import com.wire.kalium.network.exceptions.KaliumException
 import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.persistence.dao.AppDAO
+import com.wire.kalium.persistence.dao.ConnectionEntity
+import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.ServiceDAO
 import com.wire.kalium.persistence.dao.TeamDAO
 import com.wire.kalium.persistence.dao.TeamEntity
@@ -262,6 +270,55 @@ class TeamRepositoryTest {
     }
 
     @Test
+    fun givenTeamId_whenFetchingApps_thenPersistUsersAndApps() = runTest {
+        // given
+        val appProfile = TestUser.USER_PROFILE_DTO.copy(
+            id = TestUser.NETWORK_ID.copy(value = "appId"),
+            type = UserTypeDTO.APP,
+            app = AppDTO(description = "description", category = "category")
+        )
+        val (arrangement, teamRepository) = Arrangement().withApiGetTeamAppsSuccess(listOf(appProfile)).arrange()
+
+        // when
+        val result = teamRepository.fetchAppsByTeamId(teamId = TeamId(value = "teamId"))
+
+        // then
+        result.shouldSucceed()
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.userDAO.upsertUsers(any())
+        }
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.appDAO.upsertApps(any())
+        }
+    }
+
+    @Test
+    fun givenTeamId_whenFetchingCollaborators_thenSeedThemAsIncompleteUsers() = runTest {
+        // given
+        val collaborator = TeamCollaboratorDTO(
+            nonQualifiedUserId = "collaboratorId",
+            teamId = "teamId",
+            permissions = listOf(CollaboratorPermissionDTO.CREATE_TEAM_CONVERSATION)
+        )
+        val (arrangement, teamRepository) = Arrangement().withApiGetTeamCollaboratorsSuccess(listOf(collaborator)).arrange()
+
+        // when
+        val result = teamRepository.fetchCollaboratorsByTeamId(teamId = TeamId(value = "teamId"))
+
+        // then
+        result.shouldSucceed()
+        val expectedUserIds = listOf(QualifiedIDEntity("collaboratorId", TestUser.USER_ID.domain))
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.userDAO.insertOrIgnoreIncompleteUsers(eq(expectedUserIds))
+        }
+        verifySuspend(VerifyMode.exactly(1)) {
+            arrangement.userDAO.upsertConnectionStatuses(
+                eq(expectedUserIds.associateWith { ConnectionEntity.State.ACCEPTED })
+            )
+        }
+    }
+
+    @Test
     fun givenTeamIdAndUserIdAndPassword_whenApprovingLegalHoldRequest_thenItShouldSucceedAndClearRequestLocallyAndCreateEvent() = runTest {
         // given
         val (arrangement, teamRepository) = Arrangement().withApiApproveLegalHoldSuccess().withHandleLegalHoldSuccesses().arrange()
@@ -392,6 +449,7 @@ class TeamRepositoryTest {
         val userConfigDAO = mock<UserConfigDAO>(mode = MockMode.autoUnit)
         val teamsApi = mock<TeamsApi>(mode = MockMode.autoUnit)
         val serviceDAO = mock<ServiceDAO>(mode = MockMode.autoUnit)
+        val appDAO = mock<AppDAO>(mode = MockMode.autoUnit)
         val legalHoldHandler = mock<LegalHoldHandler>(mode = MockMode.autoUnit)
         val legalHoldRequestHandler = mock<LegalHoldRequestHandler>(mode = MockMode.autoUnit)
 
@@ -402,6 +460,7 @@ class TeamRepositoryTest {
             userDAO = userDAO,
             selfUserId = TestUser.USER_ID,
             serviceDAO = serviceDAO,
+            appDAO = appDAO,
             legalHoldHandler = legalHoldHandler,
             legalHoldRequestHandler = legalHoldRequestHandler,
             userConfigDAO = userConfigDAO
@@ -418,6 +477,18 @@ class TeamRepositoryTest {
             everySuspend {
                 teamsApi.whiteListedServices(any(), any())
             }.returns(NetworkResponse.Success(value = SERVICE_DETAILS_RESPONSE, headers = mapOf(), httpCode = 200))
+        }
+
+        suspend fun withApiGetTeamAppsSuccess(apps: List<UserProfileDTO>) = apply {
+            everySuspend {
+                teamsApi.getTeamApps(any())
+            }.returns(NetworkResponse.Success(value = apps, headers = mapOf(), httpCode = 200))
+        }
+
+        suspend fun withApiGetTeamCollaboratorsSuccess(collaborators: List<TeamCollaboratorDTO>) = apply {
+            everySuspend {
+                teamsApi.getTeamCollaborators(any())
+            }.returns(NetworkResponse.Success(value = collaborators, headers = mapOf(), httpCode = 200))
         }
 
         suspend fun withApiApproveLegalHoldSuccess() = apply {

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/team/SyncSelfTeamUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/team/SyncSelfTeamUseCaseTest.kt
@@ -61,6 +61,12 @@ class SyncSelfTeamUseCaseTest {
         verifySuspend(VerifyMode.not) {
             arrangement.teamRepository.syncServices(any())
         }
+        verifySuspend(VerifyMode.not) {
+            arrangement.teamRepository.fetchAppsByTeamId(any())
+        }
+        verifySuspend(VerifyMode.not) {
+            arrangement.teamRepository.fetchCollaboratorsByTeamId(any())
+        }
     }
 
     @Test
@@ -74,6 +80,8 @@ class SyncSelfTeamUseCaseTest {
                 .withTeam()
                 .withTeamMembers()
                 .withServicesSync()
+                .withAppsSync()
+                .withCollaboratorsSync()
                 .arrange()
 
             syncSelfTeamUseCase.invoke()
@@ -91,6 +99,12 @@ class SyncSelfTeamUseCaseTest {
             }
             verifySuspend(VerifyMode.exactly(1)) {
                 arrangement.teamRepository.syncServices(eq(TestUser.SELF.teamId!!))
+            }
+            verifySuspend(VerifyMode.exactly(1)) {
+                arrangement.teamRepository.fetchAppsByTeamId(eq(TestUser.SELF.teamId!!))
+            }
+            verifySuspend(VerifyMode.exactly(1)) {
+                arrangement.teamRepository.fetchCollaboratorsByTeamId(eq(TestUser.SELF.teamId!!))
             }
         }
 
@@ -116,6 +130,12 @@ class SyncSelfTeamUseCaseTest {
             arrangement.teamRepository.syncServices(any())
         }
         verifySuspend(VerifyMode.not) {
+            arrangement.teamRepository.fetchAppsByTeamId(any())
+        }
+        verifySuspend(VerifyMode.not) {
+            arrangement.teamRepository.fetchCollaboratorsByTeamId(any())
+        }
+        verifySuspend(VerifyMode.not) {
             arrangement.teamRepository.fetchMembersByTeamId(
                 eq(TestUser.SELF.teamId!!),
                 eq(TestUser.SELF.id.domain),
@@ -135,6 +155,27 @@ class SyncSelfTeamUseCaseTest {
             .withTeam()
             .withTeamMembers()
             .withFailingServicesSync()
+            .withAppsSync()
+            .withCollaboratorsSync()
+            .arrange()
+
+        val result = syncSelfTeamUseCase.invoke()
+
+        result.shouldSucceed()
+    }
+
+    @Test
+    fun givenFetchingMembersFails_whenSyncingSelfTeam_thenMembersAreIgnoredButUseCaseSucceeds() = runTest {
+        val selfUser = TestUser.SELF.right()
+
+        val (_, syncSelfTeamUseCase) = Arrangement()
+            .withSelfUser(selfUser)
+            .witFetchAllTeamMembersEagerly(null)
+            .withTeam()
+            .withFailingTeamMembers()
+            .withServicesSync()
+            .withAppsSync()
+            .withCollaboratorsSync()
             .arrange()
 
         val result = syncSelfTeamUseCase.invoke()
@@ -152,6 +193,8 @@ class SyncSelfTeamUseCaseTest {
             .withTeamMembers()
             .withTeam()
             .withServicesSync()
+            .withAppsSync()
+            .withCollaboratorsSync()
             .arrange()
 
         syncSelfTeamUseCase.invoke()
@@ -203,9 +246,27 @@ class SyncSelfTeamUseCaseTest {
             } returns Either.Right(Unit)
         }
 
+        suspend fun withFailingTeamMembers() = apply {
+            everySuspend {
+                teamRepository.fetchMembersByTeamId(any(), any(), any(), any())
+            } returns Either.Left(NetworkFailure.ServerMiscommunication(TestNetworkException.accessDenied))
+        }
+
         suspend fun withServicesSync() = apply {
             everySuspend {
                 teamRepository.syncServices(any())
+            } returns Either.Right(Unit)
+        }
+
+        suspend fun withAppsSync() = apply {
+            everySuspend {
+                teamRepository.fetchAppsByTeamId(any())
+            } returns Either.Right(Unit)
+        }
+
+        suspend fun withCollaboratorsSync() = apply {
+            everySuspend {
+                teamRepository.fetchCollaboratorsByTeamId(any())
             } returns Either.Right(Unit)
         }
 


### PR DESCRIPTION


<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-28428
<!--jira-description-action-hidden-marker-end-->


----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

https://wearezeta.atlassian.net/browse/WPB-28428

- clients are not able to show external apps to add them to conversations. External apps are returned by backend call **/teams/:tid/collaborators**
- internal apps are currently returned by **/teams/:tid/members** which will change because treating apps as team members incorrectly contributes to used seat count, that's why we need to add call to **/teams/:tid/apps** to fetch internal apps as well

### Solutions

This is a diagram of how different endpoints return different schemas, and how they all map to AppEntity in the end.

<img width="727" height="681" alt="Screenshot 2026-09-03 at 17 24 26" src="https://github.com/user-attachments/assets/a277518b-a0fa-443d-9e4a-458abd42ae11" />

This PR fetches collaborators and apps as part of **SlowSyncWorker**, analogous to the way team members are currently fetched.

Needs releases with:

- [ ] https://github.com/wireapp/wire-android/pull/5249

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution


Added unit tests in **TeamRepositoryTest** and **SyncSelfTeamUseCaseTest**.

#### How to Test

Tested 

Tested manually by clearing app data and then logging in to staging team, and verifying that internal and external apps are correctly shown. Inspected local database and network in app inspection to confirm that collaborators and apps are correctly fetched and stored.

### Attachments (Optional)

https://github.com/user-attachments/assets/14f8f0eb-a971-4651-a300-6c8c8eeb948c

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
