### PR TITLE
fix: meeting members only from self-team self-domain [WPB-28245]

### DIFF
--- a/changelog.d/search-use-case-default-arguments.changed.md
+++ b/changelog.d/search-use-case-default-arguments.changed.md
@@ -1,0 +1,9 @@
+`SearchUsersByNameUseCase` and `SearchUsersByHandleUseCase` replace
+`skipRemoteSearch` with `onlySelfTeamAndDomain`. When `true`, the new parameter
+restricts searches to the self user's team and domain instead of skipping remote
+search. Callers using the `skipRemoteSearch` named argument must update it to
+`onlySelfTeamAndDomain` and review the changed behavior, including calls that pass
+the Boolean positionally.
+
+`excludingMembersOfConversation` and `customDomain` now default to `null`,
+allowing callers to omit these arguments.

--- a/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Search.sq
+++ b/data/persistence/src/commonMain/db_user/com/wire/kalium/persistence/Search.sq
@@ -4,7 +4,17 @@ SELECT qualified_id, name, complete_asset_id, preview_asset_id, user_type, conne
     WHERE connection_status = 'ACCEPTED' AND
     user_type != 'APP' AND
     qualified_id != (SELECT id FROM SelfUser LIMIT 1) AND
-    deleted = 0;
+    deleted = 0 AND
+    -- Exclude members of the specified conversation, if excludeConversationId is provided (non-null)
+    (:excludeConversationId IS NULL OR qualified_id NOT IN (
+        SELECT user
+        FROM Member
+        WHERE conversation = :excludeConversationId
+    )) AND
+    -- Only members of the specified team, if onlyTeamId is provided (non-null)
+    (:onlyTeamId IS NULL OR team = :onlyTeamId) AND
+    -- Only members of the specified domain, if onlyDomain is provided (non-null)
+    (:onlyDomain IS NULL OR qualified_id LIKE ('%@' || :onlyDomain || ''));
 
 searchByName:
 SELECT qualified_id, name, complete_asset_id, preview_asset_id, user_type, connection_status, handle
@@ -13,34 +23,17 @@ SELECT qualified_id, name, complete_asset_id, preview_asset_id, user_type, conne
     user_type != 'APP' AND
     qualified_id != (SELECT id FROM SelfUser LIMIT 1) AND
     deleted = 0 AND
+    -- Exclude members of the specified conversation, if excludeConversationId is provided (non-null)
+    (:excludeConversationId IS NULL OR qualified_id NOT IN (
+        SELECT user
+        FROM Member
+        WHERE conversation = :excludeConversationId
+    )) AND
+    -- Only members of the specified team, if onlyTeamId is provided (non-null)
+    (:onlyTeamId IS NULL OR team = :onlyTeamId) AND
+    -- Only members of the specified domain, if onlyDomain is provided (non-null)
+    (:onlyDomain IS NULL OR qualified_id LIKE ('%@' || :onlyDomain || '')) AND
     name LIKE ('%' || :searchQuery || '%');
-
-selectAllConnectedUsersNotInConversation:
-SELECT qualified_id, name, complete_asset_id, preview_asset_id, user_type, connection_status, handle
-    FROM User
-    WHERE connection_status = 'ACCEPTED' AND
-    user_type != 'APP' AND
-    qualified_id != (SELECT id FROM SelfUser LIMIT 1) AND
-    deleted = 0 AND
-    qualified_id NOT IN (
-        SELECT user
-        FROM Member
-        WHERE conversation = :conversationId
-    );
-
-searchMyNameExcludingAConversation:
-SELECT qualified_id, name, complete_asset_id, preview_asset_id, user_type, connection_status, handle
-    FROM User
-    WHERE connection_status = 'ACCEPTED' AND
-    user_type != 'APP' AND
-    qualified_id != (SELECT id FROM SelfUser LIMIT 1) AND
-    deleted = 0 AND
-    name LIKE ('%' || :searchQuery || '%') AND
-    qualified_id NOT IN (
-        SELECT user
-        FROM Member
-        WHERE conversation = :conversationId
-    );
 
 searchByHandle:
 SELECT qualified_id, name, complete_asset_id, preview_asset_id, user_type, connection_status, handle
@@ -49,18 +42,14 @@ SELECT qualified_id, name, complete_asset_id, preview_asset_id, user_type, conne
     user_type != 'APP' AND
     qualified_id != (SELECT id FROM SelfUser LIMIT 1) AND
     deleted = 0 AND
-    handle LIKE ('%' || :searchQuery || '%');
-
-searchByHandleExcludingAConversation:
-SELECT qualified_id, name, complete_asset_id, preview_asset_id, user_type, connection_status, handle
-    FROM User
-    WHERE connection_status = 'ACCEPTED' AND
-    user_type != 'APP' AND
-    qualified_id != (SELECT id FROM SelfUser LIMIT 1) AND
-    deleted = 0 AND
-    handle LIKE ('%' || :searchQuery || '%') AND
-    qualified_id NOT IN (
+    -- Exclude members of the specified conversation, if excludeConversationId is provided (non-null)
+    (:excludeConversationId IS NULL OR qualified_id NOT IN (
         SELECT user
         FROM Member
-        WHERE conversation = :conversationId
-    );
+        WHERE conversation = :excludeConversationId
+    )) AND
+    -- Only members of the specified team, if onlyTeamId is provided (non-null)
+    (:onlyTeamId IS NULL OR team = :onlyTeamId) AND
+    -- Only members of the specified domain, if onlyDomain is provided (non-null)
+    (:onlyDomain IS NULL OR qualified_id LIKE ('%@' || :onlyDomain || '')) AND
+    handle LIKE ('%' || :searchQuery || '%');

