### PR TITLE
fix: backup restore on ss4sk device (WPB-28174)

### DIFF
--- a/.github/workflows/gradle-android-instrumented-tests.yml
+++ b/.github/workflows/gradle-android-instrumented-tests.yml
@@ -87,6 +87,16 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
+      - name: Prebuild Android test APKs
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Build/dex/package test APKs before starting the emulator, so QEMU does not compete with the heaviest Android build work.
+          ./gradlew packageAndroidDeviceTest
+          # Stop prebuild daemons before booting the emulator to free memory/CPU for the connected test phase.
+          ./gradlew --stop
+
       - name: Android Instrumentation Tests
         uses: reactivecircus/android-emulator-runner@v2.35.0
         env:

--- a/buildSrc/src/main/kotlin/OnlyAffectedTestTask.kt
+++ b/buildSrc/src/main/kotlin/OnlyAffectedTestTask.kt
@@ -77,7 +77,13 @@ open class OnlyAffectedTestTask : DefaultTask() {
         if (missingAffectedModulesData) {
             println("\uD83D\uDD27 Running all tests because affected-modules data is unavailable.")
         }
-        tasksName.forEach(::runTargetTask)
+
+        if (tasksName.isEmpty()) {
+            println("\uD83E\uDD8B No matching test tasks found for the selected modules.")
+            return
+        }
+
+        runTargetTasks(tasksName)
     }
 
     private fun readAffectedModules(): Set<String>? {
@@ -96,11 +102,19 @@ open class OnlyAffectedTestTask : DefaultTask() {
             .toSet()
     }
 
-    private fun runTargetTask(targetTask: String) {
-        println("\uD83D\uDD27 Running tests on '$targetTask'.")
+    private fun runTargetTasks(targetTasks: List<String>) {
+        println("\uD83D\uDD27 Running ${targetTasks.size} test tasks in a single Gradle invocation.")
         val execOperations = services.get<ExecOperations>()
         execOperations.exec {
-            args(targetTask)
+            val gradleArgs = buildList {
+                add("-Dorg.gradle.logging.level=lifecycle")
+                add("--console=plain")
+                if (configuration == TestTaskConfiguration.ANDROID_INSTRUMENTED_TEST_TASK) {
+                    add("--max-workers=2")
+                }
+                addAll(targetTasks)
+            }
+            args(gradleArgs)
             executable(if (System.getProperty("os.name").lowercase().contains("windows")) "gradlew.bat" else "./gradlew")
         }
     }

--- a/domain/backup/src/commonMain/kotlin/com/wire/backup/ingest/BackupImportPager.kt
+++ b/domain/backup/src/commonMain/kotlin/com/wire/backup/ingest/BackupImportPager.kt
@@ -26,6 +26,7 @@ import com.wire.kalium.protobuf.backup.BackupData
 import com.wire.kalium.protobuf.decodeFromByteArray
 import okio.Closeable
 import okio.buffer
+import pbandk.InvalidProtocolBufferException
 import kotlin.js.JsExport
 
 @JsExport
@@ -69,6 +70,14 @@ public interface ImportDataPager<T> {
     public fun nextPage(): Array<T>
 }
 
+/**
+ * Indicates that a backup page could not be decoded as protobuf data.
+ */
+public class BackupPageDecodingException(
+    public val pageName: String,
+    cause: InvalidProtocolBufferException,
+) : RuntimeException("Failed to decode backup page '$pageName'", cause)
+
 // The abstract / implementation are done this way to avoid having GenericClass<Data>, which can be lost on ObjC/Swift interop.
 // Otherwise, it could have been just a single class.
 /**
@@ -98,6 +107,7 @@ public abstract class BackupImportDataPager<T> internal constructor(entries: Lis
     /**
      * Gets the data stored in the next page, **consuming** it in the process.
      * @throws IllegalStateException if there are no further available pages.
+     * @throws BackupPageDecodingException if the page does not contain valid protobuf data.
      * @see hasMorePages
      */
     public override fun nextPage(): Array<T> {
@@ -105,7 +115,11 @@ public abstract class BackupImportDataPager<T> internal constructor(entries: Lis
             ?: throw IllegalStateException("No more pages to consume! Check if there are pages before requesting one")
         nextPageIndex++
         val bytes = page.use { it.buffer().readByteArray() }
-        return mapPageData(mapper, bytes)
+        return try {
+            mapPageData(mapper, bytes)
+        } catch (exception: InvalidProtocolBufferException) {
+            throw BackupPageDecodingException(page.name, exception)
+        }
     }
 
     internal abstract fun mapPageData(mapper: MPBackupMapper, bytes: ByteArray): Array<T>

--- a/domain/backup/src/commonTest/kotlin/com/wire/backup/ingest/BackupImportPagerTest.kt
+++ b/domain/backup/src/commonTest/kotlin/com/wire/backup/ingest/BackupImportPagerTest.kt
@@ -31,9 +31,12 @@ import com.wire.kalium.protobuf.backup.BackupInfo
 import com.wire.kalium.protobuf.backup.ExportedQualifiedId
 import com.wire.kalium.protobuf.encodeToByteArray
 import okio.Buffer
+import pbandk.InvalidProtocolBufferException
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class BackupImportPagerTest {
@@ -128,6 +131,19 @@ class BackupImportPagerTest {
         assertEquals(reaction0, pager.reactionsPager.nextPage().first())
         assertEquals(reaction1, pager.reactionsPager.nextPage().first())
         assertFalse { pager.reactionsPager.hasMorePages() }
+    }
+
+    @Test
+    fun givenMalformedProtobufPage_whenConsuming_thenThrowsTypedDecodingException() {
+        val pageName = BackupPage.USERS_PREFIX + "0" + BackupPage.PAGE_SUFFIX
+        val pager = BackupImportPager(listOf(BackupPage(pageName, Buffer().writeByte(0))))
+
+        val exception = assertFailsWith<BackupPageDecodingException> {
+            pager.usersPager.nextPage()
+        }
+
+        assertEquals(pageName, exception.pageName)
+        assertIs<InvalidProtocolBufferException>(exception.cause)
     }
 
     private fun fakeConversation(id: Int) = BackupConversation(BackupQualifiedId("conv$id", "domain"), "$id")

--- a/domain/backup/src/nonJsMain/kotlin/com/wire/backup/filesystem/FileBasedBackupPageStorage.kt
+++ b/domain/backup/src/nonJsMain/kotlin/com/wire/backup/filesystem/FileBasedBackupPageStorage.kt
@@ -19,8 +19,6 @@ package com.wire.backup.filesystem
 
 import okio.FileSystem
 import okio.Path
-import okio.Source
-import okio.use
 
 internal class FileBasedBackupPageStorage(
     private val fileSystem: FileSystem,
@@ -54,9 +52,7 @@ internal class FileBasedBackupPageStorage(
     override operator fun get(entryName: String): BackupPage? {
         val entryFile = workDirectory / entryName
         return if (fileSystem.exists(entryFile)) {
-            withReadonlySource(entryFile) { source ->
-                BackupPage(entryName, source)
-            }
+            BackupPage(entryName, fileSystem.source(entryFile))
         } else {
             null
         }
@@ -64,14 +60,7 @@ internal class FileBasedBackupPageStorage(
 
     override fun listEntries(): List<BackupPage> =
         fileSystem.list(workDirectory).map { dir ->
-            withReadonlySource(dir) { source ->
-                BackupPage(dir.name, source)
-            }
-        }
-
-    private inline fun <T> withReadonlySource(path: Path, block: (Source) -> T): T =
-        fileSystem.openReadOnly(path).use { file ->
-            block(file.source())
+            BackupPage(dir.name, fileSystem.source(dir))
         }
 
     override fun clear() {

--- a/domain/backup/src/nonJsTest/kotlin/com/wire/backup/filesystem/FileBasedBackupPageStorageTest.kt
+++ b/domain/backup/src/nonJsTest/kotlin/com/wire/backup/filesystem/FileBasedBackupPageStorageTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.backup.filesystem
+
+import okio.Buffer
+import okio.FileHandle
+import okio.ForwardingFileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+import okio.Source
+import okio.buffer
+import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class FileBasedBackupPageStorageTest {
+
+    private val delegateFileSystem = FakeFileSystem()
+    private val recordingFileSystem = RecordingFileSystem(delegateFileSystem)
+    private val workDirectory = "/backup".toPath()
+    private val storage = FileBasedBackupPageStorage(recordingFileSystem, workDirectory, true)
+
+    @AfterTest
+    fun tearDown() {
+        delegateFileSystem.checkNoOpenFiles()
+    }
+
+    @Test
+    fun givenStoredEntry_whenRetrievingByName_thenUsesFileSystemSource() {
+        val entryName = "users_0.binpb"
+        val expectedData = byteArrayOf(0x42)
+        storage.persistEntry(BackupPage(entryName, Buffer().write(expectedData)))
+        recordingFileSystem.clearRecordedReads()
+
+        val page = assertNotNull(storage[entryName])
+        page.use { source ->
+            assertContentEquals(expectedData, source.buffer().readByteArray())
+        }
+
+        assertEquals(listOf(workDirectory / entryName), recordingFileSystem.sourcePaths)
+        assertEquals(emptyList(), recordingFileSystem.openReadOnlyPaths)
+    }
+
+    @Test
+    fun givenStoredEntry_whenListingEntries_thenUsesFileSystemSource() {
+        val entryName = "users_0.binpb"
+        val expectedData = byteArrayOf(0x42)
+        storage.persistEntry(BackupPage(entryName, Buffer().write(expectedData)))
+        recordingFileSystem.clearRecordedReads()
+
+        val page = storage.listEntries().single()
+        page.use { source ->
+            assertContentEquals(expectedData, source.buffer().readByteArray())
+        }
+
+        assertEquals(listOf(workDirectory / entryName), recordingFileSystem.sourcePaths)
+        assertEquals(emptyList(), recordingFileSystem.openReadOnlyPaths)
+    }
+
+    private class RecordingFileSystem(delegate: FakeFileSystem) : ForwardingFileSystem(delegate) {
+        val sourcePaths = mutableListOf<Path>()
+        val openReadOnlyPaths = mutableListOf<Path>()
+
+        override fun source(file: Path): Source {
+            sourcePaths += file
+            return super.source(file)
+        }
+
+        override fun openReadOnly(file: Path): FileHandle {
+            openReadOnlyPaths += file
+            return super.openReadOnly(file)
+        }
+
+        fun clearRecordedReads() {
+            sourcePaths.clear()
+            openReadOnlyPaths.clear()
+        }
+    }
+}

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/RestoreBackupResult.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/RestoreBackupResult.kt
@@ -24,6 +24,7 @@ public sealed class RestoreBackupResult {
     public sealed class BackupRestoreFailure(public open val cause: String) {
         public data object InvalidPassword : BackupRestoreFailure("The provided password is invalid")
         public data object InvalidUserId : BackupRestoreFailure("User id in the backup file does not match the current user id")
+        public data object CorruptedOrUnreadableBackup : BackupRestoreFailure("The backup is corrupted or unreadable")
         public data class IncompatibleBackup(override val cause: String) : BackupRestoreFailure(cause)
         public data class BackupIOFailure(override val cause: String) : BackupRestoreFailure(cause)
         public data class DecryptionFailure(override val cause: String) : BackupRestoreFailure(cause)

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/RestoreMPBackupUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/backup/RestoreMPBackupUseCase.kt
@@ -17,6 +17,7 @@
  */
 package com.wire.kalium.logic.feature.backup
 
+import com.wire.backup.ingest.BackupPageDecodingException
 import com.wire.backup.ingest.ImportDataPager
 import com.wire.backup.ingest.ImportResultPager
 import com.wire.kalium.common.functional.fold
@@ -92,10 +93,17 @@ internal class RestoreMPBackupUseCaseImpl(
 
             when (val result = importer.importFromFile(backupFilePath.toString(), password)) {
                 is ImportResult.Success -> {
-                    persistBackupData(result.pager) { currentPage, totalPages ->
-                        onProgress(currentPage.toFloat() / totalPages)
+                    try {
+                        persistBackupData(result.pager) { currentPage, totalPages ->
+                            onProgress(currentPage.toFloat() / totalPages)
+                        }
+                        RestoreBackupResult.Success
+                    } catch (exception: BackupPageDecodingException) {
+                        kaliumLogger.e("Invalid protobuf data during backup restore", exception)
+                        RestoreBackupResult.Failure(
+                            RestoreBackupResult.BackupRestoreFailure.CorruptedOrUnreadableBackup
+                        )
                     }
-                    RestoreBackupResult.Success
                 }
 
                 ImportResult.Failure.MissingOrWrongPassphrase -> RestoreBackupResult.Failure(

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/RestoreMPBackupUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/backup/RestoreMPBackupUseCaseTest.kt
@@ -23,7 +23,10 @@ import com.wire.backup.data.BackupMessage
 import com.wire.backup.data.BackupQualifiedId
 import com.wire.backup.data.BackupReaction
 import com.wire.backup.data.BackupUser
+import com.wire.backup.ingest.BackupPageDecodingException
 import com.wire.kalium.common.functional.right
+import com.wire.kalium.protobuf.backup.BackupData
+import com.wire.kalium.protobuf.decodeFromByteArray
 import com.wire.kalium.logic.data.asset.FakeKaliumFileSystem
 import com.wire.kalium.logic.data.backup.BackupRepository
 import com.wire.kalium.logic.data.conversation.Conversation
@@ -57,10 +60,12 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import okio.Path.Companion.toPath
+import pbandk.InvalidProtocolBufferException
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -162,6 +167,25 @@ class RestoreMPBackupUseCaseTest {
     }
 
     @Test
+    fun givenMalformedProtobufPage_whenRestoring_thenCorruptedOrUnreadableBackupIsReturned() = runTest {
+        val (arrangement, useCase) = Arrangement()
+            .withSuccessImport()
+            .withPageDecodingFailure()
+            .arrange()
+
+        val result = useCase(arrangement.storedPath, null) {}
+
+        assertEquals(
+            RestoreBackupResult.Failure(RestoreBackupResult.BackupRestoreFailure.CorruptedOrUnreadableBackup),
+            result
+        )
+        coVerify { arrangement.backupRepository.insertUsers(any()) }.wasNotInvoked()
+        coVerify { arrangement.backupRepository.insertConversations(any()) }.wasNotInvoked()
+        coVerify { arrangement.backupRepository.insertMessages(any()) }.wasNotInvoked()
+        coVerify { arrangement.backupRepository.insertReactions(any()) }.wasNotInvoked()
+    }
+
+    @Test
     fun givenBackupContainsUsersWithEmptyDomain_whenRestoring_thenMalformedUserIsSkipped() = runTest {
         val malformedBackupUser = testUser.toBackupUser().copy(
             id = BackupQualifiedId("participant-malformed", "")
@@ -223,6 +247,7 @@ class RestoreMPBackupUseCaseTest {
         var usersInsertStubConfigured = false
         var conversationsInsertStubConfigured = false
         var messagesInsertStubConfigured = false
+        var pageDecodingException: BackupPageDecodingException? = null
 
         val storedPath = "testPath/backupFile.zip".toPath()
 
@@ -259,6 +284,16 @@ class RestoreMPBackupUseCaseTest {
 
         fun withUsersPages(vararg pages: Array<BackupUser>) = apply {
             usersPages = pages.toList()
+        }
+
+        fun withPageDecodingFailure() = apply {
+            val decodingCause = assertFailsWith<InvalidProtocolBufferException> {
+                BackupData.decodeFromByteArray(byteArrayOf(0))
+            }
+            pageDecodingException = BackupPageDecodingException(
+                pageName = "users_0.binpb",
+                cause = decodingCause
+            )
         }
 
         suspend fun captureInsertedUsers(captured: MutableList<List<OtherUser>>) = apply {
@@ -309,7 +344,9 @@ class RestoreMPBackupUseCaseTest {
 
             val usersHasMorePagesValues = MutableList(usersPages.size) { true } + false
             every { usersPager.hasMorePages() }.returnsMany(*usersHasMorePagesValues.toTypedArray())
-            every { usersPager.nextPage() }.returnsMany(*usersPages.toTypedArray())
+            pageDecodingException?.let { exception ->
+                every { usersPager.nextPage() }.throws(exception)
+            } ?: every { usersPager.nextPage() }.returnsMany(*usersPages.toTypedArray())
 
             every { conversationsPager.hasMorePages() }.returnsMany(true, false)
             every { conversationsPager.nextPage() }.returnsMany(arrayOf(TestConversation.CONVERSATION.toBackupConversation()))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-28174
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-28174
----

# What's new in this PR?

### Issues

Multiplatform backup restore could fail while reading stored pages, and malformed protobuf pages could throw an uncaught InvalidProtocolBufferException, potentially crashing the restore process.

### Causes (Optional)

FileBasedBackupPageStorage exposed pages through the openReadOnly()/FileHandle path instead of the filesystem’s sequential source() API. Additionally, protobuf decoding errors escaped the import pager pager and had no typed representation in the restore result contract.
The issue reproduced on the builds for Samsung Knox devices due to additional manipulations to the APK file done by SecuSmart scripts.

### Solutions

Use fileSystem.source(path) directly for indexed and listed backup pages, with regression tests ensuring openReadOnly() is never used.
Wrap protobuf parsing failures in BackupPageDecodingException, preserving the page name and original pbandk exception. Handle that exception during persistence and return Failure(CorruptedOrUnreadableBackup) while preserving cleanup, cancellation propagation, and existing I/O failure handling.