### PR TITLE
feat: api 18 support for adminless groups (WPB-28560)

### DIFF
--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/BackendMetaDataUtil.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/BackendMetaDataUtil.kt
@@ -27,7 +27,7 @@ val SupportedApiVersions: Set<Int> = setOf(0, 1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12
 
 // They are not truly constants as set is not a primitive type, yet are treated as one in this context
 @Suppress("MagicNumber")
-val DevelopmentApiVersions: Set<Int> = setOf(16, 17)
+val DevelopmentApiVersions: Set<Int> = setOf(16, 17, 18)
 
 // You can use scripts/generate_new_api_version.sh or gradle task network:generateNewApiVersion to
 // bump API version and generate all needed classes

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationApi.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/base/authenticated/conversation/ConversationApi.kt
@@ -77,6 +77,16 @@ interface ConversationApi : BaseApi {
         createConversationRequest: CreateConversationRequest
     ): NetworkResponse<ConversationResponse>
 
+    /**
+     * Replaces direct membership, retaining members associated through user groups.
+     * The requested role applies only to newly added members; existing roles are preserved.
+     * Available in Kalium from API v18.
+     */
+    suspend fun replaceMembers(
+        conversationId: ConversationId,
+        request: AddConversationMembersRequest
+    ): NetworkResponse<Unit> = getApiNotSupportedError("replaceMembers", MIN_API_VERSION_REPLACE_MEMBERS)
+
     suspend fun addMember(
         addParticipantRequest: AddConversationMembersRequest,
         conversationId: ConversationId
@@ -196,6 +206,8 @@ interface ConversationApi : BaseApi {
     ): NetworkResponse<Unit>
 
     companion object {
+        const val MIN_API_VERSION_REPLACE_MEMBERS = 18
+
         fun getApiNotSupportError(apiName: String, apiVersion: String = "4") = NetworkResponse.Error(
             APINotSupported("${this::class.simpleName}: $apiName api is only available on API V$apiVersion")
         )

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/AccessTokenApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/AccessTokenApiV18.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v18.authenticated
+
+import com.wire.kalium.network.api.v17.authenticated.AccessTokenApiV17
+import io.ktor.client.HttpClient
+
+internal open class AccessTokenApiV18 internal constructor(
+    httpClient: HttpClient
+) : AccessTokenApiV17(httpClient)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/AssetApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/AssetApiV18.kt
@@ -1,0 +1,28 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v18.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.model.UserId
+import com.wire.kalium.network.api.v17.authenticated.AssetApiV17
+
+internal open class AssetApiV18 internal constructor(
+    authenticatedNetworkClient: AuthenticatedNetworkClient,
+    selfUserId: UserId,
+) : AssetApiV17(authenticatedNetworkClient, selfUserId)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/CallApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/CallApiV18.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v18.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.v17.authenticated.CallApiV17
+
+internal open class CallApiV18 internal constructor(
+    authenticatedNetworkClient: AuthenticatedNetworkClient
+) : CallApiV17(authenticatedNetworkClient)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/ClientApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/ClientApiV18.kt
@@ -1,0 +1,25 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v18.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.v17.authenticated.ClientApiV17
+
+internal open class ClientApiV18 internal constructor(authenticatedNetworkClient: AuthenticatedNetworkClient) :
+    ClientApiV17(authenticatedNetworkClient)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/ConnectionApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/ConnectionApiV18.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v18.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.v17.authenticated.ConnectionApiV17
+
+internal open class ConnectionApiV18 internal constructor(
+    authenticatedNetworkClient: AuthenticatedNetworkClient
+) : ConnectionApiV17(authenticatedNetworkClient)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/ConversationApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/ConversationApiV18.kt
@@ -1,0 +1,56 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v18.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.authenticated.conversation.AddConversationMembersRequest
+import com.wire.kalium.network.api.model.AdminlessConversationErrorResponse
+import com.wire.kalium.network.api.model.ConversationId
+import com.wire.kalium.network.api.v17.authenticated.ConversationApiV17
+import com.wire.kalium.network.exceptions.AdminlessConversationError
+import com.wire.kalium.network.utils.NetworkResponse
+import com.wire.kalium.network.utils.wrapRequest
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.http.HttpStatusCode
+
+internal open class ConversationApiV18 internal constructor(
+    authenticatedNetworkClient: AuthenticatedNetworkClient
+) : ConversationApiV17(authenticatedNetworkClient) {
+
+    override suspend fun replaceMembers(
+        conversationId: ConversationId,
+        request: AddConversationMembersRequest
+    ): NetworkResponse<Unit> = wrapRequest(
+        customErrorInterceptor = { responseData ->
+            val error = runCatching {
+                responseData.parseBody<AdminlessConversationErrorResponse>()
+            }.getOrNull()
+            if (responseData.status == HttpStatusCode.Forbidden && error?.label == AdminlessConversationErrorResponse.LABEL) {
+                NetworkResponse.Error(AdminlessConversationError(error))
+            } else {
+                null
+            }
+        }
+    ) {
+        httpClient.put("$PATH_CONVERSATIONS/${conversationId.domain}/${conversationId.value}/$PATH_MEMBERS") {
+            setBody(request)
+        }
+    }
+}

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/ConversationHistoryApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/ConversationHistoryApiV18.kt
@@ -1,0 +1,25 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v18.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.v17.authenticated.ConversationHistoryApiV17
+
+internal open class ConversationHistoryApiV18 internal constructor(networkClient: AuthenticatedNetworkClient) :
+    ConversationHistoryApiV17(networkClient)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/E2EIApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/E2EIApiV18.kt
@@ -1,0 +1,25 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.v18.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.v17.authenticated.E2EIApiV17
+
+internal open class E2EIApiV18 internal constructor(
+    authenticatedNetworkClient: AuthenticatedNetworkClient
+) : E2EIApiV17(authenticatedNetworkClient)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/FeatureConfigApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/FeatureConfigApiV18.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v18.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.v17.authenticated.FeatureConfigApiV17
+
+internal open class FeatureConfigApiV18 internal constructor(
+    authenticatedNetworkClient: AuthenticatedNetworkClient
+) : FeatureConfigApiV17(authenticatedNetworkClient)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/KeyPackageApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/KeyPackageApiV18.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v18.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.v17.authenticated.KeyPackageApiV17
+
+internal open class KeyPackageApiV18 internal constructor(
+    authenticatedNetworkClient: AuthenticatedNetworkClient
+) : KeyPackageApiV17(authenticatedNetworkClient)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/LogoutApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/LogoutApiV18.kt
@@ -1,0 +1,28 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v18.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.v17.authenticated.LogoutApiV17
+import com.wire.kalium.network.session.SessionManager
+
+internal open class LogoutApiV18 internal constructor(
+    authenticatedNetworkClient: AuthenticatedNetworkClient,
+    sessionManager: SessionManager
+) : LogoutApiV17(authenticatedNetworkClient, sessionManager)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/MLSMessageApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/MLSMessageApiV18.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v18.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.v17.authenticated.MLSMessageApiV17
+
+internal open class MLSMessageApiV18 internal constructor(
+    authenticatedNetworkClient: AuthenticatedNetworkClient
+) : MLSMessageApiV17(authenticatedNetworkClient)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/MLSPublicKeyApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/MLSPublicKeyApiV18.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v18.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.v17.authenticated.MLSPublicKeyApiV17
+
+internal open class MLSPublicKeyApiV18 internal constructor(
+    authenticatedNetworkClient: AuthenticatedNetworkClient
+) : MLSPublicKeyApiV17(authenticatedNetworkClient)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/MeetingApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/MeetingApiV18.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v18.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.v17.authenticated.MeetingApiV17
+
+internal open class MeetingApiV18 internal constructor(
+    authenticatedNetworkClient: AuthenticatedNetworkClient
+) : MeetingApiV17(authenticatedNetworkClient)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/MessageApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/MessageApiV18.kt
@@ -1,0 +1,28 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v18.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.base.authenticated.message.EnvelopeProtoMapper
+import com.wire.kalium.network.api.v17.authenticated.MessageApiV17
+
+internal open class MessageApiV18 internal constructor(
+    authenticatedNetworkClient: AuthenticatedNetworkClient,
+    envelopeProtoMapper: EnvelopeProtoMapper
+) : MessageApiV17(authenticatedNetworkClient, envelopeProtoMapper)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/NotificationApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/NotificationApiV18.kt
@@ -1,0 +1,30 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v18.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.AuthenticatedWebSocketClient
+import com.wire.kalium.network.api.unbound.configuration.ServerConfigDTO
+import com.wire.kalium.network.api.v17.authenticated.NotificationApiV17
+
+internal open class NotificationApiV18 internal constructor(
+    authenticatedNetworkClient: AuthenticatedNetworkClient,
+    authenticatedWebSocketClient: AuthenticatedWebSocketClient,
+    serverLinks: ServerConfigDTO.Links
+) : NotificationApiV17(authenticatedNetworkClient, authenticatedWebSocketClient, serverLinks)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/PreKeyApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/PreKeyApiV18.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v18.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.v17.authenticated.PreKeyApiV17
+
+internal open class PreKeyApiV18 internal constructor(
+    authenticatedNetworkClient: AuthenticatedNetworkClient
+) : PreKeyApiV17(authenticatedNetworkClient)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/PropertiesApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/PropertiesApiV18.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v18.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.v17.authenticated.PropertiesApiV17
+
+internal open class PropertiesApiV18 internal constructor(
+    authenticatedNetworkClient: AuthenticatedNetworkClient
+) : PropertiesApiV17(authenticatedNetworkClient)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/SelfApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/SelfApiV18.kt
@@ -1,0 +1,28 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v18.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.v17.authenticated.SelfApiV17
+import com.wire.kalium.network.session.SessionManager
+
+internal open class SelfApiV18 internal constructor(
+    authenticatedNetworkClient: AuthenticatedNetworkClient,
+    sessionManager: SessionManager
+) : SelfApiV17(authenticatedNetworkClient, sessionManager)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/ServerTimeApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/ServerTimeApiV18.kt
@@ -1,0 +1,24 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.v18.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.v17.authenticated.ServerTimeApiV17
+
+internal open class ServerTimeApiV18(authenticatedNetworkClient: AuthenticatedNetworkClient) :
+    ServerTimeApiV17(authenticatedNetworkClient)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/TeamsApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/TeamsApiV18.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v18.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.v17.authenticated.TeamsApiV17
+
+internal open class TeamsApiV18 internal constructor(
+    authenticatedNetworkClient: AuthenticatedNetworkClient
+) : TeamsApiV17(authenticatedNetworkClient)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/UpgradePersonalToTeamApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/UpgradePersonalToTeamApiV18.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v18.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.v17.authenticated.UpgradePersonalToTeamApiV17
+
+internal open class UpgradePersonalToTeamApiV18 internal constructor(
+    authenticatedNetworkClient: AuthenticatedNetworkClient,
+) : UpgradePersonalToTeamApiV17(authenticatedNetworkClient)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/UserDetailsApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/UserDetailsApiV18.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v18.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.v17.authenticated.UserDetailsApiV17
+
+internal open class UserDetailsApiV18 internal constructor(
+    authenticatedNetworkClient: AuthenticatedNetworkClient
+) : UserDetailsApiV17(authenticatedNetworkClient)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/UserSearchApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/UserSearchApiV18.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v18.authenticated
+
+import com.wire.kalium.network.AuthenticatedNetworkClient
+import com.wire.kalium.network.api.v17.authenticated.UserSearchApiV17
+
+internal open class UserSearchApiV18 internal constructor(
+    authenticatedNetworkClient: AuthenticatedNetworkClient
+) : UserSearchApiV17(authenticatedNetworkClient)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/networkContainer/AuthenticatedNetworkContainerV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/authenticated/networkContainer/AuthenticatedNetworkContainerV18.kt
@@ -1,0 +1,181 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v18.authenticated.networkContainer
+
+import com.wire.kalium.logger.KaliumLogger
+import com.wire.kalium.network.api.base.authenticated.AccessTokenApi
+import com.wire.kalium.network.api.base.authenticated.CallApi
+import com.wire.kalium.network.api.base.authenticated.ServerTimeApi
+import com.wire.kalium.network.api.base.authenticated.TeamsApi
+import com.wire.kalium.network.api.base.authenticated.UpgradePersonalToTeamApi
+import com.wire.kalium.network.api.base.authenticated.WildCardApi
+import com.wire.kalium.network.api.base.authenticated.asset.AssetApi
+import com.wire.kalium.network.api.base.authenticated.client.ClientApi
+import com.wire.kalium.network.api.base.authenticated.connection.ConnectionApi
+import com.wire.kalium.network.api.base.authenticated.conversation.ConversationApi
+import com.wire.kalium.network.api.base.authenticated.conversation.history.ConversationHistoryApi
+import com.wire.kalium.network.api.base.authenticated.e2ei.E2EIApi
+import com.wire.kalium.network.api.base.authenticated.featureConfigs.FeatureConfigApi
+import com.wire.kalium.network.api.base.authenticated.keypackage.KeyPackageApi
+import com.wire.kalium.network.api.base.authenticated.logout.LogoutApi
+import com.wire.kalium.network.api.base.authenticated.meeting.MeetingApi
+import com.wire.kalium.network.api.base.authenticated.message.EnvelopeProtoMapperImpl
+import com.wire.kalium.network.api.base.authenticated.message.MLSMessageApi
+import com.wire.kalium.network.api.base.authenticated.message.MessageApi
+import com.wire.kalium.network.api.base.authenticated.nomaddevice.NomadDeviceSyncApi
+import com.wire.kalium.network.api.base.authenticated.notification.NotificationApi
+import com.wire.kalium.network.api.base.authenticated.prekey.PreKeyApi
+import com.wire.kalium.network.api.base.authenticated.properties.PropertiesApi
+import com.wire.kalium.network.api.base.authenticated.search.UserSearchApi
+import com.wire.kalium.network.api.base.authenticated.self.SelfApi
+import com.wire.kalium.network.api.base.authenticated.serverpublickey.MLSPublicKeyApi
+import com.wire.kalium.network.api.base.authenticated.userDetails.UserDetailsApi
+import com.wire.kalium.network.api.model.UserId
+import com.wire.kalium.network.api.v18.authenticated.AccessTokenApiV18
+import com.wire.kalium.network.api.v18.authenticated.AssetApiV18
+import com.wire.kalium.network.api.v18.authenticated.CallApiV18
+import com.wire.kalium.network.api.v18.authenticated.ClientApiV18
+import com.wire.kalium.network.api.v18.authenticated.ConnectionApiV18
+import com.wire.kalium.network.api.v18.authenticated.ConversationApiV18
+import com.wire.kalium.network.api.v18.authenticated.ConversationHistoryApiV18
+import com.wire.kalium.network.api.v18.authenticated.E2EIApiV18
+import com.wire.kalium.network.api.v18.authenticated.FeatureConfigApiV18
+import com.wire.kalium.network.api.v18.authenticated.KeyPackageApiV18
+import com.wire.kalium.network.api.v18.authenticated.LogoutApiV18
+import com.wire.kalium.network.api.v18.authenticated.MLSMessageApiV18
+import com.wire.kalium.network.api.v18.authenticated.MLSPublicKeyApiV18
+import com.wire.kalium.network.api.v18.authenticated.MessageApiV18
+import com.wire.kalium.network.api.v0.authenticated.NomadDeviceSyncApiV0
+import com.wire.kalium.network.api.v18.authenticated.MeetingApiV18
+import com.wire.kalium.network.api.v18.authenticated.NotificationApiV18
+import com.wire.kalium.network.api.v18.authenticated.PreKeyApiV18
+import com.wire.kalium.network.api.v18.authenticated.PropertiesApiV18
+import com.wire.kalium.network.api.v18.authenticated.SelfApiV18
+import com.wire.kalium.network.api.v18.authenticated.ServerTimeApiV18
+import com.wire.kalium.network.api.v18.authenticated.TeamsApiV18
+import com.wire.kalium.network.api.v18.authenticated.UpgradePersonalToTeamApiV18
+import com.wire.kalium.network.api.v18.authenticated.UserDetailsApiV18
+import com.wire.kalium.network.api.v18.authenticated.UserSearchApiV18
+import com.wire.kalium.network.api.vcommon.WildCardApiImpl
+import com.wire.kalium.network.defaultHttpEngine
+import com.wire.kalium.network.networkContainer.AuthenticatedHttpClientProvider
+import com.wire.kalium.network.networkContainer.AuthenticatedHttpClientProviderImpl
+import com.wire.kalium.network.networkContainer.AuthenticatedNetworkContainer
+import com.wire.kalium.network.session.CertificatePinning
+import com.wire.kalium.network.session.SessionManager
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.websocket.WebSocketSession
+
+@Suppress("LongParameterList")
+internal class AuthenticatedNetworkContainerV18 internal constructor(
+    private val sessionManager: SessionManager,
+    nomadServiceUrl: String? = null,
+    private val selfUserId: UserId,
+    certificatePinning: CertificatePinning,
+    mockEngine: HttpClientEngine?,
+    mockWebSocketSession: WebSocketSession?,
+    kaliumLogger: KaliumLogger,
+    engine: HttpClientEngine = mockEngine ?: defaultHttpEngine(
+        serverConfigDTOApiProxy = sessionManager.serverConfig().links.apiProxy,
+        proxyCredentials = sessionManager.proxyCredentials(),
+        certificatePinning = certificatePinning
+    )
+) : AuthenticatedNetworkContainer,
+    AuthenticatedHttpClientProvider by AuthenticatedHttpClientProviderImpl(
+        sessionManager = sessionManager,
+        nomadServiceUrl = nomadServiceUrl,
+        accessTokenApi = { httpClient -> AccessTokenApiV18(httpClient) },
+        engine = engine,
+        kaliumLogger = kaliumLogger,
+        webSocketSessionProvider = if (mockWebSocketSession != null) {
+            { _, _ -> mockWebSocketSession }
+        } else {
+            null
+        }
+    ) {
+
+    override val accessTokenApi: AccessTokenApi get() = AccessTokenApiV18(networkClient.httpClient)
+
+    override val logoutApi: LogoutApi get() = LogoutApiV18(networkClient, sessionManager)
+
+    override val clientApi: ClientApi get() = ClientApiV18(networkClient)
+
+    override val messageApi: MessageApi
+        get() = MessageApiV18(
+            networkClient,
+            EnvelopeProtoMapperImpl()
+        )
+    override val nomadDeviceSyncApi: NomadDeviceSyncApi get() = NomadDeviceSyncApiV0(networkClient, nomadServiceUrl)
+
+    override val mlsMessageApi: MLSMessageApi get() = MLSMessageApiV18(networkClient)
+
+    override val e2eiApi: E2EIApi get() = E2EIApiV18(networkClient)
+
+    override val conversationApi: ConversationApi get() = ConversationApiV18(networkClient)
+
+    override val keyPackageApi: KeyPackageApi get() = KeyPackageApiV18(networkClient)
+
+    override val preKeyApi: PreKeyApi get() = PreKeyApiV18(networkClient)
+
+    override val assetApi: AssetApi get() = AssetApiV18(networkClientWithoutCompression, selfUserId)
+
+    // It is important that this is lazy, since we need a single instance of the websocket client
+    override val notificationApi: NotificationApi by lazy {
+        NotificationApiV18(
+            networkClient,
+            websocketClient,
+            backendConfig
+        )
+    }
+
+    override val teamsApi: TeamsApi get() = TeamsApiV18(networkClient)
+
+    override val selfApi: SelfApi get() = SelfApiV18(networkClient, sessionManager)
+
+    override val userDetailsApi: UserDetailsApi get() = UserDetailsApiV18(networkClient)
+
+    override val userSearchApi: UserSearchApi get() = UserSearchApiV18(networkClient)
+
+    override val callApi: CallApi get() = CallApiV18(networkClient)
+
+    override val connectionApi: ConnectionApi get() = ConnectionApiV18(networkClient)
+
+    override val featureConfigApi: FeatureConfigApi get() = FeatureConfigApiV18(networkClient)
+
+    override val mlsPublicKeyApi: MLSPublicKeyApi get() = MLSPublicKeyApiV18(networkClient)
+
+    override val propertiesApi: PropertiesApi get() = PropertiesApiV18(networkClient)
+
+    override val wildCardApi: WildCardApi get() = WildCardApiImpl(networkClient)
+
+    override val conversationHistoryApi: ConversationHistoryApi get() = ConversationHistoryApiV18(networkClient)
+
+    override val upgradePersonalToTeamApi: UpgradePersonalToTeamApi
+        get() = UpgradePersonalToTeamApiV18(
+            networkClient
+        )
+
+    override val serverTimeApi: ServerTimeApi
+        get() = ServerTimeApiV18(networkClient)
+
+    override val meetingApi: MeetingApi get() = MeetingApiV18(networkClient)
+
+    override val cellsHttpClient: HttpClient = networkClient.httpClient
+}

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/unauthenticated/DomainLookupApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/unauthenticated/DomainLookupApiV18.kt
@@ -1,0 +1,25 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.v18.unauthenticated
+
+import com.wire.kalium.network.UnauthenticatedNetworkClient
+import com.wire.kalium.network.api.v17.unauthenticated.DomainLookupApiV17
+
+internal open class DomainLookupApiV18 internal constructor(
+    unauthenticatedNetworkClient: UnauthenticatedNetworkClient
+) : DomainLookupApiV17(unauthenticatedNetworkClient)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/unauthenticated/GetDomainRegistrationApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/unauthenticated/GetDomainRegistrationApiV18.kt
@@ -1,0 +1,25 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.v18.unauthenticated
+
+import com.wire.kalium.network.UnauthenticatedNetworkClient
+import com.wire.kalium.network.api.v17.unauthenticated.GetDomainRegistrationApiV17
+
+internal open class GetDomainRegistrationApiV18 internal constructor(
+    unauthenticatedNetworkClient: UnauthenticatedNetworkClient
+) : GetDomainRegistrationApiV17(unauthenticatedNetworkClient)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/unauthenticated/LoginApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/unauthenticated/LoginApiV18.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v18.unauthenticated
+
+import com.wire.kalium.network.UnauthenticatedNetworkClient
+import com.wire.kalium.network.api.v17.unauthenticated.LoginApiV17
+
+internal open class LoginApiV18 internal constructor(
+    unauthenticatedNetworkClient: UnauthenticatedNetworkClient
+) : LoginApiV17(unauthenticatedNetworkClient)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/unauthenticated/RegisterApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/unauthenticated/RegisterApiV18.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v18.unauthenticated
+
+import com.wire.kalium.network.UnauthenticatedNetworkClient
+import com.wire.kalium.network.api.v17.unauthenticated.RegisterApiV17
+
+internal open class RegisterApiV18 internal constructor(
+    unauthenticatedNetworkClient: UnauthenticatedNetworkClient
+) : RegisterApiV17(unauthenticatedNetworkClient)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/unauthenticated/SSOLoginApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/unauthenticated/SSOLoginApiV18.kt
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v18.unauthenticated
+
+import com.wire.kalium.network.UnauthenticatedNetworkClient
+import com.wire.kalium.network.api.v17.unauthenticated.SSOLoginApiV17
+
+internal open class SSOLoginApiV18 internal constructor(
+    unauthenticatedNetworkClient: UnauthenticatedNetworkClient
+) : SSOLoginApiV17(unauthenticatedNetworkClient)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/unauthenticated/VerificationCodeApiV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/unauthenticated/VerificationCodeApiV18.kt
@@ -1,0 +1,25 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.kalium.network.api.v18.unauthenticated
+
+import com.wire.kalium.network.UnauthenticatedNetworkClient
+import com.wire.kalium.network.api.v17.unauthenticated.VerificationCodeApiV17
+
+internal open class VerificationCodeApiV18 internal constructor(
+    unauthenticatedNetworkClient: UnauthenticatedNetworkClient
+) : VerificationCodeApiV17(unauthenticatedNetworkClient)

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/unauthenticated/networkContainer/UnauthenticatedNetworkContainerV18.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/api/v18/unauthenticated/networkContainer/UnauthenticatedNetworkContainerV18.kt
@@ -1,0 +1,92 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.kalium.network.api.v18.unauthenticated.networkContainer
+
+import com.wire.kalium.network.api.base.unauthenticated.appVersioning.AppVersioningApi
+import com.wire.kalium.network.api.base.unauthenticated.appVersioning.AppVersioningApiImpl
+import com.wire.kalium.network.api.base.unauthenticated.systemsettings.UnauthorizedSettingsApi
+import com.wire.kalium.network.api.base.unauthenticated.systemsettings.UnauthorizedSettingsApiImpl
+import com.wire.kalium.network.api.base.unauthenticated.domainLookup.DomainLookupApi
+import com.wire.kalium.network.api.base.unauthenticated.domainregistration.GetDomainRegistrationApi
+import com.wire.kalium.network.api.base.unauthenticated.login.LoginApi
+import com.wire.kalium.network.api.base.unauthenticated.register.RegisterApi
+import com.wire.kalium.network.api.base.unauthenticated.sso.SSOLoginApi
+import com.wire.kalium.network.api.base.unauthenticated.verification.VerificationCodeApi
+import com.wire.kalium.network.api.base.unbound.configuration.ServerConfigApi
+import com.wire.kalium.network.api.base.unbound.configuration.ServerConfigApiImpl
+import com.wire.kalium.network.api.base.unbound.versioning.VersionApi
+import com.wire.kalium.network.api.base.unbound.versioning.VersionApiImpl
+import com.wire.kalium.network.api.model.ProxyCredentialsDTO
+import com.wire.kalium.network.api.unbound.configuration.ServerConfigDTO
+import com.wire.kalium.network.api.v18.unauthenticated.DomainLookupApiV18
+import com.wire.kalium.network.api.v18.unauthenticated.GetDomainRegistrationApiV18
+import com.wire.kalium.network.api.v18.unauthenticated.LoginApiV18
+import com.wire.kalium.network.api.v18.unauthenticated.RegisterApiV18
+import com.wire.kalium.network.api.v18.unauthenticated.SSOLoginApiV18
+import com.wire.kalium.network.api.v18.unauthenticated.VerificationCodeApiV18
+import com.wire.kalium.network.defaultHttpEngine
+import com.wire.kalium.network.networkContainer.UnauthenticatedNetworkClientProvider
+import com.wire.kalium.network.networkContainer.UnauthenticatedNetworkClientProviderImpl
+import com.wire.kalium.network.networkContainer.UnauthenticatedNetworkContainer
+import com.wire.kalium.network.session.CertificatePinning
+import io.ktor.client.engine.HttpClientEngine
+
+@Suppress("LongParameterList")
+class UnauthenticatedNetworkContainerV18 internal constructor(
+    backendLinks: ServerConfigDTO,
+    proxyCredentials: ProxyCredentialsDTO?,
+    certificatePinning: CertificatePinning,
+    mockEngine: HttpClientEngine?,
+    engine: HttpClientEngine = mockEngine ?: defaultHttpEngine(
+        serverConfigDTOApiProxy = backendLinks.links.apiProxy,
+        proxyCredentials = proxyCredentials,
+        certificatePinning = certificatePinning
+    ),
+    private val developmentApiEnabled: Boolean
+) : UnauthenticatedNetworkContainer,
+    UnauthenticatedNetworkClientProvider by UnauthenticatedNetworkClientProviderImpl(
+        backendLinks,
+        engine
+    ) {
+    override val loginApi: LoginApi get() = LoginApiV18(unauthenticatedNetworkClient)
+    override val verificationCodeApi: VerificationCodeApi
+        get() = VerificationCodeApiV18(
+            unauthenticatedNetworkClient
+        )
+    override val domainLookupApi: DomainLookupApi
+        get() = DomainLookupApiV18(
+            unauthenticatedNetworkClient
+        )
+    override val remoteVersion: VersionApi
+        get() = VersionApiImpl(
+            unauthenticatedNetworkClient,
+            developmentApiEnabled = developmentApiEnabled
+        )
+    override val serverConfigApi: ServerConfigApi
+        get() = ServerConfigApiImpl(unauthenticatedNetworkClient)
+    override val registerApi: RegisterApi get() = RegisterApiV18(unauthenticatedNetworkClient)
+    override val sso: SSOLoginApi get() = SSOLoginApiV18(unauthenticatedNetworkClient)
+    override val appVersioningApi: AppVersioningApi
+        get() = AppVersioningApiImpl(
+            unauthenticatedNetworkClient
+        )
+    override val unauthorizedSettingsApi: UnauthorizedSettingsApi get() = UnauthorizedSettingsApiImpl(unauthenticatedNetworkClient)
+    override val getDomainRegistrationApi: GetDomainRegistrationApi
+        get() = GetDomainRegistrationApiV18(unauthenticatedNetworkClient)
+}

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/networkContainer/AuthenticatedNetworkContainer.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/networkContainer/AuthenticatedNetworkContainer.kt
@@ -58,6 +58,7 @@ import com.wire.kalium.network.api.v14.authenticated.networkContainer.Authentica
 import com.wire.kalium.network.api.v15.authenticated.networkContainer.AuthenticatedNetworkContainerV15
 import com.wire.kalium.network.api.v16.authenticated.networkContainer.AuthenticatedNetworkContainerV16
 import com.wire.kalium.network.api.v17.authenticated.networkContainer.AuthenticatedNetworkContainerV17
+import com.wire.kalium.network.api.v18.authenticated.networkContainer.AuthenticatedNetworkContainerV18
 import com.wire.kalium.network.api.v2.authenticated.networkContainer.AuthenticatedNetworkContainerV2
 import com.wire.kalium.network.api.v4.authenticated.networkContainer.AuthenticatedNetworkContainerV4
 import com.wire.kalium.network.api.v5.authenticated.networkContainer.AuthenticatedNetworkContainerV5
@@ -363,6 +364,17 @@ interface AuthenticatedNetworkContainer {
                     mockEngine,
                     mockWebSocketSession,
                     kaliumLogger
+                )
+
+                18 -> AuthenticatedNetworkContainerV18(
+                    sessionManager,
+                    nomadServiceUrl,
+                    selfUserId,
+                    certificatePinning,
+                    mockEngine,
+                    mockWebSocketSession,
+                    kaliumLogger,
+                    engine = engine,
                 )
 
                 // You can use scripts/generate_new_api_version.sh or gradle task network:generateNewApiVersion to

--- a/data/network/src/commonMain/kotlin/com/wire/kalium/network/networkContainer/UnauthenticatedNetworkContainer.kt
+++ b/data/network/src/commonMain/kotlin/com/wire/kalium/network/networkContainer/UnauthenticatedNetworkContainer.kt
@@ -41,6 +41,7 @@ import com.wire.kalium.network.api.v14.unauthenticated.networkContainer.Unauthen
 import com.wire.kalium.network.api.v15.unauthenticated.networkContainer.UnauthenticatedNetworkContainerV15
 import com.wire.kalium.network.api.v16.unauthenticated.networkContainer.UnauthenticatedNetworkContainerV16
 import com.wire.kalium.network.api.v17.unauthenticated.networkContainer.UnauthenticatedNetworkContainerV17
+import com.wire.kalium.network.api.v18.unauthenticated.networkContainer.UnauthenticatedNetworkContainerV18
 import com.wire.kalium.network.api.v2.unauthenticated.networkContainer.UnauthenticatedNetworkContainerV2
 import com.wire.kalium.network.api.v4.unauthenticated.networkContainer.UnauthenticatedNetworkContainerV4
 import com.wire.kalium.network.api.v5.unauthenticated.networkContainer.UnauthenticatedNetworkContainerV5
@@ -252,6 +253,15 @@ interface UnauthenticatedNetworkContainer {
                     certificatePinning = certificatePinning,
                     mockEngine = mockEngine,
                     developmentApiEnabled = developmentApiEnabled
+                )
+
+                18 -> UnauthenticatedNetworkContainerV18(
+                    backendLinks = serverConfigDTO,
+                    proxyCredentials = proxyCredentials,
+                    certificatePinning = certificatePinning,
+                    mockEngine = mockEngine,
+                    developmentApiEnabled = developmentApiEnabled,
+                    engine = engine,
                 )
 
                 // You can use scripts/generate_new_api_version.sh or gradle task network:generateNewApiVersion to


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-28560
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-28560
----

# What's new in this PR?

Adding API 18 support for Adminless Groups feature.