--- a/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/SearchDAO.kt
+++ b/data/persistence/src/commonMain/kotlin/com/wire/kalium/persistence/dao/SearchDAO.kt
@@ -57,14 +57,22 @@ private object UserSearchEntityMapper {
 }
 
 interface SearchDAO {
-    suspend fun getKnownContacts(): List<UserSearchEntity>
-    suspend fun searchList(query: String): List<UserSearchEntity>
-    suspend fun getKnownContactsExcludingAConversation(conversationId: ConversationIDEntity): List<UserSearchEntity>
-    suspend fun searchListExcludingAConversation(conversationId: ConversationIDEntity, query: String): List<UserSearchEntity>
-    suspend fun handleSearch(searchQuery: String): List<UserSearchEntity>
-    suspend fun handleSearchExcludingAConversation(
+    suspend fun getKnownContacts(
+        excludeConversationId: ConversationIDEntity? = null,
+        onlyTeamId: String? = null,
+        onlyDomain: String? = null,
+    ): List<UserSearchEntity>
+    suspend fun searchByName(
         searchQuery: String,
-        conversationId: ConversationIDEntity
+        excludeConversationId: ConversationIDEntity? = null,
+        onlyTeamId: String? = null,
+        onlyDomain: String? = null,
+    ): List<UserSearchEntity>
+    suspend fun searchByHandle(
+        searchQuery: String,
+        excludeConversationId: ConversationIDEntity? = null,
+        onlyTeamId: String? = null,
+        onlyDomain: String? = null,
     ): List<UserSearchEntity>
 }
 
@@ -73,47 +81,45 @@ internal class SearchDAOImpl internal constructor(
     private val readDispatcher: ReadDispatcher,
 ) : SearchDAO {
 
-    override suspend fun getKnownContacts(): List<UserSearchEntity> = withContext(readDispatcher.value) {
-        searchQueries.selectAllConnectedUsers(mapper = UserSearchEntityMapper::map).awaitAsList()
-    }
-
-    override suspend fun searchList(query: String): List<UserSearchEntity> = withContext(readDispatcher.value) {
-        searchQueries.searchByName(query, mapper = UserSearchEntityMapper::map).awaitAsList()
-    }
-
-    override suspend fun getKnownContactsExcludingAConversation(conversationId: ConversationIDEntity): List<UserSearchEntity> =
-        withContext(readDispatcher.value) {
-            searchQueries.selectAllConnectedUsersNotInConversation(
-                conversationId,
-                mapper = UserSearchEntityMapper::map
-            ).awaitAsList()
-        }
-
-    override suspend fun searchListExcludingAConversation(
-        conversationId: ConversationIDEntity,
-        query: String
+    override suspend fun getKnownContacts(
+        excludeConversationId: ConversationIDEntity?,
+        onlyTeamId: String?,
+        onlyDomain: String?,
     ): List<UserSearchEntity> = withContext(readDispatcher.value) {
-        searchQueries.searchMyNameExcludingAConversation(
-            query,
-            conversationId,
+        searchQueries.selectAllConnectedUsers(
+            excludeConversationId = excludeConversationId,
+            onlyTeamId = onlyTeamId,
+            onlyDomain = onlyDomain,
             mapper = UserSearchEntityMapper::map
         ).awaitAsList()
     }
 
-    override suspend fun handleSearch(searchQuery: String): List<UserSearchEntity> = withContext(readDispatcher.value) {
-        searchQueries.searchByHandle(
-            searchQuery,
-            mapper = UserSearchEntityMapper::map
-        ).awaitAsList()
-    }
-
-    override suspend fun handleSearchExcludingAConversation(
+    override suspend fun searchByName(
         searchQuery: String,
-        conversationId: ConversationIDEntity
+        excludeConversationId: ConversationIDEntity?,
+        onlyTeamId: String?,
+        onlyDomain: String?,
     ): List<UserSearchEntity> = withContext(readDispatcher.value) {
-        searchQueries.searchByHandleExcludingAConversation(
-            searchQuery,
-            conversationId,
+        searchQueries.searchByName(
+            searchQuery = searchQuery,
+            excludeConversationId = excludeConversationId,
+            onlyTeamId = onlyTeamId,
+            onlyDomain = onlyDomain,
+            mapper = UserSearchEntityMapper::map
+        ).awaitAsList()
+    }
+
+    override suspend fun searchByHandle(
+        searchQuery: String,
+        excludeConversationId: ConversationIDEntity?,
+        onlyTeamId: String?,
+        onlyDomain: String?,
+    ): List<UserSearchEntity> = withContext(readDispatcher.value) {
+        searchQueries.searchByHandle(
+            searchQuery = searchQuery,
+            excludeConversationId = excludeConversationId,
+            onlyTeamId = onlyTeamId,
+            onlyDomain = onlyDomain,
             mapper = UserSearchEntityMapper::map
         ).awaitAsList()
     }

--- a/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/SearchDAOTest.kt
+++ b/data/persistence/src/commonTest/kotlin/com/wire/kalium/persistence/dao/SearchDAOTest.kt
@@ -126,8 +126,8 @@ class SearchDAOTest : BaseDatabaseTest() {
                 MemberEntity.Role.Member
             ), conversationToExclude.id
         )
-        searchDAO.getKnownContactsExcludingAConversation(
-            conversationToExclude.id
+        searchDAO.getKnownContacts(
+            excludeConversationId = conversationToExclude.id
         ).also {
             assertEquals(2, it.size)
             assertEquals(connectedUser1.id, it[0].id)
@@ -136,7 +136,7 @@ class SearchDAOTest : BaseDatabaseTest() {
     }
 
     @Test
-    fun givenUsers_whenSearching_thenOnlyReturnConnectedUsers() = runTest {
+    fun givenUsers_whenSearchingByName_thenOnlyReturnConnectedUsers() = runTest {
         val searchQuery = "searchQuery"
         val connectedUser1 = newUserEntity(id = "1").copy(name = "searchQuery", connectionStatus = ConnectionEntity.State.ACCEPTED)
         val connectedUser2 = newUserEntity(id = "2").copy(name = "qwerty", connectionStatus = ConnectionEntity.State.ACCEPTED)
@@ -161,14 +161,14 @@ class SearchDAOTest : BaseDatabaseTest() {
             )
         )
 
-        searchDAO.searchList(searchQuery).also {
+        searchDAO.searchByName(searchQuery).also {
             assertEquals(1, it.size)
             assertEquals(connectedUser1.id, it[0].id)
         }
     }
 
     @Test
-    fun givenUsers_whenSearchingAndExcludingAConversation_thenOnlyReturnConnectedUsersThatAreNotMembers() = runTest {
+    fun givenUsers_whenSearchingByNameAndExcludingAConversation_thenOnlyReturnConnectedUsersThatAreNotMembers() = runTest {
         val searchQuery = "searchQuery"
         val connectedUser1 = newUserEntity(id = "1").copy(name = searchQuery, connectionStatus = ConnectionEntity.State.ACCEPTED)
         val connectedUser2 = newUserEntity(id = "2").copy(name = searchQuery, connectionStatus = ConnectionEntity.State.ACCEPTED)
@@ -202,7 +202,7 @@ class SearchDAOTest : BaseDatabaseTest() {
             ), conversation.id
         )
 
-        searchDAO.searchListExcludingAConversation(conversation.id, searchQuery).also {
+        searchDAO.searchByName(excludeConversationId = conversation.id, searchQuery = searchQuery).also {
             assertEquals(1, it.size)
             assertEquals(connectedUser2.id, it[0].id)
         }
@@ -234,14 +234,14 @@ class SearchDAOTest : BaseDatabaseTest() {
             )
         )
 
-        searchDAO.handleSearch(searchQuery).also {
+        searchDAO.searchByHandle(searchQuery = searchQuery).also {
             assertEquals(1, it.size)
             assertEquals(connectedUser1.id, it[0].id)
         }
     }
 
     @Test
-    fun givenUsers_whenSearchingVByHandleAndExcludingAConversation_thenOnlyReturnConnectedUsersThatAreNotMembers() = runTest {
+    fun givenUsers_whenSearchingByHandleAndExcludingAConversation_thenOnlyReturnConnectedUsersThatAreNotMembers() = runTest {
         val searchQuery = "searchQuery"
         val connectedUser1 = newUserEntity(id = "1").copy(handle = searchQuery, connectionStatus = ConnectionEntity.State.ACCEPTED)
         val connectedUser2 = newUserEntity(id = "2").copy(handle = searchQuery, connectionStatus = ConnectionEntity.State.ACCEPTED)
@@ -275,7 +275,7 @@ class SearchDAOTest : BaseDatabaseTest() {
             ), conversation.id
         )
 
-        searchDAO.handleSearchExcludingAConversation(searchQuery, conversation.id).also {
+        searchDAO.searchByHandle(searchQuery = searchQuery, excludeConversationId = conversation.id).also {
             assertEquals(1, it.size)
             assertEquals(connectedUser2.id, it[0].id)
         }

--- a/logic/api/logic.klib.api
+++ b/logic/api/logic.klib.api
@@ -1677,11 +1677,11 @@ abstract interface com.wire.kalium.logic.feature.search/IsFederationSearchAllowe
 }
 
 abstract interface com.wire.kalium.logic.feature.search/SearchUsersByHandleUseCase { // com.wire.kalium.logic.feature.search/SearchUsersByHandleUseCase|null[0]
-    abstract suspend fun invoke(kotlin/String, com.wire.kalium.logic.data.id/QualifiedID?, kotlin/Boolean = ..., kotlin/String?): com.wire.kalium.logic.feature.search/SearchUserResult // com.wire.kalium.logic.feature.search/SearchUsersByHandleUseCase.invoke|invoke(kotlin.String;com.wire.kalium.logic.data.id.QualifiedID?;kotlin.Boolean;kotlin.String?){}[0]
+    abstract suspend fun invoke(kotlin/String, com.wire.kalium.logic.data.id/QualifiedID? = ..., kotlin/Boolean = ..., kotlin/String? = ...): com.wire.kalium.logic.feature.search/SearchUserResult // com.wire.kalium.logic.feature.search/SearchUsersByHandleUseCase.invoke|invoke(kotlin.String;com.wire.kalium.logic.data.id.QualifiedID?;kotlin.Boolean;kotlin.String?){}[0]
 }
 
 abstract interface com.wire.kalium.logic.feature.search/SearchUsersByNameUseCase { // com.wire.kalium.logic.feature.search/SearchUsersByNameUseCase|null[0]
-    abstract suspend fun invoke(kotlin/String, com.wire.kalium.logic.data.id/QualifiedID?, kotlin/Boolean = ..., kotlin/String?): com.wire.kalium.logic.feature.search/SearchUserResult // com.wire.kalium.logic.feature.search/SearchUsersByNameUseCase.invoke|invoke(kotlin.String;com.wire.kalium.logic.data.id.QualifiedID?;kotlin.Boolean;kotlin.String?){}[0]
+    abstract suspend fun invoke(kotlin/String, com.wire.kalium.logic.data.id/QualifiedID? = ..., kotlin/Boolean = ..., kotlin/String? = ...): com.wire.kalium.logic.feature.search/SearchUserResult // com.wire.kalium.logic.feature.search/SearchUsersByNameUseCase.invoke|invoke(kotlin.String;com.wire.kalium.logic.data.id.QualifiedID?;kotlin.Boolean;kotlin.String?){}[0]
 }
 
 abstract interface com.wire.kalium.logic.feature.selfDeletingMessages/ObserveSelfDeletionTimerSettingsForConversationUseCase { // com.wire.kalium.logic.feature.selfDeletingMessages/ObserveSelfDeletionTimerSettingsForConversationUseCase|null[0]

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepository.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepository.kt
@@ -19,9 +19,15 @@
 package com.wire.kalium.logic.data.publicuser
 
 import com.wire.kalium.common.error.CoreFailure
-import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.error.wrapApiRequest
+import com.wire.kalium.common.error.wrapStorageRequest
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.flatMap
+import com.wire.kalium.common.functional.getOrElse
+import com.wire.kalium.common.functional.map
+import com.wire.kalium.common.functional.onSuccess
+import com.wire.kalium.logic.data.app.AppMapper
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.SelfTeamIdProvider
 import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.publicuser.model.UserSearchDetails
@@ -31,17 +37,9 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.UserMapper
 import com.wire.kalium.logic.data.user.toDao
 import com.wire.kalium.logic.di.MapperProvider
-import com.wire.kalium.common.functional.Either
-import com.wire.kalium.common.functional.flatMap
-import com.wire.kalium.common.functional.getOrElse
-import com.wire.kalium.common.functional.map
-import com.wire.kalium.common.functional.onSuccess
-import com.wire.kalium.common.error.wrapApiRequest
-import com.wire.kalium.common.error.wrapStorageRequest
-import com.wire.kalium.logic.data.app.AppMapper
 import com.wire.kalium.network.api.authenticated.userDetails.ListUserRequest
-import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
 import com.wire.kalium.network.api.authenticated.userDetails.qualifiedIds
+import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
 import com.wire.kalium.network.api.model.UserProfileDTO
 import com.wire.kalium.network.api.model.UserTypeDTO
 import com.wire.kalium.persistence.dao.AppDAO
@@ -57,35 +55,29 @@ internal interface SearchUserRepository {
         searchUsersOptions: SearchUsersOptions
     ): Either<CoreFailure, UserSearchResult>
 
-    suspend fun getKnownContacts(excludeConversation: ConversationId?): Either<StorageFailure, List<UserSearchDetails>>
+    suspend fun getKnownContacts(
+        searchUsersOptions: SearchUsersOptions
+    ): Either<CoreFailure, List<UserSearchDetails>>
 
     suspend fun searchLocalByName(
         name: String,
-        excludeMembersOfConversation: ConversationId?
-    ): Either<StorageFailure, List<UserSearchDetails>>
+        searchUsersOptions: SearchUsersOptions
+    ): Either<CoreFailure, List<UserSearchDetails>>
 
     suspend fun searchLocalByHandle(
         handle: String,
-        excludeMembersOfConversation: ConversationId?
-    ): Either<StorageFailure, List<UserSearchDetails>>
+        searchUsersOptions: SearchUsersOptions
+    ): Either<CoreFailure, List<UserSearchDetails>>
 
 }
 
 internal data class SearchUsersOptions(
-    val conversationExcluded: ConversationMemberExcludedOptions,
-    val selfUserIncluded: Boolean
+    val conversationMembersExcluded: ConversationId? = null, // By default, do not exclude any conversation members
+    val onlySelfTeamAndDomain: Boolean = false, // By default, search users from all teams or no team
 ) {
     internal companion object {
-        internal val Default = SearchUsersOptions(
-            conversationExcluded = ConversationMemberExcludedOptions.None,
-            selfUserIncluded = false
-        )
+        internal val Default = SearchUsersOptions()
     }
-}
-
-internal sealed class ConversationMemberExcludedOptions {
-    internal data object None : ConversationMemberExcludedOptions()
-    internal data class ConversationExcluded(val conversationId: QualifiedID) : ConversationMemberExcludedOptions()
 }
 
 @Suppress("LongParameterList")
@@ -108,10 +100,11 @@ internal class SearchUserRepositoryImpl(
     ): Either<CoreFailure, UserSearchResult> =
         selfTeamIdProvider().flatMap { selfTeamId ->
             userSearchAPiWrapper.search(
-                searchQuery,
-                domain,
-                maxResultSize,
-                searchUsersOptions
+                searchQuery = searchQuery,
+                domain = domain,
+                maxResultSize = maxResultSize,
+                selfTeamId = selfTeamId,
+                searchUsersOptions = searchUsersOptions
             ).flatMap { userSearchResponse ->
 
                 if (userSearchResponse.documents.isEmpty()) return Either.Right(UserSearchResult(listOf()))
@@ -143,25 +136,31 @@ internal class SearchUserRepositoryImpl(
             }
         }
 
-    override suspend fun getKnownContacts(excludeConversation: ConversationId?): Either<StorageFailure, List<UserSearchDetails>> =
+    override suspend fun getKnownContacts(
+        searchUsersOptions: SearchUsersOptions
+    ): Either<CoreFailure, List<UserSearchDetails>> = selfTeamIdProvider().flatMap { selfTeamId ->
         wrapStorageRequest {
-            if (excludeConversation == null) {
-                searchDAO.getKnownContacts()
-            } else {
-                searchDAO.getKnownContactsExcludingAConversation(excludeConversation.toDao())
-            }
-        }.map {
-            it.map(userMapper::fromSearchEntityToUserSearchDetails)
+            searchDAO.getKnownContacts(
+                excludeConversationId = searchUsersOptions.conversationMembersExcluded?.toDao(),
+                onlyTeamId = if (searchUsersOptions.onlySelfTeamAndDomain) selfTeamId?.value else null,
+                onlyDomain = if (searchUsersOptions.onlySelfTeamAndDomain) selfUserId.domain else null,
+            )
         }
+    }.map {
+        it.map(userMapper::fromSearchEntityToUserSearchDetails)
+    }
 
     override suspend fun searchLocalByName(
         name: String,
-        excludeMembersOfConversation: ConversationId?
-    ): Either<StorageFailure, List<UserSearchDetails>> = wrapStorageRequest {
-        if (excludeMembersOfConversation == null) {
-            searchDAO.searchList(name)
-        } else {
-            searchDAO.searchListExcludingAConversation(excludeMembersOfConversation.toDao(), name)
+        searchUsersOptions: SearchUsersOptions
+    ): Either<CoreFailure, List<UserSearchDetails>> = selfTeamIdProvider().flatMap { selfTeamId ->
+        wrapStorageRequest {
+            searchDAO.searchByName(
+                searchQuery = name,
+                excludeConversationId = searchUsersOptions.conversationMembersExcluded?.toDao(),
+                onlyTeamId = if (searchUsersOptions.onlySelfTeamAndDomain) selfTeamId?.value else null,
+                onlyDomain = if (searchUsersOptions.onlySelfTeamAndDomain) selfUserId.domain else null,
+            )
         }
     }.map {
         it.map(userMapper::fromSearchEntityToUserSearchDetails)
@@ -169,19 +168,18 @@ internal class SearchUserRepositoryImpl(
 
     override suspend fun searchLocalByHandle(
         handle: String,
-        excludeMembersOfConversation: ConversationId?
-    ): Either<StorageFailure, List<UserSearchDetails>> = if (excludeMembersOfConversation == null) {
+        searchUsersOptions: SearchUsersOptions
+    ): Either<CoreFailure, List<UserSearchDetails>> = selfTeamIdProvider().flatMap { selfTeamId ->
         wrapStorageRequest {
-            searchDAO.handleSearch(handle)
-        }.map {
-            it.map(userMapper::fromSearchEntityToUserSearchDetails)
+            searchDAO.searchByHandle(
+                searchQuery = handle,
+                excludeConversationId = searchUsersOptions.conversationMembersExcluded?.toDao(),
+                onlyTeamId = if (searchUsersOptions.onlySelfTeamAndDomain) selfTeamId?.value else null,
+                onlyDomain = if (searchUsersOptions.onlySelfTeamAndDomain) selfUserId.domain else null,
+            )
         }
-    } else {
-        wrapStorageRequest {
-            searchDAO.handleSearchExcludingAConversation(handle, excludeMembersOfConversation.toDao())
-        }.map {
-            it.map(userMapper::fromSearchEntityToUserSearchDetails)
-        }
+    }.map {
+        it.map(userMapper::fromSearchEntityToUserSearchDetails)
     }
 
     private suspend fun updateLocalUsers(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/UserSearchApiWrapper.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/publicuser/UserSearchApiWrapper.kt
@@ -19,27 +19,29 @@
 package com.wire.kalium.logic.data.publicuser
 
 import com.wire.kalium.common.error.NetworkFailure
+import com.wire.kalium.common.error.wrapApiRequest
+import com.wire.kalium.common.functional.Either
+import com.wire.kalium.common.functional.map
+import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.id.toModel
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.common.functional.Either
-import com.wire.kalium.common.functional.map
-import com.wire.kalium.common.error.wrapApiRequest
-import com.wire.kalium.network.api.base.authenticated.search.UserSearchApi
 import com.wire.kalium.network.api.authenticated.search.UserSearchRequest
 import com.wire.kalium.network.api.authenticated.search.UserSearchResponse
+import com.wire.kalium.network.api.base.authenticated.search.UserSearchApi
 import com.wire.kalium.persistence.dao.member.MemberDAO
 import kotlinx.coroutines.flow.firstOrNull
 
 internal interface UserSearchApiWrapper {
     /*
      * Searches for users that match given the [searchQuery] using the API.
-     * Depending on the [searchUsersOptions], the members of a conversation can be excluded.
+     * Depending on the [searchUsersOptions], some users of the search result may be filtered out.
      */
     suspend fun search(
         searchQuery: String,
         domain: String,
         maxResultSize: Int?,
+        selfTeamId: TeamId?,
         searchUsersOptions: SearchUsersOptions
     ): Either<NetworkFailure, UserSearchResponse>
 }
@@ -54,6 +56,7 @@ internal class UserSearchApiWrapperImpl(
         searchQuery: String,
         domain: String,
         maxResultSize: Int?,
+        selfTeamId: TeamId?,
         searchUsersOptions: SearchUsersOptions
     ): Either<NetworkFailure, UserSearchResponse> =
         wrapApiRequest {
@@ -65,43 +68,32 @@ internal class UserSearchApiWrapperImpl(
                 )
             )
         }.map { userSearchResponse ->
-            filter(userSearchResponse, searchUsersOptions)
+            filter(
+                selfTeamId = selfTeamId,
+                userSearchResponse = userSearchResponse,
+                searchUsersOptions = searchUsersOptions
+            )
         }
 
     private suspend fun filter(
+        selfTeamId: TeamId?,
         userSearchResponse: UserSearchResponse,
         searchUsersOptions: SearchUsersOptions
     ): UserSearchResponse {
 
         // if we do not exclude the conversation members, we just return empty list
-        val conversationMembersId = if (searchUsersOptions.conversationExcluded is ConversationMemberExcludedOptions.ConversationExcluded) {
+        val conversationMembersId = searchUsersOptions.conversationMembersExcluded?.let { conversationMembersExcluded ->
             memberDAO.observeConversationMembers(
-                qualifiedID = searchUsersOptions.conversationExcluded.conversationId.toDao()
+                qualifiedID = conversationMembersExcluded.toDao()
             ).firstOrNull()?.map { it.user.toModel() }
-        } else {
-            emptyList()
-        }
+        } ?: emptyList()
 
         val filteredContactResponse = userSearchResponse.documents.filter { contactDTO ->
-            val domainId = contactDTO.qualifiedID.toModel()
+            val isSelfUser = contactDTO.qualifiedID.toModel() == selfUserId
+            val isExcludedConversationMember = conversationMembersId.contains(contactDTO.qualifiedID.toModel())
+            val isSameTeamAndDomain = contactDTO.team == selfTeamId?.value && contactDTO.qualifiedID.domain == selfUserId.domain
 
-            var isConversationMember = false
-
-            // if conversation members are empty it means there is nothing to exclude
-            // from the search results, so we keep isConversationMember to be false
-            if (!conversationMembersId.isNullOrEmpty()) {
-                isConversationMember = conversationMembersId.contains(domainId)
-            }
-
-            // if we do not include the self user in the search options
-            // we always set it to false, making the final OR operation
-            // care only about isConversationMember value, since it is going to be
-            // !(isConversationMember || 0) making it a operation based only on negated isConversationMember value
-            // since !(0 || 0) = 1 , !(1 || 0) = 0
-            val isSelfUser: Boolean = if (searchUsersOptions.selfUserIncluded) false else selfUserId == domainId
-
-            // negate it because that is exactly what we do not want to have in filter results
-            !(isConversationMember || isSelfUser)
+            !isSelfUser && !isExcludedConversationMember && (!searchUsersOptions.onlySelfTeamAndDomain || isSameTeamAndDomain)
         }
 
         return userSearchResponse.copy(

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/search/SearchUsersByHandleUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/search/SearchUsersByHandleUseCase.kt
@@ -17,14 +17,13 @@
  */
 package com.wire.kalium.logic.feature.search
 
+import com.wire.kalium.common.functional.getOrElse
+import com.wire.kalium.common.functional.map
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.publicuser.ConversationMemberExcludedOptions
 import com.wire.kalium.logic.data.publicuser.SearchUserRepository
 import com.wire.kalium.logic.data.publicuser.SearchUsersOptions
 import com.wire.kalium.logic.data.publicuser.model.UserSearchDetails
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.common.functional.getOrElse
-import com.wire.kalium.common.functional.map
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 
@@ -34,15 +33,15 @@ import kotlinx.coroutines.coroutineScope
 public interface SearchUsersByHandleUseCase {
     /**
      * @param searchHandle The search query.
-     * @param excludingConversation The conversation to exclude its members from the search.
-     * @param skipRemoteSearch Whether to skip remote search and only search locally, e.g. exclude not connected users from the search.
+     * @param excludingMembersOfConversation The conversation to exclude its members from the search.
+     * @param onlySelfTeamAndDomain Only search in the self user team and domain if true.
      * @param customDomain The custom domain to search in if null the search will be on the self user domain.
      */
     public suspend operator fun invoke(
         searchHandle: String,
-        excludingConversation: ConversationId?,
-        skipRemoteSearch: Boolean = false,
-        customDomain: String?
+        excludingMembersOfConversation: ConversationId? = null,
+        onlySelfTeamAndDomain: Boolean = false,
+        customDomain: String? = null,
     ): SearchUserResult
 }
 
@@ -53,10 +52,14 @@ public class SearchUsersByHandleUseCaseImpl internal constructor(
 ) : SearchUsersByHandleUseCase {
     public override suspend operator fun invoke(
         searchHandle: String,
-        excludingConversation: ConversationId?,
-        skipRemoteSearch: Boolean,
+        excludingMembersOfConversation: ConversationId?,
+        onlySelfTeamAndDomain: Boolean,
         customDomain: String?
     ): SearchUserResult = coroutineScope {
+        val searchUsersOptions = SearchUsersOptions(
+            conversationMembersExcluded = excludingMembersOfConversation,
+            onlySelfTeamAndDomain = onlySelfTeamAndDomain,
+        )
         val cleanSearchQuery = searchHandle
             .trim()
             .removePrefix("@")
@@ -67,17 +70,11 @@ public class SearchUsersByHandleUseCaseImpl internal constructor(
         }
 
         val remoteResultsDeferred = async {
-            if (skipRemoteSearch) return@async mutableMapOf()
-
             searchUserRepository.searchUserRemoteDirectory(
-                cleanSearchQuery,
-                customDomain ?: selfUserId.domain,
-                maxRemoteSearchResultCount,
-                SearchUsersOptions(
-                    conversationExcluded = excludingConversation?.let { ConversationMemberExcludedOptions.ConversationExcluded(it) }
-                        ?: ConversationMemberExcludedOptions.None,
-                    selfUserIncluded = false
-                )
+                searchQuery = cleanSearchQuery,
+                domain = customDomain ?: selfUserId.domain,
+                maxResultSize = maxRemoteSearchResultCount,
+                searchUsersOptions = searchUsersOptions,
             ).map { userSearchResult ->
                 userSearchResult.result.map {
                     UserSearchDetails(
@@ -96,10 +93,8 @@ public class SearchUsersByHandleUseCaseImpl internal constructor(
         }
 
         val localSearchResultDeferred = async {
-            searchUserRepository.searchLocalByHandle(
-                cleanSearchQuery,
-                excludingConversation
-            ).getOrElse(emptyList())
+            searchUserRepository.searchLocalByHandle(handle = cleanSearchQuery, searchUsersOptions = searchUsersOptions)
+                .getOrElse(emptyList())
                 .associateBy { it.id }
                 .toMutableMap()
         }

--- a/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/search/SearchUsersByNameUseCase.kt
+++ b/logic/src/commonMain/kotlin/com/wire/kalium/logic/feature/search/SearchUsersByNameUseCase.kt
@@ -17,14 +17,13 @@
  */
 package com.wire.kalium.logic.feature.search
 
+import com.wire.kalium.common.functional.getOrElse
+import com.wire.kalium.common.functional.map
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.publicuser.ConversationMemberExcludedOptions
 import com.wire.kalium.logic.data.publicuser.SearchUserRepository
 import com.wire.kalium.logic.data.publicuser.SearchUsersOptions
 import com.wire.kalium.logic.data.publicuser.model.UserSearchDetails
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.common.functional.getOrElse
-import com.wire.kalium.common.functional.map
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 
@@ -35,14 +34,14 @@ public interface SearchUsersByNameUseCase {
     /**
      * @param searchQuery The search query.
      * @param excludingMembersOfConversation The conversation to exclude its members from the search.
-     * @param skipRemoteSearch Whether to skip remote search and only search locally, e.g. exclude not connected users from the search.
+     * @param onlySelfTeamAndDomain Only search in the self user team and domain if true.
      * @param customDomain The custom domain to search in if null the search will be on the self user domain.
      */
     public suspend operator fun invoke(
         searchQuery: String,
-        excludingMembersOfConversation: ConversationId?,
-        skipRemoteSearch: Boolean = false,
-        customDomain: String?
+        excludingMembersOfConversation: ConversationId? = null,
+        onlySelfTeamAndDomain: Boolean = false,
+        customDomain: String? = null,
     ): SearchUserResult
 }
 
@@ -54,39 +53,36 @@ internal class SearchUsersByNameUseCaseImpl internal constructor(
     override suspend operator fun invoke(
         searchQuery: String,
         excludingMembersOfConversation: ConversationId?,
-        skipRemoteSearch: Boolean,
+        onlySelfTeamAndDomain: Boolean,
         customDomain: String?
     ): SearchUserResult {
+        val searchUsersOptions = SearchUsersOptions(
+            conversationMembersExcluded = excludingMembersOfConversation,
+            onlySelfTeamAndDomain = onlySelfTeamAndDomain,
+        )
         return if (searchQuery.isBlank()) {
             SearchUserResult(
-                connected = searchUserRepository.getKnownContacts(excludingMembersOfConversation).getOrElse(emptyList()),
+                connected = searchUserRepository.getKnownContacts(searchUsersOptions).getOrElse(emptyList()),
                 notConnected = emptyList()
             )
         } else {
-            handleSearch(searchQuery, excludingMembersOfConversation, skipRemoteSearch, customDomain)
+            handleSearch(searchQuery = searchQuery, customDomain = customDomain, searchUsersOptions = searchUsersOptions)
         }
     }
 
     private suspend fun handleSearch(
         searchQuery: String,
-        excludingConversation: ConversationId?,
-        skipRemoteSearch: Boolean,
-        customDomain: String?
+        customDomain: String?,
+        searchUsersOptions: SearchUsersOptions,
     ): SearchUserResult = coroutineScope {
         val cleanSearchQuery = searchQuery.trim().lowercase()
 
         val remoteResultsDeferred = async {
-            if (skipRemoteSearch) return@async mutableMapOf()
-
             searchUserRepository.searchUserRemoteDirectory(
-                cleanSearchQuery,
-                customDomain ?: selfUserId.domain,
-                maxRemoteSearchResultCount,
-                SearchUsersOptions(
-                    conversationExcluded = excludingConversation?.let { ConversationMemberExcludedOptions.ConversationExcluded(it) }
-                        ?: ConversationMemberExcludedOptions.None,
-                    selfUserIncluded = false
-                )
+                searchQuery = cleanSearchQuery,
+                domain = customDomain ?: selfUserId.domain,
+                maxResultSize = maxRemoteSearchResultCount,
+                searchUsersOptions = searchUsersOptions
             ).map { userSearchResult ->
                 userSearchResult.result.map {
                     UserSearchDetails(
@@ -105,7 +101,7 @@ internal class SearchUsersByNameUseCaseImpl internal constructor(
         }
 
         val localSearchResultDeferred = async {
-            searchUserRepository.searchLocalByName(cleanSearchQuery, excludingConversation)
+            searchUserRepository.searchLocalByName(name = cleanSearchQuery, searchUsersOptions = searchUsersOptions)
                 .getOrElse(emptyList())
                 .associateBy { it.id }
                 .toMutableMap()

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepositoryTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/SearchUserRepositoryTest.kt
@@ -99,7 +99,7 @@ class SearchUserRepositoryTest {
 
         // then
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.userSearchApiWrapper.search(any(), any(), any(), any())
+            arrangement.userSearchApiWrapper.search(any(), any(), any(), any(), any())
         }
     }
 
@@ -153,7 +153,7 @@ class SearchUserRepositoryTest {
 
             // then
             verifySuspend(VerifyMode.exactly(1)) {
-                arrangement.userSearchApiWrapper.search(any(), any(), any(), any())
+                arrangement.userSearchApiWrapper.search(any(), any(), any(), any(), any())
             }
 
             verifySuspend(VerifyMode.exactly(1)) {
@@ -432,7 +432,7 @@ class SearchUserRepositoryTest {
             }
 
         // when
-        searchUserRepository.getKnownContacts(null).shouldSucceed {
+        searchUserRepository.getKnownContacts(SearchUsersOptions.Default).shouldSucceed {
             assertEquals(expected, it)
         }
 
@@ -473,17 +473,17 @@ class SearchUserRepositoryTest {
         val (arrangement, searchUserRepository) = Arrangement()
             .arrange {
                 withTeamId(Either.Right(TestUser.SELF.teamId))
-                withGetKnownContactsExcludingAConversation(searchResult)
+                withGetKnownContacts(result = searchResult, excludeConversationId = { it == conversationId.toDao() })
             }
 
         // when
-        searchUserRepository.getKnownContacts(conversationId).shouldSucceed {
+        searchUserRepository.getKnownContacts(SearchUsersOptions(conversationMembersExcluded = conversationId)).shouldSucceed {
             assertEquals(expected, it)
         }
 
         // then
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.searchDAO.getKnownContactsExcludingAConversation(conversationId.toDao())
+            arrangement.searchDAO.getKnownContacts(excludeConversationId = conversationId.toDao())
         }
     }
 
@@ -517,17 +517,17 @@ class SearchUserRepositoryTest {
         val (arrangement, searchUserRepository) = Arrangement()
             .arrange {
                 withTeamId(Either.Right(TestUser.SELF.teamId))
-                withSearchList(searchResult)
+                withSearchByName(searchResult)
             }
 
         // when
-        searchUserRepository.searchLocalByName("name", null).shouldSucceed {
+        searchUserRepository.searchLocalByName("name", SearchUsersOptions.Default).shouldSucceed {
             assertEquals(expected, it)
         }
 
         // then
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.searchDAO.searchList("name")
+            arrangement.searchDAO.searchByName(searchQuery = "name")
         }
     }
 
@@ -562,17 +562,17 @@ class SearchUserRepositoryTest {
         val (arrangement, searchUserRepository) = Arrangement()
             .arrange {
                 withTeamId(Either.Right(TestUser.SELF.teamId))
-                withSearchListExcludingAConversation(searchResult)
+                withSearchByName(result = searchResult, excludeConversationId = { it == conversationId.toDao() })
             }
 
         // when
-        searchUserRepository.searchLocalByName("name", conversationId).shouldSucceed {
+        searchUserRepository.searchLocalByName("name", SearchUsersOptions(conversationMembersExcluded = conversationId)).shouldSucceed {
             assertEquals(expected, it)
         }
 
         // then
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.searchDAO.searchListExcludingAConversation(conversationId.toDao(), any())
+            arrangement.searchDAO.searchByName(searchQuery = "name", excludeConversationId = conversationId.toDao())
         }
     }
 
@@ -581,12 +581,13 @@ class SearchUserRepositoryTest {
         val (arrangement, searchUserRepository) = Arrangement()
             .arrange {
                 withSearchByHandle(emptyList())
+                withTeamId(Either.Right(TestUser.SELF.teamId))
             }
 
-        searchUserRepository.searchLocalByHandle("handle", null).shouldSucceed()
+        searchUserRepository.searchLocalByHandle("handle", SearchUsersOptions.Default).shouldSucceed()
 
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.searchDAO.handleSearch("handle")
+            arrangement.searchDAO.searchByHandle(searchQuery = "handle")
         }
     }
 
@@ -595,13 +596,15 @@ class SearchUserRepositoryTest {
         val conversationId = ConversationId("conversationId", "domain")
         val (arrangement, searchUserRepository) = Arrangement()
             .arrange {
-                withSearchByHandleExcludingConversation(emptyList())
+                withSearchByHandle(result = emptyList(), excludeConversationId = { it == conversationId.toDao() })
+                withTeamId(Either.Right(TestUser.SELF.teamId))
             }
 
-        searchUserRepository.searchLocalByHandle("handle", conversationId).shouldSucceed()
+        searchUserRepository.searchLocalByHandle("handle", SearchUsersOptions(conversationMembersExcluded = conversationId))
+            .shouldSucceed()
 
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.searchDAO.handleSearchExcludingAConversation("handle", conversationId.toDao())
+            arrangement.searchDAO.searchByHandle(searchQuery = "handle", excludeConversationId = conversationId.toDao())
         }
     }
 
@@ -627,61 +630,37 @@ class SearchUserRepositoryTest {
             this to searchUserRepository
         }
 
-        suspend fun withSearchResult(result: Either<NetworkFailure, UserSearchResponse>) = apply {
+        fun withSearchResult(result: Either<NetworkFailure, UserSearchResponse>) = apply {
             everySuspend {
-                userSearchApiWrapper.search(any(), any(), any(), any())
+                userSearchApiWrapper.search(any(), any(), any(), any(), any())
             }.returns(result)
         }
 
-        suspend fun withGetMultipleUsersResult(result: NetworkResponse<ListUsersDTO>) = apply {
+        fun withGetMultipleUsersResult(result: NetworkResponse<ListUsersDTO>) = apply {
             everySuspend {
                 userDetailsApi.getMultipleUsers(any())
             }.returns(result)
         }
 
-        suspend fun withGetUsersDetailsByQualifiedIdListResult(result: List<UserDetailsEntity>) = apply {
+        fun withGetUsersDetailsByQualifiedIdListResult(result: List<UserDetailsEntity>) = apply {
             everySuspend {
                 userDAO.getUsersDetailsByQualifiedIDList(any())
             }.returns(result)
         }
 
-        suspend fun withGetUsersDetailsByQualifiedIdListFailure(exception: Exception) = apply {
+        fun withGetUsersDetailsByQualifiedIdListFailure(exception: Exception) = apply {
             everySuspend {
                 userDAO.getUsersDetailsByQualifiedIDList(any())
             }.throws(exception)
         }
 
-        suspend fun withObserveUserDetailsByQualifiedIdResult(result: Flow<UserDetailsEntity?>) = apply {
+        fun withObserveUserDetailsByQualifiedIdResult(result: Flow<UserDetailsEntity?>) = apply {
             everySuspend {
                 userDAO.observeUserDetailsByQualifiedID(any())
             }.returns(result)
         }
 
-        suspend fun withGetUsersDetailsNotInConversationByNameOrHandleOrEmailResult(result: Flow<List<UserDetailsEntity>>) = apply {
-            everySuspend {
-                userDAO.getUsersDetailsNotInConversationByNameOrHandleOrEmail(any(), any())
-            }.returns(result)
-        }
-
-        suspend fun withGetUserDetailsByNameOrHandleOrEmailAndConnectionStatesResult(result: Flow<List<UserDetailsEntity>>) = apply {
-            everySuspend {
-                userDAO.getUserDetailsByNameOrHandleOrEmailAndConnectionStates(any(), any())
-            }.returns(result)
-        }
-
-        suspend fun withGetUserDetailsByHandleAndConnectionStatesResult(result: Flow<List<UserDetailsEntity>>) = apply {
-            everySuspend {
-                userDAO.getUserDetailsByHandleAndConnectionStates(any(), any())
-            }.returns(result)
-        }
-
-        suspend fun withGetUsersDetailsNotInConversationByHandleResult(result: Flow<List<UserDetailsEntity>>) = apply {
-            everySuspend {
-                userDAO.getUsersDetailsNotInConversationByHandle(any(), any())
-            }.returns(result)
-        }
-
-        suspend fun withUpsertUsersSuccess() = apply {
+        fun withUpsertUsersSuccess() = apply {
             everySuspend {
                 userDAO.upsertUsers(any())
             }.returns(Unit)

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/UserSearchApiWrapperTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/data/publicuser/UserSearchApiWrapperTest.kt
@@ -20,410 +20,132 @@ package com.wire.kalium.logic.data.publicuser
 
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.id.QualifiedID
-import com.wire.kalium.logic.data.user.ConnectionState
-import com.wire.kalium.logic.data.user.SelfUser
-import com.wire.kalium.logic.data.user.UserAvailabilityStatus
+import com.wire.kalium.logic.data.id.TeamId
+import com.wire.kalium.logic.data.id.toDao
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.data.user.type.UserType
-import com.wire.kalium.logic.data.user.type.UserTypeInfo
 import com.wire.kalium.logic.util.arrangement.dao.MemberDAOArrangement
 import com.wire.kalium.logic.util.arrangement.dao.MemberDAOArrangementImpl
 import com.wire.kalium.network.api.authenticated.search.ContactDTO
 import com.wire.kalium.network.api.authenticated.search.SearchPolicyDTO
 import com.wire.kalium.network.api.authenticated.search.UserSearchResponse
 import com.wire.kalium.network.api.base.authenticated.search.UserSearchApi
-import com.wire.kalium.network.api.model.UserId as UserIdDTO
 import com.wire.kalium.network.utils.NetworkResponse
-import com.wire.kalium.persistence.dao.QualifiedIDEntity
 import com.wire.kalium.persistence.dao.member.MemberEntity
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
-import kotlin.test.assertTrue
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.runTest
+import com.wire.kalium.network.api.model.UserId as UserIdDTO
 
 class UserSearchApiWrapperTest {
 
     @Test
-    fun givenUserSearchIncludesContactMember_whenSearchingForUsersExcludingSelfUser_ThenResultDoesNotContainTheContactMembers() = runTest {
-        val conversationMembers = listOf(
-            MemberEntity(
-                user = QualifiedIDEntity(
-                    "value1",
-                    "someDomain"
-                ),
-                role = MemberEntity.Role.Member
-            )
+    fun givenNoConversationExcludedAndAllTeamsAndDomains_whenSearching_thenReturnsExpectedContacts() = runTest {
+        verifySearch(
+            searchUsersOptions = SearchUsersOptions(conversationMembersExcluded = null, onlySelfTeamAndDomain = false),
+            expectedContacts = listOf(CONVERSATION_MEMBER, TEAMMATE, OTHER_TEAM_CONTACT, OTHER_DOMAIN_CONTACT, NO_TEAM_CONTACT)
         )
-
-        val selfUser = Arrangement.generateSelfUser(QualifiedID("selfUserId", "someDomain"))
-
-        val searchResultUsers = listOf(
-            Arrangement.generateContactDTO(UserIdDTO("value1", "someDomain")),
-            Arrangement.generateContactDTO(UserIdDTO("value2", "someDomain")),
-            Arrangement.generateContactDTO(UserIdDTO("value3", "someDomain")),
-            Arrangement.generateContactDTO(UserIdDTO(selfUser.id.value, selfUser.id.domain))
-        )
-
-        val expectedResult = listOf(
-            Arrangement.generateContactDTO(UserIdDTO("value2", "someDomain")),
-            Arrangement.generateContactDTO(UserIdDTO("value3", "someDomain"))
-        )
-
-        val (_, userSearchApiWrapper) = Arrangement()
-            .withSelfUserId(selfUser.id)
-            .withSuccessConversationExcludedFullSearch(
-                conversationMembers,
-                searchResultUsers
-            ).arrange()
-
-        val result = userSearchApiWrapper.search(
-            "someQuery",
-            "someDomain",
-            null,
-            searchUsersOptions = SearchUsersOptions(
-                ConversationMemberExcludedOptions.ConversationExcluded(
-                    ConversationId(
-                        "someValue",
-                        "someDomain"
-                    )
-                ),
-                selfUserIncluded = false
-            )
-        )
-
-        assertIs<Either.Right<UserSearchResponse>>(result)
-        assertTrue { result.value.documents == expectedResult }
-        assertTrue { result.value.found == expectedResult.size }
     }
 
     @Test
-    fun givenUserSearchIncludesOnlyContactMembers_WhenSearchingForUsersExcludingSelfUser_ThenResultIsEmpty() = runTest {
-        val conversationMembers = listOf(
-            MemberEntity(
-                user = QualifiedIDEntity(
-                    "value1",
-                    "someDomain"
-                ),
-                role = MemberEntity.Role.Member
-            ),
-            MemberEntity(
-                user = QualifiedIDEntity(
-                    "value2",
-                    "someDomain"
-                ),
-                role = MemberEntity.Role.Member
-            ),
-            MemberEntity(
-                user = QualifiedIDEntity(
-                    "value3",
-                    "someDomain"
-                ), role = MemberEntity.Role.Member
-            )
+    fun givenConversationExcludedAndAllTeamsAndDomains_whenSearching_thenReturnsExpectedContacts() = runTest {
+        verifySearch(
+            searchUsersOptions = SearchUsersOptions(conversationMembersExcluded = CONVERSATION_ID, onlySelfTeamAndDomain = false),
+            expectedContacts = listOf(TEAMMATE, OTHER_TEAM_CONTACT, OTHER_DOMAIN_CONTACT, NO_TEAM_CONTACT)
         )
-
-        val selfUser = Arrangement.generateSelfUser(QualifiedID("selfUserId", "someDomain"))
-
-        val searchResultUsers = listOf(
-            Arrangement.generateContactDTO(UserIdDTO("value1", "someDomain")),
-            Arrangement.generateContactDTO(UserIdDTO("value2", "someDomain")),
-            Arrangement.generateContactDTO(UserIdDTO("value3", "someDomain")),
-            Arrangement.generateContactDTO(UserIdDTO(selfUser.id.value, selfUser.id.domain))
-        )
-
-        val (_, userSearchApiWrapper) = Arrangement()
-            .withSelfUserId(selfUser.id)
-            .withSuccessConversationExcludedFullSearch(
-                conversationMembers,
-                searchResultUsers
-            ).arrange()
-
-        val result = userSearchApiWrapper.search(
-            "someQuery",
-            "someDomain",
-            null,
-            searchUsersOptions = SearchUsersOptions(
-                ConversationMemberExcludedOptions.ConversationExcluded(
-                    ConversationId(
-                        "someValue",
-                        "someDomain"
-                    )
-                ), selfUserIncluded = false
-            )
-        )
-
-        assertIs<Either.Right<UserSearchResponse>>(result)
-        assertTrue { result.value.documents.isEmpty() }
-        assertEquals(0, result.value.found)
     }
 
     @Test
-    fun givenUserSearchIncludesSelfUser_WhenSearchingForUsersExcludingSelfUser_ThenPropagateUsersWithoutSelfUser() = runTest {
-        val selfUser = Arrangement.generateSelfUser(QualifiedID("selfUserId", "someDomain"))
-
-        val searchResultUsers = listOf(
-            Arrangement.generateContactDTO(UserIdDTO("value1", "someDomain")),
-            Arrangement.generateContactDTO(UserIdDTO("value2", "someDomain")),
-            Arrangement.generateContactDTO(UserIdDTO("value3", "someDomain")),
-            Arrangement.generateContactDTO(UserIdDTO(selfUser.id.value, selfUser.id.domain))
+    fun givenNoConversationExcludedAndOnlySelfTeamAndDomain_whenSearching_thenReturnsExpectedContacts() = runTest {
+        verifySearch(
+            searchUsersOptions = SearchUsersOptions(conversationMembersExcluded = null, onlySelfTeamAndDomain = true),
+            expectedContacts = listOf(CONVERSATION_MEMBER, TEAMMATE)
         )
+    }
 
-        val expectedResult = listOf(
-            Arrangement.generateContactDTO(UserIdDTO("value1", "someDomain")),
-            Arrangement.generateContactDTO(UserIdDTO("value2", "someDomain")),
-            Arrangement.generateContactDTO(UserIdDTO("value3", "someDomain"))
+    @Test
+    fun givenConversationExcludedAndOnlySelfTeamAndDomain_whenSearching_thenReturnsExpectedContacts() = runTest {
+        verifySearch(
+            searchUsersOptions = SearchUsersOptions(conversationMembersExcluded = CONVERSATION_ID, onlySelfTeamAndDomain = true),
+            expectedContacts = listOf(TEAMMATE)
         )
+    }
 
+    private suspend fun verifySearch(searchUsersOptions: SearchUsersOptions, expectedContacts: List<ContactDTO>) {
+        val conversationMemberEntity = MemberEntity(
+            user = UserId(CONVERSATION_MEMBER.qualifiedID.value, CONVERSATION_MEMBER.qualifiedID.domain).toDao(),
+            role = MemberEntity.Role.Member
+        )
         val (_, userSearchApiWrapper) = Arrangement()
-            .withSelfUserId(selfUser.id)
-            .withSuccessFullSearch(searchResultUsers)
+            .withSuccessFullSearch(searchApiUsers = SEARCH_CONTACTS)
+            .apply {
+                if (searchUsersOptions.conversationMembersExcluded != null) {
+                    withObserveConversationMembers(
+                        result = flowOf(listOf(conversationMemberEntity)),
+                        conversationId = { it == CONVERSATION_ID.toDao() }
+                    )
+                }
+            }
             .arrange()
 
         val result = userSearchApiWrapper.search(
-            "someQuery",
-            "someDomain",
-            null,
-            searchUsersOptions = SearchUsersOptions.Default
+            searchQuery = "someQuery",
+            domain = SELF_USER_ID.domain,
+            maxResultSize = null,
+            selfTeamId = SELF_TEAM_ID,
+            searchUsersOptions = searchUsersOptions
         )
 
         assertIs<Either.Right<UserSearchResponse>>(result)
-        assertTrue { result.value.documents == expectedResult }
-        assertTrue { result.value.found == expectedResult.size }
-    }
-
-    @Test
-    fun givenUserSearchHasOnlySelfUser_WhenSearchingForUsersExcludingSelfUser_ThenSearchResultIsEmpty() = runTest {
-        val selfUser = Arrangement.generateSelfUser(QualifiedID("selfUserId", "someDomain"))
-
-        val searchResultUsers = listOf(
-            Arrangement.generateContactDTO(UserIdDTO(selfUser.id.value, selfUser.id.domain))
-        )
-
-        val (_, userSearchApiWrapper) = Arrangement()
-            .withSelfUserId(selfUser.id)
-            .withSuccessFullSearch(searchResultUsers)
-            .arrange()
-
-        val result = userSearchApiWrapper.search(
-            "someQuery",
-            "someDomain",
-            null,
-            searchUsersOptions = SearchUsersOptions.Default,
-        )
-
-        assertIs<Either.Right<UserSearchResponse>>(result)
-        assertTrue { result.value.documents.isEmpty() }
-        assertTrue { result.value.found == 0 }
-    }
-
-    @Test
-    fun givenUserSearchHasOnlySelfUser_WhenSearchingForUsersIncludingSelfUserThatIsNotInConversation_ThenSearchResultContainsSelfUser() =
-        runTest {
-            val selfUser = Arrangement.generateSelfUser(QualifiedID("selfUserId", "someDomain"))
-
-            val expectedResult = listOf(
-                Arrangement.generateContactDTO(UserIdDTO(selfUser.id.value, selfUser.id.domain))
-            )
-
-            val searchResultUsers = listOf(
-                Arrangement.generateContactDTO(UserIdDTO(selfUser.id.value, selfUser.id.domain))
-            )
-
-            val (_, userSearchApiWrapper) = Arrangement()
-                .withSelfUserId(selfUser.id)
-                .withSuccessFullSearch(searchResultUsers)
-                .arrange()
-
-            val result = userSearchApiWrapper.search(
-                "someQuery",
-                "someDomain",
-                null,
-                searchUsersOptions = SearchUsersOptions.Default.copy(selfUserIncluded = true),
-            )
-
-            assertIs<Either.Right<UserSearchResponse>>(result)
-            assertTrue { result.value.documents == expectedResult }
-            assertTrue { result.value.found == 1 }
-        }
-
-    @Test
-    fun givenUserSearchHasOnlySelfUser_WhenSearchingForUsersIncludingSelfUserThatIsPartOfConversation_ThenSearchResultIsEmpty() = runTest {
-        val selfUser = Arrangement.generateSelfUser(QualifiedID("selfUserId", "someDomain"))
-
-        val conversationMembers = listOf(
-            MemberEntity(
-                user = QualifiedIDEntity(
-                    "value1",
-                    "someDomain"
-                ),
-                role = MemberEntity.Role.Member
-            ),
-            MemberEntity(
-                user = QualifiedIDEntity(
-                    "value2",
-                    "someDomain"
-                ),
-                role = MemberEntity.Role.Member
-            ),
-            MemberEntity(
-                user = QualifiedIDEntity(
-                    "value3",
-                    "someDomain"
-                ), role = MemberEntity.Role.Member
-            ),
-            MemberEntity(
-                user = QualifiedIDEntity(
-                    selfUser.id.value,
-                    selfUser.id.domain
-                ), role = MemberEntity.Role.Member
-            )
-        )
-
-        val searchResultUsers = listOf(
-            Arrangement.generateContactDTO(UserIdDTO(selfUser.id.value, selfUser.id.domain))
-        )
-
-        val (_, userSearchApiWrapper) = Arrangement()
-            .withSelfUserId(selfUser.id)
-            .withSuccessConversationExcludedFullSearch(
-                conversationMembers,
-                searchResultUsers
-            ).arrange()
-
-        val result = userSearchApiWrapper.search(
-            "someQuery",
-            "someDomain",
-            null,
-            searchUsersOptions = SearchUsersOptions(
-                ConversationMemberExcludedOptions.ConversationExcluded(
-                    ConversationId(
-                        "someValue",
-                        "someDomain"
-                    )
-                ), selfUserIncluded = true
-            )
-        )
-
-        assertIs<Either.Right<UserSearchResponse>>(result)
-        assertTrue { result.value.documents.isEmpty() }
-        assertTrue { result.value.found == 0 }
+        assertEquals(expectedContacts, result.value.documents)
+        assertEquals(expectedContacts.size, result.value.found)
+        assertEquals(expectedContacts.size, result.value.returned)
     }
 
     private class Arrangement : MemberDAOArrangement by MemberDAOArrangementImpl() {
-
-        lateinit var selfUserId: UserId
         private val userSearchApi: UserSearchApi = mock<UserSearchApi>(mode = MockMode.autoUnit)
 
-        fun withSelfUserId(selfUserId: UserId) = apply {
-            this.selfUserId = selfUserId
-        }
-
-        suspend fun withSuccessConversationExcludedFullSearch(
-            conversationMembers: List<MemberEntity>,
-            searchApiUsers: List<ContactDTO>,
-        ): Arrangement {
-
-            withObserveConversationMembers(flowOf(conversationMembers))
-
-            everySuspend {
-                userSearchApi.search(any())
-            }.returns(
-                    NetworkResponse.Success(
-                        generateUserSearchResponse(searchApiUsers),
-                        mapOf(),
-                        200
-                    )
-                )
-
-            return this
-        }
-
-        suspend fun withSuccessFullSearch(
-            searchApiUsers: List<ContactDTO>,
-        ): Arrangement {
-
-            everySuspend {
-                userSearchApi.search(any())
-            }.returns(
-                    NetworkResponse.Success(
-                        generateUserSearchResponse(searchApiUsers),
-                        mapOf(),
-                        200
-                    )
-                )
-
-            return this
-        }
-
-        fun arrange() = this to UserSearchApiWrapperImpl(
-            userSearchApi,
-            memberDAO,
-            selfUserId
-        ) as UserSearchApiWrapper
-
-        companion object {
-            fun generateContactDTO(id: UserIdDTO): ContactDTO {
-                return ContactDTO(
-                    accentId = null,
-                    handle = null,
-                    name = "",
-                    qualifiedID = id,
-                    team = null
-                )
-            }
-
-            fun generateUserSearchResponse(contactDTOs: List<ContactDTO> = listOf()): UserSearchResponse {
-                return UserSearchResponse(
-                    documents = contactDTOs,
-                    found = contactDTOs.size,
-                    returned = contactDTOs.size,
+        fun withSuccessFullSearch(searchApiUsers: List<ContactDTO>) = apply {
+            everySuspend { userSearchApi.search(any()) } returns NetworkResponse.Success(
+                value = UserSearchResponse(
+                    documents = searchApiUsers,
+                    found = searchApiUsers.size,
+                    returned = searchApiUsers.size,
                     searchPolicy = SearchPolicyDTO.FULL_SEARCH,
                     took = 100
-                )
-            }
-
-            fun generateSelfUser(id: QualifiedID): SelfUser {
-                return SelfUser(
-                    id = id,
-                    name = null,
-                    handle = null,
-                    email = null,
-                    phone = null,
-                    accentId = 0,
-                    teamId = null,
-                    connectionStatus = ConnectionState.NOT_CONNECTED,
-                    previewPicture = null,
-                    completePicture = null,
-                    availabilityStatus = UserAvailabilityStatus.AVAILABLE,
-                    expiresAt = null,
-                    supportedProtocols = null,
-                    userType = UserTypeInfo.Regular(UserType.INTERNAL),
-                )
-            }
-
-            val SELF_USER = SelfUser(
-                id = QualifiedID("someValue", "someId"),
-                name = null,
-                handle = null,
-                email = null,
-                phone = null,
-                accentId = 0,
-                teamId = null,
-                connectionStatus = ConnectionState.NOT_CONNECTED,
-                previewPicture = null,
-                completePicture = null,
-                availabilityStatus = UserAvailabilityStatus.AVAILABLE,
-                expiresAt = null,
-                supportedProtocols = null,
-                userType = UserTypeInfo.Regular(UserType.INTERNAL),
+                ),
+                headers = mapOf(),
+                httpCode = 200
             )
         }
+
+        fun arrange() = this to UserSearchApiWrapperImpl(userSearchApi, memberDAO, SELF_USER_ID)
+    }
+
+    private companion object {
+        val SELF_USER_ID = UserId(value = "selfUserId", domain = "someDomain")
+        val SELF_TEAM_ID = TeamId(value = "selfTeamId")
+        val CONVERSATION_ID = ConversationId(value = "conversationId", domain = SELF_USER_ID.domain)
+        val SELF_CONTACT = contact(id = SELF_USER_ID.value)
+        val CONVERSATION_MEMBER = contact(id = "conversationMember")
+        val TEAMMATE = contact(id = "teammate")
+        val OTHER_TEAM_CONTACT = contact(id = "otherTeam", team = "otherTeamId")
+        val OTHER_DOMAIN_CONTACT = contact(id = "otherDomain", domain = "otherDomain")
+        val NO_TEAM_CONTACT = contact(id = "noTeam", team = null)
+        val SEARCH_CONTACTS = listOf(SELF_CONTACT, CONVERSATION_MEMBER, TEAMMATE, OTHER_TEAM_CONTACT, OTHER_DOMAIN_CONTACT, NO_TEAM_CONTACT)
+
+        fun contact(id: String, team: String? = SELF_TEAM_ID.value, domain: String = SELF_USER_ID.domain) = ContactDTO(
+            accentId = null,
+            handle = null,
+            name = "",
+            qualifiedID = UserIdDTO(value = id, domain = domain),
+            team = team
+        )
     }
 }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/search/SearchUsersByHandleUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/search/SearchUsersByHandleUseCaseTest.kt
@@ -19,6 +19,7 @@ package com.wire.kalium.logic.feature.search
 
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.StorageFailure
+import com.wire.kalium.common.functional.Either
 import com.wire.kalium.common.functional.right
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.TeamId
@@ -34,8 +35,6 @@ import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.logic.data.user.type.UserTypeInfo
-import com.wire.kalium.common.functional.Either
-import com.wire.kalium.logic.data.publicuser.ConversationMemberExcludedOptions
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
@@ -59,7 +58,7 @@ class SearchUsersByHandleUseCaseTest {
 
         val result = searchUseCase(
             searchHandle = "",
-            excludingConversation = null,
+            excludingMembersOfConversation = null,
             customDomain = null
         )
 
@@ -73,7 +72,7 @@ class SearchUsersByHandleUseCaseTest {
             actual = result.notConnected
         )
         verifySuspend(VerifyMode.not) {
-            arrangement.searchUserRepository.getKnownContacts(excludeConversation = null)
+            arrangement.searchUserRepository.getKnownContacts(searchUsersOptions = any())
         }
 
         verifySuspend(VerifyMode.not) {
@@ -90,7 +89,7 @@ class SearchUsersByHandleUseCaseTest {
 
         val result = searchUseCase(
             searchHandle = "",
-            excludingConversation = conversationId,
+            excludingMembersOfConversation = conversationId,
             customDomain = null
         )
 
@@ -105,7 +104,7 @@ class SearchUsersByHandleUseCaseTest {
         )
 
         verifySuspend(VerifyMode.not) {
-            arrangement.searchUserRepository.getKnownContacts(excludeConversation = any())
+            arrangement.searchUserRepository.getKnownContacts(searchUsersOptions = any())
         }
 
         verifySuspend(VerifyMode.not) {
@@ -128,7 +127,7 @@ class SearchUsersByHandleUseCaseTest {
 
         val result = searchUseCase(
             searchHandle = "searchQuery",
-            excludingConversation = null,
+            excludingMembersOfConversation = null,
             customDomain = null
         )
 
@@ -137,10 +136,7 @@ class SearchUsersByHandleUseCaseTest {
             actual = result.connected
         )
 
-        val expectedSearchUsersOptions = SearchUsersOptions(
-            conversationExcluded = ConversationMemberExcludedOptions.None,
-            selfUserIncluded = false
-        )
+        val expectedSearchUsersOptions = SearchUsersOptions.Default.copy(conversationMembersExcluded = null)
 
         verifySuspend(VerifyMode.exactly(1)) {
             arrangement.searchUserRepository.searchUserRemoteDirectory(
@@ -148,7 +144,7 @@ class SearchUsersByHandleUseCaseTest {
             )
         }
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.searchUserRepository.searchLocalByHandle(handle = "searchquery", excludeMembersOfConversation = null)
+            arrangement.searchUserRepository.searchLocalByHandle(handle = "searchquery", searchUsersOptions = expectedSearchUsersOptions)
         }
     }
 
@@ -166,7 +162,7 @@ class SearchUsersByHandleUseCaseTest {
 
         val result = searchUseCase(
             searchHandle = "searchQuery",
-            excludingConversation = conversationId,
+            excludingMembersOfConversation = conversationId,
             customDomain = null
         )
 
@@ -175,10 +171,7 @@ class SearchUsersByHandleUseCaseTest {
             actual = result.connected
         )
 
-        val expectedSearchUsersOptions = SearchUsersOptions(
-            conversationExcluded = ConversationMemberExcludedOptions.ConversationExcluded(conversationId),
-            selfUserIncluded = false
-        )
+        val expectedSearchUsersOptions = SearchUsersOptions.Default.copy(conversationMembersExcluded = conversationId)
 
         verifySuspend(VerifyMode.exactly(1)) {
             arrangement.searchUserRepository.searchUserRemoteDirectory(
@@ -186,12 +179,12 @@ class SearchUsersByHandleUseCaseTest {
             )
         }
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.searchUserRepository.searchLocalByHandle(handle = "searchquery", excludeMembersOfConversation = conversationId)
+            arrangement.searchUserRepository.searchLocalByHandle(handle = "searchquery", searchUsersOptions = expectedSearchUsersOptions)
         }
     }
 
     @Test
-    fun givenEmptySearchQueryAndNoExcludedNotConnected_whenInvokingSearch_thenReturnEmptySearchResult() = runTest {
+    fun givenEmptySearchQueryAndSearchForAllTeamsAndDomains_whenInvokingSearch_thenReturnEmptySearchResult() = runTest {
         val (arrangement, searchUseCase) = Arrangement().arrange {
             withGetKnownContacts(
                 result = emptyList<UserSearchDetails>().right(),
@@ -200,8 +193,8 @@ class SearchUsersByHandleUseCaseTest {
 
         val result = searchUseCase(
             searchHandle = "",
-            excludingConversation = null,
-            skipRemoteSearch = false,
+            excludingMembersOfConversation = null,
+            onlySelfTeamAndDomain = false,
             customDomain = null
         )
 
@@ -214,25 +207,28 @@ class SearchUsersByHandleUseCaseTest {
             expected = emptyList<UserSearchDetails>(),
             actual = result.notConnected
         )
+
+        val expectedSearchUsersOptions = SearchUsersOptions.Default.copy(onlySelfTeamAndDomain = false)
+
         verifySuspend(VerifyMode.not) {
-            arrangement.searchUserRepository.getKnownContacts(excludeConversation = null)
+            arrangement.searchUserRepository.getKnownContacts(searchUsersOptions = expectedSearchUsersOptions)
         }
 
         verifySuspend(VerifyMode.not) {
             arrangement.searchUserRepository.searchUserRemoteDirectory(
-                searchQuery = any(), domain = any(), maxResultSize = any(), searchUsersOptions = any()
+                searchQuery = any(), domain = any(), maxResultSize = any(), searchUsersOptions = expectedSearchUsersOptions
             )
         }
     }
 
     @Test
-    fun givenEmptySearchQueryAndExcludedNotConnected_whenInvokingSearch_thenReturnEmptySearchResult() = runTest {
+    fun givenEmptySearchQueryAndSearchForOnlySelfTeamAndDomain_whenInvokingSearch_thenReturnEmptySearchResult() = runTest {
         val (arrangement, searchUseCase) = Arrangement().arrange { }
 
         val result = searchUseCase(
             searchHandle = "",
-            excludingConversation = null,
-            skipRemoteSearch = true,
+            excludingMembersOfConversation = null,
+            onlySelfTeamAndDomain = true,
             customDomain = null
         )
 
@@ -246,19 +242,21 @@ class SearchUsersByHandleUseCaseTest {
             actual = result.notConnected
         )
 
+        val expectedSearchUsersOptions = SearchUsersOptions.Default.copy(onlySelfTeamAndDomain = true)
+
         verifySuspend(VerifyMode.not) {
-            arrangement.searchUserRepository.getKnownContacts(excludeConversation = any())
+            arrangement.searchUserRepository.getKnownContacts(searchUsersOptions = expectedSearchUsersOptions)
         }
 
         verifySuspend(VerifyMode.not) {
             arrangement.searchUserRepository.searchUserRemoteDirectory(
-                searchQuery = any(), domain = any(), maxResultSize = any(), searchUsersOptions = any()
+                searchQuery = any(), domain = any(), maxResultSize = any(), searchUsersOptions = expectedSearchUsersOptions
             )
         }
     }
 
     @Test
-    fun givenNonEmptySearchQueryAndNotExcludedNotConnected_whenInvokingSearch_thenSearchRemoteAndLocal() = runTest {
+    fun givenNonEmptySearchQueryAndSearchForAllTeamsAndDomains_whenInvokingSearch_thenSearchForAllTeamsAndDomains() = runTest {
         val (arrangement, searchUseCase) = Arrangement().arrange {
             withSearchByHandle(
                 result = emptyList<UserSearchDetails>().right(),
@@ -270,8 +268,8 @@ class SearchUsersByHandleUseCaseTest {
 
         val result = searchUseCase(
             searchHandle = "searchQuery",
-            excludingConversation = null,
-            skipRemoteSearch = false,
+            excludingMembersOfConversation = null,
+            onlySelfTeamAndDomain = false,
             customDomain = null
         )
 
@@ -280,10 +278,7 @@ class SearchUsersByHandleUseCaseTest {
             actual = result.connected
         )
 
-        val expectedSearchUsersOptions = SearchUsersOptions(
-            conversationExcluded = ConversationMemberExcludedOptions.None,
-            selfUserIncluded = false
-        )
+        val expectedSearchUsersOptions = SearchUsersOptions.Default.copy(onlySelfTeamAndDomain = false)
 
         verifySuspend(VerifyMode.exactly(1)) {
             arrangement.searchUserRepository.searchUserRemoteDirectory(
@@ -291,12 +286,12 @@ class SearchUsersByHandleUseCaseTest {
             )
         }
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.searchUserRepository.searchLocalByHandle(handle = "searchquery", excludeMembersOfConversation = null)
+            arrangement.searchUserRepository.searchLocalByHandle(handle = "searchquery", searchUsersOptions = expectedSearchUsersOptions)
         }
     }
 
     @Test
-    fun givenNonEmptySearchQueryAndExcludedNotConnected_whenInvokingSearch_thenSearchLocalOnly() = runTest {
+    fun givenNonEmptySearchQueryAndSearchForOnlySelfTeamAndDomain_whenInvokingSearch_thenSearchForOnlySelfTeamAndDomain() = runTest {
         val (arrangement, searchUseCase) = Arrangement().arrange {
             withSearchByHandle(
                 result = emptyList<UserSearchDetails>().right(),
@@ -308,8 +303,8 @@ class SearchUsersByHandleUseCaseTest {
 
         val result = searchUseCase(
             searchHandle = "searchQuery",
-            excludingConversation = null,
-            skipRemoteSearch = true,
+            excludingMembersOfConversation = null,
+            onlySelfTeamAndDomain = true,
             customDomain = null
         )
 
@@ -318,13 +313,15 @@ class SearchUsersByHandleUseCaseTest {
             actual = result.connected
         )
 
+        val expectedSearchUsersOptions = SearchUsersOptions.Default.copy(onlySelfTeamAndDomain = true)
+
         verifySuspend(VerifyMode.exactly(0)) {
             arrangement.searchUserRepository.searchUserRemoteDirectory(
-                searchQuery = "searchquery", domain = any(), maxResultSize = any(), searchUsersOptions = any()
+                searchQuery = "searchquery", domain = any(), maxResultSize = any(), searchUsersOptions = expectedSearchUsersOptions
             )
         }
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.searchUserRepository.searchLocalByHandle(handle = "searchquery", excludeMembersOfConversation = null)
+            arrangement.searchUserRepository.searchLocalByHandle(handle = "searchquery", searchUsersOptions = expectedSearchUsersOptions)
         }
     }
 
@@ -334,7 +331,7 @@ class SearchUsersByHandleUseCaseTest {
             newOtherUser("remoteAndLocalUser1").copy(name = "updatedNewName"),
             newOtherUser("remoteUser2").copy(
                 teamId = TeamId("otherTeamId"),
-                connectionStatus = ConnectionState.SENT
+                connectionStatus = ConnectionState.PENDING
             ),
         )
 
@@ -349,7 +346,7 @@ class SearchUsersByHandleUseCaseTest {
                 newUserSearchDetails("localUser2")
             ),
             notConnected = listOf(
-                newUserSearchDetails("remoteUser2").copy(connectionStatus = ConnectionState.SENT),
+                newUserSearchDetails("remoteUser2").copy(connectionStatus = ConnectionState.PENDING),
             )
         )
 
@@ -366,7 +363,7 @@ class SearchUsersByHandleUseCaseTest {
 
         val result = searchUseCase(
             searchHandle = "searchQuery",
-            excludingConversation = null,
+            excludingMembersOfConversation = null,
             customDomain = null
         )
 
@@ -380,7 +377,7 @@ class SearchUsersByHandleUseCaseTest {
             )
         }
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.searchUserRepository.searchLocalByHandle(handle = "searchquery", excludeMembersOfConversation = any())
+            arrangement.searchUserRepository.searchLocalByHandle(handle = "searchquery", searchUsersOptions = any())
         }
     }
 
@@ -401,7 +398,7 @@ class SearchUsersByHandleUseCaseTest {
 
         val result = searchUseCase(
             searchHandle = searchQuery,
-            excludingConversation = null,
+            excludingMembersOfConversation = null,
             customDomain = null
         )
 
@@ -415,7 +412,7 @@ class SearchUsersByHandleUseCaseTest {
             )
         }
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.searchUserRepository.searchLocalByHandle(handle = cleanQuery, excludeMembersOfConversation = any())
+            arrangement.searchUserRepository.searchLocalByHandle(handle = cleanQuery, searchUsersOptions = any())
         }
     }
 
@@ -483,7 +480,7 @@ class SearchUsersByHandleUseCaseTest {
         }
 
         fun withGetKnownContacts(result: Either<StorageFailure, List<UserSearchDetails>>) {
-            everySuspend { searchUserRepository.getKnownContacts(excludeConversation = any()) } returns result
+            everySuspend { searchUserRepository.getKnownContacts(searchUsersOptions = any()) } returns result
         }
 
         fun withSearchByHandle(
@@ -491,7 +488,7 @@ class SearchUsersByHandleUseCaseTest {
             searchQuery: String? = null
         ) {
             everySuspend {
-                searchUserRepository.searchLocalByHandle(handle = searchQuery ?: any(), excludeMembersOfConversation = any())
+                searchUserRepository.searchLocalByHandle(handle = searchQuery ?: any(), searchUsersOptions = any())
             } returns result
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/search/SearchUsersByHandleUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/search/SearchUsersByHandleUseCaseTest.kt
@@ -315,7 +315,7 @@ class SearchUsersByHandleUseCaseTest {
 
         val expectedSearchUsersOptions = SearchUsersOptions.Default.copy(onlySelfTeamAndDomain = true)
 
-        verifySuspend(VerifyMode.exactly(0)) {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.searchUserRepository.searchUserRemoteDirectory(
                 searchQuery = "searchquery", domain = any(), maxResultSize = any(), searchUsersOptions = expectedSearchUsersOptions
             )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/search/SearchUsersByNameUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/search/SearchUsersByNameUseCaseTest.kt
@@ -17,9 +17,11 @@
  */
 package com.wire.kalium.logic.feature.search
 
+import com.wire.kalium.common.functional.right
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.publicuser.SearchUserRepository
+import com.wire.kalium.logic.data.publicuser.SearchUsersOptions
 import com.wire.kalium.logic.data.publicuser.model.UserSearchDetails
 import com.wire.kalium.logic.data.publicuser.model.UserSearchResult
 import com.wire.kalium.logic.data.user.ConnectionState
@@ -29,9 +31,6 @@ import com.wire.kalium.logic.data.user.UserAssetId
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
-import com.wire.kalium.common.functional.right
-import com.wire.kalium.logic.data.publicuser.ConversationMemberExcludedOptions
-import com.wire.kalium.logic.data.publicuser.SearchUsersOptions
 import com.wire.kalium.logic.data.user.type.UserTypeInfo
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
@@ -60,12 +59,14 @@ class SearchUsersByNameUseCaseTest {
             customDomain = null
         )
 
+
+        val expectedSearchUsersOptions = SearchUsersOptions.Default.copy(conversationMembersExcluded = null)
         assertEquals(
             expected = emptyList(),
             actual = result.connected
         )
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.searchUserRepository.getKnownContacts(excludeConversation = null)
+            arrangement.searchUserRepository.getKnownContacts(searchUsersOptions = expectedSearchUsersOptions)
         }
     }
 
@@ -85,12 +86,13 @@ class SearchUsersByNameUseCaseTest {
             customDomain = null
         )
 
+        val expectedSearchUsersOptions = SearchUsersOptions.Default.copy(conversationMembersExcluded = conversationId)
         assertEquals(
             expected = emptyList(),
             actual = result.connected
         )
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.searchUserRepository.getKnownContacts(excludeConversation = conversationId)
+            arrangement.searchUserRepository.getKnownContacts(searchUsersOptions = expectedSearchUsersOptions)
         }
     }
 
@@ -116,10 +118,7 @@ class SearchUsersByNameUseCaseTest {
             actual = result.connected
         )
 
-        val expectedSearchUsersOptions = SearchUsersOptions(
-            conversationExcluded = ConversationMemberExcludedOptions.None,
-            selfUserIncluded = false
-        )
+        val expectedSearchUsersOptions = SearchUsersOptions(conversationMembersExcluded = null)
 
         verifySuspend(VerifyMode.exactly(1)) {
             arrangement.searchUserRepository.searchUserRemoteDirectory(
@@ -127,7 +126,7 @@ class SearchUsersByNameUseCaseTest {
             )
         }
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.searchUserRepository.searchLocalByName(name = "searchquery", excludeMembersOfConversation = null)
+            arrangement.searchUserRepository.searchLocalByName(name = "searchquery", searchUsersOptions = expectedSearchUsersOptions)
         }
     }
 
@@ -154,10 +153,7 @@ class SearchUsersByNameUseCaseTest {
             actual = result.connected
         )
 
-        val expectedSearchUsersOptions = SearchUsersOptions(
-            conversationExcluded = ConversationMemberExcludedOptions.ConversationExcluded(conversationId),
-            selfUserIncluded = false
-        )
+        val expectedSearchUsersOptions = SearchUsersOptions(conversationMembersExcluded = conversationId)
 
         verifySuspend(VerifyMode.exactly(1)) {
             arrangement.searchUserRepository.searchUserRemoteDirectory(
@@ -165,12 +161,12 @@ class SearchUsersByNameUseCaseTest {
             )
         }
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.searchUserRepository.searchLocalByName(name = "searchquery", excludeMembersOfConversation = conversationId)
+            arrangement.searchUserRepository.searchLocalByName(name = "searchquery", searchUsersOptions = expectedSearchUsersOptions)
         }
     }
 
     @Test
-    fun givenEmptySearchQueryAndNoExcludedNotConnected_whenInvokingSearch_thenRespondWithAllKnownContacts() = runTest {
+    fun givenEmptySearchQueryAndSearchForAllTeamsAndDomains_whenInvokingSearch_thenRespondWithAllKnownContacts() = runTest {
         val (arrangement, searchUseCase) = Arrangement().arrange {
             withGetKnownContacts(
                 result = emptyList<UserSearchDetails>().right()
@@ -180,21 +176,22 @@ class SearchUsersByNameUseCaseTest {
         val result = searchUseCase(
             searchQuery = "",
             excludingMembersOfConversation = null,
-            skipRemoteSearch = false,
+            onlySelfTeamAndDomain = false,
             customDomain = null
         )
 
+        val expectedSearchUsersOptions = SearchUsersOptions.Default.copy(onlySelfTeamAndDomain = false)
         assertEquals(
             expected = emptyList(),
             actual = result.connected
         )
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.searchUserRepository.getKnownContacts(excludeConversation = null)
+            arrangement.searchUserRepository.getKnownContacts(searchUsersOptions = expectedSearchUsersOptions)
         }
     }
 
     @Test
-    fun givenEmptySearchQueryAndExcludedNotConnected_whenInvokingSearch_thenReturnAllKnownContacts() = runTest {
+    fun givenEmptySearchQueryAndSearchForOnlySelfTeamAndDomain_whenInvokingSearch_thenReturnOnlySelfTeamAndDomainContacts() = runTest {
         val (arrangement, searchUseCase) = Arrangement().arrange {
             withGetKnownContacts(
                 result = emptyList<UserSearchDetails>().right()
@@ -204,21 +201,22 @@ class SearchUsersByNameUseCaseTest {
         val result = searchUseCase(
             searchQuery = "",
             excludingMembersOfConversation = null,
-            skipRemoteSearch = true,
+            onlySelfTeamAndDomain = true,
             customDomain = null
         )
 
+        val expectedSearchUsersOptions = SearchUsersOptions.Default.copy(onlySelfTeamAndDomain = true)
         assertEquals(
             expected = emptyList(),
             actual = result.connected
         )
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.searchUserRepository.getKnownContacts(excludeConversation = null)
+            arrangement.searchUserRepository.getKnownContacts(searchUsersOptions = expectedSearchUsersOptions)
         }
     }
 
     @Test
-    fun givenNonEmptySearchQueryAndNoExcludedNotConnected_whenInvokingSearch_thenSearchRemoteAndLocal() = runTest {
+    fun givenNonEmptySearchQueryAndSearchForAllTeamsAndDomains_whenInvokingSearch_thenSearchForAllTeamsAndDomains() = runTest {
         val (arrangement, searchUseCase) = Arrangement().arrange {
             withSearchLocalByName(
                 result = emptyList<UserSearchDetails>().right(),
@@ -231,7 +229,7 @@ class SearchUsersByNameUseCaseTest {
         val result = searchUseCase(
             searchQuery = "searchQuery",
             excludingMembersOfConversation = null,
-            skipRemoteSearch = false,
+            onlySelfTeamAndDomain = false,
             customDomain = null
         )
 
@@ -240,10 +238,7 @@ class SearchUsersByNameUseCaseTest {
             actual = result.connected
         )
 
-        val expectedSearchUsersOptions = SearchUsersOptions(
-            conversationExcluded = ConversationMemberExcludedOptions.None,
-            selfUserIncluded = false
-        )
+        val expectedSearchUsersOptions = SearchUsersOptions.Default.copy(onlySelfTeamAndDomain = false)
 
         verifySuspend(VerifyMode.exactly(1)) {
             arrangement.searchUserRepository.searchUserRemoteDirectory(
@@ -251,12 +246,12 @@ class SearchUsersByNameUseCaseTest {
             )
         }
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.searchUserRepository.searchLocalByName(name = "searchquery", excludeMembersOfConversation = null)
+            arrangement.searchUserRepository.searchLocalByName(name = "searchquery", searchUsersOptions = expectedSearchUsersOptions)
         }
     }
 
     @Test
-    fun givenNonEmptySearchQueryAndExcludedNotConnected_whenInvokingSearch_thenSearchLocalOnly() = runTest {
+    fun givenNonEmptySearchQueryAndSearchForOnlySelfTeamAndDomain_whenInvokingSearch_thenSearchForOnlySelfTeamAndDomain() = runTest {
         val (arrangement, searchUseCase) = Arrangement().arrange {
             withSearchLocalByName(
                 result = emptyList<UserSearchDetails>().right(),
@@ -269,7 +264,7 @@ class SearchUsersByNameUseCaseTest {
         val result = searchUseCase(
             searchQuery = "searchQuery",
             excludingMembersOfConversation = null,
-            skipRemoteSearch = true,
+            onlySelfTeamAndDomain = true,
             customDomain = null
         )
 
@@ -277,14 +272,16 @@ class SearchUsersByNameUseCaseTest {
             expected = emptyList(),
             actual = result.connected
         )
+
+        val expectedSearchUsersOptions = SearchUsersOptions.Default.copy(onlySelfTeamAndDomain = true)
 
         verifySuspend(VerifyMode.exactly(0)) {
             arrangement.searchUserRepository.searchUserRemoteDirectory(
-                searchQuery = "searchquery", domain = any(), maxResultSize = any(), searchUsersOptions = any()
+                searchQuery = "searchquery", domain = any(), maxResultSize = any(), searchUsersOptions = expectedSearchUsersOptions
             )
         }
         verifySuspend(VerifyMode.exactly(1)) {
-            arrangement.searchUserRepository.searchLocalByName(name = "searchquery", excludeMembersOfConversation = null)
+            arrangement.searchUserRepository.searchLocalByName(name = "searchquery", searchUsersOptions = expectedSearchUsersOptions)
         }
     }
 
@@ -295,7 +292,7 @@ class SearchUsersByNameUseCaseTest {
             newOtherUser("remoteAndLocalUser1").copy(name = "updatedNewName"),
             newOtherUser("remoteUser2").copy(
                 teamId = TeamId("otherTeamId"),
-                connectionStatus = ConnectionState.SENT
+                connectionStatus = ConnectionState.PENDING
             ),
         )
 
@@ -310,7 +307,7 @@ class SearchUsersByNameUseCaseTest {
                 newUserSearchDetails("localUser2")
             ),
             notConnected = listOf(
-                newUserSearchDetails("remoteUser2").copy(connectionStatus = ConnectionState.SENT),
+                newUserSearchDetails("remoteUser2").copy(connectionStatus = ConnectionState.PENDING),
             )
         )
 
@@ -425,7 +422,7 @@ class SearchUsersByNameUseCaseTest {
         }.run { this to searchUseCase }
 
         fun withGetKnownContacts(result: com.wire.kalium.common.functional.Either<com.wire.kalium.common.error.StorageFailure, List<UserSearchDetails>>) {
-            everySuspend { searchUserRepository.getKnownContacts(excludeConversation = any()) } returns result
+            everySuspend { searchUserRepository.getKnownContacts(searchUsersOptions = any()) } returns result
         }
 
         fun withSearchUserRemoteDirectory(
@@ -447,7 +444,7 @@ class SearchUsersByNameUseCaseTest {
             searchQuery: String? = null
         ) {
             everySuspend {
-                searchUserRepository.searchLocalByName(name = searchQuery ?: any(), excludeMembersOfConversation = any())
+                searchUserRepository.searchLocalByName(name = searchQuery ?: any(), searchUsersOptions = any())
             } returns result
         }
     }

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/search/SearchUsersByNameUseCaseTest.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/feature/search/SearchUsersByNameUseCaseTest.kt
@@ -275,7 +275,7 @@ class SearchUsersByNameUseCaseTest {
 
         val expectedSearchUsersOptions = SearchUsersOptions.Default.copy(onlySelfTeamAndDomain = true)
 
-        verifySuspend(VerifyMode.exactly(0)) {
+        verifySuspend(VerifyMode.exactly(1)) {
             arrangement.searchUserRepository.searchUserRemoteDirectory(
                 searchQuery = "searchquery", domain = any(), maxResultSize = any(), searchUsersOptions = expectedSearchUsersOptions
             )

--- a/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/dao/SearchDAOArrangement.kt
+++ b/logic/src/commonTest/kotlin/com/wire/kalium/logic/util/arrangement/dao/SearchDAOArrangement.kt
@@ -32,34 +32,26 @@ internal interface SearchDAOArrangement {
     val appDAO: AppDAO
 
     suspend fun withGetKnownContacts(
-        result: List<UserSearchEntity>
+        result: List<UserSearchEntity>,
+        excludeConversationId: (ConversationIDEntity?) -> Boolean = { true },
+        onlyTeamId: (String?) -> Boolean = { true },
+        onlyDomain: (String?) -> Boolean = { true }
     )
 
-    suspend fun withGetKnownContactsExcludingAConversation(
+    suspend fun withSearchByName(
         result: List<UserSearchEntity>,
-        conversationId: (ConversationIDEntity) -> Boolean = { true }
-    )
-
-    suspend fun withSearchList(
-        result: List<UserSearchEntity>,
-        query: (String) -> Boolean = { true }
-    )
-
-    suspend fun withSearchListExcludingAConversation(
-        result: List<UserSearchEntity>,
-        conversationId: (ConversationIDEntity) -> Boolean = { true },
-        query: (String) -> Boolean = { true }
+        query: (String) -> Boolean = { true },
+        excludeConversationId: (ConversationIDEntity?) -> Boolean = { true },
+        onlyTeamId: (String?) -> Boolean = { true },
+        onlyDomain: (String?) -> Boolean = { true }
     )
 
     suspend fun withSearchByHandle(
         result: List<UserSearchEntity>,
-        handle: (String) -> Boolean = { true }
-    )
-
-    suspend fun withSearchByHandleExcludingConversation(
-        result: List<UserSearchEntity>,
-        conversationId: (ConversationIDEntity) -> Boolean = { true },
-        handle: (String) -> Boolean = { true }
+        handle: (String) -> Boolean = { true },
+        excludeConversationId: (ConversationIDEntity?) -> Boolean = { true },
+        onlyTeamId: (String?) -> Boolean = { true },
+        onlyDomain: (String?) -> Boolean = { true }
     )
 }
 
@@ -69,58 +61,50 @@ internal class SearchDAOArrangementImpl : SearchDAOArrangement {
     override val appDAO: AppDAO = mock(mode = MockMode.autoUnit)
 
     override suspend fun withGetKnownContacts(
-        result: List<UserSearchEntity>
-    ) {
-        everySuspend {
-            searchDAO.getKnownContacts()
-        } returns result
-    }
-
-    override suspend fun withGetKnownContactsExcludingAConversation(
         result: List<UserSearchEntity>,
-        conversationId: (ConversationIDEntity) -> Boolean
+        excludeConversationId: (ConversationIDEntity?) -> Boolean,
+        onlyTeamId: (String?) -> Boolean,
+        onlyDomain: (String?) -> Boolean
     ) {
         everySuspend {
-            searchDAO.getKnownContactsExcludingAConversation(matches { conversationId(it) })
-        } returns result
-    }
-
-    override suspend fun withSearchList(result: List<UserSearchEntity>, query: (String) -> Boolean) {
-        everySuspend {
-            searchDAO.searchList(matches { query(it) })
-        } returns result
-    }
-
-    override suspend fun withSearchListExcludingAConversation(
-        result: List<UserSearchEntity>,
-        conversationId: (ConversationIDEntity) -> Boolean,
-        query: (String) -> Boolean
-    ) {
-        everySuspend {
-            searchDAO.searchListExcludingAConversation(
-                matches { conversationId(it) },
-                matches { query(it) }
+            searchDAO.getKnownContacts(
+                excludeConversationId = matches { excludeConversationId(it) },
+                onlyTeamId = matches { onlyTeamId(it) },
+                onlyDomain = matches { onlyDomain(it) }
             )
         } returns result
     }
 
-    override suspend fun withSearchByHandle(result: List<UserSearchEntity>, handle: (String) -> Boolean) {
+    override suspend fun withSearchByName(
+        result: List<UserSearchEntity>,
+        query: (String) -> Boolean,
+        excludeConversationId: (ConversationIDEntity?) -> Boolean,
+        onlyTeamId: (String?) -> Boolean,
+        onlyDomain: (String?) -> Boolean
+    ) {
         everySuspend {
-            searchDAO.handleSearch(
-                matches { handle(it) }
+            searchDAO.searchByName(
+                searchQuery = matches { query(it) },
+                excludeConversationId = matches { excludeConversationId(it) },
+                onlyTeamId = matches { onlyTeamId(it) },
+                onlyDomain = matches { onlyDomain(it) }
             )
         } returns result
     }
 
-    override suspend fun withSearchByHandleExcludingConversation(
+    override suspend fun withSearchByHandle(
         result: List<UserSearchEntity>,
-        conversationId: (ConversationIDEntity) -> Boolean,
-        handle: (String) -> Boolean
+        handle: (String) -> Boolean,
+        excludeConversationId: (ConversationIDEntity?) -> Boolean,
+        onlyTeamId: (String?) -> Boolean,
+        onlyDomain: (String?) -> Boolean
     ) {
         everySuspend {
-            searchDAO.handleSearchExcludingAConversation(
-                matches { handle(it) },
-                matches { conversationId(it) }
+            searchDAO.searchByHandle(
+                searchQuery = matches { handle(it) },
+                excludeConversationId = matches { excludeConversationId(it) },
+                onlyTeamId = matches { onlyTeamId(it) },
+                onlyDomain = matches { onlyDomain(it) }
             )
         } returns result
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-28245
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Currently, Wire Meetings should allow adding only people from same team and same domain to the meeting, instead of all contacts. In this PR, the flag allowing to filter only locally known contacts is replaced with a flag allowing to return only people from the same team and domain.
Search queries are merged for simplicity - the ones with "ExcludingAConversation" and without are grouped into single query without any loss of performance, simply it doesn't filter out conversation members if this parameter is null. Also added filtering for the team and domain. Also remote search is filtered by team and domain if needed, according to the [docs](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/157254411/Use+case+search+users#Backend-interaction).

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Create a meeting and try to add some participants - there should be no guests nor federated, only team members.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
